### PR TITLE
(AUTO-53) Define launch config schema (ready for review)

### DIFF
--- a/doc/launch_config.rst
+++ b/doc/launch_config.rst
@@ -4,17 +4,36 @@ Launch Config Schema
 
 **Document type: launch_server**::
 
+The server arg contains arguments that will be passed to nova's create server API.  It is treated as opaque to autoscale.  (Nova should handle validation).
+
     {
         "type": "launch_servers",
         "args": {
             "server": {
-                "...nova create server args..."
+                "flavorRef": 3,
+                "name": "webhead",
+                "imageRef": "0d589460-f177-4b0f-81c1-8ab8903ac7d8",
+                "OS-DCF:diskConfig": "AUTO",
+                "metadata": {
+                    "mykey": "myvalue"
+                },
+                "personality": [
+                    {
+                        "path": '/root/.ssh/authorized_keys',
+                        "contents": (
+                            "ICAgICAgDQoiQSBjbG91ZCBkb2VzIG5vdCBrbm93IHdoeSBp")
+                    }
+                ],
+                "networks": [
+                    {
+                        "uuid": "11111111-1111-1111-1111-111111111111"
+                    }
+                ],
             },
             "loadBalancers":
                 {
-                    "id": "",
-                    "port": "",
-                    "network": ""
+                    "id": 500,
+                    "port": 80
                 }
             ]
         }

--- a/otter/test/json_schema/test_scaling_group.py
+++ b/otter/test/json_schema/test_scaling_group.py
@@ -144,7 +144,7 @@ class ServerLaunchConfigTestCase(TestCase):
 
     def test_invalid_load_balancer_does_not_validate(self):
         """
-        Load balancers need to have 3 values: lbid, port, and network.
+        Load balancers need to have 2 values: loadBalancerId and port.
         """
         base = {
             "type": "launch_server",
@@ -153,17 +153,13 @@ class ServerLaunchConfigTestCase(TestCase):
             }
         }
         invalids = [
-            ({'loadBalancerId': '', 'port': 80, 'network': 'public'},
-             'not of type'),
-            ({'loadBalancerId': 3, 'port': '80', 'network': 'public'},
-             'not of type'),
-            ({'loadBalancerId': 3, 'port': 80,
-             'network': '11111111-1111-1111-111111111111'}, 'is not one of')
+            {'loadBalancerId': '', 'port': 80},
+            {'loadBalancerId': 3, 'port': '80'}
         ]
-        for invalid, regexp in invalids:
+        for invalid in invalids:
             base["args"]["loadBalancers"] = [invalid]
-            # the type fails ot valdiate because of "regexp" region
-            self.assertRaisesRegexp(ValidationError, regexp, validate,
+            # the type fails ot valdiate because of 'not of type'
+            self.assertRaisesRegexp(ValidationError, 'not of type', validate,
                                     base, scaling_group.launch_server)
             # because the type schema fails to validate, the config schema
             # fails to validate because it is not the given type
@@ -180,8 +176,8 @@ class ServerLaunchConfigTestCase(TestCase):
             "args": {
                 "server": {},
                 "loadBalancers": [
-                    {'loadBalancerId': 1, 'port': 80, 'network': 'public'},
-                    {'loadBalancerId': 1, 'port': 80, 'network': 'public'}
+                    {'loadBalancerId': 1, 'port': 80},
+                    {'loadBalancerId': 1, 'port': 80}
                 ]
             }
         }


### PR DESCRIPTION
**Note: this PR is dependent upon https://github.com/racker/otter/pull/15**

This is the schema for the launch config the user needs to provide to start new servers.

As per discussion, the "create server" args provided to nova should be opaque to us, unless nova provides us with some type of validation (we should not attempt to duplicate nova's validation).

This means that it is possible for the user to create/change a launch config in such a way that it is invalid, so that no new servers can be created.

This schema also takes arguments for adding the server to an already existing loadbalancer - these args cannot be opaque to us, because many of the load balancer args do not make sense in the case of autoscale.

Adding volumes is going to be deferred to later:  volumes cannot be added to multiple servers (although one server may have multiple volumes), so the only thing that makes sense is to create a volume for each new server and add it to the new server.  We should find out of our customers want this.

Finally, this schema uses complex union types (so types are arrays of schemas) because presumably the args schema is different dependent on what launch config type it is, and json schema draft 3 doesn't support conditional schemas yet.  I'm not super happy with this solution for several reasons:
1. According to some random person on the internet, Draft 4 will no longer support this feature.
2. The ValidationError when validating against the whole schema will be "X is not of type <giant schema here>", since the instance schema didn't match the particular type schema.  The actual error (such as a string being too long, or an extra property isn't valid) that comes from trying to validate against the _type_ schema gets hidden.  We can possibly either try to monkey patch this in jsonschema or submit a PR to jsonschema.
