### PR TITLE
Define scaling policy schema (ready for review)

### DIFF
--- a/otter/json_schema/scaling_group.py
+++ b/otter/json_schema/scaling_group.py
@@ -261,7 +261,6 @@ scaling_policy = {
             "properties": {
                 "name": {},
                 "cooldown": {},
-                "capabilityUrls": {},
                 "changePercent": {"required": True}
             },
             "additionalProperties": False
@@ -271,7 +270,6 @@ scaling_policy = {
             "properties": {
                 "name": {},
                 "cooldown": {},
-                "capabilityUrls": {},
                 "change": {"required": True}
             },
             "additionalProperties": False
@@ -281,7 +279,6 @@ scaling_policy = {
             "properties": {
                 "name": {},
                 "cooldown": {},
-                "capabilityUrls": {},
                 "steadyState": {"required": True}
             },
             "additionalProperties": False
@@ -337,40 +334,6 @@ scaling_policy = {
                 "does not affect the global scaling group cooldown."),
             "minimum": 0,
             "required": True
-        },
-        "capabilityUrls": {
-            "type": "array",
-            "description": (
-                "A list of capability URLs, their short names, and an id."),
-            "items": {
-                "type": "object",
-                "description": (
-                    "A list of capability URLs.  The URLs themselves are "
-                    "unique and thus serve as their own unique ID, but they "
-                    "can also be named with a non-unique, human readable "
-                    "string.  If an object has only a name and not a URL, "
-                    "a capability URL will be generated.  All changes to the "
-                    "url properties will be ignored."),
-                "properties": {
-                    "url": {
-                        "type": "string",
-                        "description": (
-                            "A unique capability URL for the scaling policy. "
-                            "This is read-only; that means that all changes "
-                            "will be ignored."),
-                        "required": False
-                    },
-                    "name": {
-                        "type": "string",
-                        "description": (
-                            "A short, human-readable name that describes this "
-                            "capability URL."),
-                        "required": True,
-                        "maxLength": 256
-                    }
-                },
-                "additionalProperties": False
-            }
         }
     }
 }
@@ -385,16 +348,7 @@ scaling_policy_examples = [
     {
         "name": 'scale down a 5.5 percent because of a tweet',
         "changePercent": -5.5,
-        "cooldown": 6,
-        "capabilityUrls": [
-            {
-                "url": "https://autoscale.rax.io/3908sdkldg0950wds05kdgazpfc",
-                "name": "twitter"
-            },
-            {
-                "name": "tweetbot"
-            }
-        ]
+        "cooldown": 6
     },
     {
         "name": 'set number of servers to 10',

--- a/otter/test/json_schema/test_scaling_group.py
+++ b/otter/test/json_schema/test_scaling_group.py
@@ -273,17 +273,3 @@ class ScalingPolicyTestCase(TestCase):
         self.assertRaisesRegexp(
             ValidationError, 'not of type',
             validate, invalid, scaling_group.scaling_policy)
-
-    def test_capability_urls_only_have_url_and_name(self):
-        """
-        Scaling policy capability url items can only have the following
-        properties: name, url.  Any other property results in an error.
-        """
-        invalid = {
-            "name": "",
-            "url": "",
-            "poofy": True
-        }
-        self.assertRaisesRegexp(
-            ValidationError, 'not of type',
-            validate, invalid, scaling_group.scaling_policy)


### PR DESCRIPTION
So, this was a first stab at specifying a schema for viewing/edting and creating scaling policies.

I'm not entirely sure whether this is a good way to handle capability URLs.  Since it's auto-generated, we don't want the user to be able to modify the URLs, but we want them to be able to delete them.

**EDIT**:  Based on discussions here and IRL, going to remove the capability URLS entirely.  Seems like the consensus is that the list of capability URLs should never show up in any manifested scaling policy schema-only view, nor can they be added or updated when updating the scaling policy.
