### PR TITLE
Add a bootstrap-virtualenv.sh script.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ _builddoc
 .self.txt
 otter-deploy*
 *.egg-info
+.ve
+build

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,9 @@ test:	unit integration
 run:
 	PYTHONPATH=".:${PYTHONPATH}" twistd -n web --resource-script=${CODEDIR}/server.rpy
 
+env:
+	./scripts/bootstrap-virtualenv.sh
+
 lint:
 	${PYTHONLINT} ${PYDIRS}
 
@@ -38,7 +41,7 @@ clean: cleandocs
 	find . -name '_trial_coverage' -print0 | xargs rm -rf
 	find . -name '_trial_temp' -print0 | xargs rm -rf
 	rm -rf dist build *.egg-info
-	rm -rf otter-deploy*
+	rm -rf otter-deploy* .ve
 
 bundle:
 	./scripts/bundle.sh

--- a/scripts/bootstrap-virtualenv.sh
+++ b/scripts/bootstrap-virtualenv.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+#
+# Create an initial virtualenv based on the VE_DIR environment variable (.ve)
+# by default.  This is used by the Makefile `make env` to allow bootstrapping in
+# environments where virtualenvwrapper is unavailable or unappropriate.  Such
+# as on Jenkins.
+#
+
+VE_DIR=${VE_DIR:=.ve}
+
+rm -rf ${VE_DIR}
+
+virtualenv ${VE_DIR}
+
+source .ve/bin/activate
+
+pip install -r dev_requirements.txt
+pip install -r requirements.txt


### PR DESCRIPTION
This is for bootstrapping primarily on the Jenkins slaves where it is
in appropriate to use virtualenvwrapper.

This could have easily been embedded in a Build Step but having files in
version control is better.
