### PR TITLE
Install dev requirements if --dev is passed to bundle.sh (ready for review)

### DIFF
--- a/scripts/bundle.sh
+++ b/scripts/bundle.sh
@@ -42,8 +42,15 @@ fi
 
 echo "${SELF_DEP}" > ./.self.txt
 
+REQUIREMENTS="./requirements.txt ./.self.txt"
+
+if [[ "$1" == "--dev" ]]; then
+    # if bundling for development, also include the development requirements
+    REQUIREMENTS="./dev_requirements.txt $REQUIREMENTS"
+fi
+
 echo "Building virtualenv..."
-terrarium --target ${TARGET} install ./requirements.txt ./.self.txt
+terrarium --target ${TARGET} install $REQUIREMENTS
 
 if [[ "$1" == "--dev" ]]; then
     #


### PR DESCRIPTION
To fix a problem with the dev environment (https://github.com/racker/autoscaling-chef/pull/43) where if the deploy virtualenv is activated, linting and doc generation can't happen because sphinx and pep8 are not importable.

This does not fix the problem of running the unit tests and getting:

```
otter.test.indexer.test_poller
===============================================================================
[ERROR]
Traceback (most recent call last):
  File "/tmp/otter/deploy-ve/local/lib/python2.7/site-packages/twisted/trial/runner.py", line 556, in loadPackage
    module = modinfo.load()
  File "/tmp/otter/deploy-ve/local/lib/python2.7/site-packages/twisted/python/modules.py", line 383, in load
    return self.pathEntry.pythonPath.moduleLoader(self.name)
  File "/tmp/otter/deploy-ve/local/lib/python2.7/site-packages/twisted/python/reflect.py", line 506, in namedAny
    topLevelPackage = _importAndCheckStack(trialname)
  File "/mnt/hgfs/otter/otter/test/indexer/test_atom.py", line 9, in <module>
    from otter.indexer.atom import (
  File "/mnt/hgfs/otter/otter/indexer/atom.py", line 5, in <module>
    from lxml import etree
exceptions.ImportError: dynamic module does not define init function (initetree)
```

errors though.
