### PR TITLE
Import all the submodules of rest in __init__ and fix server.rpy (ready for review)

### DIFF
--- a/otter/rest/__init__.py
+++ b/otter/rest/__init__.py
@@ -1,0 +1,10 @@
+"""
+The otter REST API implementation.
+"""
+
+# Groups, configs, etc. have to be imported else the routes never get loaded
+
+from otter.rest import groups as _g, configs as _c
+
+groups = _g
+configs = _c

--- a/otter/server.rpy
+++ b/otter/server.rpy
@@ -1,14 +1,18 @@
-"""Null"""
+"""
+Resource script for the autoscale API
+"""
 
 import os
 import sys
+
 from tryfer.http import TracingWrapperResource
 from tryfer.tracers import push_tracer, DebugTracer, EndAnnotationTracer
 
-import otter.scaling_groups
+from otter.rest.application import root
 
-# Add the debug tracer.
-push_tracer(EndAnnotationTracer(DebugTracer(sys.stdout)))
+# Add the debug tracer, if in debug environment
+if os.getenv("OTTER_ENV", None) == "debug":
+    push_tracer(EndAnnotationTracer(DebugTracer(sys.stdout)))
 
-resource = TracingWrapperResource(otter.scaling_groups.root, service_name='otter')
 
+resource = TracingWrapperResource(root, service_name='otter')

--- a/otter/test/rest/test_configs.py
+++ b/otter/test/rest/test_configs.py
@@ -19,11 +19,6 @@ from otter.rest.decorators import InvalidJsonError
 
 from otter.test.rest.request import DummyException, RestAPITestMixin
 
-# import groups in order to get the routes created - the assignment is a trick
-# to ignore pyflakes
-import otter.rest.configs as _c
-configs = _c
-
 
 class GroupConfigTestCase(RestAPITestMixin, TestCase):
     """

--- a/otter/test/rest/test_groups.py
+++ b/otter/test/rest/test_groups.py
@@ -19,11 +19,6 @@ from otter.rest.decorators import InvalidJsonError
 
 from otter.test.rest.request import DummyException, RestAPITestMixin
 
-# import groups in order to get the routes created - the assignment is a trick
-# to ignore pyflakes
-import otter.rest.groups as _g
-groups = _g
-
 
 class AllGroupsEndpointTestCase(RestAPITestMixin, TestCase):
     """

--- a/otter/test/unitgration/test_rest_mock_model.py
+++ b/otter/test/unitgration/test_rest_mock_model.py
@@ -24,12 +24,6 @@ from otter.rest.application import root, set_store
 from otter.test.rest.request import request
 from otter.test.utils import DeferredTestMixin
 
-# make all the route endpoints
-import otter.rest.groups as _g
-groups = _g
-import otter.rest.configs as _c
-configs = _c
-
 
 class MockStoreRestTestCase(DeferredTestMixin, TestCase):
     """


### PR DESCRIPTION
This broke when we refactored the rest code into a bunch of submodules.  This PR fixes the rpy so that make run works again.

Also, all the importing of the submodules now happens in `otter.rest.__init__` so the imports can be left off of the tests.
