### PR TITLE
Remove docstrings from functions that implement the interface 

### DIFF
--- a/otter/models/cass.py
+++ b/otter/models/cass.py
@@ -476,7 +476,7 @@ class CassScalingGroupCollection:
 
     def list_scaling_groups(self, tenant_id):
         """
-        see :meth:`otter.models.interface.IScalingGroupCollection.list_scaling_group`
+        see :meth:`otter.models.interface.IScalingGroupCollection.list_scaling_groups`
         """
         def _grab_list(rawResponse):
             if rawResponse is None:

--- a/otter/models/mock.py
+++ b/otter/models/mock.py
@@ -431,7 +431,7 @@ class MockScalingGroupCollection:
 
     def list_scaling_groups(self, tenant):
         """
-        see :meth:`otter.models.interface.IScalingGroupCollection.list_scaling_group`
+        see :meth:`otter.models.interface.IScalingGroupCollection.list_scaling_groups`
         """
         return defer.succeed(self.data.get(tenant, {}).values())
 


### PR DESCRIPTION
refer to the interface method instead 
