### PR TITLE
copy ascii otter to virtualenv

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,10 @@ if os.path.exists('twisted/plugins'):
 setup(
     name=NAME,
     version='0.0.0',
-    packages=packages
+    packages=packages,
+    data_files = [
+        ('otter/rest', ['otter/rest/otter_ascii.txt'])
+    ]
 )
 
 # Make Twisted regenerate the dropin.cache, if possible.  This is necessary


### PR DESCRIPTION
An ascii otter was added in #69 but the text file is not getting installed.
This way seems to work, not sure if its the best.
