### PR TITLE
Use large-random tokens for capabilities.

### DIFF
--- a/otter/models/cass.py
+++ b/otter/models/cass.py
@@ -150,12 +150,12 @@ def _build_webhooks(bare_webhooks, webhooks_table, queries, cql_parameters,
         #       hash versions can be stored
         webhook_real = {'metadata': {}, 'capability': {}}
         webhook_real.update(bare_webhooks[i])
-        (token, webhook_real['capability']['hash'],
-            webhook_real['capability']['version']) = generate_capability()
+        (webhook_real['capability']['version'],
+         webhook_real['capability']['hash']) = generate_capability()
 
         cql_parameters[name] = _serial_json_data(webhook_real, 1)
         cql_parameters['{0}Id'.format(name)] = webhook_id
-        cql_parameters['{0}Key'.format(name)] = token
+        cql_parameters['{0}Key'.format(name)] = webhook_real['capability']['hash']
         output[webhook_id] = webhook_real
 
 

--- a/otter/models/mock.py
+++ b/otter/models/mock.py
@@ -318,8 +318,8 @@ class MockScalingGroup:
                 webhook_real.update(webhook_input)
                 webhook_real['capability'] = {}
 
-                (ignore, webhook_real['capability']['hash'],
-                 webhook_real['capability']['version']) = generate_capability()
+                (webhook_real['capability']['version'],
+                 webhook_real['capability']['hash']) = generate_capability()
 
                 uuid = str(uuid4())
                 self.webhooks[policy_id][uuid] = webhook_real

--- a/otter/test/models/test_cass_models.py
+++ b/otter/test/models/test_cass_models.py
@@ -129,7 +129,7 @@ class CassScalingGroupTestCase(IScalingGroupProviderMixin, TestCase):
 
         self.capability_patch = mock.patch(
             'otter.models.cass.generate_capability',
-            return_value=('x', 'y', '1'))
+            return_value=('ver', 'hash'))
         self.mock_capability = self.capability_patch.start()
         self.addCleanup(self.capability_patch.stop)
 
@@ -721,7 +721,7 @@ class CassScalingGroupTestCase(IScalingGroupProviderMixin, TestCase):
             '100001': {'metadata': {}},
             '100002': {'metadata': 'who'}
         }
-        capability = {'capability': {"hash": 'y', "version": '1'}}
+        capability = {'capability': {"hash": 'hash', "version": 'ver'}}
         for value in expected_results.values():
             value.update(capability)
 
@@ -752,9 +752,9 @@ class CassScalingGroupTestCase(IScalingGroupProviderMixin, TestCase):
             "groupId": '12345678g',
             "policyId": '23456789',
             'webhook0Id': '100001',
-            "webhook0Key": "x",
+            "webhook0Key": "hash",
             'webhook1Id': '100002',
-            "webhook1Key": "x"
+            "webhook1Key": "hash"
         }
         for key, val in expected_params.iteritems():
             self.assertEqual(cql_params[key], val)

--- a/otter/test/models/test_mock_models.py
+++ b/otter/test/models/test_mock_models.py
@@ -485,7 +485,7 @@ class MockScalingGroupTestCase(IScalingGroupProviderMixin, TestCase):
         self.assert_deferred_failed(deferred, NoSuchPolicyError)
 
     @mock.patch('otter.models.mock.generate_capability',
-                return_value=("num", "hash", "ver"))
+                return_value=("ver", "hash"))
     def test_create_webhooks_succeed(self, fake_random):
         """
         Adding new webhooks to the scaling policy returns a dictionary of
@@ -804,7 +804,7 @@ class MockScalingGroupsCollectionTestCase(IScalingGroupCollectionProviderMixin,
         self.assert_deferred_failed(deferred, NoSuchScalingGroupError)
 
     @mock.patch('otter.models.mock.generate_capability',
-                return_value=("num", "hash", "ver"))
+                return_value=("ver", "hash"))
     def test_webhook_execute(self, mock_generation):
         """
         Tests that we can execute a webhook given a capability token.
@@ -832,7 +832,7 @@ class MockScalingGroupsCollectionTestCase(IScalingGroupCollectionProviderMixin,
         self.assert_deferred_succeeded(deferred)
 
     @mock.patch('otter.models.mock.generate_capability',
-                return_value=("num", "hash", "ver"))
+                return_value=("ver", "hash"))
     def test_webhook_execute_no_hash(self, mock_generation):
         """
         Tests that, given a bad capability token, we error out.
@@ -860,7 +860,7 @@ class MockScalingGroupsCollectionTestCase(IScalingGroupCollectionProviderMixin,
         self.assert_deferred_failed(deferred, UnrecognizedCapabilityError)
 
     @mock.patch('otter.models.mock.generate_capability',
-                return_value=("num", "hash", "ver"))
+                return_value=("ver", "hash"))
     def _call_all_methods_on_group(self, group_id, mock_generation):
         """
         Gets a group, asserts that it's a MockScalingGroup, and runs all of its

--- a/otter/test/test_util.py
+++ b/otter/test/test_util.py
@@ -1,10 +1,12 @@
 """
 Tests for ``otter.util``
 """
+import mock
 
 from twisted.trial.unittest import TestCase
 
 from otter.util.http import append_segments
+from otter.util.hashkey import generate_capability
 
 
 class HTTPUtilityTests(TestCase):
@@ -44,3 +46,33 @@ class HTTPUtilityTests(TestCase):
             append_segments('http://example.com', 'foo bar'),
             'http://example.com/foo%20bar'
         )
+
+
+class CapabilityTests(TestCase):
+    """
+    Test capability generation.
+    """
+    @mock.patch('otter.util.hashkey.os.urandom')
+    def test_urandom_32_bytes(self, urandom):
+        """
+        generate_capability will use os.urandom to get 32 bytes of random
+        data.
+        """
+        (_v, _cap) = generate_capability()
+        urandom.assert_called_once_with(32)
+
+    @mock.patch('otter.util.hashkey.os.urandom')
+    def test_hex_encoded_cap(self, urandom):
+        """
+        generate_capability will hex encode the random bytes from os.urandom.
+        """
+        urandom.return_value = '\xde\xad\xbe\xef'
+        (_v, cap) = generate_capability()
+        self.assertEqual(cap, 'deadbeef')
+
+    def test_version_1(self):
+        """
+        generate_capability returns a version 1 capability.
+        """
+        (v, _cap) = generate_capability()
+        self.assertEqual(v, "1")

--- a/otter/util/hashkey.py
+++ b/otter/util/hashkey.py
@@ -2,20 +2,8 @@
 Hash key related library code
 """
 
-from hashlib import sha256
-import hmac
+import os
 import uuid
-
-
-# TODO: do this for real
-def _get_hmac_secret(version="1"):
-    """
-    Given a version number, return cryptographically secure key to be used to
-    hash a possibly pseudorandom number as its message
-
-    :return: secret key
-    """
-    return "sekrit!!!!"
 
 
 def generate_transaction_id():
@@ -38,18 +26,12 @@ def generate_key_str(keytype):
 
 
 # TODO: versioning
-def generate_capability(number=None, version="1"):
+def generate_capability():
     """
-    Generates a random number and HMAC it with a secure key to produce
-    the an unguessable (due to the super secret key) capability hash.
+    Generates a 256-bit random number from /dev/urandom and encodes it as
+    64 hex characters.
 
-    :return: a tuple of the the random number, the capability hash (which is
-        the number concatenated with the HMAC of the number), and the version
-        number of this capability generation scheme.
+    :return: a tuple of capability version and the random hex string.
     :rtype: ``tuple``
     """
-    number = number or uuid.uuid4().hex
-    version = "1"  # force version to be one
-    hashed_number = hmac.new(_get_hmac_secret(version), number, sha256)
-    message = "".join((number, hashed_number.hexdigest()))
-    return (number, message, version)
+    return ("1", os.urandom(32).encode('hex'))


### PR DESCRIPTION
generate_capability now returns a 2-tuple of the version (always 1)
and a hex encoded 256-bit random integer.

This branch fixes all existing test coverage and adds specific tests for
generate_capability.
