### PR TITLE
Auto 216 163 delete group webhook bug (ready for review)

### DIFF
--- a/otter/models/cass.py
+++ b/otter/models/cass.py
@@ -731,7 +731,7 @@ class CassScalingGroupCollection:
 
             deferreds = []
             for policy_id in policy_dict:
-                deferreds.append(group.delete_policy(policy_id))
+                deferreds.append(group._naive_delete_policy(policy_id))
             return defer.gatherResults(deferreds)
 
         def _delete_it(lastRev, group):
@@ -741,6 +741,7 @@ class CassScalingGroupCollection:
             ])
             d.addCallback(lambda _: None)
             return d
+
         group = self.get_scaling_group(log, tenant_id, scaling_group_id)
         d = group.view_config()  # ensure that it's actually there
         return d.addCallback(_delete_it, group)  # only delete if it exists


### PR DESCRIPTION
216 was caused by the `naive_list_policies` still checking the config if the list is empty.  When you delete a group, the config is gone, so that failed.  That was fixed in a previous pull request, but I noticed that `delete_scaling_group` calls `delete_policy`, which checks to see if the policy exists before deleting it.

I had a hard time telling if this was going to be a problem or not, so I just preemptively fixed it and tried to make it and the tests easier to reason about, so if the scaling group does have webhooks the delete scaling group tests won't fail
