### PR TITLE
Auto 218 mock scaling state (ready for review)

### DIFF
--- a/otter/json_schema/model_schemas.py
+++ b/otter/json_schema/model_schemas.py
@@ -1,111 +1,16 @@
 """
 JSON schema to be used to verify the return values from implementations of the
 model interface.
+
+This is only going to be used internally to verify the schemas returned by the
+interface.  Probably easier to test just by asserting simplified dictionaries
+so that all the correct data doesn't have to be mocked.
+
+Please delete from this file.
 """
 from copy import deepcopy
 from otter.json_schema import group_schemas
 
-# example:
-# {
-#   "active": {
-#     "server_name": {
-#       "instanceId": "instance id",
-#       "instanceUri": "instance uri",
-#       "created": "created timestamp"
-#     },
-#     ...
-#   },
-#   "pending": {
-#     "job_id": {
-#         "created": "created timestamp"
-#     },
-#       ...
-#   },
-#   "groupTouched": "timestamp any policy was last executed"
-#   "policyTouched": {
-#     "policy_id": "timestamp this policy was last executed",
-#     ...
-#   },
-#   "paused": false
-# }
-#
-pending_jobs = {
-    'type': 'object',
-    'description': "The pending job IDs of servers not yet built",
-    'patternProperties': {
-        "^\S+$": {
-            'type': 'object',
-            'properties': {
-                "created": {
-                    'description': "The time the job was started",
-                    'type': 'string',
-                    'required': True
-                }
-            },
-            'additionalProperties': False
-        }
-    },
-    'additionalProperties': False,
-    'required': True
-}
-
-
-group_state = {
-    'type': 'object',
-    'properties': {
-        'paused': {
-            'type': 'boolean',
-            'required': True
-        },
-        'active': {
-            'type': 'object',
-            'description': "The active servers in this group",
-            'patternProperties': {
-                "^\S+$": {
-                    'type': 'object',
-                    'properties': {
-                        "instanceId": {
-                            'type': 'string',
-                            'description': "The instance ID of the server",
-                            'required': True
-                        },
-                        "instanceUri": {
-                            'type': 'string',
-                            'description': "The instance URI of the server",
-                            'required': True
-                        },
-                        "created": {
-                            'type': 'string',
-                            'description': "The time the server was created",
-                            'required': True
-                        }
-                    },
-                    "additionalProperties": False
-                }
-            },
-            'additionalProperties': False,
-            'required': True
-        },
-        'pending': pending_jobs,
-        "groupTouched": {
-            'description': "The timestamp of the last time any policy was executed",
-            'type': ['null', 'string'],
-            'required': True
-        },
-        "policyTouched": {
-            'description': "The timestamp of the last time a particular policy was executed",
-            'patternProperties': {
-                "^\S+$": {
-                    'type': 'string',
-                    'description': "The timestamp of the last time this policy was executed",
-                }
-            },
-            'additionalProperties': False,
-            'required': True
-        }
-    },
-    'additionalProperties': False
-}
 
 # unlike updating or inputing a group config, the returned config must actually
 # have all the properties

--- a/otter/models/interface.py
+++ b/otter/models/interface.py
@@ -92,16 +92,31 @@ class IScalingGroup(Interface):
 
     def view_state():
         """
-        The state of the scaling group consists of a mapping of entity id's to
-        entity links for the current entities in the scaling group, a mapping
-        of entity id's to entity links for the pending entities in the scaling
-        group, the desired steady state number of entities, and a boolean
-        specifying whether scaling is currently paused.
+        :return: the state information for the group, which looks like::
 
-        The entity links are in JSON link format.
+            {
+              "active": {
+                "server_name": {
+                  "instanceId": "instance id",
+                  "instanceUri": "instance uri",
+                  "created": "created timestamp"
+                },
+                ...
+              },
+              "pending": {
+                "job_id": {
+                    "created": "created timestamp"
+                },
+                  ...
+              },
+              "groupTouched": "timestamp any policy was last executed"
+              "policyTouched": {
+                "policy_id": "timestamp this policy was last executed",
+                ...
+              },
+              "paused": false
+            }
 
-        :return: a view of the state of the scaling group corresponding to the
-            JSON schema at :data:``otter.json_schema.model_schemas.group_state``
 
         :rtype: a :class:`twisted.internet.defer.Deferred` that fires with
             ``dict``

--- a/otter/test/json_schema/test_schemas.py
+++ b/otter/test/json_schema/test_schemas.py
@@ -6,8 +6,7 @@ from copy import deepcopy
 from twisted.trial.unittest import TestCase
 from jsonschema import Draft3Validator, validate, ValidationError
 
-from otter.json_schema import (
-    group_schemas, group_examples, rest_schemas, model_schemas)
+from otter.json_schema import group_schemas, group_examples, rest_schemas
 
 
 class ScalingGroupConfigTestCase(TestCase):
@@ -376,36 +375,3 @@ class CreateScalingGroupTestCase(TestCase):
                 group_examples.launch_server_config()[0],
                 'scalingPolicies': {"Hello!": "Yes quite."}
             }, rest_schemas.create_group_request)
-
-
-class GroupStateModelTestCase(TestCase):
-    """
-    Tests for the group state model schema
-    """
-    valid = {
-        'paused': False,
-        'pending': {},
-        'active': {},
-        'groupTouched': '2012-01-01T12:01:00',
-        'policyTouched': {}
-    }
-
-    def test_schema_valid(self):
-        """
-        The schema itself is a valid Draft 3 schema and the valid schema
-        validates
-        """
-        Draft3Validator.check_schema(model_schemas.group_state)
-        validate(self.valid, model_schemas.group_state)
-
-    def test_missing_parameter_does_not_validate(self):
-        """
-        paused, pending, active, groupTouched, and policyTouched must all
-        be there
-        """
-        for key in self.valid:
-            invalid = self.valid.copy()
-            del invalid[key]
-
-            self.assertRaises(ValidationError, validate, invalid,
-                              model_schemas.group_state)

--- a/otter/test/models/test_interface.py
+++ b/otter/test/models/test_interface.py
@@ -70,18 +70,6 @@ class IScalingGroupProviderMixin(DeferredTestMixin):
         validate(result, launch_config)
         return result
 
-    def validate_view_state_return_value(self, *args, **kwargs):
-        """
-        Calls ``view_state()``, and validates that it returns a state
-        dictionary containing relevant state values
-
-        :return: the return value of ``view_state()``
-        """
-        result = self.assert_deferred_succeeded(
-            self.group.view_state(*args, **kwargs))
-        validate(result, model_schemas.group_state)
-        return result
-
     def validate_list_policies_return_value(self, *args, **kwargs):
         """
         Calls ``list_policies``, and validates that it returns a policy

--- a/otter/test/models/test_mock_models.py
+++ b/otter/test/models/test_mock_models.py
@@ -130,10 +130,11 @@ class MockScalingGroupTestCase(IScalingGroupProviderMixin, TestCase):
 
     def test_view_state_returns_valid_scheme_when_empty(self):
         """
-        ``view_state`` returns something conforming to the scheme whether or
-        not there are entities in the system
+        ``view_state`` returns all the state information stored in the
+        MockScalingGroup as the required keys
         """
-        self.assertEquals(self.validate_view_state_return_value(), {
+        result = self.assert_deferred_succeeded(self.group.view_state())
+        self.assertEquals(result, {
             'active': {},
             'pending': {},
             'paused': False,


### PR DESCRIPTION
Changed the mock scaling state to match what was discussed re: state storage in cassandra.

This only changes the model schema and the mock implementation of view state.

Adding active servers, pending jobs, etc. should be in a different PR.
