### PR TITLE
Changing models to reduce the incidence of multiple reads

### DIFF
--- a/otter/models/cass.py
+++ b/otter/models/cass.py
@@ -713,13 +713,13 @@ class CassScalingGroup(object):
 
         return _jsonloads_data(results[0]['data'])
 
-    def add_server(self, name, instance_id, uri, pending_job_id, created=None):
+    def add_server(self, state, name, instance_id, uri, pending_job_id, created=None):
         """
         see :meth:`otter.models.interface.IScalingGroupState.add_server`
         """
         raise NotImplementedError()
 
-    def update_jobs(self, job_dict, transaction_id, policy_id=None,
+    def update_jobs(self, state, job_dict, transaction_id, policy_id=None,
                     timestamp=None):
         """
         see :meth:`otter.models.interface.IScalingGroupState.update_jobs`

--- a/otter/models/interface.py
+++ b/otter/models/interface.py
@@ -54,11 +54,13 @@ class IScalingGroupState(Interface):
     Represents an accessor for group state.
     """
 
-    def add_server(name, instance_id, uri, pending_job_id, created=None):
+    def add_server(state, name, instance_id, uri, pending_job_id, created=None):
         """
         Takes information about an active server and adds it to the store of
         active servers.
 
+        :param dict state: a dict, like you'd see returned from view_state,
+            containing the state of the group
         :param str name: the name of the server
         :param str instance_id: the instance id of the server
         :param str uri: the link to the server
@@ -72,13 +74,16 @@ class IScalingGroupState(Interface):
         :return: a :class:`twisted.internet.defer.Deferred` that fires with None
         """
 
-    def update_jobs(job_dict, transaction_id, policy_id=None, timestamp=None):
+    def update_jobs(state, job_dict, transaction_id, policy_id=None, timestamp=None):
         """
         Update jobs with the jobs dict, which should contain all outstanding
         jobs in the group, not just new jobs.
 
         If the jobs changed as a result of hte policy, modify the touched times
         for the given policy (and the group at large).
+
+        :param dict state: a dict, like you'd see returned from view_state,
+            containing the state of the group
 
         :param dict job_dict: a dictionary mapping jobs to a dictionary as
             defined by :data:`otter.json_schema.model_schemas.pending_jobs`.

--- a/otter/models/mock.py
+++ b/otter/models/mock.py
@@ -364,13 +364,13 @@ class MockScalingGroup:
             return defer.fail(NoSuchWebhookError(self.tenant_id, self.uuid,
                                                  policy_id, webhook_id))
 
-    def add_server(self, name, instance_id, uri, pending_job_id, created=None):
+    def add_server(self, state, name, instance_id, uri, pending_job_id, created=None):
         """
         see :meth:`otter.models.interface.IScalingGroupState.add_server`
         """
         raise NotImplementedError()
 
-    def update_jobs(self, job_dict, transaction_id, policy_id=None,
+    def update_jobs(self, state, job_dict, transaction_id, policy_id=None,
                     timestamp=None):
         """
         see :meth:`otter.models.interface.IScalingGroupState.update_jobs`


### PR DESCRIPTION
live discussion with @cyli where we realized that the interface needed to change to avoid repeated read-write cycles and such.

The intent is that you will pass the record you received from view_state at the beginning of the modifiy cycle and the mutation functions will then do whatever they need to... without having the state object, you might have to add a second read.
