### PR TITLE
Fix failing cassandra unitgration tests (ready for review)

### DIFF
--- a/otter/models/cass.py
+++ b/otter/models/cass.py
@@ -53,8 +53,8 @@ _cql_insert = ('INSERT INTO {cf}("tenantId", "groupId", data, deleted) '
 _cql_insert_policy = ('INSERT INTO {cf}("tenantId", "groupId", "policyId", data, deleted) '
                       'VALUES (:tenantId, :groupId, {name}Id, {name}, False)')
 _cql_create_group_state = ('INSERT INTO {cf}("tenantId", "groupId", active, pending, '
-                           '"policyTouched", paused, deleted) VALUES(:tenantId, :groupId, "{{}}", '
-                           '"{{}}", "{{}}", False, False)')
+                           '"policyTouched", paused, deleted) VALUES(:tenantId, :groupId, \'{{}}\', '
+                           '\'{{}}\', \'{{}}\', False, False)')
 _cql_insert_group_state = ('INSERT INTO {cf}("tenantId", "groupId", active, pending, "groupTouched", '
                            '"policyTouched", paused, deleted) VALUES(:tenantId, :groupId, :active:'
                            ':pending, :groupTouched, :policyTouched, :paused, False)')

--- a/otter/test/models/test_cass_models.py
+++ b/otter/test/models/test_cass_models.py
@@ -1358,8 +1358,8 @@ class CassScalingGroupsCollectionTestCase(IScalingGroupCollectionProviderMixin,
                        ':scaling, False) INSERT INTO launch_config("tenantId", '
                        '"groupId", data, deleted) VALUES (:tenantId, :groupId, :launch, False) '
                        'INSERT INTO group_state("tenantId", "groupId", active, pending, '
-                       '"policyTouched", paused, deleted) VALUES(:tenantId, :groupId, "{}", '
-                       '"{}", "{}", False, False) APPLY BATCH;')
+                       '"policyTouched", paused, deleted) VALUES(:tenantId, :groupId, \'{}\', '
+                       '\'{}\', \'{}\', False, False) APPLY BATCH;')
         self.mock_key.return_value = '12345678'
         d = self.collection.create_scaling_group(self.mock_log, '123', {}, {})
         self.assertEqual(self.assert_deferred_succeeded(d),
@@ -1385,8 +1385,8 @@ class CassScalingGroupsCollectionTestCase(IScalingGroupCollectionProviderMixin,
                        ':scaling, False) INSERT INTO launch_config("tenantId", '
                        '"groupId", data, deleted) VALUES (:tenantId, :groupId, :launch, False) '
                        'INSERT INTO group_state("tenantId", "groupId", active, pending, '
-                       '"policyTouched", paused, deleted) VALUES(:tenantId, :groupId, "{}", '
-                       '"{}", "{}", False, False) '
+                       '"policyTouched", paused, deleted) VALUES(:tenantId, :groupId, \'{}\', '
+                       '\'{}\', \'{}\', False, False) '
                        'INSERT INTO scaling_policies("tenantId", "groupId", "policyId", data, deleted) '
                        'VALUES (:tenantId, :groupId, :policy0Id, :policy0, False) '
                        'APPLY BATCH;')
@@ -1417,8 +1417,8 @@ class CassScalingGroupsCollectionTestCase(IScalingGroupCollectionProviderMixin,
                        ':scaling, False) INSERT INTO launch_config("tenantId", '
                        '"groupId", data, deleted) VALUES (:tenantId, :groupId, :launch, False) '
                        'INSERT INTO group_state("tenantId", "groupId", active, pending, '
-                       '"policyTouched", paused, deleted) VALUES(:tenantId, :groupId, "{}", '
-                       '"{}", "{}", False, False) '
+                       '"policyTouched", paused, deleted) VALUES(:tenantId, :groupId, \'{}\', '
+                       '\'{}\', \'{}\', False, False) '
                        'INSERT INTO scaling_policies("tenantId", "groupId", "policyId", data, deleted) '
                        'VALUES (:tenantId, :groupId, :policy0Id, :policy0, False) '
                        'INSERT INTO scaling_policies("tenantId", "groupId", "policyId", data, deleted) '


### PR DESCRIPTION
Changed the default dictionary value quoting in create group state to single quotes.  Double quotes were causing a cassandra error.

Apparently double quotes are only used for quoted identifiers.  String literals have to be single quotes.
