### PR TITLE
Put an empty string as the API root so / does not 404.  

### DIFF
--- a/otter/rest/application.py
+++ b/otter/rest/application.py
@@ -2,12 +2,11 @@
 Contains the actual Klein app, backing store, and utilities used by the route
 handlers for the REST service.
 """
-import os.path
 from functools import partial
 
 from twisted.web.resource import Resource
 from twisted.web.server import Request
-from twisted.web.static import File
+from twisted.web.static import Data
 
 from klein import Klein
 
@@ -16,7 +15,6 @@ from otter.util.http import append_segments
 
 _store = None
 _urlRoot = 'http://127.0.0.1'
-_otter = File(os.path.join(os.path.dirname(__file__), 'otter_ascii.txt'))
 
 Request.defaultContentType = 'application/json'  # everything should be json
 
@@ -163,4 +161,4 @@ app.route = partial(app.route, strict_slashes=False)
 
 root = Resource()
 root.putChild('v1.0', app.resource())
-root.putChild('', _otter)
+root.putChild('', Data('', 'text/plain'))


### PR DESCRIPTION
This will allow us to move forward with repose integration without burning a whole day trying to fix our setup.py
