### PR TITLE
Fix bug where if there is no such group view state would die (ready for review)

### DIFF
--- a/otter/models/cass.py
+++ b/otter/models/cass.py
@@ -242,20 +242,6 @@ def _jsonize_cassandra_data(raw_response):
     return results
 
 
-def _unwrap_one_row(raw_response):
-    """
-    Unwrap a row into a dict - None is an acceptable raw response
-    """
-    if raw_response is None:
-        return None
-
-    if len(raw_response) != 1:
-        raise CassBadDataError("multiple responses when we expected 1")
-
-    results = _jsonize_cassandra_data(raw_response)
-    return results[0]
-
-
 def _jsonloads_data(raw_data):
     try:
         data = json.loads(raw_data)
@@ -387,9 +373,10 @@ class CassScalingGroup(object):
         see :meth:`otter.models.interface.IScalingGroup.view_state`
         """
         def _do_state_lookup(state_rec):
-            res = _unwrap_one_row(state_rec)
-            if res is None:
+            res = _jsonize_cassandra_data(state_rec)
+            if len(res) == 0:
                 raise NoSuchScalingGroupError(self.tenant_id, self.uuid)
+            res = res[0]
             active = _jsonloads_data(res["active"])
             policyTouched = _jsonloads_data(res["policyTouched"])
             groupTouched = res["groupTouched"]

--- a/otter/test/models/test_cass_models.py
+++ b/otter/test/models/test_cass_models.py
@@ -460,6 +460,16 @@ class CassScalingGroupTestCase(IScalingGroupProviderMixin, TestCase):
                              'policyTouched': {'F': 'R'},
                              'paused': False})
 
+    def test_view_state_no_such_group(self):
+        """
+        Calling ``view_state`` on a group that doesn't exist raises a
+        ``NoSuchScalingGroupError``
+        """
+        self.returns = [[]]
+        d = self.group.view_state()
+        f = self.failureResultOf(d)
+        self.assertTrue(f.check(NoSuchScalingGroupError))
+
     def test_view_paused_state(self):
         """
         view_state returns a dictionary with a key paused equal to True for a


### PR DESCRIPTION
Because the result is an empty list, which triggers unwrap first row's error since it expects exactly one row.

Simplifying this so we don't have so many unmarshalling methods, but also no longer checking to make sure there is only one row, and not a bunch of them.

Not sure if this was ok, but we don't test for when there is more than one result anyway. These unmarshalling methods should probably also go into silverberg at some point.
