### PR TITLE
Add some logging and more correctly support parameterization by using th...

### DIFF
--- a/otter/supervisor.py
+++ b/otter/supervisor.py
@@ -40,6 +40,7 @@ def execute_config(log, transaction_id, auth_function, scaling_group, launch_con
     def when_authenticated((auth_token, service_catalog)):
         log.msg("Executing launch config.")
         return launch_server_v1.launch_server(
+            log,
             'ORD',  # TODO: Get the region probably from the config or something.
             scaling_group,
             service_catalog,

--- a/otter/tap/api.py
+++ b/otter/tap/api.py
@@ -47,14 +47,29 @@ class Options(usage.Options):
         """
         Merge our commandline arguments with our config file.
         """
+        # Inject some default values into the config.  Right now this is
+        # only used to support distinguishing between staging and production.
+        self.update({
+            'regionOverrides': {},
+            'cloudServersOpenStack': 'cloudServersOpenStack',
+            'cloudLoadBalancers': 'cloudLoadBalancers'
+        })
+
         self.update(jsonfig.from_path(self['config']))
+
+        # The staging service catalog has some unfortunate differences
+        # from the production one, so these are here to hint at the
+        # correct ocnfiguration for staging.
+        if self.get('environment') == 'staging':
+            self['cloudServersOpenStack'] = 'cloudServersPreprod'
+            self['regionOverrides']['cloudLoadBalancers'] = 'STAGING'
 
 
 def makeService(config):
     """
     Set up the otter-api service.
     """
-    set_config_data(config)
+    set_config_data(dict(config))
 
     if not config_value('mock'):
         seed_endpoints = [

--- a/otter/test/test_supervisor.py
+++ b/otter/test/test_supervisor.py
@@ -84,6 +84,7 @@ class SupervisorExecuteTests(TestCase):
         self.assertEqual(None, result)
 
         self.launch_server.assert_called_once_with(
+            mock.ANY,
             'ORD',
             self.group,
             self.service_catalog,


### PR DESCRIPTION
...e config to isolate some of the global state.

Previously parameterization of service names and the region override were happening at import time of the module which is too early for it to be affected by the config read from disk.
