### PR TITLE
Fix webhook execution (ready for review)

### DIFF
--- a/otter/test/rest/request.py
+++ b/otter/test/rest/request.py
@@ -254,6 +254,15 @@ class RestAPITestMixin(RequestTestMixin):
 
         set_store(self.mock_store)
 
+        # mock out modify state
+        self.mock_state = mock.MagicMock(spec=[])  # so nothing can call it
+
+        def _mock_modify_state(modifier, *args, **kwargs):
+            modifier(self.mock_group, self.mock_state, *args, **kwargs)
+            return defer.succeed(None)
+
+        self.mock_group.modify_state.side_effect = _mock_modify_state
+
     def test_invalid_methods_are_405(self):
         """
         All methods other than GET return a 405: Forbidden Method

--- a/otter/test/rest/test_policies.py
+++ b/otter/test/rest/test_policies.py
@@ -313,6 +313,7 @@ class OnePolicyTestCase(RestAPITestMixin, TestCase):
         """
         Try to execute a nonexistant policy, fails with a 404.
         """
+        self.mock_group.modify_state.side_effect = None
         self.mock_group.modify_state.return_value = defer.fail(
             NoSuchPolicyError('11111', '1', '2'))
 


### PR DESCRIPTION
This currently calls `maybe_execute_scaling_policy` directly, which breaks a bunch of cloudcafe tests.  This fixes them.
