### PR TITLE
Set default maxEntities and metadata on configs on creation and update (ready for review)

### DIFF
--- a/otter/rest/configs.py
+++ b/otter/rest/configs.py
@@ -83,6 +83,8 @@ def edit_config_for_scaling_group(request, log, tenantId, groupId, data):
             partial(controller.obey_config_change, log, transaction_id(request),
                     data))
 
+    data.setdefault('maxEntities', 25)
+    data.setdefault('metadata', {})
     rec = get_store().get_scaling_group(log, tenantId, groupId)
     deferred = rec.update_config(data).addCallback(_do_obey_config_change, rec)
     return deferred

--- a/otter/rest/groups.py
+++ b/otter/rest/groups.py
@@ -288,6 +288,9 @@ def create_new_scaling_group(request, log, tenantId, data):
         }
 
     """
+    data['groupConfiguration'].setdefault('maxEntities', 25)
+    data['groupConfiguration'].setdefault('metadata', {})
+
     deferred = get_store().create_scaling_group(
         log, tenantId, data['groupConfiguration'], data['launchConfiguration'],
         data.get('scalingPolicies', None))


### PR DESCRIPTION
This is not a good way to solve this.  Probably there should be a Config object that should  set the defaults, maybe interact with the json schema, but this was the quickest and ugliest way for me to do this.

This by itself does not resolve the `autoscaling_cloudcafe` test errors.  In the state, `groupTouched` is None, which needs to be fixed, but these are orthogonal changes.
