### PR TITLE
Fail with a 409 if a policy cannot be executed (ready for review)

### DIFF
--- a/otter/rest/errors.py
+++ b/otter/rest/errors.py
@@ -19,7 +19,7 @@ exception_codes = {
     NoSuchScalingGroupError: 404,
     NoSuchPolicyError: 404,
     NoSuchWebhookError: 404,
-    GroupNotEmptyError: 409,
-    CannotExecutePolicyError: 409,
+    GroupNotEmptyError: 403,
+    CannotExecutePolicyError: 403,
     NotImplementedError: 501
 }

--- a/otter/test/rest/test_groups.py
+++ b/otter/test/rest/test_groups.py
@@ -439,14 +439,14 @@ class OneGroupTestCase(RestAPITestMixin, TestCase):
         self.assertEqual(resp['type'], 'NoSuchScalingGroupError')
         self.flushLoggedErrors(NoSuchScalingGroupError)
 
-    def test_group_delete_409(self):
+    def test_group_delete_403(self):
         """
-        Deleting a non-empty group fails with a 409.
+        Deleting a non-empty group fails with a 403.
         """
         self.mock_group.delete_group.return_value = defer.fail(
             GroupNotEmptyError('11111', '1'))
 
-        response_body = self.assert_status_code(409, method="DELETE")
+        response_body = self.assert_status_code(403, method="DELETE")
         self.mock_store.get_scaling_group.assert_called_once_with(
             mock.ANY, '11111', 'one')
         self.mock_group.delete_group.assert_called_once_with()

--- a/otter/test/rest/test_policies.py
+++ b/otter/test/rest/test_policies.py
@@ -318,16 +318,16 @@ class OnePolicyTestCase(RestAPITestMixin, TestCase):
         self.assertEqual(resp['type'], 'NoSuchPolicyError')
         self.flushLoggedErrors(NoSuchPolicyError)
 
-    def test_execute_policy_failure_409(self):
+    def test_execute_policy_failure_403(self):
         """
         If a policy cannot be executed due to cooldowns or budgetary constraints,
-        fail with a 409.
+        fail with a 403.
         """
         self.mock_group.modify_state.side_effect = None
         self.mock_group.modify_state.return_value = defer.fail(
             CannotExecutePolicyError('11111', '1', '2', 'meh'))
 
-        response_body = self.assert_status_code(409,
+        response_body = self.assert_status_code(403,
                                                 endpoint=self.endpoint + 'execute/',
                                                 method="POST")
         resp = json.loads(response_body)


### PR DESCRIPTION
Due to budgetary constraints.  This has a more helpful error message than "Internal error"
