### PR TITLE
Return 501 for not implemented errors

### DIFF
--- a/otter/controller.py
+++ b/otter/controller.py
@@ -13,18 +13,18 @@ TODO:
 
 Storage model for state information:
  * active list
-    * Instance URI
+    * Instance links
     * Created time
  * pending list
     * Job ID
  * last touched information for group
- * last touched information for polciy
-
+ * last touched information for policy
 """
 from datetime import datetime
 from decimal import Decimal, ROUND_UP
 from functools import partial
 import iso8601
+import json
 
 from twisted.internet import defer
 
@@ -55,7 +55,7 @@ def pause_scaling_group(log, transaction_id, scaling_group):
 
     :return: None
     """
-    return None
+    raise NotImplementedError('Pause is not yet implemented')
 
 
 def resume_scaling_group(log, transaction_id, scaling_group):
@@ -68,7 +68,7 @@ def resume_scaling_group(log, transaction_id, scaling_group):
 
     :return: None
     """
-    return None
+    raise NotImplementedError('Resume is not yet implemented')
 
 
 def obey_config_change(log, transaction_id, config, scaling_group, state):
@@ -238,7 +238,9 @@ def calculate_delta(log, state, config, policy):
     elif "desiredCapacity" in policy:
         desired = policy["desiredCapacity"]
     else:
-        raise NotImplementedError()
+        raise AttributeError(
+            "Policy doesn't have attributes 'change', 'changePercent', or "
+            "'desiredCapacity: {0}".format(json.dumps(policy)))
 
     return constrain(desired) - current
 
@@ -312,7 +314,7 @@ def execute_launch_config(log, transaction_id, state, launch, scaling_group, del
             for i in range(delta)
         ]
     else:
-        raise NotImplementedError()
+        raise NotImplementedError("Scaling down has not been implemented yet.")
 
     pendings_deferred = defer.gatherResults(deferreds, consumeErrors=True)
     pendings_deferred.addCallback(_update_state)

--- a/otter/rest/errors.py
+++ b/otter/rest/errors.py
@@ -17,5 +17,6 @@ exception_codes = {
     NoSuchScalingGroupError: 404,
     NoSuchPolicyError: 404,
     NoSuchWebhookError: 404,
-    GroupNotEmptyError: 409
+    GroupNotEmptyError: 409,
+    NotImplementedError: 501
 }

--- a/otter/test/rest/test_groups.py
+++ b/otter/test/rest/test_groups.py
@@ -525,24 +525,24 @@ class GroupPauseTestCase(RestAPITestMixin, TestCase):
     endpoint = "/v1.0/11111/groups/one/pause/"
     invalid_methods = ("DELETE", "GET", "PUT")
 
-    def setUp(self):
-        """
-        Set the uuid of the group to "one"
-        """
-        super(GroupPauseTestCase, self).setUp()
-        self.mock_pause = patch(
-            self, 'otter.rest.groups.controller.pause_scaling_group',
-            return_value=defer.succeed(None))
-
     def test_pause(self):
         """
         Pausing should call the controller's ``pause_scaling_group`` function
         """
+        mock_pause = patch(
+            self, 'otter.rest.groups.controller.pause_scaling_group',
+            return_value=defer.succeed(None))
         response_body = self.assert_status_code(204, method="POST")
         self.assertEqual(response_body, "")
 
-        self.mock_pause.assert_called_once_with(mock.ANY, 'transaction-id',
-                                                self.mock_group)
+        mock_pause.assert_called_once_with(mock.ANY, 'transaction-id',
+                                           self.mock_group)
+
+    def test_pause_not_implemented(self):
+        """
+        Resume currently raises 501 not implemented
+        """
+        self.assert_status_code(501, method="POST")
 
 
 class GroupResumeTestCase(RestAPITestMixin, TestCase):
@@ -552,21 +552,21 @@ class GroupResumeTestCase(RestAPITestMixin, TestCase):
     endpoint = "/v1.0/11111/groups/one/resume/"
     invalid_methods = ("DELETE", "GET", "PUT")
 
-    def setUp(self):
-        """
-        Set the uuid of the group to "one"
-        """
-        super(GroupResumeTestCase, self).setUp()
-        self.mock_resume = patch(
-            self, 'otter.rest.groups.controller.resume_scaling_group',
-            return_value=defer.succeed(None))
-
     def test_resume(self):
         """
         Resume should call the controller's ``resume_scaling_group`` function
         """
+        mock_resume = patch(
+            self, 'otter.rest.groups.controller.resume_scaling_group',
+            return_value=defer.succeed(None))
         response_body = self.assert_status_code(204, method="POST")
         self.assertEqual(response_body, "")
 
-        self.mock_resume.assert_called_once_with(mock.ANY, 'transaction-id',
-                                                 self.mock_group)
+        mock_resume.assert_called_once_with(mock.ANY, 'transaction-id',
+                                            self.mock_group)
+
+    def test_resume_not_implemented(self):
+        """
+        Resume currently raises 501 not implemented
+        """
+        self.assert_status_code(501, method="POST")

--- a/otter/test/rest/test_policies.py
+++ b/otter/test/rest/test_policies.py
@@ -316,3 +316,14 @@ class OnePolicyTestCase(RestAPITestMixin, TestCase):
         resp = json.loads(response_body)
         self.assertEqual(resp['type'], 'NoSuchPolicyError')
         self.flushLoggedErrors(NoSuchPolicyError)
+
+    def test_execute_policy_failure_501(self):
+        """
+        Try to execute a scale down policy fails with a 501 not implemented.
+        """
+        self.mock_controller.maybe_execute_scaling_policy.side_effect = (
+            NotImplementedError)
+
+        self.assert_status_code(501, endpoint=self.endpoint + 'execute/',
+                                method="POST")
+        self.flushLoggedErrors(NotImplementedError)

--- a/otter/test/test_controller.py
+++ b/otter/test/test_controller.py
@@ -323,14 +323,15 @@ class CalculateDeltaTestCase(TestCase):
 
     def test_no_change_or_percent_or_desired_fails(self):
         """
-        If 'change' or 'changePercent' or 'desiredCapacity' is not there in scaling policy,
-        then ``calculate_delta`` doesn't know how to handle the policy
+        If 'change' or 'changePercent' or 'desiredCapacity' is not there in
+        scaling policy, then ``calculate_delta`` doesn't know how to handle the
+        policy and raises a ValueError
         """
         fake_policy = {'changeNone': 5}
         fake_config = {'minEntities': 0, 'maxEntities': 10}
         fake_state = self.get_state({}, {})
 
-        self.assertRaises(NotImplementedError,
+        self.assertRaises(AttributeError,
                           controller.calculate_delta,
                           self.mock_log, fake_state, fake_config, fake_policy)
 


### PR DESCRIPTION
In case people wonder why they can't scale down.  =/  Also change one of the calculate delta checks to raise AttributeError, because we don't plan on implementing anything that doesn't have 'change', 'changePercent', or 'desiredCapacity'
