### PR TITLE
Fix removing job bug (ready for review)

### DIFF
--- a/otter/models/interface.py
+++ b/otter/models/interface.py
@@ -276,9 +276,10 @@ class IScalingGroup(Interface):
     def modify_state(modifier_callable, *args, **kwargs):
         """
         Updates the scaling group state, replacing the whole thing.  This
-        takes a callable which produces a state, and then saves it,
-        overwriting the entire previous state.  This method should handle its
-        own locking, if necessary.
+        takes a callable which produces a state, and then saves it if the
+        callable successfully returns it, overwriting the entire previous state.
+        This method should handle its own locking, if necessary.  If the
+        callback is unsuccessful, does not save.
 
         :param modifier_callable: a ``callable`` that takes as first two
             arguments the :class:`IScalingGroup`, a :class:`GroupState`, and

--- a/otter/test/models/test_cass_models.py
+++ b/otter/test/models/test_cass_models.py
@@ -263,8 +263,7 @@ class CassScalingGroupTestCase(IScalingGroupProviderMixin, TestCase):
                 side_effect=lambda *args: _S(args[0]))
     def test_modify_state_succeeds(self, mock_serial):
         """
-        ``modify_state`` writes the state the synchronous modifier returns to
-        the database
+        ``modify_state`` writes the state the modifier returns to the database
         """
         def modifier(group, state):
             return GroupState(self.tenant_id, self.group_id, {}, {}, None, {}, True)
@@ -288,10 +287,10 @@ class CassScalingGroupTestCase(IScalingGroupProviderMixin, TestCase):
                                                         expectedData,
                                                         ConsistencyLevel.TWO)
 
-    def test_modify_state_propagates_modifier_error(self):
+    def test_modify_state_propagates_modifier_error_and_does_not_save(self):
         """
-        ``modify_state`` writes the state the synchronous modifier returns to
-        the database
+        ``modify_state`` does not write anything to the db if the modifier
+        raises an exception
         """
         def modifier(group, state):
             raise NoSuchScalingGroupError(self.tenant_id, self.group_id)


### PR DESCRIPTION
The modify state function only writes the state on callback.  If the modifier fails, it writes nothing.  Therefore, on job failure, still return the modified state with the job removed.

Also, fix the modify_state docstring and tests to more accurately reflect this expectation.
