### PR TITLE
Bump treq version up to 0.2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ jsonschema==0.7
 yunomi==0.2.2
 iso8601==0.1.4
 lxml==3.0.1
-treq==0.1.0
+treq==0.2.0
 silverberg==0.0.5
 pyOpenSSL==0.13
 jsonfig==0.1.1


### PR DESCRIPTION
@dreid has released treq 0.2.0, so added treq 0.2.0 to the pypi mirror (https://github.com/racker/pypi/commit/baa3468f73c9750045ba5d228320efd0241d1ca7) and bumped the requirement version
