### PR TITLE
Fix how scaling group is passed to the log in the controller (ready for review)

### DIFF
--- a/otter/controller.py
+++ b/otter/controller.py
@@ -87,16 +87,16 @@ def obey_config_change(log, transaction_id, config, scaling_group, state):
     :return: a ``Deferred`` that fires with the updated (or not)
         :class:`otter.models.interface.GroupState` if successful
     """
-    bound_log = log.bind(scaling_group=scaling_group.uuid)
+    bound_log = log.bind(scaling_group_id=scaling_group.uuid)
 
     # XXX:  this is a hack to create an internal zero-change policy so
     # calculate delta will work
     delta = calculate_delta(bound_log, state, config, {'change': 0})
     if delta != 0:
         deferred = scaling_group.view_launch_config()
-        deferred.addCallback(partial(execute_launch_config, log, transaction_id,
-                                     state, scaling_group=scaling_group,
-                                     delta=delta))
+        deferred.addCallback(partial(execute_launch_config, bound_log,
+                                     transaction_id, state,
+                                     scaling_group=scaling_group, delta=delta))
         deferred.addCallback(lambda _: state)
         return deferred
 
@@ -129,7 +129,7 @@ def maybe_execute_scaling_policy(
     :raises: Some exception about why you don't want to execute the policy. This
         Exception should also have an audit log id
     """
-    bound_log = log.bind(scaling_group=scaling_group.uuid, policy_id=policy_id)
+    bound_log = log.bind(scaling_group_id=scaling_group.uuid, policy_id=policy_id)
     bound_log.msg("beginning to execute scaling policy")
 
     # make sure that the policy (and the group) exists before doing anything else

--- a/otter/test/test_controller.py
+++ b/otter/test/test_controller.py
@@ -486,6 +486,14 @@ class ObeyConfigChangeTestCase(TestCase):
         self.group = iMock(IScalingGroup, tenant_id='tenant', uuid='group')
         self.group.view_launch_config.return_value = defer.succeed("launch")
 
+    def test_parameters_bound_to_log(self):
+        """
+        Relevant values are bound to the log.
+        """
+        controller.obey_config_change(self.log, 'transaction-id',
+                                      'config', self.group, self.state)
+        self.log.bind.assert_called_once_with(scaling_group_id=self.group.uuid)
+
     def test_zero_delta_nothing_happens_state_is_returned(self):
         """
         If the delta is zero, ``execute_launch_config`` is not called and
@@ -507,7 +515,7 @@ class ObeyConfigChangeTestCase(TestCase):
                                           'config', self.group, self.state)
         self.assertIs(self.successResultOf(d), self.state)
         self.execute_launch_config.assert_called_once_with(
-            self.log, 'transaction-id', self.state, 'launch',
+            self.log.bind.return_value, 'transaction-id', self.state, 'launch',
             scaling_group=self.group, delta=5)
 
     def test_nonzero_delta_execute_errors_propagated(self):
@@ -522,7 +530,7 @@ class ObeyConfigChangeTestCase(TestCase):
         f = self.failureResultOf(d)
         self.assertTrue(f.check(Exception))
         self.execute_launch_config.assert_called_once_with(
-            self.log, 'transaction-id', self.state, 'launch',
+            self.log.bind.return_value, 'transaction-id', self.state, 'launch',
             scaling_group=self.group, delta=5)
 
 
@@ -590,7 +598,7 @@ class MaybeExecuteScalingPolicyTestCase(DeferredTestMixin, TestCase):
 
         # log should have been updated
         self.mock_log.bind.assert_called_once_with(
-            scaling_group=self.group.uuid, policy_id='pol1')
+            scaling_group_id=self.group.uuid, policy_id='pol1')
 
         self.mocks['check_cooldowns'].assert_called_once_with(
             self.mock_log.bind.return_value, self.mock_state, "config", "policy", 'pol1')


### PR DESCRIPTION
The bound log containing the scaling group ID was not passed to `execute_launch_config` from `obey_config_change` - only the original log with the transaction ID was.

Fix that, and also pass in the scaling group as `scaling_group_id` from everywhere in the controller, since that seems to be how it's bound in the the cass models and it is technically more correct than `scaling_group`.  (It really only matters that they are consistent, not which one it is).
