### PR TITLE
Don't use assert_deferred_succeeded anywhere anymore (ready for review)

### DIFF
--- a/doc/standards.rst
+++ b/doc/standards.rst
@@ -231,9 +231,9 @@ If it is possible to do so, instrument everything in the test to return immediat
 test after you get your :class:`Deferred`, assert that the :class:`Deferred` has already fired. Then
 run the tests on the result of that :class:`Deferred`.
 
-In :mod:`test.utils`, three methods are provided to help test :class:`Deferred` code:
-:meth:`test.utils.DeferredTestingMixin.assert_deferred_succeeded`, and
-:meth:`test.utils.DeferredTestingMixin.assert_deferred_failed`.
+Use :meth:`twisted.trial.unittest.TestCase.successResultOf`, and
+:meth:`twisted.trial.unittest.TestCase.failureResultOf` to assert that your deferreds have fired or
+failed immediately.
 
 Obviously, if you cannot completely patch everything in your test, just go ahead and return the
 :class:`Deferred` from the test case.

--- a/otter/test/models/test_cass_models.py
+++ b/otter/test/models/test_cass_models.py
@@ -202,7 +202,7 @@ class CassScalingGroupTestCase(IScalingGroupProviderMixin, TestCase):
              'key': ''}]
         self.returns = [cass_response]
         d = self.group.view_config()
-        r = self.assert_deferred_succeeded(d)
+        r = self.successResultOf(d)
         expectedCql = ('SELECT data FROM scaling_config WHERE '
                        '"tenantId" = :tenantId AND "groupId" = :groupId AND deleted = False;')
         expectedData = {"tenantId": "11111", "groupId": "12345678g"}
@@ -379,7 +379,7 @@ class CassScalingGroupTestCase(IScalingGroupProviderMixin, TestCase):
              'key': ''}]
         self.returns = [cass_response]
         d = self.group.view_config()
-        r = self.assert_deferred_succeeded(d)
+        r = self.successResultOf(d)
         self.assertEqual(r, {})
 
     def test_view_launch(self):
@@ -395,7 +395,7 @@ class CassScalingGroupTestCase(IScalingGroupProviderMixin, TestCase):
              'key': ''}]
         self.returns = [cass_response]
         d = self.group.view_launch_config()
-        r = self.assert_deferred_succeeded(d)
+        r = self.successResultOf(d)
         expectedCql = ('SELECT data FROM launch_config WHERE '
                        '"tenantId" = :tenantId AND "groupId" = :groupId AND deleted = False;')
         expectedData = {"tenantId": "11111", "groupId": "12345678g"}
@@ -446,7 +446,7 @@ class CassScalingGroupTestCase(IScalingGroupProviderMixin, TestCase):
              'key': ''}]
         self.returns = [cass_response]
         d = self.group.view_launch_config()
-        r = self.assert_deferred_succeeded(d)
+        r = self.successResultOf(d)
         self.assertEqual(r, {})
 
     def test_update_config(self):
@@ -463,7 +463,7 @@ class CassScalingGroupTestCase(IScalingGroupProviderMixin, TestCase):
 
         self.returns = [cass_response, None]
         d = self.group.update_config({"b": "lah"})
-        self.assertIsNone(self.assert_deferred_succeeded(d))  # update returns None
+        self.assertIsNone(self.successResultOf(d))  # update returns None
         expectedCql = ('BEGIN BATCH INSERT INTO scaling_config("tenantId", "groupId", data) VALUES '
                        '(:tenantId, :groupId, :scaling) APPLY BATCH;')
         expectedData = {"scaling": '{"_ver": 1, "b": "lah"}',
@@ -486,7 +486,7 @@ class CassScalingGroupTestCase(IScalingGroupProviderMixin, TestCase):
 
         self.returns = [cass_response, None]
         d = self.group.update_launch_config({"b": "lah"})
-        self.assertIsNone(self.assert_deferred_succeeded(d))  # update returns None
+        self.assertIsNone(self.successResultOf(d))  # update returns None
         expectedCql = ('BEGIN BATCH INSERT INTO launch_config("tenantId", "groupId", data) VALUES '
                        '(:tenantId, :groupId, :launch) APPLY BATCH;')
         expectedData = {"launch": '{"_ver": 1, "b": "lah"}',
@@ -528,7 +528,7 @@ class CassScalingGroupTestCase(IScalingGroupProviderMixin, TestCase):
              'key': ''}]
         self.returns = [cass_response]
         d = self.group.get_policy("3444")
-        r = self.assert_deferred_succeeded(d)
+        r = self.successResultOf(d)
         expectedCql = ('SELECT data FROM scaling_policies WHERE "tenantId" = :tenantId '
                        'AND "groupId" = :groupId AND "policyId" = :policyId AND deleted = False;')
         expectedData = {"tenantId": "11111", "groupId": "12345678g", "policyId": "3444"}
@@ -579,7 +579,7 @@ class CassScalingGroupTestCase(IScalingGroupProviderMixin, TestCase):
              'key': ''}]
         self.returns = [cass_response]
         d = self.group.get_policy("3444")
-        r = self.assert_deferred_succeeded(d)
+        r = self.successResultOf(d)
         self.assertEqual(r, {})
 
     def test_naive_list_policies_with_policies(self):
@@ -595,7 +595,7 @@ class CassScalingGroupTestCase(IScalingGroupProviderMixin, TestCase):
         expectedCql = ('SELECT "policyId", data FROM scaling_policies WHERE "tenantId" = :tenantId '
                        'AND "groupId" = :groupId AND deleted = False;')
         d = self.group._naive_list_policies()
-        r = self.assert_deferred_succeeded(d)
+        r = self.successResultOf(d)
         self.assertEqual(r, {'policy1': {}, 'policy2': {}})
 
         self.connection.execute.assert_called_once_with(expectedCql,
@@ -611,7 +611,7 @@ class CassScalingGroupTestCase(IScalingGroupProviderMixin, TestCase):
         """
         self.returns = [[]]
         d = self.group._naive_list_policies()
-        r = self.assert_deferred_succeeded(d)
+        r = self.successResultOf(d)
         self.assertEqual(r, {})
         self.assertEqual(len(mock_view_config.mock_calls), 0)
 
@@ -627,7 +627,7 @@ class CassScalingGroupTestCase(IScalingGroupProviderMixin, TestCase):
         mock_naive.return_value = defer.succeed(expected_result)
 
         d = self.group.list_policies()
-        r = self.assert_deferred_succeeded(d)
+        r = self.successResultOf(d)
         self.assertEqual(r, expected_result)
 
         mock_naive.assert_called_once_with()
@@ -645,7 +645,7 @@ class CassScalingGroupTestCase(IScalingGroupProviderMixin, TestCase):
         view config doesn't raise an error.
         """
         d = self.group.list_policies()
-        r = self.assert_deferred_succeeded(d)
+        r = self.successResultOf(d)
         self.assertEqual(r, {})
 
         mock_naive.assert_called_once_with()
@@ -713,7 +713,7 @@ class CassScalingGroupTestCase(IScalingGroupProviderMixin, TestCase):
                        'value': '{"_ver": 2}', 'ttl': None}], 'key': ''}]
         self.returns = [cass_response]
         d = self.group.list_policies()
-        r = self.assert_deferred_succeeded(d)
+        r = self.successResultOf(d)
         self.assertEqual(r, {'group1': {}, 'group3': {}})
 
     def test_add_scaling_policy(self):
@@ -730,7 +730,7 @@ class CassScalingGroupTestCase(IScalingGroupProviderMixin, TestCase):
 
         self.returns = [cass_response, None]
         d = self.group.create_policies([{"b": "lah"}])
-        result = self.assert_deferred_succeeded(d)
+        result = self.successResultOf(d)
         expectedCql = ('BEGIN BATCH INSERT INTO scaling_policies("tenantId", "groupId", "policyId", '
                        'data, deleted) VALUES (:tenantId, :groupId, :policy0Id, :policy0, False) '
                        'APPLY BATCH;')
@@ -751,7 +751,7 @@ class CassScalingGroupTestCase(IScalingGroupProviderMixin, TestCase):
         self.group.view_config = mock.MagicMock(return_value=defer.succeed({}))
         self.returns = [None]
         d = self.group.create_policies([{"b": "lah"}])
-        self.assert_deferred_succeeded(d)
+        self.successResultOf(d)
         self.group.view_config.assert_called_once_with()
 
     @mock.patch('otter.models.cass.CassScalingGroup.get_policy',
@@ -842,7 +842,7 @@ class CassScalingGroupTestCase(IScalingGroupProviderMixin, TestCase):
         """
         d = self.group.delete_policy('3222')
         # delete returns None
-        self.assertIsNone(self.assert_deferred_succeeded(d))
+        self.assertIsNone(self.successResultOf(d))
         mock_get_policy.assert_called_once_with('3222')
         mock_naive.assert_called_once_with('3222', ConsistencyLevel.TWO)
 
@@ -875,7 +875,7 @@ class CassScalingGroupTestCase(IScalingGroupProviderMixin, TestCase):
 
         self.returns = [cass_response, None]
         d = self.group.update_policy('12345678', {"b": "lah"})
-        self.assertIsNone(self.assert_deferred_succeeded(d))  # update returns None
+        self.assertIsNone(self.successResultOf(d))  # update returns None
         expectedCql = (
             'BEGIN BATCH INSERT INTO scaling_policies("tenantId", "groupId", "policyId", data) '
             'VALUES (:tenantId, :groupId, :policyId, :policy) APPLY BATCH;')
@@ -1054,7 +1054,7 @@ class CassScalingGroupTestCase(IScalingGroupProviderMixin, TestCase):
         expectedCql = ('SELECT "webhookId", data, capability FROM policy_webhooks '
                        'WHERE "tenantId" = :tenantId AND "groupId" = :groupId AND '
                        '"policyId" = :policyId AND deleted = False;')
-        r = self.assert_deferred_succeeded(
+        r = self.successResultOf(
             self.group._naive_list_webhooks('23456789'))
 
         expected_data['capability'] = {
@@ -1077,7 +1077,7 @@ class CassScalingGroupTestCase(IScalingGroupProviderMixin, TestCase):
         even if the policy were invalid
         """
         self.returns = [[]]
-        r = self.assert_deferred_succeeded(
+        r = self.successResultOf(
             self.group._naive_list_webhooks('23456789'))
         self.assertEqual(r, {})
         self.assertEqual(len(mock_get_policy.mock_calls), 0)
@@ -1143,7 +1143,7 @@ class CassScalingGroupTestCase(IScalingGroupProviderMixin, TestCase):
         self.returns = [_cassandrify_data(
             [{'data': '{"name": "pokey"}', 'capability': '{"1": "h"}'}])]
         d = self.group.get_webhook("3444", "4555")
-        r = self.assert_deferred_succeeded(d)
+        r = self.successResultOf(d)
         expectedCql = ('SELECT data, capability FROM policy_webhooks WHERE '
                        '"tenantId" = :tenantId AND "groupId" = :groupId AND '
                        '"policyId" = :policyId AND "webhookId" = :webhookId AND '
@@ -1179,7 +1179,7 @@ class CassScalingGroupTestCase(IScalingGroupProviderMixin, TestCase):
         """
         self.returns = [_cassandrify_data([{'data': '{"_ver": 5}'}])]
         d = self.group.get_policy("3444")
-        r = self.assert_deferred_succeeded(d)
+        r = self.successResultOf(d)
         self.assertEqual(r, {})
 
     @mock.patch('otter.models.cass.CassScalingGroup.get_webhook')
@@ -1197,7 +1197,7 @@ class CassScalingGroupTestCase(IScalingGroupProviderMixin, TestCase):
         }
 
         d = self.group.update_webhook('3444', '4555', new_webhook_data)
-        self.assertIsNone(self.assert_deferred_succeeded(d))
+        self.assertIsNone(self.successResultOf(d))
 
         expectedCql = (
             'INSERT INTO policy_webhooks("tenantId", "groupId", "policyId", '
@@ -1228,7 +1228,7 @@ class CassScalingGroupTestCase(IScalingGroupProviderMixin, TestCase):
         self.returns = [None]
 
         d = self.group.update_webhook('3444', '4555', {'name': 'newname'})
-        self.assertIsNone(self.assert_deferred_succeeded(d))
+        self.assertIsNone(self.successResultOf(d))
 
         self.assertEqual(
             json.loads(self.connection.execute.call_args[0][1]['data']),
@@ -1256,7 +1256,7 @@ class CassScalingGroupTestCase(IScalingGroupProviderMixin, TestCase):
             _cassandrify_data([{'data': '{}', 'capability': '{"1": "h"}'}]),
             None]
         d = self.group.delete_webhook('3444', '4555')
-        self.assertIsNone(self.assert_deferred_succeeded(d))  # delete returns None
+        self.assertIsNone(self.successResultOf(d))  # delete returns None
         expectedCql = ('UPDATE policy_webhooks SET deleted=True WHERE '
                        '"tenantId" = :tenantId AND "groupId" = :groupId AND '
                        '"policyId" = :policyId AND "webhookId" = :webhookId')
@@ -1649,7 +1649,7 @@ class CassScalingGroupsCollectionTestCase(IScalingGroupCollectionProviderMixin,
         expectedCql = ('SELECT "tenantId", "groupId", "policyId", deleted FROM policy_webhooks WHERE '
                        '"webhookKey" = :webhookKey;')
         d = self.collection.webhook_info_by_hash(self.mock_log, 'x')
-        r = self.assert_deferred_succeeded(d)
+        r = self.successResultOf(d)
         self.assertEqual(r, ('123', 'group1', 'pol1'))
         self.connection.execute.assert_called_any(expectedCql,
                                                   expectedData,

--- a/otter/test/models/test_interface.py
+++ b/otter/test/models/test_interface.py
@@ -234,7 +234,7 @@ class IScalingGroupProviderMixin(DeferredTestMixin):
 
         :return: the return value of ``view_manifest()``
         """
-        result = self.assert_deferred_succeeded(
+        result = self.successResultOf(
             self.group.view_manifest(*args, **kwargs))
         validate(result, model_schemas.manifest)
         return result
@@ -247,7 +247,7 @@ class IScalingGroupProviderMixin(DeferredTestMixin):
 
         :return: the return value of ``view_config()``
         """
-        result = self.assert_deferred_succeeded(
+        result = self.successResultOf(
             self.group.view_config(*args, **kwargs))
         validate(result, model_schemas.group_config)
         return result
@@ -260,7 +260,7 @@ class IScalingGroupProviderMixin(DeferredTestMixin):
 
         :return: the return value of ``view_launch_config()``
         """
-        result = self.assert_deferred_succeeded(
+        result = self.successResultOf(
             self.group.view_config(*args, **kwargs))
         validate(result, launch_config)
         return result
@@ -272,7 +272,7 @@ class IScalingGroupProviderMixin(DeferredTestMixin):
 
         :return: the return value of ``list_policies()``
         """
-        result = self.assert_deferred_succeeded(
+        result = self.successResultOf(
             self.group.list_policies(*args, **kwargs))
         validate(result, model_schemas.policy_list)
         return result
@@ -284,7 +284,7 @@ class IScalingGroupProviderMixin(DeferredTestMixin):
 
         :return: the return value of ``list_policies()``
         """
-        result = self.assert_deferred_succeeded(
+        result = self.successResultOf(
             self.group.create_policies(*args, **kwargs))
         validate(result, model_schemas.policy_list)
         return result
@@ -296,7 +296,7 @@ class IScalingGroupProviderMixin(DeferredTestMixin):
 
         :return: the return value of ``list_webhooks(policy_id)``
         """
-        result = self.assert_deferred_succeeded(
+        result = self.successResultOf(
             self.group.list_webhooks(*args, **kwargs))
         validate(result, model_schemas.webhook_list)
         return result
@@ -308,7 +308,7 @@ class IScalingGroupProviderMixin(DeferredTestMixin):
 
         :return: the return value of ``create_webhooks(policy_id, data)``
         """
-        result = self.assert_deferred_succeeded(
+        result = self.successResultOf(
             self.group.create_webhooks(*args, **kwargs))
         validate(result, model_schemas.webhook_list)
         return result
@@ -320,7 +320,7 @@ class IScalingGroupProviderMixin(DeferredTestMixin):
 
         :return: the return value of ``get_webhook(policy_id, webhook_id)``
         """
-        result = self.assert_deferred_succeeded(
+        result = self.successResultOf(
             self.group.get_webhook(*args, **kwargs))
         validate(result, model_schemas.webhook)
         return result
@@ -361,7 +361,7 @@ class IScalingGroupCollectionProviderMixin(DeferredTestMixin):
 
         :return: the return value of ``list_scaling_group_states()``
         """
-        result = self.assert_deferred_succeeded(
+        result = self.successResultOf(
             self.collection.list_scaling_group_states(*args, **kwargs))
 
         self.assertEqual(type(result), list)

--- a/otter/test/models/test_mock_models.py
+++ b/otter/test/models/test_mock_models.py
@@ -130,7 +130,7 @@ class MockScalingGroupTestCase(IScalingGroupProviderMixin, TestCase):
         one it was created with.  There is currently no validation for what
         goes in and hence what goes out, so just check if they are the same.
         """
-        result = self.assert_deferred_succeeded(self.group.view_launch_config())
+        result = self.successResultOf(self.group.view_launch_config())
         self.assertEqual(result, self.launch_config)
 
     def test_view_state_returns_empty_state(self):
@@ -191,7 +191,7 @@ class MockScalingGroupTestCase(IScalingGroupProviderMixin, TestCase):
             'maxEntities': 15,
             'name': 'UPDATED'
         }
-        self.assert_deferred_succeeded(self.group.update_config(expected))
+        self.successResultOf(self.group.update_config(expected))
         result = self.validate_view_config_return_value()
         self.assertEqual(result, expected)
 
@@ -201,7 +201,7 @@ class MockScalingGroupTestCase(IScalingGroupProviderMixin, TestCase):
         `partial_update` flag is provided as True, the keys that are not
         provided are not overwritten.
         """
-        self.assert_deferred_succeeded(self.group.update_config(
+        self.successResultOf(self.group.update_config(
             {}, partial_update=True))
         result = self.validate_view_config_return_value()
 
@@ -216,7 +216,7 @@ class MockScalingGroupTestCase(IScalingGroupProviderMixin, TestCase):
         """
         When the config is updated, the launch config doesn't change.
         """
-        self.assert_deferred_succeeded(self.group.update_config({
+        self.successResultOf(self.group.update_config({
             'cooldown': 1000,
             'metadata': {'UPDATED': 'UPDATED'},
             'minEntities': 10,
@@ -224,7 +224,7 @@ class MockScalingGroupTestCase(IScalingGroupProviderMixin, TestCase):
             'name': 'UPDATED'
         }))
         self.assertEqual(
-            self.assert_deferred_succeeded(self.group.view_launch_config()),
+            self.successResultOf(self.group.view_launch_config()),
             self.launch_config)
 
     def test_update_launch_config_overwrites_existing_data(self):
@@ -236,20 +236,20 @@ class MockScalingGroupTestCase(IScalingGroupProviderMixin, TestCase):
             "type": "launch_server",
             "args": {"server": {"here are": "new args"}}
         }
-        self.assert_deferred_succeeded(self.group.update_launch_config(updated))
-        result = self.assert_deferred_succeeded(self.group.view_launch_config())
+        self.successResultOf(self.group.update_launch_config(updated))
+        result = self.successResultOf(self.group.view_launch_config())
         self.assertEqual(result, updated)
 
     def test_update_launch_config_does_not_change_config(self):
         """
         When the launch_config is updated, the config doesn't change.
         """
-        self.assert_deferred_succeeded(self.group.update_launch_config({
+        self.successResultOf(self.group.update_launch_config({
             "type": "launch_server",
             "args": {"server": {"here are": "new args"}}
         }))
         self.assertEqual(
-            self.assert_deferred_succeeded(self.group.view_config()),
+            self.successResultOf(self.group.view_config()),
             self.output_config)
 
     def test_create_new_scaling_policies(self):
@@ -271,7 +271,7 @@ class MockScalingGroupTestCase(IScalingGroupProviderMixin, TestCase):
                 "type": "webhook"
             }
         ])
-        list_result = self.assert_deferred_succeeded(self.group.list_policies())
+        list_result = self.successResultOf(self.group.list_policies())
         self.assertGreater(len(list_result), len(create_response))
         for key, value in create_response.iteritems():
             self.assertEqual(list_result[key], value)
@@ -322,10 +322,10 @@ class MockScalingGroupTestCase(IScalingGroupProviderMixin, TestCase):
         """
         Try to get a policy by looking up all available UUIDs, and getting one.
         """
-        policy_list = self.assert_deferred_succeeded(self.group.list_policies())
+        policy_list = self.successResultOf(self.group.list_policies())
         uuid = policy_list.keys()[0]
         value = policy_list.values()[0]
-        result = self.assert_deferred_succeeded(self.group.get_policy(uuid))
+        result = self.successResultOf(self.group.get_policy(uuid))
         self.assertEqual(value, result)
 
     def test_get_nonexistent_policy_fails(self):
@@ -340,10 +340,10 @@ class MockScalingGroupTestCase(IScalingGroupProviderMixin, TestCase):
         """
         Delete a policy, check that it is actually deleted.
         """
-        policy_list = self.assert_deferred_succeeded(self.group.list_policies())
+        policy_list = self.successResultOf(self.group.list_policies())
         uuid = policy_list.keys()[0]
-        self.assert_deferred_succeeded(self.group.delete_policy(uuid))
-        result = self.assert_deferred_succeeded(self.group.list_policies())
+        self.successResultOf(self.group.delete_policy(uuid))
+        result = self.successResultOf(self.group.list_policies())
         self.assertNotIn(uuid, result)
         self.assertEqual({}, result)
 
@@ -360,14 +360,14 @@ class MockScalingGroupTestCase(IScalingGroupProviderMixin, TestCase):
         """
         self.group.policies = {"2": {}}
         self.group.webhooks = {"2": {}}
-        self.assert_deferred_succeeded(self.group.delete_policy("2"))
+        self.successResultOf(self.group.delete_policy("2"))
         self.assertNotIn("2", self.group.webhooks)
 
     def test_update_policy_succeeds(self):
         """
         Get a UUID and attempt to update the policy.
         """
-        policy_list = self.assert_deferred_succeeded(self.group.list_policies())
+        policy_list = self.successResultOf(self.group.list_policies())
         uuid = policy_list.keys()[0]
         update_data = {
             "name": "Otters are not good pets",
@@ -375,8 +375,8 @@ class MockScalingGroupTestCase(IScalingGroupProviderMixin, TestCase):
             "cooldown": 555,
             "type": "webhook"
         }
-        self.assert_deferred_succeeded(self.group.update_policy(uuid, update_data))
-        result = self.assert_deferred_succeeded(
+        self.successResultOf(self.group.update_policy(uuid, update_data))
+        result = self.successResultOf(
             self.group.get_policy(uuid))
         self.assertEqual(update_data, result)
 
@@ -406,7 +406,7 @@ class MockScalingGroupTestCase(IScalingGroupProviderMixin, TestCase):
         If there are no webhooks, an empty dictionary is returned when
         ``list_webhooks`` is called
         """
-        policy_list = self.assert_deferred_succeeded(self.group.list_policies())
+        policy_list = self.successResultOf(self.group.list_policies())
         uuid = policy_list.keys()[0]
         result = self.validate_list_webhooks_return_value(uuid)
         self.assertEqual(result, {})
@@ -416,7 +416,7 @@ class MockScalingGroupTestCase(IScalingGroupProviderMixin, TestCase):
         If there are webhooks for a particular policy, listing webhooks returns
         a dictionary for all of them
         """
-        policy_list = self.assert_deferred_succeeded(self.group.list_policies())
+        policy_list = self.successResultOf(self.group.list_policies())
         uuid = policy_list.keys()[0]
         webhooks = {
             '10': self.sample_webhook_data,
@@ -471,7 +471,7 @@ class MockScalingGroupTestCase(IScalingGroupProviderMixin, TestCase):
             }, creation.values())
 
         # listing should return 3
-        listing = self.assert_deferred_succeeded(self.group.list_webhooks('2'))
+        listing = self.successResultOf(self.group.list_webhooks('2'))
         self.assertGreater(len(listing), len(creation))
 
     def test_get_webhook_nonexistent_policy_fails(self):
@@ -505,7 +505,7 @@ class MockScalingGroupTestCase(IScalingGroupProviderMixin, TestCase):
         self.group.policies = {'2': {}}
         self.group.webhooks = {'2': {'3': expected_webhook}}
         deferred = self.group.get_webhook("2", "3")
-        self.assertEqual(self.assert_deferred_succeeded(deferred),
+        self.assertEqual(self.successResultOf(deferred),
                          expected_webhook)
 
     def test_update_webhook_nonexistent_policy_fails(self):
@@ -544,7 +544,7 @@ class MockScalingGroupTestCase(IScalingGroupProviderMixin, TestCase):
             'name': 'updated',
             'metadata': {'key2': 'value2'}
         })
-        self.assertIsNone(self.assert_deferred_succeeded(deferred))
+        self.assertIsNone(self.successResultOf(deferred))
         self.assertEqual(self.group.webhooks, {
             '2': {
                 '3': {
@@ -571,7 +571,7 @@ class MockScalingGroupTestCase(IScalingGroupProviderMixin, TestCase):
             }
         }
         deferred = self.group.update_webhook("2", "3", {'name': 'updated'})
-        self.assertIsNone(self.assert_deferred_succeeded(deferred))
+        self.assertIsNone(self.successResultOf(deferred))
         self.assertEqual(self.group.webhooks, {
             '2': {
                 '3': {
@@ -614,7 +614,7 @@ class MockScalingGroupTestCase(IScalingGroupProviderMixin, TestCase):
             }
         }
         deferred = self.group.delete_webhook("2", "3")
-        self.assertIsNone(self.assert_deferred_succeeded(deferred))
+        self.assertIsNone(self.successResultOf(deferred))
         self.assertEqual(self.group.webhooks, {'2': {}})
 
 
@@ -724,21 +724,21 @@ class MockScalingGroupsCollectionTestCase(IScalingGroupCollectionProviderMixin,
             "change": 10,
             "cooldown": 5
         }
-        manifest = self.assert_deferred_succeeded(
+        manifest = self.successResultOf(
             self.collection.create_scaling_group(
                 self.mock_log, self.tenant_id, self.config, launch, {}))
 
         group = self.collection.get_scaling_group(self.mock_log, self.tenant_id,
                                                   manifest['id'])
 
-        pol_rec = self.assert_deferred_succeeded(group.create_policies([policy]))
+        pol_rec = self.successResultOf(group.create_policies([policy]))
 
         pol_uuid = pol_rec.keys()[0]
 
-        self.assert_deferred_succeeded(group.create_webhooks(pol_uuid, [{}]))
+        self.successResultOf(group.create_webhooks(pol_uuid, [{}]))
 
         deferred = self.collection.webhook_info_by_hash(self.mock_log, 'hash')
-        webhook_info = self.assert_deferred_succeeded(deferred)
+        webhook_info = self.successResultOf(deferred)
         self.assertEqual(webhook_info, (self.tenant_id, group.uuid, pol_uuid))
 
     @mock.patch('otter.models.mock.generate_capability',
@@ -753,18 +753,18 @@ class MockScalingGroupsCollectionTestCase(IScalingGroupCollectionProviderMixin,
             "change": 10,
             "cooldown": 5
         }
-        manifest = self.assert_deferred_succeeded(
+        manifest = self.successResultOf(
             self.collection.create_scaling_group(
                 self.mock_log, self.tenant_id, self.config, launch, {}))
 
         group = self.collection.get_scaling_group(self.mock_log, self.tenant_id,
                                                   manifest['id'])
 
-        pol_rec = self.assert_deferred_succeeded(group.create_policies([policy]))
+        pol_rec = self.successResultOf(group.create_policies([policy]))
 
         pol_uuid = pol_rec.keys()[0]
 
-        self.assert_deferred_succeeded(group.create_webhooks(pol_uuid, [{}]))
+        self.successResultOf(group.create_webhooks(pol_uuid, [{}]))
 
         deferred = self.collection.webhook_info_by_hash(self.mock_log, 'weasel')
         self.assert_deferred_failed(deferred, UnrecognizedCapabilityError)
@@ -830,7 +830,7 @@ class MockScalingGroupsCollectionTestCase(IScalingGroupCollectionProviderMixin,
 
         succeeded_deferreds = self._call_all_methods_on_group(uuid)
         for deferred in succeeded_deferreds:
-            self.assert_deferred_succeeded(deferred)
+            self.successResultOf(deferred)
 
     def test_get_scaling_group_works_but_methods_do_not(self):
         """

--- a/otter/test/rest/request.py
+++ b/otter/test/rest/request.py
@@ -223,7 +223,7 @@ class RequestTestMixin(DeferredTestMixin):
 
         :return: the response body as a string
         """
-        response_wrapper = self.assert_deferred_succeeded(
+        response_wrapper = self.successResultOf(
             request(root, method, endpoint or self.endpoint, body=body))
 
         self.assert_response(response_wrapper, expected_status)

--- a/otter/test/rest/test_decorators.py
+++ b/otter/test/rest/test_decorators.py
@@ -73,7 +73,7 @@ class TransactionIdTestCase(DeferredTestMixin, TestCase):
             return defer.succeed('hello')
 
         d = doWork(self.mockRequest)
-        r = self.assert_deferred_succeeded(d)
+        r = self.successResultOf(d)
 
         self.mock_log_patch.bind.assert_called_once_with(
             system='otter.test.rest.test_decorators.doWork',
@@ -114,7 +114,7 @@ class FaultTestCase(DeferredTestMixin, TestCase):
             return defer.succeed('hello')
 
         d = doWork(self.mockRequest, self.mockLog)
-        r = self.assert_deferred_succeeded(d)
+        r = self.successResultOf(d)
         self.mockRequest.setResponseCode.assert_called_once_with(204)
 
         self.mockLog.bind.assert_called_once_with(code=204, uri='/')
@@ -134,7 +134,7 @@ class FaultTestCase(DeferredTestMixin, TestCase):
             return defer.succeed('hello')
 
         d = doWork(self.mockRequest, self.mockLog)
-        r = self.assert_deferred_succeeded(d)
+        r = self.successResultOf(d)
         self.mockRequest.setResponseCode.assert_called_once_with(204)
         self.mockLog.bind.assert_called_once_with(code=204, uri='/')
         self.mockLog.bind().msg.assert_called_once_with('Request succeeded')
@@ -152,7 +152,7 @@ class FaultTestCase(DeferredTestMixin, TestCase):
             return defer.fail(BlahError('fail'))
 
         d = doWork(self.mockRequest, self.mockLog)
-        r = self.assert_deferred_succeeded(d)
+        r = self.successResultOf(d)
         self.mockRequest.setResponseCode.assert_called_once_with(404)
 
         self.mockLog.bind.assert_called_once_with(code=404, uri='/',
@@ -180,7 +180,7 @@ class FaultTestCase(DeferredTestMixin, TestCase):
             return defer.fail(DetailsError('fail'))
 
         d = doWork(self.mockRequest, self.mockLog)
-        r = self.assert_deferred_succeeded(d)
+        r = self.successResultOf(d)
         self.mockRequest.setResponseCode.assert_called_once_with(404)
 
         self.mockLog.bind.assert_called_once_with(code=404, uri='/',
@@ -209,7 +209,7 @@ class FaultTestCase(DeferredTestMixin, TestCase):
             return defer.fail(DetailsError('fail'))
 
         d = doWork(self.mockRequest, self.mockLog)
-        r = self.assert_deferred_succeeded(d)
+        r = self.successResultOf(d)
         self.mockRequest.setResponseCode.assert_called_once_with(404)
 
         # Not testing the logging here; if you do it out of order, it still
@@ -247,7 +247,7 @@ class FaultTestCase(DeferredTestMixin, TestCase):
             return defer.fail(BlahError('fail'))
 
         d = doWork(self.mockRequest, self.mockLog)
-        r = self.assert_deferred_succeeded(d)
+        r = self.successResultOf(d)
         self.mockRequest.setResponseCode.assert_called_once_with(400)
 
         self.mockLog.bind.assert_called_once_with(code=400, uri='/',
@@ -278,7 +278,7 @@ class FaultTestCase(DeferredTestMixin, TestCase):
             return defer.fail(blah)
 
         d = doWork(self.mockRequest, self.mockLog)
-        r = self.assert_deferred_succeeded(d)
+        r = self.successResultOf(d)
         self.mockRequest.setResponseCode.assert_called_once_with(500)
 
         class _CmpFailure(object):
@@ -343,7 +343,7 @@ class ValidateBodyTestCase(DeferredTestMixin, TestCase):
         kwargs = {'one': 'two'}
 
         d = handle_body(self.request, *args, **kwargs)
-        result = self.assert_deferred_succeeded(d)
+        result = self.successResultOf(d)
 
         # assert that it was validated
         self.mock_validate.assert_called_once_with(expected_value, schema)

--- a/otter/test/test_cqlbatch.py
+++ b/otter/test/test_cqlbatch.py
@@ -26,7 +26,7 @@ class CqlBatchTestCase(DeferredTestMixin, TestCase):
         """
         batch = Batch(['INSERT * INTO BLAH', 'INSERT * INTO BLOO'], {})
         d = batch.execute(self.connection)
-        self.assert_deferred_succeeded(d)
+        self.successResultOf(d)
         expected = 'BEGIN BATCH INSERT * INTO BLAH'
         expected += ' INSERT * INTO BLOO APPLY BATCH;'
         self.connection.execute.assert_called_once_with(expected, {},
@@ -40,7 +40,7 @@ class CqlBatchTestCase(DeferredTestMixin, TestCase):
         batch = Batch(['INSERT :blah INTO BLAH', 'INSERT * INTO BLOO'],
                       params)
         d = batch.execute(self.connection)
-        self.assert_deferred_succeeded(d)
+        self.successResultOf(d)
         expected = 'BEGIN BATCH INSERT :blah INTO BLAH'
         expected += ' INSERT * INTO BLOO APPLY BATCH;'
         self.connection.execute.assert_called_once_with(expected, params,
@@ -52,7 +52,7 @@ class CqlBatchTestCase(DeferredTestMixin, TestCase):
         """
         batch = Batch(['INSERT * INTO BLAH'], {}, timestamp=123)
         d = batch.execute(self.connection)
-        self.assert_deferred_succeeded(d)
+        self.successResultOf(d)
         expected = 'BEGIN BATCH USING TIMESTAMP 123'
         expected += ' INSERT * INTO BLAH APPLY BATCH;'
         self.connection.execute.assert_called_once_with(expected, {},
@@ -65,7 +65,7 @@ class CqlBatchTestCase(DeferredTestMixin, TestCase):
         batch = Batch(['INSERT * INTO BLAH'], {},
                       consistency=ConsistencyLevel.QUORUM)
         d = batch.execute(self.connection)
-        self.assert_deferred_succeeded(d)
+        self.successResultOf(d)
         expected = 'BEGIN BATCH'
         expected += ' INSERT * INTO BLAH APPLY BATCH;'
         self.connection.execute.assert_called_once_with(expected, {},

--- a/otter/test/unitgration/test_rest_mock_model.py
+++ b/otter/test/unitgration/test_rest_mock_model.py
@@ -92,7 +92,7 @@ class MockStoreRestScalingGroupTestCase(DeferredTestMixin, TestCase):
             "groupConfiguration": self.config,
             "launchConfiguration": launch_server_config()[0]
         }
-        wrapper = self.assert_deferred_succeeded(request(
+        wrapper = self.successResultOf(request(
             root, 'POST', '/v1.0/11111/groups/', body=json.dumps(request_body)))
 
         self.assertEqual(wrapper.response.code, 201,
@@ -110,7 +110,7 @@ class MockStoreRestScalingGroupTestCase(DeferredTestMixin, TestCase):
         # now make sure the Location header points to something good!
         path = _strip_base_url(headers[0])
 
-        wrapper = self.assert_deferred_succeeded(request(root, 'GET', path))
+        wrapper = self.successResultOf(request(root, 'GET', path))
         self.assertEqual(wrapper.response.code, 200, path)
 
         response = json.loads(wrapper.content)
@@ -120,7 +120,7 @@ class MockStoreRestScalingGroupTestCase(DeferredTestMixin, TestCase):
 
         # make sure the created group has enough pending entities, and is
         # not paused
-        wrapper = self.assert_deferred_succeeded(
+        wrapper = self.successResultOf(
             request(root, 'GET', path + 'state/'))
         self.assertEqual(wrapper.response.code, 200)
 
@@ -134,15 +134,15 @@ class MockStoreRestScalingGroupTestCase(DeferredTestMixin, TestCase):
         Deleting a scaling group returns with a 204 no content.  The next
         attempt to view the scaling group should return a 404 not found.
         """
-        wrapper = self.assert_deferred_succeeded(request(root, 'DELETE', path))
+        wrapper = self.successResultOf(request(root, 'DELETE', path))
         self.assertEqual(wrapper.response.code, 204,
                          "Delete failed: {0}".format(wrapper.content))
         self.assertEqual(wrapper.content, "")
 
         # now try to view
-        wrapper = self.assert_deferred_succeeded(request(root, 'GET', path))
+        wrapper = self.successResultOf(request(root, 'GET', path))
         self.assertEqual(wrapper.response.code, 404)
-        wrapper = self.assert_deferred_succeeded(
+        wrapper = self.successResultOf(
             request(root, 'GET', path + 'state/'))
         self.assertEqual(wrapper.response.code, 404)
 
@@ -153,7 +153,7 @@ class MockStoreRestScalingGroupTestCase(DeferredTestMixin, TestCase):
         """
         Asserts that there are ``number`` number of scaling groups
         """
-        wrapper = self.assert_deferred_succeeded(
+        wrapper = self.successResultOf(
             request(root, 'GET', '/v1.0/11111/groups/'))
         self.assertEqual(200, wrapper.response.code)
 
@@ -186,7 +186,7 @@ class MockStoreRestScalingGroupTestCase(DeferredTestMixin, TestCase):
         path = self.create_and_view_scaling_group() + 'launch/'
         edited_launch = launch_server_config()[1]
 
-        wrapper = self.assert_deferred_succeeded(
+        wrapper = self.successResultOf(
             request(root, 'PUT', path, body=json.dumps(edited_launch)))
 
         self.assertEqual(wrapper.response.code, 204,
@@ -194,7 +194,7 @@ class MockStoreRestScalingGroupTestCase(DeferredTestMixin, TestCase):
         self.assertEqual(wrapper.content, "")
 
         # now try to view again - the config should be the edited config
-        wrapper = self.assert_deferred_succeeded(
+        wrapper = self.successResultOf(
             request(root, 'GET', path))
         self.assertEqual(wrapper.response.code, 200)
         self.assertEqual(json.loads(wrapper.content),
@@ -216,7 +216,7 @@ class MockStoreRestScalingPolicyTestCase(DeferredTestMixin, TestCase):
         """
         store = MockScalingGroupCollection()
         self.mock_log = mock.MagicMock()
-        manifest = self.assert_deferred_succeeded(
+        manifest = self.successResultOf(
             store.create_scaling_group(self.mock_log, self.tenant_id, config()[0],
                                        launch_server_config()[0]))
         self.group_id = manifest['id']
@@ -238,7 +238,7 @@ class MockStoreRestScalingPolicyTestCase(DeferredTestMixin, TestCase):
         """
         Asserts that there are ``number`` number of scaling policies
         """
-        wrapper = self.assert_deferred_succeeded(
+        wrapper = self.successResultOf(
             request(root, 'GET', self.policies_url))
         self.assertEqual(200, wrapper.response.code)
 
@@ -255,7 +255,7 @@ class MockStoreRestScalingPolicyTestCase(DeferredTestMixin, TestCase):
             to be in any consistent order)
         """
         request_body = policy()[:-1]  # however many of them there are minus one
-        wrapper = self.assert_deferred_succeeded(request(
+        wrapper = self.successResultOf(request(
             root, 'POST', self.policies_url, body=json.dumps(request_body)))
 
         self.assertEqual(wrapper.response.code, 201,
@@ -292,14 +292,14 @@ class MockStoreRestScalingPolicyTestCase(DeferredTestMixin, TestCase):
         the policy again, it should contain the updated version.
         """
         request_body = policy()[-1]  # the one that was not created
-        wrapper = self.assert_deferred_succeeded(
+        wrapper = self.successResultOf(
             request(root, 'PUT', path, body=json.dumps(request_body)))
         self.assertEqual(wrapper.response.code, 204,
                          "Update failed: {0}".format(wrapper.content))
         self.assertEqual(wrapper.content, "")
 
         # now try to view
-        wrapper = self.assert_deferred_succeeded(request(root, 'GET', path))
+        wrapper = self.successResultOf(request(root, 'GET', path))
         self.assertEqual(wrapper.response.code, 200)
 
         response = json.loads(wrapper.content)
@@ -320,13 +320,13 @@ class MockStoreRestScalingPolicyTestCase(DeferredTestMixin, TestCase):
         Deleting a scaling policy returns with a 204 no content.  The next
         attempt to view the scaling policy should return a 404 not found.
         """
-        wrapper = self.assert_deferred_succeeded(request(root, 'DELETE', path))
+        wrapper = self.successResultOf(request(root, 'DELETE', path))
         self.assertEqual(wrapper.response.code, 204,
                          "Delete failed: {0}".format(wrapper.content))
         self.assertEqual(wrapper.content, "")
 
         # now try to view
-        wrapper = self.assert_deferred_succeeded(request(root, 'GET', path))
+        wrapper = self.successResultOf(request(root, 'GET', path))
         self.assertEqual(wrapper.response.code, 404)
 
         # flush any logged errors
@@ -368,7 +368,7 @@ class MockStoreRestScalingPolicyTestCase(DeferredTestMixin, TestCase):
 
         self.assert_number_of_scaling_policies(len(first_policies))
 
-        wrapper = self.assert_deferred_succeeded(
+        wrapper = self.successResultOf(
             request(root, 'POST', first_policies[0] + 'execute/'))
         self.assertEqual(wrapper.response.code, 202,
                          "Execute failed: {0}".format(wrapper.content))
@@ -382,7 +382,7 @@ class MockStoreRestScalingPolicyTestCase(DeferredTestMixin, TestCase):
         self.mock_controller.maybe_execute_scaling_policy.return_value = defer.fail(
             NoSuchPolicyError('11111', '1', '2'))
 
-        wrapper = self.assert_deferred_succeeded(
+        wrapper = self.successResultOf(
             request(root, 'POST', self.policies_url + '1/execute/'))
         self.assertEqual(wrapper.response.code, 404,
                          "Execute did not fail as expected: {0}".format(wrapper.content))
@@ -405,14 +405,14 @@ class MockStoreRestWebhooksTestCase(DeferredTestMixin, TestCase):
         """
         self.mock_log = mock.MagicMock()
         store = MockScalingGroupCollection()
-        manifest = self.assert_deferred_succeeded(
+        manifest = self.successResultOf(
             store.create_scaling_group(self.mock_log, self.tenant_id,
                                        config()[0],
                                        launch_server_config()[0]))
         self.group_id = manifest['id']
         group = store.get_scaling_group(self.mock_log,
                                         self.tenant_id, self.group_id)
-        self.policy_id = self.assert_deferred_succeeded(
+        self.policy_id = self.successResultOf(
             group.create_policies([{
                 "name": 'set number of servers to 10',
                 "change": 10,
@@ -440,7 +440,7 @@ class MockStoreRestWebhooksTestCase(DeferredTestMixin, TestCase):
         """
         Asserts that there are ``number`` number of scaling policies
         """
-        wrapper = self.assert_deferred_succeeded(
+        wrapper = self.successResultOf(
             request(root, 'GET', self.webhooks_url))
         self.assertEqual(200, wrapper.response.code)
 
@@ -460,7 +460,7 @@ class MockStoreRestWebhooksTestCase(DeferredTestMixin, TestCase):
             {'name': 'first', 'metadata': {'notes': 'first webhook'}},
             {'name': 'second', 'metadata': {'notes': 'second webhook'}}
         ]
-        wrapper = self.assert_deferred_succeeded(request(
+        wrapper = self.successResultOf(request(
             root, 'POST', self.webhooks_url, body=json.dumps(request_body)))
 
         self.assertEqual(wrapper.response.code, 201,
@@ -501,14 +501,14 @@ class MockStoreRestWebhooksTestCase(DeferredTestMixin, TestCase):
         the webhook again, it should contain the updated version.
         """
         request_body = {'name': 'updated_webhook', 'metadata': {'foo': 'bar'}}
-        wrapper = self.assert_deferred_succeeded(
+        wrapper = self.successResultOf(
             request(root, 'PUT', path, body=json.dumps(request_body)))
         self.assertEqual(wrapper.response.code, 204,
                          "Update failed: {0}".format(wrapper.content))
         self.assertEqual(wrapper.content, "")
 
         # now try to view
-        wrapper = self.assert_deferred_succeeded(request(root, 'GET', path))
+        wrapper = self.successResultOf(request(root, 'GET', path))
         self.assertEqual(wrapper.response.code, 200)
 
         response = json.loads(wrapper.content)
@@ -533,13 +533,13 @@ class MockStoreRestWebhooksTestCase(DeferredTestMixin, TestCase):
         Deleting a webhook returns with a 204 no content.  The next attempt to
         view the webhook should return a 404 not found.
         """
-        wrapper = self.assert_deferred_succeeded(request(root, 'DELETE', path))
+        wrapper = self.successResultOf(request(root, 'DELETE', path))
         self.assertEqual(wrapper.response.code, 204,
                          "Delete failed: {0}".format(wrapper.content))
         self.assertEqual(wrapper.content, "")
 
         # now try to view
-        wrapper = self.assert_deferred_succeeded(request(root, 'GET', path))
+        wrapper = self.successResultOf(request(root, 'GET', path))
         self.assertEqual(wrapper.response.code, 404)
 
         # flush any logged errors
@@ -579,12 +579,12 @@ class MockStoreRestWebhooksTestCase(DeferredTestMixin, TestCase):
         self.assert_number_of_webhooks(0)
         first_webhooks = self.create_and_view_webhooks()
 
-        wrapper = self.assert_deferred_succeeded(request(root, 'GET', first_webhooks[0]))
+        wrapper = self.successResultOf(request(root, 'GET', first_webhooks[0]))
         webhook = json.loads(wrapper.content)['webhook']
         links = {link['rel']: link['href'] for link in webhook['links']}
         cap_path = _strip_base_url(links['capability'])
 
-        wrapper = self.assert_deferred_succeeded(request(root, 'POST', cap_path))
+        wrapper = self.successResultOf(request(root, 'POST', cap_path))
         self.assertEqual(wrapper.response.code, 202)
 
     def test_execute_non_existant_webhook_by_hash(self):
@@ -593,6 +593,6 @@ class MockStoreRestWebhooksTestCase(DeferredTestMixin, TestCase):
         """
         self.assert_number_of_webhooks(0)
 
-        wrapper = self.assert_deferred_succeeded(
+        wrapper = self.successResultOf(
             request(root, 'POST', '/v1.0/execute/1/1/'))
         self.assertEqual(wrapper.response.code, 202)

--- a/otter/test/utils.py
+++ b/otter/test/utils.py
@@ -53,14 +53,6 @@ class DeferredTestMixin(object):
     failed
     """
 
-    def assert_deferred_succeeded(self, deferred):
-        """
-        Synonym for self.successResultOf - provided for compatibility and
-        because self.assert_deferred_failed is still needed to check for
-        expected failures.
-        """
-        return self.successResultOf(deferred)
-
     def assert_deferred_failed(self, deferred, *expected_failures):
         """
         Asserts that the deferred should have errbacked with the given


### PR DESCRIPTION
Just search and replaced everything.  Unfortunately `assert_deferred_succeeded` must remain, because changes to make twisted's `failureResultOf` compatible isn't in 13.0, but should be in the next release.
