### PR TITLE
Fix all the KeyErrors caused by reprs of dicts being logged as strings, ...

### DIFF
--- a/otter/log/formatters.py
+++ b/otter/log/formatters.py
@@ -2,6 +2,7 @@
 Composable log observers for use with Twisted's log module.
 """
 import json
+from twisted.python.failure import Failure
 
 
 class ReprFallbackEncoder(json.JSONEncoder):
@@ -98,7 +99,12 @@ def PEP3101FormattingWrapper(observer):
             message = ' '.join(eventDict['message'])
 
             if message:
-                eventDict['message'] = (message.format(**eventDict),)
+                try:
+                    eventDict['message'] = (message.format(**eventDict),)
+                except:
+                    failure = Failure()
+                    eventDict['message_formatting_error'] = str(failure)
+                    eventDict['message'] = message
 
         observer(eventDict)
 

--- a/otter/test/test_log.py
+++ b/otter/test/test_log.py
@@ -14,7 +14,8 @@ from otter.log.formatters import StreamObserverWrapper
 from otter.log.formatters import SystemFilterWrapper
 from otter.log.formatters import PEP3101FormattingWrapper
 
-from otter.test.utils import SameJSON
+from testtools.matchers import Contains
+from otter.test.utils import SameJSON, matches
 
 
 class BoundLogTests(TestCase):
@@ -230,3 +231,14 @@ class PEP3101FormattingWrapperTests(TestCase):
         """
         self.wrapper({'message': ('foo', 'bar', 'baz', '{bax}'), 'bax': 'bax'})
         self.observer.assert_called_once_with({'message': ('foo bar baz bax',), 'bax': 'bax'})
+
+    def test_formatting_failure(self):
+        """
+        PEP3101FormattingWrapper should fall back to using the unformatted
+        message and include an 'exception_formatting_message' key.
+        """
+        self.wrapper({'message': ('{u"Hello": "There"}',)})
+        self.observer.assert_called_once_with({
+            'message': '{u"Hello": "There"}',
+            'message_formatting_error': matches(Contains('KeyError'))
+        })


### PR DESCRIPTION
...and generally make formatting safer.

https://autoscale.airbrake.io/groups/60982359
https://autoscale.airbrake.io/groups/60887965
https://autoscale.airbrake.io/groups/60887967
https://autoscale.airbrake.io/groups/60799899
https://autoscale.airbrake.io/groups/60722210
https://autoscale.airbrake.io/groups/60722209
https://autoscale.airbrake.io/groups/60721378
https://autoscale.airbrake.io/groups/60232366
https://autoscale.airbrake.io/groups/60236162
https://autoscale.airbrake.io/groups/60232365
https://autoscale.airbrake.io/groups/59617630
