### PR TITLE
Force the artifact region to DFW.

### DIFF
--- a/scripts/upload_artifacts.py
+++ b/scripts/upload_artifacts.py
@@ -11,7 +11,10 @@ RS_USERNAME = os.environ['RACKSPACE_USERNAME']
 RS_API_KEY = os.environ['RACKSPACE_API_KEY']
 container_name = os.environ.get('CONTAINER_NAME') or 'otter_artifacts'
 
-driver = get_driver(Provider.CLOUDFILES_US)(RS_USERNAME, RS_API_KEY)
+driver = get_driver(Provider.CLOUDFILES_US)(
+    RS_USERNAME,
+    RS_API_KEY,
+    ex_force_service_region='dfw')
 
 # Create a container if it doesn't already exist
 try:


### PR DESCRIPTION
libcloud by default picks the arbitrary first region based on the ordering of regions in the response.  So when they added a syd region they also changed the ordering and we started uploading artifacts to ORD.  This fixes that by forcing the upload script to use a poorly named parameter to force the region to DFW.
