### PR TITLE
part of auto-398: does not allow only time or date

### DIFF
--- a/otter/json_schema/group_schemas.py
+++ b/otter/json_schema/group_schemas.py
@@ -9,8 +9,6 @@ from croniter import croniter
 from otter.util.timestamp import from_timestamp
 from otter.json_schema import format_checker
 
-import iso8601
-
 # This is built using union types which may not be available in Draft 4
 # see: http://stackoverflow.com/questions/9029524/json-schema-specify-field-is-
 # required-based-on-value-of-another-field
@@ -203,7 +201,7 @@ zero = {
 
 # Register cron and ISO8601 date-time format checkers with the global checker.
 format_checker.checks('cron', raises=ValueError)(croniter)
-format_checker.checks('date-time', raises=iso8601.iso8601.ParseError)(from_timestamp)
+format_checker.checks('date-time', raises=Exception)(from_timestamp)
 
 _policy_base_type = {
     "type": "object",

--- a/otter/test/json_schema/test_schemas.py
+++ b/otter/test/json_schema/test_schemas.py
@@ -512,6 +512,22 @@ class ScalingPolicyTestCase(TestCase):
         invalid['args']['at'] = 'junk'
         self.assertRaises(ValidationError, validate, invalid, group_schemas.policy)
 
+    def test_only_date_timestamp(self):
+        """
+        policy with only date in timestamp raises ``ValidationError``
+        """
+        invalid = self.at_policy
+        invalid['args']['at'] = '2012-10-10'
+        self.assertRaises(ValidationError, validate, invalid, group_schemas.policy)
+
+    def test_only_time_timestamp(self):
+        """
+        policy with only time in timestamp raises ``ValidationError``
+        """
+        invalid = self.at_policy
+        invalid['args']['at'] = '11:25'
+        self.assertRaises(ValidationError, validate, invalid, group_schemas.policy)
+
     def test_invalid_cron(self):
         """
         policy with invalid cron entry raises ``ValidationError``


### PR DESCRIPTION
`iso8601.parse_date` does not allow only date or time but returns `TypeError` instead `ParseError` when it
sees only date. Since it is undocumented/unexpected, I am catching `Exception` for any validation error
