### PR TITLE
Include job name in the deploy tarball built by bundle.sh (ready for review)

### DIFF
--- a/scripts/bundle.sh
+++ b/scripts/bundle.sh
@@ -12,7 +12,8 @@
 
 set -e
 
-NAME="otter-deploy"
+JOB_NAME=${JOB_NAME:="otter"}
+NAME="${JOB_NAME}-deploy"
 TARGET=${TARGET:="$NAME"}
 DIST_DIR=${DIST_DIR:="."}
 


### PR DESCRIPTION
This is needed so that both pr builder jobs and deploy jobs can be built without stomping on each other.
