### PR TITLE
Fixup stats script

### DIFF
--- a/scripts/stats.py
+++ b/scripts/stats.py
@@ -48,14 +48,8 @@ def run(args):
     # connect
     if args.verbose > 0:
         print "Attempting to connect to {0}:{1}".format(args.host, args.port)
-    try:
-        connection = connect(args.host, args.port, cql_version='3.0.4')
-    except Exception as e:
-        if getattr(e, 'why', False):
-            e.message = e.why
-        print "CONNECTION ERROR: {0}".format(e.message)
-        sys.exit(1)
 
+    connection = connect(args.host, args.port, cql_version='3.0.4')
     cursor = connection.cursor()
 
     for command, displayResults, label in commands:


### PR DESCRIPTION
Running `python stats.py` the first time gave me:

```
CONNECTION ERROR:
```

with no other information.

After printing the actual exception, I saw the error message is actually contained in the _why_ field. This led me to fix the main issue that _cql_version_ should follow [semantic versioning](http://semver.org)
