### PR TITLE
AUTO-419 - delete a group's events from the scaling schedule table (ready for review)

### DIFF
--- a/otter/models/cass.py
+++ b/otter/models/cass.py
@@ -716,20 +716,36 @@ class CassScalingGroup(object):
         """
         see :meth:`otter.models.interface.IScalingGroup.delete_group`
         """
+        # Events can only be deleted by policy id, since that and trigger are
+        # the only parts of the compound key
+        def _delete_everything(policies):
+            params = {
+                'tenantId': self.tenant_id,
+                'groupId': self.uuid
+            }
+            queries = [
+                _cql_delete_all_in_group.format(cf=table) for table in
+                (self.config_table, self.launch_table, self.policies_table,
+                 self.webhooks_table, self.state_table)]
+
+            if len(policies) > 0:
+                events_query, events_params = _delete_events_query_and_params(
+                    policies.keys(), self.event_table)
+                queries.append(events_query.rstrip(';'))
+                params.update(events_params)
+
+            b = Batch(queries, params,
+                      consistency=get_consistency_level('delete', 'group'))
+
+            return b.execute(self.connection)
+
         def _maybe_delete(state):
             if len(state.active) + len(state.pending) > 0:
                 raise GroupNotEmptyError(self.tenant_id, self.uuid)
 
-            queries = [
-                _cql_delete_all_in_group.format(cf=table) for table in
-                (self.config_table, self.launch_table, self.policies_table,
-                 self.webhooks_table, self.state_table, self.event_table)]
-
-            b = Batch(queries,
-                      {"tenantId": self.tenant_id, "groupId": self.uuid},
-                      consistency=get_consistency_level('delete', 'group'))
-
-            return b.execute(self.connection)
+            d = self._naive_list_policies()
+            d.addCallback(_delete_everything)
+            return d
 
         def _delete_group():
             d = self.view_state()
@@ -738,6 +754,23 @@ class CassScalingGroup(object):
 
         lock = BasicLock(self.connection, LOCK_TABLE_NAME, self.uuid)
         return with_lock(lock, _delete_group)
+
+
+def _delete_events_query_and_params(policy_ids, event_table):
+    """
+    Given an iterable of policy_ids, returns the query and params needed to
+    execute deleting all events associated with the policy ids.
+
+    :param iterable policy_ids: strings representing the policy ids
+    :return: ``tuple`` of query, params that can be passed to execute
+    """
+    policy_ids_cql = ','.join(
+        [':policyid{0}'.format(i) for i in range(len(policy_ids))])
+    params = {'policyid{0}'.format(i): policy_id
+              for i, policy_id in enumerate(policy_ids)}
+    query = _cql_delete_events.format(cf=event_table,
+                                      policy_ids=policy_ids_cql)
+    return (query, params)
 
 
 @implementer(IScalingGroupCollection, IScalingScheduleCollection)
@@ -859,11 +892,9 @@ class CassScalingGroupCollection:
         """
         see :meth:`otter.models.interface.IScalingScheduleCollection.delete_events`
         """
-        policy_ids_cql = ','.join([':policyid{0}'.format(i) for i in range(len(policy_ids))])
-        id_values_dict = {'policyid{0}'.format(i): policy_id for i, policy_id in enumerate(policy_ids)}
-        d = self.connection.execute(_cql_delete_events.format(cf=self.event_table,
-                                                              policy_ids=policy_ids_cql),
-                                    id_values_dict, get_consistency_level('delete', 'events'))
+        query, params = _delete_events_query_and_params(policy_ids, self.event_table)
+        d = self.connection.execute(query, params,
+                                    get_consistency_level('delete', 'events'))
         return d
 
     def update_events_trigger(self, policy_and_triggers):

--- a/otter/test/models/test_cass_models.py
+++ b/otter/test/models/test_cass_models.py
@@ -1207,18 +1207,61 @@ class CassScalingGroupTestCase(IScalingGroupProviderMixin, LockMixin, TestCase):
         self.flushLoggedErrors(GroupNotEmptyError)
 
     @mock.patch('otter.models.cass.CassScalingGroup.view_state')
-    def test_delete_empty_scaling_group_with_policies(self, mock_view_state):
+    @mock.patch('otter.models.cass.CassScalingGroup._naive_list_policies')
+    def test_delete_empty_scaling_group_with_policies(self, mock_naive,
+                                                      mock_view_state):
         """
         ``delete_group`` deletes config, launch config, state, and the group's
-        policies and webhooks if the scaling group is empty.
-        It uses naive calls all the way down.
+        policies and webhooks and events if the scaling group is empty.
+        It uses naive list policies to figure out what events to delete.
         """
         mock_view_state.return_value = defer.succeed(GroupState(
             self.tenant_id, self.group_id, {}, {}, None, {}, False))
+        mock_naive.return_value = defer.succeed({'policyA': {}, 'policyB': {}})
 
         self.returns = [None]
         result = self.successResultOf(self.group.delete_group())
         self.assertIsNone(result)  # delete returns None
+        mock_naive.assert_called_once_with()
+
+        expected_data = {'tenantId': self.tenant_id,
+                         'groupId': self.group_id,
+                         'policyid0': 'policyA',
+                         'policyid1': 'policyB'}
+        expected_cql = (
+            'BEGIN BATCH '
+            'DELETE FROM scaling_config WHERE "tenantId" = :tenantId AND "groupId" = :groupId '
+            'DELETE FROM launch_config WHERE "tenantId" = :tenantId AND "groupId" = :groupId '
+            'DELETE FROM scaling_policies WHERE "tenantId" = :tenantId AND "groupId" = :groupId '
+            'DELETE FROM policy_webhooks WHERE "tenantId" = :tenantId AND "groupId" = :groupId '
+            'DELETE FROM group_state WHERE "tenantId" = :tenantId AND "groupId" = :groupId '
+            'DELETE FROM scaling_schedule WHERE "policyId" IN (:policyid0,:policyid1) '
+            'APPLY BATCH;')
+
+        self.connection.execute.assert_called_once_with(
+            expected_cql, expected_data, ConsistencyLevel.TWO)
+
+        self.lock.acquire.assert_called_once_with()
+        self.lock.release.assert_called_once_with()
+
+    @mock.patch('otter.models.cass.CassScalingGroup.view_state')
+    @mock.patch('otter.models.cass.CassScalingGroup._naive_list_policies')
+    def test_delete_empty_scaling_group_with_zero_policies(self, mock_naive,
+                                                           mock_view_state):
+        """
+        ``delete_group`` deletes config, launch config, state, and the group's
+        policies and webhooks but not events if the scaling group is empty but
+        has no policies.
+        It uses naive list policies to figure out what events to delete.
+        """
+        mock_view_state.return_value = defer.succeed(GroupState(
+            self.tenant_id, self.group_id, {}, {}, None, {}, False))
+        mock_naive.return_value = defer.succeed({})
+
+        self.returns = [None]
+        result = self.successResultOf(self.group.delete_group())
+        self.assertIsNone(result)  # delete returns None
+        mock_naive.assert_called_once_with()
 
         expected_data = {'tenantId': self.tenant_id,
                          'groupId': self.group_id}
@@ -1229,7 +1272,6 @@ class CassScalingGroupTestCase(IScalingGroupProviderMixin, LockMixin, TestCase):
             'DELETE FROM scaling_policies WHERE "tenantId" = :tenantId AND "groupId" = :groupId '
             'DELETE FROM policy_webhooks WHERE "tenantId" = :tenantId AND "groupId" = :groupId '
             'DELETE FROM group_state WHERE "tenantId" = :tenantId AND "groupId" = :groupId '
-            'DELETE FROM scaling_schedule WHERE "tenantId" = :tenantId AND "groupId" = :groupId '
             'APPLY BATCH;')
 
         self.connection.execute.assert_called_once_with(


### PR DESCRIPTION
When deleting a group, also delete its entries in the scaling schedule table

This does not fix the update problem.

A couple problems with this:
1. That helper function for getting the delete events query and param is pretty hideous.  The `.rstrip` is also kind of meh.  Perhaps I should just add the semicolon to the other statement.  Not sure what else to do without a big-ish refactor.
2. This doesn't ensure that someone might go and create a scheduling policy right after the delete lists all policies, and so those events won't be deleted from the table.  But I think that might be ok?  The scheduler will eventually clean up those events.  
