### PR TITLE
Change to internal comments instead of Disqus for now.

### DIFF
--- a/docbook/pom.xml
+++ b/docbook/pom.xml
@@ -36,8 +36,8 @@
           </execution>
         </executions>
         <configuration>
-	  <enableDisqus>1</enableDisqus>
-	  <feedbackEmail>rose.coste@rackspace.com</feedbackEmail>
+	  <enableDisqus>intranet</enableDisqus>
+	  <feedbackEmail>rose.coste@rackspace.com,michael.mcgrail@rackspace.com</feedbackEmail>
 	  <branding>rackspace</branding>
           <failOnValidationerror>no</failOnValidationerror>
 	  <showXslMessages>true</showXslMessages>


### PR DESCRIPTION
Since these documents are internal-only initially, let's not use Disqus, but instead use our internal commenting system. 
