### PR TITLE
Change CQL version to follow the semver spec.

### DIFF
--- a/otter/test/resources.py
+++ b/otter/test/resources.py
@@ -96,7 +96,7 @@ class RunningCassandraCluster(object):
     existing cassandra processes what ports they are listening on and what data
     dir they are using?
     """
-    def __init__(self, host="localhost", port=9160, cql_version="3",
+    def __init__(self, host="localhost", port=9160, cql_version="3.0.4",
                  setup_cql=None, teardown_cql=None, overwrite_keyspaces=True):
         self.host = host
         self.port = port


### PR DESCRIPTION
CQL requires that the version passed into cql_version follows the [semver](http://semver.org) spec. This allows these tests to not be skipped when run on my local machine.
