### PR TITLE
wait_for_active was checking that the status was != 'BUILDING' when in reality the status string is 'BUILD'.

### DIFF
--- a/otter/test/worker/test_launch_server_v1.py
+++ b/otter/test/worker/test_launch_server_v1.py
@@ -359,7 +359,7 @@ class ServerTests(TestCase):
         """
         clock = Clock()
 
-        server_status = ['BUILDING']
+        server_status = ['BUILD']
 
         def _server_status(*args, **kwargs):
             return succeed({'server': {'status': server_status[0]}})
@@ -394,7 +394,7 @@ class ServerTests(TestCase):
         """
         clock = Clock()
 
-        server_status = ['BUILDING', 'ERROR']
+        server_status = ['BUILD', 'ERROR']
 
         def _server_status(*args, **kwargs):
             return succeed({'server': {'status': server_status.pop(0)}})
@@ -420,7 +420,7 @@ class ServerTests(TestCase):
         wait_for_active stops looping when it encounters an error.
         """
         clock = Clock()
-        server_status = ['BUILDING', 'ERROR']
+        server_status = ['BUILD', 'ERROR']
 
         def _server_status(*args, **kwargs):
             return succeed({'server': {'status': server_status.pop(0)}})
@@ -452,7 +452,7 @@ class ServerTests(TestCase):
         wait_for_active stops looping when it encounters the active state.
         """
         clock = Clock()
-        server_status = ['BUILDING', 'ACTIVE']
+        server_status = ['BUILD', 'ACTIVE']
 
         def _server_status(*args, **kwargs):
             return succeed({'server': {'status': server_status.pop(0)}})

--- a/otter/worker/launch_server_v1.py
+++ b/otter/worker/launch_server_v1.py
@@ -98,7 +98,7 @@ def wait_for_active(log,
             log.msg("Waiting for 'ACTIVE' got {status}.", status=status)
             if server['server']['status'] == 'ACTIVE':
                 d.callback(server)
-            elif server['server']['status'] != 'BUILDING':
+            elif server['server']['status'] != 'BUILD':
                 d.errback(UnexpectedServerStatus(
                     server_id,
                     status,


### PR DESCRIPTION
This was surfaced in errors of this form.

{{{
UnexpectedServerStatus('Expected 8a69332e-8762-43f4-abda-3e22b30bb963 to have ACTIVE, has BUILD',)
}}}

Not having a well documented or stable state machine is going to continue to be problematic.
