### PR TITLE
Fix an unused import

### DIFF
--- a/autoscale_cloudroast/test_repo/autoscale/system/schedule_policies/test_system_multi_scheduler_webhook_policies.py
+++ b/autoscale_cloudroast/test_repo/autoscale/system/schedule_policies/test_system_multi_scheduler_webhook_policies.py
@@ -3,7 +3,6 @@ System tests for multiple scheduler and webhook policies
 """
 from test_repo.autoscale.fixtures import AutoscaleFixture
 from time import sleep
-import unittest
 
 
 class MultipleSchedulerWebhookPoliciesTest(AutoscaleFixture):


### PR DESCRIPTION
Somehow https://github.com/rackerlabs/otter/pull/290 passed lint tests, but the merged version failed to.  Remove the unused import.
