### PR TITLE
Auto 488 timeout verify (ready for review)

### DIFF
--- a/otter/test/worker/test_launch_server_v1.py
+++ b/otter/test/worker/test_launch_server_v1.py
@@ -916,7 +916,7 @@ class DeleteServerTests(TestCase):
         self.treq.head.assert_called_once_with('http://url/servers/serverId',
                                                headers=expected_headers)
 
-        self.log.msg.assert_called_once_with(mock.ANY, instance_id='serverId')
+        self.log.msg.assert_called_with(mock.ANY, instance_id='serverId')
 
     def test_verified_delete_propagates_delete_server_api_failures(self):
         """
@@ -957,8 +957,8 @@ class DeleteServerTests(TestCase):
         clock = Clock()
         self.treq.delete.return_value = succeed(
             mock.Mock(spec=['code'], code=204))
-        self.treq.head.return_value = Deferred()
         self.treq.content.side_effect = lambda *args: succeed("")
+        self.treq.head.return_value = Deferred()
 
         verified_delete(self.log, 'http://url/', 'my-auth-token',
                         'serverId', interval=5, clock=clock)

--- a/otter/util/retry.py
+++ b/otter/util/retry.py
@@ -180,3 +180,10 @@ def retry(do_work, can_retry=None, next_interval=None, clock=None):
 
     retrier = _Retrier(do_work, can_retry, next_interval, clock)
     return retrier.start()
+
+
+class TransientRetryError(Exception):
+    """
+    Exception that can be used to represent retry-able status in a
+    retry-function.
+    """


### PR DESCRIPTION
Add a timeout function that can time out deferreds, and time out polling for whether a server has been deleted.  If it hasn't within the timeout, log an error.

Update:  Some new issues with this:
- [x] Ord and DFW doesn't actually delete immediately, only if you happen to delete in an magic time period between when the create server request responded, and ???  But if you try to delete 20 seconds, for example, after creating the server, it only deletes after it's active.  So the timeout for delete success needs to go up.
- [x] Refactor timing out a Deferred, as per @manishtomar's comment
- [x] Log messages with times - need to make sure the clock is available.
