### PR TITLE
AUTO-476 unhelpful message on past 'at' datetime

### DIFF
--- a/otter/json_schema/group_schemas.py
+++ b/otter/json_schema/group_schemas.py
@@ -11,6 +11,7 @@ from croniter import croniter
 
 from otter.util.timestamp import from_timestamp
 from otter.json_schema import format_checker
+from jsonschema import ValidationError
 
 # This is built using union types which may not be available in Draft 4
 # see: http://stackoverflow.com/questions/9029524/json-schema-specify-field-is-
@@ -220,7 +221,7 @@ def validate_datetime(dt_str):
         raise ValueError('Error parsing datetime str')
     # Ensure time is in future
     if datetime.utcfromtimestamp(calendar.timegm(dt.utctimetuple())) <= datetime.utcnow():
-        raise ValueError('time must be in future')
+        raise ValidationError('Invalid "{}" datetime: It must be in the future'.format(dt_str))
     return True
 
 
@@ -240,7 +241,7 @@ def validate_cron(cron):
         # https://github.com/taichino/croniter/issues/23
         raise ValueError('Error parsing cron')
     if len(cron.split()) == 6:
-        raise ValueError('Seconds not allowed')
+        raise ValidationError('Invalid "{}" cron entry: Seconds not allowed'.format(cron))
     return True
 
 _policy_base_type = {

--- a/otter/test/json_schema/test_schemas.py
+++ b/otter/test/json_schema/test_schemas.py
@@ -548,7 +548,7 @@ class ScalingPolicyTestCase(TestCase):
         invalid = self.at_policy
         past = datetime.utcnow() - timedelta(days=1)
         invalid['args']['at'] = past.isoformat() + 'Z'
-        self.assertRaisesRegexp(ValueError, 'time must be in future',
+        self.assertRaisesRegexp(ValidationError, 'must be in the future',
                                 group_schemas.validate_datetime, invalid['args']['at'])
         self.assertRaises(ValidationError, validate, invalid, group_schemas.policy)
 
@@ -592,7 +592,7 @@ class ScalingPolicyTestCase(TestCase):
         # This is tested for validation in above test.
         # Here it is checked for correct exception rased
         invalid_cron = '* * * * * *'
-        self.assertRaisesRegexp(ValueError, 'Seconds not allowed',
+        self.assertRaisesRegexp(ValidationError, 'Seconds not allowed',
                                 group_schemas.validate_cron, invalid_cron)
 
 


### PR DESCRIPTION
Giving proper message now for 'at' and 'cron'
