### PR TITLE
Changes in preparation for publishing to the external site

### DIFF
--- a/docbook/olink.xml
+++ b/docbook/olink.xml
@@ -1,0 +1,5 @@
+<books xmlns="http://docs.rackspace.com/olink">
+  <book path="src/docbkx/autoscale-gettingstarted.xml"/>
+  <book path="src/docbkx/autoscale-devguide.xml"/>
+</books>
+

--- a/docbook/pom.xml
+++ b/docbook/pom.xml
@@ -14,8 +14,21 @@
     <plugins>
       <plugin>
         <groupId>com.rackspace.cloud.api</groupId>
+        <artifactId>olink-maven-plugin</artifactId>
+        <version>1.0</version>
+        <executions>
+          <execution>
+	    <phase>initialize</phase>
+	    <goals>
+	      <goal>olink</goal>
+	    </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>com.rackspace.cloud.api</groupId>
         <artifactId>clouddocs-maven-plugin</artifactId>
-        <version>1.8.0</version>
+        <version>1.9.0</version>
         <executions>
           <execution>
             <id>autoscale</id>
@@ -39,11 +52,13 @@
           </execution>
         </executions>
         <configuration>
-	  <enableDisqus>intranet</enableDisqus>
-    <!-- notify these people when comments are posted on docs-internal.rackspace.com -->
+	  <enableDisqus>internet</enableDisqus>
+	  <socialIcons>0</socialIcons>
+	  <metaRobots>1</metaRobots>
+	  <!-- notify these people when comments are posted on docs-internal.rackspace.com -->
 	  <feedbackEmail>rose.coste@rackspace.com,constanze.kratel@rackspace.com,felix.sargent@rackspace.com</feedbackEmail>
 	  <branding>rackspace</branding>
-    <failOnValidationerror>no</failOnValidationerror>
+	  <!-- <failOnValidationerror>no</failOnValidationerror> -->
 	  <showXslMessages>true</showXslMessages>
 	  <highlightSource>false</highlightSource>
         </configuration>

--- a/docbook/src/docbkx/autoscale-devguide.xml
+++ b/docbook/src/docbkx/autoscale-devguide.xml
@@ -54,6 +54,7 @@ format="SVG" scale="60"/>
 <title>&PRODNAME; Developer Guide</title>
 <titleabbrev>&PRODABBV; DevGuide</titleabbrev>    
 <?rax title.font.size="35px" subtitle.font.size="20px"
+      status.bar.text="Early Access" 
       canonical.url.base="http://docs.rackspace.com/autoscale/api/v1.0/cas-devguide/content"?>
     <info>
         <releaseinfo>API v1.0</releaseinfo>
@@ -105,7 +106,7 @@ format="SVG" scale="60"/>
             </revision>           
         </revhistory>
       <!-- raxm:product appears in WAR for publication: cas-v1.0-autoscale-devguide-internal.war -->
-	<raxm:metadata xmlns:raxm="http://docs.rackspace.com/api/metadata">
+	<raxm:metadata role="hidden" xmlns:raxm="http://docs.rackspace.com/api/metadata">
             <raxm:displayname>API Developer Guide</raxm:displayname>
             <raxm:product version="v1.0">cas</raxm:product>
             <raxm:priority>20</raxm:priority>

--- a/docbook/src/docbkx/autoscale-gettingstarted.xml
+++ b/docbook/src/docbkx/autoscale-gettingstarted.xml
@@ -55,7 +55,8 @@ format="SVG" scale="60"/>
 <!-- The &PRODNAME; and &PRODABBV; are set in the entities at the top of this document -->
 <title>&PRODNAME; Getting Started Guide</title>
 <titleabbrev>&PRODABBV; Intro</titleabbrev>    
-<?rax title.font.size="35px" subtitle.font.size="20px"?
+<?rax title.font.size="35px" subtitle.font.size="20px"
+      status.bar.text="Early Access" 
       canonical.url.base="http://docs.rackspace.com/autoscale/api/v1.0/cas-gettingstarted/content"?>
     <info>
         <releaseinfo>API v1.0</releaseinfo>
@@ -106,7 +107,7 @@ format="SVG" scale="60"/>
                 </revdescription>
             </revision>
         </revhistory>
-        <raxm:metadata>
+        <raxm:metadata role="hidden">
             <raxm:displayname>Getting Started Guide</raxm:displayname>
             <raxm:product version="v1.0">cas</raxm:product>
             <raxm:priority>10</raxm:priority>


### PR DESCRIPTION
- Add Early Access banner.
- Hide entry from landing page.
- Turn on ROBOTs meta tag, Disqus, and turn off social icons.
- Support new olink mechanism.
- Use latest version of clouddocs-maven-plugin
