### PR TITLE
removing hard-coded max entities

### DIFF
--- a/otter/rest/groups.py
+++ b/otter/rest/groups.py
@@ -8,6 +8,7 @@ import json
 from otter import controller
 
 from otter.json_schema.rest_schemas import create_group_request
+from otter.json_schema.group_schemas import MAX_ENTITIES
 from otter.rest.application import app, get_autoscale_links, get_store, transaction_id
 from otter.rest.decorators import (validate_body, fails_with, succeeds_with,
                                    with_transaction_id)
@@ -280,7 +281,7 @@ def create_new_scaling_group(request, log, tenant_id, data):
         }
 
     """
-    data['groupConfiguration'].setdefault('maxEntities', 25)
+    data['groupConfiguration'].setdefault('maxEntities', MAX_ENTITIES)
     data['groupConfiguration'].setdefault('metadata', {})
 
     if data['groupConfiguration']['minEntities'] > data['groupConfiguration']['maxEntities']:

--- a/otter/test/rest/test_groups.py
+++ b/otter/test/rest/test_groups.py
@@ -16,6 +16,7 @@ from otter.json_schema.group_examples import (
     policy as policy_examples)
 
 from otter.json_schema import rest_schemas, validate
+from otter.json_schema.group_schemas import MAX_ENTITIES
 
 from otter.models.interface import (
     GroupState, GroupNotEmptyError, NoSuchScalingGroupError)
@@ -248,7 +249,7 @@ class AllGroupsEndpointTestCase(RestAPITestMixin, TestCase):
         policies = request_body.get('scalingPolicies', [])
 
         expected_config = config.copy()
-        expected_config.setdefault('maxEntities', 25)
+        expected_config.setdefault('maxEntities', MAX_ENTITIES)
         expected_config.setdefault('metadata', {})
 
         rval = {
@@ -300,6 +301,20 @@ class AllGroupsEndpointTestCase(RestAPITestMixin, TestCase):
                 "name": "group",
                 "minEntities": 10,
                 "maxEntities": 10,
+                "cooldown": 10,
+                "metadata": {}
+            },
+            'launchConfiguration': launch_examples()[0]
+        })
+
+    def test_group_create_default_maxentities(self):
+        """
+        A scaling group without maxentities defaults to configured maxEntities
+        """
+        self._test_successful_create({
+            'groupConfiguration': {
+                "name": "group",
+                "minEntities": 10,
                 "cooldown": 10,
                 "metadata": {}
             },


### PR DESCRIPTION
Scaling group creation was hard-coding max entities to 25 even after changing it to 1000 in earlier commit. Now using the value from group_schemas.py
