### PR TITLE
logging scheduler policy exec failure with ids

### DIFF
--- a/otter/scheduler.py
+++ b/otter/scheduler.py
@@ -150,5 +150,5 @@ class SchedulerService(TimerService):
             deleted_policy_ids.add(policy_id)
 
         d.addErrback(collect_deleted_policy)
-        d.addErrback(log.err)
+        d.addErrback(log.err, 'Scheduler failed to execute policy')
         return d

--- a/otter/test/test_scheduler.py
+++ b/otter/test/test_scheduler.py
@@ -386,5 +386,6 @@ class SchedulerTestCase(TestCase):
         d = self.scheduler_service.execute_event(log, event, mock.Mock())
 
         self.assertIsNone(self.successResultOf(d))
-        log.err.assert_called_once_with(CheckFailure(ValueError), tenant_id='1234',
+        log.err.assert_called_once_with(CheckFailure(ValueError),
+                                        'Scheduler failed to execute policy', tenant_id='1234',
                                         scaling_group_id='scal44', policy_id='pol44')


### PR DESCRIPTION
When policy execution fails due `BusyLockError` or any other reason, the error is logged with tenant_id,
group_id and policy_id. Moved the collection of deleted policy ids to execute_event for this
