### PR TITLE
Cleanup get_metrics method. (ready for review)

### DIFF
--- a/otter/models/cass.py
+++ b/otter/models/cass.py
@@ -1046,7 +1046,7 @@ class CassAdmin(object):
             dc.addCallback(_format_result, label)
             return dc
 
-        tables = ['scaling_config', 'scaling_policies', 'policy_webhooks']
+        tables = ['scaling_group', 'scaling_policies', 'policy_webhooks']
         labels = ['groups', 'policies', 'webhooks']
         mapping = zip(tables, labels)
 

--- a/otter/test/models/test_cass_models.py
+++ b/otter/test/models/test_cass_models.py
@@ -2156,7 +2156,7 @@ class CassAdminTestCase(TestCase):
                 'time': 1234567890
             }
         ]
-        config_query = ('SELECT COUNT(*) FROM scaling_config;')
+        config_query = ('SELECT COUNT(*) FROM scaling_group;')
         policy_query = ('SELECT COUNT(*) FROM scaling_policies;')
         webhook_query = ('SELECT COUNT(*) FROM policy_webhooks;')
 


### PR DESCRIPTION
Formatting only happens on a single result, and association between
field and label is now easier to maintain.

The test was changed because `list.append` is no longer used, and thus the order is different.
