### PR TITLE
fixed failing without-server-name in launch config test (ready for review)

### DIFF
--- a/autoscale_cloudroast/test_repo/autoscale/fixtures.py
+++ b/autoscale_cloudroast/test_repo/autoscale/fixtures.py
@@ -245,7 +245,7 @@ class AutoscaleFixture(BaseTestFixture):
         list_servers_on_tenant = self.server_client.list_servers_with_detail().entity
         metadata_list = [self.autoscale_behaviors.to_data(each_server.metadata) for each_server
                          in list_servers_on_tenant]
-        group_ids_list_from_metadata = [each['rax:auto_scaling_group_id'] for each in metadata_list]
+        group_ids_list_from_metadata = [each.get('rax:auto_scaling_group_id') for each in metadata_list]
         return group_ids_list_from_metadata.count(group_id)
 
     def wait_for_expected_number_of_active_servers(self, group_id, expected_servers,


### PR DESCRIPTION
Sometimes the metadata is not yet set on some servers while building, or that the metadata is being deleted first, while the servers is in 'deleting' status, due to which the test is failing with a key error, hence the change. 
