### PR TITLE
scheduler batch tests (ready for review)

### DIFF
--- a/autoscale_cloudroast/test_repo/autoscale/system/schedule_policies/test_system_execute_scheduler_negative.py
+++ b/autoscale_cloudroast/test_repo/autoscale/system/schedule_policies/test_system_execute_scheduler_negative.py
@@ -130,8 +130,8 @@ class ExecuteNegativeSchedulerPolicy(AutoscaleFixture):
         of them are executed in the batch size specified.
         """
         at_style_policies_list = []
-        size = 2
-        at_style_time = self.autoscale_behaviors.get_time_in_utc(3)
+        size = 1
+        at_style_time = self.autoscale_behaviors.get_time_in_utc(10)
         for policy in (range(self.scheduler_batch * size)):
             policy = {
                 'args': {'at': at_style_time},
@@ -140,14 +140,14 @@ class ExecuteNegativeSchedulerPolicy(AutoscaleFixture):
                 'name': 'multi_at_style{0}'.format(policy),
                 'change': 1}
             at_style_policies_list.append(policy)
-        create_group_reponse = self.autoscale_behaviors.create_scaling_group_given(
+        create_group_response = self.autoscale_behaviors.create_scaling_group_given(
             lc_name='scheduler_batch_size_check', gc_cooldown=0,
             sp_list=at_style_policies_list)
-        self.resources.add(
-            create_group_reponse.entity, self.empty_scaling_group)
+        group = create_group_response.entity
+        self.resources.add(group, self.empty_scaling_group)
         sleep(self.scheduler_interval * 2)
-        self.verify_group_state(
-            create_group_reponse.entity.id, self.scheduler_batch * size)
+        self.check_for_expected_number_of_building_servers(group.id, self.scheduler_batch * size)
+        self.verify_group_state(group.id, self.scheduler_batch * size)
 
     @tags(speed='slow')
     def test_create_multiple_scheduler_policies_to_execute_simaltaneously(self):

--- a/autoscale_cloudroast/test_repo/autoscale/system/schedule_policies/test_system_multi_scheduler_webhook_policies.py
+++ b/autoscale_cloudroast/test_repo/autoscale/system/schedule_policies/test_system_multi_scheduler_webhook_policies.py
@@ -125,6 +125,25 @@ class MultipleSchedulerWebhookPoliciesTest(AutoscaleFixture):
             wb_policy_cp, at_style_policy_cp, cron_style_policy_cp,
             wb_policy_dc, at_style_policy_dc, cron_style_policy_dc)
 
+    @tags(speed='quick')
+    def test_system_webhook_and_scheduler_policies_many_different_groups(self):
+        """
+        Create many groups each with the same type of scheduler and webhook policies and
+        verify the servers after each of their executions
+        """
+        at_style_policy = dict(
+            args=dict(at=self.autoscale_behaviors.get_time_in_utc(30)),
+            cooldown=self.gc_cooldown, type='schedule', name='multi_at_style',
+            change=self.change)
+        group_list = []
+        for each in range(4):
+            group = self._create_multi_policy_group(1, 201, at_style_policy)
+            group_list.append(group.id)
+        sleep(self.scheduler_interval + 30)
+        for each_group in group_list:
+            self.verify_group_state(each_group, self.change)
+            self.verify_server_count_using_server_metadata(each_group, self.change)
+
     def _unchanged_policy(self, policy_list):
         return {i: policy_list[i] for i in policy_list if i != 'change'}
 


### PR DESCRIPTION
- added test for many groups with scheduled polices to execute at the same time
- included assert on server count for the scheduler batch size test
- reduced the number of servers built in both the tests, to a minimum
