### PR TITLE
Auto 722 force delete errors

### DIFF
--- a/otter/rest/groups.py
+++ b/otter/rest/groups.py
@@ -489,15 +489,13 @@ class OtterGroup(object):
                 return group.update_config(_config)
             d.addCallback(update_config)
 
-            def view_state(_):
-                return group.view_state()
-            d.addCallback(view_state)
-
-            def obey_config(group_state):
+            def modify_state(_):
                 _config = config[0]
-                return controller.obey_config_change(
-                    self.log, transaction_id(request), _config, group, group_state)
-            d.addCallback(obey_config)
+                d = group.modify_state(
+                    partial(controller.obey_config_change, self.log,
+                            transaction_id(request), _config))
+                return d
+            d.addCallback(modify_state)
 
             return d.addCallback(lambda _: group.delete_group())
         else:

--- a/otter/test/rest/test_groups.py
+++ b/otter/test/rest/test_groups.py
@@ -679,10 +679,13 @@ class OneGroupTestCase(RestAPITestMixin, TestCase):
         """
         Deleting a group with force sets min/max to zero and deletes it.
         """
+        self.mock_controller = patch(self, 'otter.rest.groups.controller')
+
         self.mock_group.view_config.return_value = defer.succeed(
             {'name': 'group1', 'minEntities': '10', 'maxEntities': '1000'})
         self.mock_group.delete_group.return_value = defer.succeed(None)
         self.mock_group.update_config.return_value = defer.succeed(None)
+        self.mock_controller.obey_config_change.return_value = defer.succeed(None)
 
         self.assert_status_code(
             204, endpoint="{0}?force=true".format(self.endpoint),
@@ -690,15 +693,19 @@ class OneGroupTestCase(RestAPITestMixin, TestCase):
 
         self.mock_group.update_config.assert_called_once_with(
             {'maxEntities': 0, 'minEntities': 0, 'name': 'group1'})
+        self.assertEqual(1, self.mock_controller.obey_config_change.call_count)
         self.mock_group.delete_group.assert_called_once_with()
 
     def test_group_delete_force_case_insensitive(self):
         """
         The 'true' specified in force is case insensitive.
         """
+        self.mock_controller = patch(self, 'otter.rest.groups.controller')
+
         self.mock_group.view_config.return_value = defer.succeed({'name': 'group1'})
         self.mock_group.delete_group.return_value = defer.succeed(None)
         self.mock_group.update_config.return_value = defer.succeed(None)
+        self.mock_controller.obey_config_change.return_value = defer.succeed(None)
 
         self.assert_status_code(
             204, endpoint="{0}?force=true".format(self.endpoint),
@@ -706,6 +713,7 @@ class OneGroupTestCase(RestAPITestMixin, TestCase):
 
         self.mock_group.update_config.assert_called_once_with(
             {'maxEntities': 0, 'minEntities': 0, 'name': 'group1'})
+        self.assertEqual(1, self.mock_controller.obey_config_change.call_count)
         self.mock_group.delete_group.assert_called_once_with()
 
     def test_group_delete_force_garbage_arg(self):


### PR DESCRIPTION
Force delete changes in this branch:
- Only allow "true" as a valid argument to force (otherwise, don't specify it)
- Make "true" case insensitive.
- Fetch the config, update min/max, and then set that new (complete) config
