### PR TITLE
Initial RBAC role annotations.

### DIFF
--- a/docbook/src/wadl/autoscale.wadl
+++ b/docbook/src/wadl/autoscale.wadl
@@ -449,7 +449,7 @@
           &commonFaults; &getFaults; &postPutFaults; 
     </method>
 
-    <method id="getGroups" name="GET" rax:roles="autoscale:observer">
+    <method id="getGroups" name="GET" rax:roles="observer autoscale:observer">
         <wadl:doc title="List Scaling Groups" xml:lang="EN"
             xmlns="http://docbook.org/ns/docbook">
             <para role="shortdesc">
@@ -469,7 +469,7 @@
         &commonFaults; &getFaults;  
     </method>
 
-    <method id="getGroupManifest" name="GET" rax:roles="autoscale:observer">
+    <method id="getGroupManifest" name="GET" rax:roles="observer autoscale:observer">
         <wadl:doc title="List All Group Details" xmlns="http://docbook.org/ns/docbook">
             <para role="shortdesc">
                 This operation returns details about the configuration for a specified autoscaling group.
@@ -505,7 +505,7 @@
         &commonFaults; &getFaults; &postPutFaults; 
     </method>
 
-    <method id="getGroupState" name="GET" rax:roles="autoscale:observer">
+    <method id="getGroupState" name="GET" rax:roles="observer autoscale:observer">
         <doc title="Get Group State">
             <db:para role="shortdesc">
                This operation returns the state of an autoscaling group.
@@ -528,7 +528,7 @@
         &commonFaults; &getFaults; 
     </method>
 
-    <method id="getGroupConfig" name="GET" rax:roles="autoscale:observer">
+    <method id="getGroupConfig" name="GET" rax:roles="observer autoscale:observer">
         <doc title="Get Group Configuration">
             <db:para role="shortdesc">
                This operation lists the configuration for an autoscaling group.
@@ -579,7 +579,7 @@
         &commonFaults; &getFaults; &postPutFaults; 
     </method>
 
-    <method id="getLaunchConfig" name="GET" rax:roles="autoscale:observer">
+    <method id="getLaunchConfig" name="GET" rax:roles="observer autoscale:observer">
         <doc title="Get Launch Configuration">
             <db:para role="shortdesc">
                 This operation lists the launch configuration.
@@ -668,7 +668,7 @@
         &commonFaults; &getFaults; &postPutFaults; 
     </method>
 
-    <method name="GET" id="getPolicies" rax:roles="autoscale:observer">
+    <method name="GET" id="getPolicies" rax:roles="observer autoscale:observer">
         <doc title="Get Policies List">
             <db:para role="shortdesc">
                 This operation lists scaling policies in the autoscaling group.
@@ -690,7 +690,7 @@
         &commonFaults; &getFaults; 
     </method>
 
-    <method name="POST" id="createPolicies" rax:roles="creator autoscale:creator">
+    <method name="POST" id="createPolicies" rax:roles="autoscale:creator">
         <doc title="Create Policy">
             <db:para role="shortdesc">
                 This operation creates an autoscaling policy.
@@ -771,7 +771,7 @@
         &commonFaults; &getFaults; &postPutFaults; 
     </method>
 
-    <method name="GET" id="getPolicy" rax:roles="autoscale:observer">
+    <method name="GET" id="getPolicy" rax:roles="observer autoscale:observer">
         <doc title="Get Policy Details">
             <db:para role="shortdesc">
                 This operation returns details for a specified autoscaling policy.
@@ -849,7 +849,7 @@
         &commonFaults; &getFaults; &postPutFaults; 
     </method>
 
-    <method name="GET" id="getWebhooks" rax:roles="autoscale:observer">
+    <method name="GET" id="getWebhooks" rax:roles="observer autoscale:observer">
         <doc title="Get a list of webhooks for the policy">
             <db:para role="shortdesc">
                 This operation obtains a list of webhooks for the autoscaling policy.
@@ -869,7 +869,7 @@
         &commonFaults; &getFaults; &postPutFaults; 
     </method>
 
-    <method id="createWebhook" name="POST" rax:roles="creator autoscale:creator">
+    <method id="createWebhook" name="POST" rax:roles="autoscale:creator">
         <doc title="Create a webhook">
             <db:para role="shortdesc">
                 This operation creates a webhook.
@@ -898,7 +898,7 @@
         &commonFaults; &getFaults; &postPutFaults; 
     </method>
 
-    <method id="getWebhook" name="GET" rax:roles="autoscale:observer">
+    <method id="getWebhook" name="GET" rax:roles="observer autoscale:observer">
         <doc title="View Webhook">
             <db:para role="shortdesc">
                 This operation returns the description for a webhook.


### PR DESCRIPTION
# About the patch

Started the process of setting  rax:roles attributes -- these will be used by Repose to add RBAC capabilities to the API.  You should complete the process and let the Repose team know when you're done.
# How rax:roles works

`rax:roles` is an attribute that can be added to a resource or a method.  The attribute denotes what which roles have access to a resource or method.  It  can contain the name of one or more roles separated by whitespace. There is a special role named `#all` this means anyone can access the resource or method. 

When added to a resource the role has access to that resource all of its methods and sub-resources.

Example:

``` xml
<resource id="version" path="v1.0/" rax:roles="admin autoscale:admin">
     <method name="GET" />
     <resource path="foo">
             <method name="GET" rax:roles="observer"/>
      </resource>
      <resource path="bar">
              <method name="PUT"/>
      </resource>
</resource>
```

Will give you:

<table>
    <tr>
       <th>Method</th>  <th>URI</th> <th>admin</th><th>autoscale:admin</th><th>observer</th>
    </tr>
    <tr>
          <td>GET</td>  <td>v1</td> <td>X</td><td>X</td><td>  </td>
    </tr><tr>
          <td>GET</td>  <td>v1/foo</td> <td>X</td><td>X</td><td>X</td>
    </tr><tr>
          <td>PUT</td>  <td>v1/bar</td> <td>X</td><td>X</td><td> </td>
    </tr>
</table>

# About  Roles

All products must support the  Global Admin ( `admin`) and  Global Observer (`observer`) roles.  A global admin has access to all API calls (but is bound to a single tenant).  A global observer can read data, but cannot create, delete, or otherwise modify resources.

Aside from the global roles you must support the following product specific roles:

`autoscale:admin`  :  like global `admin` but the privileged is specific to the auto scale api.
`autoscale:observer` : like global  `observer` but specific to only the auto scale api.
`autoscale:creator`  : may create auto scale resources, but not necessarily delete them
`autoscale:service-admin` : this is an optional role, it should allow access to the API across tenants. Only users with the right to administrate the auto scale service should have these roles.

It's important that you make sure product specific roles get created in global auth.
# What's Next

We are still working on adding `rax:roles` capabilities in Repose.  Once those capabilities are added you can use this WADL directly. In the interim, you can supply this  WADL to the repose team and we'll use that to generate configs that will work with Repose today.
