### PR TITLE
Adding initial documentation to error code responses

### DIFF
--- a/docbook/src/common/common.ent
+++ b/docbook/src/common/common.ent
@@ -5,34 +5,41 @@
      -->
      <!ENTITY commonFaults
            '
-        <response xmlns="http://wadl.dev.java.net/2009/02">
-            <representation mediaType="application/xml" element="identity:identityFault"/>
-            <representation mediaType="application/json"/>
-        </response>
-        <response status="400" xmlns="http://wadl.dev.java.net/2009/02">
-            <representation mediaType="application/xml" element="identity:badRequest"/>
-            <representation mediaType="application/json"/>
-        </response>
-        <response status="401" xmlns="http://wadl.dev.java.net/2009/02">
-            <representation mediaType="application/xml" element="identity:unauthorized"/>
-            <representation mediaType="application/json"/>
-        </response>
-        <response status="403" xmlns="http://wadl.dev.java.net/2009/02">
-            <representation mediaType="application/xml" element="identity:forbidden"/>
-            <representation mediaType="application/json"/>
-        </response>
-        <response status="405" xmlns="http://wadl.dev.java.net/2009/02">
-            <representation mediaType="application/xml" element="identity:badMethod"/>
-            <representation mediaType="application/json"/>
-        </response>
-        <response status="413" xmlns="http://wadl.dev.java.net/2009/02">
-            <representation mediaType="application/xml" element="identity:overLimit"/>
-            <representation mediaType="application/json"/>
-        </response>
-        <response status="503" xmlns="http://wadl.dev.java.net/2009/02">
-            <representation mediaType="application/xml" element="identity:serviceUnavailable"/>
-            <representation mediaType="application/json"/>
-        </response>
+          <response xmlns="http://wadl.dev.java.net/2009/02">
+              <doc title="Identity fault"></doc>
+              <representation mediaType="application/xml" element="identity:identityFault"/>
+              <representation mediaType="application/json"/>
+          </response>
+          <response status="400" xmlns="http://wadl.dev.java.net/2009/02">
+              <doc title="Error">A general error occured.</doc>
+              <representation mediaType="application/xml" element="identity:badRequest"/>
+              <representation mediaType="application/json"/>
+          </response>
+          <response status="401" xmlns="http://wadl.dev.java.net/2009/02">
+              <doc title="Bad Request">The format of the specified request is invalid.</doc>
+              <representation mediaType="application/xml" element="identity:unauthorized"/>
+              <representation mediaType="application/json"/>
+          </response>
+          <response status="403" xmlns="http://wadl.dev.java.net/2009/02">
+              <doc title="Forbidden"></doc>
+              <representation mediaType="application/xml" element="identity:forbidden"/>
+              <representation mediaType="application/json"/>
+          </response>
+          <response status="405" xmlns="http://wadl.dev.java.net/2009/02">
+               <doc title="Bad Method">The method is unavailable</doc>
+              <representation mediaType="application/xml" element="identity:badMethod"/>
+              <representation mediaType="application/json"/>
+          </response>
+          <response status="413" xmlns="http://wadl.dev.java.net/2009/02">
+              <doc title="Over Limit">The number of items returned is above the allowed limit.</doc>
+              <representation mediaType="application/xml" element="identity:overLimit"/>
+              <representation mediaType="application/json"/>
+          </response>
+          <response status="503" xmlns="http://wadl.dev.java.net/2009/02">
+              <doc title="Service Unavailable">The requested service is unavailable.</doc>
+              <representation mediaType="application/xml" element="identity:serviceUnavailable"/>
+              <representation mediaType="application/json"/>
+          </response>
            '>
       <!--
           Faults on GET
@@ -40,6 +47,7 @@
      <!ENTITY getFaults
            '
         <response status="404" xmlns="http://wadl.dev.java.net/2009/02">
+            <doc title="File not found">Resource not found.</doc>
             <representation mediaType="application/xml" element="identity:itemNotFound"/>
             <representation mediaType="application/json"/>
         </response>


### PR DESCRIPTION
This is to show how the markup should look. I can't vouch for the
text. Once I cut a new release of the plugin, the result will look like this:

http://docs-beta.rackspace.com/drafts/david/autoscale-devguide-responseTables/content/GET_getGroups_v1.0__tenantId__groups_Groups.html
