### PR TITLE
Single method that binds the audit log keyword (ready for review)

### DIFF
--- a/otter/log/__init__.py
+++ b/otter/log/__init__.py
@@ -8,6 +8,7 @@ from twisted.python.log import msg, err
 
 log = BoundLog(msg, err).bind(system='otter')
 
+
 def audit(log):
     """
     Single method to ensure that the log object is an audit log (by binding
@@ -21,5 +22,3 @@ def audit(log):
 
 
 __all__ = ['observer_factory', 'observer_factory_debug', 'log']
-
-

--- a/otter/test/test_log.py
+++ b/otter/test/test_log.py
@@ -62,16 +62,25 @@ class AuditLoggerTests(TestCase):
     Test the method that binds the audit log
     """
     def setUp(self):
+        """
+        Set up the mocks and a new BoundLog.
+        """
         self.msg = mock.Mock()
         self.err = mock.Mock()
         self.log = BoundLog(self.msg, self.err)
 
     def test_audit_msg(self):
+        """
+        audit_log keyword is bound when msg is called
+        """
         auditlog = audit(self.log)
         auditlog.msg('hey')
         self.msg.assert_called_once_with('hey', audit_log=True)
 
     def test_audit_err(self):
+        """
+        audit_log keyword is bound when err is called
+        """
         exc = ValueError('boo')
         auditlog = audit(self.log)
         auditlog.err(exc)


### PR DESCRIPTION
Thanks Manish for suggesting this, that way although everything has to import the audit function, the keyword is consistent everywhere and not just hard coded.
