### PR TITLE
Audit log formatter (might be ready for review)

### DIFF
--- a/otter/log/formatters.py
+++ b/otter/log/formatters.py
@@ -162,7 +162,6 @@ def audit_log_formatter(eventDict, timestamp):
     audit_log_params = {
         "@version": 1,
         "@timestamp": timestamp,
-        "level": eventDict.get("level", 6),
         "is_error": False
     }
 
@@ -175,7 +174,6 @@ def audit_log_formatter(eventDict, timestamp):
             str(m) for m in eventDict["message"]])
 
     if eventDict.get("isError", False):
-        audit_log_params['level'] = 3
         audit_log_params["is_error"] = True
 
         # create the fault dictionary, if it doesn't exist, without clobbering

--- a/otter/test/test_log.py
+++ b/otter/test/test_log.py
@@ -444,7 +444,6 @@ class AuditLogFormatterTests(TestCase):
                 '@version': 1,
                 '_message': 'Hello',
                 '@timestamp': 0,
-                'level': 6,
                 'is_error': False
             })
 
@@ -459,7 +458,6 @@ class AuditLogFormatterTests(TestCase):
                 '@version': 1,
                 '_message': 'Failed: meh.',
                 '@timestamp': 0,
-                'level': 3,
                 'is_error': True,
                 'fault': {'details': {}}
             })
@@ -475,7 +473,6 @@ class AuditLogFormatterTests(TestCase):
                 '@version': 1,
                 '_message': 'Failed: meh. is the sky blue',
                 '@timestamp': 0,
-                'level': 3,
                 'is_error': True,
                 'fault': {'details': {}}
             })
@@ -491,7 +488,6 @@ class AuditLogFormatterTests(TestCase):
                 '@version': 1,
                 '_message': 'Failed: meh.',
                 '@timestamp': 0,
-                'level': 3,
                 'is_error': True,
                 'fault': {'details': {}, 'message': 'boo'}
             })
@@ -508,7 +504,6 @@ class AuditLogFormatterTests(TestCase):
                 '@version': 1,
                 '_message': 'Failed: meh.',
                 '@timestamp': 0,
-                'level': 3,
                 'is_error': True,
                 'fault': {
                     'message': '1',
@@ -531,7 +526,6 @@ class AuditLogFormatterTests(TestCase):
                 '@version': 1,
                 '_message': 'Failed: meh.',
                 '@timestamp': 0,
-                'level': 3,
                 'is_error': True,
                 'fault': {
                     'message': '1',
@@ -558,7 +552,6 @@ class AuditLogFormatterTests(TestCase):
                 '@version': 1,
                 '_message': 'Failed: meh.',
                 '@timestamp': 0,
-                'level': 3,
                 'is_error': True,
                 'scaling_group_id': '5',
                 'tenant_id': '5',


### PR DESCRIPTION
On its own it's ready for review.  I've tested this by arbitrarily setting `audit_log=True` on the `succeeds_with` logging and hit an endpoint, and saw two logs emitted, not in much detail.

Emitting 2 logs instead of 1 so that less filtering on the endpoint has to happen, and also just in case the combined log is too big.  We seem to be having some issues with tracebacks and whatnot, so I just wanted to make sure if there was some issue 1 clean audit log would at least make it.

Could combine them eventually to be the same log, and just do more filtering in the history endpoint.

I'd like to actually finish one of the logging rest request issues and run it with this formatter though before merging it.

Caveats: formatting of _message with "Failure" might be a mistake.
