### PR TITLE
Mock kz client in rest test case (ready for review)

### DIFF
--- a/otter/test/unitgration/test_rest_cass_model.py
+++ b/otter/test/unitgration/test_rest_cass_model.py
@@ -318,6 +318,7 @@ class CassStoreRestScalingPolicyTestCase(TestCase, RequestTestMixin, LockMixin):
         """
         keyspace.resume()
         self.root = Otter(store).app.resource()
+        store.kz_client = mock.Mock(Lock=self.mock_lock())
 
         set_config_data(limits)
         self.addCleanup(set_config_data, {})


### PR DESCRIPTION
If the non-scaling policy tests ran after the general group tests, they pass, because the client has already been set on the store, since the store itself is created on import.

Set the client in both test cases.
