### PR TITLE
Update schedule policy no args change bugfix

### DIFF
--- a/otter/models/cass.py
+++ b/otter/models/cass.py
@@ -682,7 +682,7 @@ class CassScalingGroup(object):
             if "type" in lastRev:
                 if lastRev["type"] != data["type"]:
                     raise ValidationError("Cannot change type of a scaling policy")
-                if lastRev["type"] == 'schedule' and lastRev['args'] != data['args']:
+                if lastRev["type"] == 'schedule':
                     _build_schedule_policy(data, self.event_table, queries,
                                            cqldata, '', self.buckets)
 


### PR DESCRIPTION
If schedule policy is updated without any args change, then it'll not be scheduled. This is because policy is updated with new version and existing entry in scaling_schedule table is with old version.

Now changed to insert in scaling_schedule table with new version
