### PR TITLE
Locking on a group. NOT as a whole

### DIFF
--- a/otter/models/cass.py
+++ b/otter/models/cass.py
@@ -542,7 +542,7 @@ class CassScalingGroup(object):
             d.addCallback(lambda state: modifier_callable(self, state, *args, **kwargs))
             return d.addCallback(_write_state)
 
-        lock = self.kz_client.Lock(LOCK_PATH, self.uuid)
+        lock = self.kz_client.Lock(LOCK_PATH + '/' + self.uuid)
         lock.acquire = functools.partial(lock.acquire, timeout=120)
         # TODO: Better way to get reactor instead of importing?
         return with_lock(reactor, lock, log.bind(category='locking'), _modify_state)
@@ -893,7 +893,7 @@ class CassScalingGroup(object):
             d.addCallback(_maybe_delete)
             return d
 
-        lock = self.kz_client.Lock(LOCK_PATH, self.uuid)
+        lock = self.kz_client.Lock(LOCK_PATH + '/' + self.uuid)
         lock.acquire = functools.partial(lock.acquire, timeout=120)
         return with_lock(reactor, lock, log.bind(category='locking'), _delete_group)
 

--- a/otter/test/models/test_cass_models.py
+++ b/otter/test/models/test_cass_models.py
@@ -401,7 +401,7 @@ class CassScalingGroupTests(CassScalingGroupTestCase):
                                                         expectedData,
                                                         ConsistencyLevel.TWO)
 
-        self.kz_lock.Lock.assert_called_once_with('/locks', self.group.uuid)
+        self.kz_lock.Lock.assert_called_once_with('/locks/' + self.group.uuid)
 
         self.lock._acquire.assert_called_once_with(timeout=120)
         self.lock.release.assert_called_once_with()
@@ -424,6 +424,7 @@ class CassScalingGroupTests(CassScalingGroupTestCase):
         self.failureResultOf(d, ValueError)
 
         self.assertEqual(self.connection.execute.call_count, 0)
+        self.kz_lock.Lock.assert_called_once_with('/locks/' + self.group.uuid)
         self.lock._acquire.assert_called_once_with(timeout=120)
         self.assertEqual(self.lock.release.call_count, 0)
 
@@ -1517,6 +1518,7 @@ class CassScalingGroupTests(CassScalingGroupTestCase):
         self.connection.execute.assert_called_once_with(
             expected_cql, expected_data, ConsistencyLevel.TWO)
 
+        self.kz_lock.Lock.assert_called_once_with('/locks/' + self.group.uuid)
         self.lock._acquire.assert_called_once_with(timeout=120)
         self.lock.release.assert_called_once_with()
 
@@ -1551,6 +1553,7 @@ class CassScalingGroupTests(CassScalingGroupTestCase):
         self.connection.execute.assert_called_once_with(
             expected_cql, expected_data, ConsistencyLevel.TWO)
 
+        self.kz_lock.Lock.assert_called_once_with('/locks/' + self.group.uuid)
         self.lock._acquire.assert_called_once_with(timeout=120)
         self.lock.release.assert_called_once_with()
 
@@ -1568,6 +1571,7 @@ class CassScalingGroupTests(CassScalingGroupTestCase):
         self.failureResultOf(d, ValueError)
 
         self.assertFalse(self.connection.execute.called)
+        self.kz_lock.Lock.assert_called_once_with('/locks/' + self.group.uuid)
         self.lock._acquire.assert_called_once_with(timeout=120)
 
     @mock.patch('otter.models.cass.CassScalingGroup.view_state')


### PR DESCRIPTION
Currently, the lock is acquired globally. That is any group's delete and modify will be locked. Now, changed it to that particular group
