### PR TITLE
delete_server succeeds on 404

### DIFF
--- a/otter/test/worker/test_launch_server_v1.py
+++ b/otter/test/worker/test_launch_server_v1.py
@@ -1157,7 +1157,7 @@ class DeleteServerTests(TestCase):
         d = delete_server(self.log, 'DFW', fake_service_catalog,
                           'my-auth-token', instance_details)
         self.successResultOf(d)
-        self.log.msg.assert_any_call('Server to delete does not exist')
+        self.log.msg.assert_any_call('Server to delete does not exist', server_id='a')
 
     @mock.patch('otter.worker.launch_server_v1.remove_from_load_balancer')
     def test_delete_server_propagates_loadbalancer_failures(
@@ -1215,6 +1215,7 @@ class DeleteServerTests(TestCase):
                                                  headers=expected_headers)
         self.treq.head.assert_called_once_with('http://url/servers/serverId',
                                                headers=expected_headers)
+        self.log.msg.assert_called_with(mock.ANY, server_id='serverId')
 
     def test_verified_delete_propagates_delete_server_api_failures(self):
         """
@@ -1302,7 +1303,8 @@ class DeleteServerTests(TestCase):
             mock.call('http://url/servers/serverId', headers=expected_headers),
             mock.call('http://url/servers/serverId', headers=expected_headers)
         ])
-        self.log.err.assert_called_once_with(CheckFailure(TimedOutError))
+        self.log.err.assert_called_once_with(CheckFailure(TimedOutError),
+                                             server_id='serverId')
 
         # the loop has stopped
         clock.advance(5)

--- a/otter/worker/launch_server_v1.py
+++ b/otter/worker/launch_server_v1.py
@@ -502,14 +502,15 @@ def verified_delete(log,
 
     :return: Deferred that fires when the expected status has been seen.
     """
-    log.msg('Deleting server')
+    serv_log = log.bind(server_id=server_id)
+    serv_log.msg('Deleting server')
 
     path = append_segments(server_endpoint, 'servers', server_id)
     d = treq.delete(path, headers=headers(auth_token))
 
     def log_404(response):
         if response.code == 404:
-            log.msg('Server to delete does not exist')
+            serv_log.msg('Server to delete does not exist')
         return response
 
     d.addCallback(log_404)
@@ -540,11 +541,11 @@ def verified_delete(log,
 
         def on_success(_):
             time_delete = clock.seconds() - start_time
-            log.msg('Server deleted successfully: {time_delete} seconds.',
-                    time_delete=time_delete)
+            serv_log.msg('Server deleted successfully: {time_delete} seconds.',
+                         time_delete=time_delete)
 
         verify_d.addCallback(on_success)
-        verify_d.addErrback(log.err)
+        verify_d.addErrback(serv_log.err)
 
     d.addCallback(verify)
     return d


### PR DESCRIPTION
If server to delete does not exist, we are good. Also, removed `instance_id` log binding as `delete_server` is called with `server_id` bound log
