### PR TITLE
AUTO-606: Having all server logs bound to `server_id`

### DIFF
--- a/otter/supervisor.py
+++ b/otter/supervisor.py
@@ -120,7 +120,7 @@ class SupervisorService(object, Service):
             # to pass to the controller to store in the active state is returned
             server_details, lb_info = result
             log.msg("Done executing launch config.",
-                    instance_id=server_details['server']['id'])
+                    server_id=server_details['server']['id'])
             return {
                 'id': server_details['server']['id'],
                 'links': server_details['server']['links'],

--- a/otter/worker/launch_server_v1.py
+++ b/otter/worker/launch_server_v1.py
@@ -330,17 +330,9 @@ def launch_server(log, region, scaling_group, service_catalog, auth_token,
     cloudLoadBalancers = config_value('cloudLoadBalancers')
     cloudServersOpenStack = config_value('cloudServersOpenStack')
 
-    log.msg("Looking for load balancer endpoint",
-            service_name=cloudLoadBalancers,
-            region=lb_region)
-
     lb_endpoint = public_endpoint_url(service_catalog,
                                       cloudLoadBalancers,
                                       lb_region)
-
-    log.msg("Looking for cloud servers endpoint",
-            service_name=cloudServersOpenStack,
-            region=region)
 
     server_endpoint = public_endpoint_url(service_catalog,
                                           cloudServersOpenStack,
@@ -360,7 +352,7 @@ def launch_server(log, region, scaling_group, service_catalog, auth_token,
         undo.push(
             verified_delete, log, server_endpoint, auth_token, server_id)
 
-        ilog = log.bind(instance_id=server_id)
+        ilog = log.bind(server_id=server_id)
         return wait_for_active(
             ilog,
             server_endpoint,
@@ -439,17 +431,9 @@ def delete_server(log, region, service_catalog, auth_token, instance_details):
     cloudLoadBalancers = config_value('cloudLoadBalancers')
     cloudServersOpenStack = config_value('cloudServersOpenStack')
 
-    log.msg("Looking for load balancer endpoint: %(service_name)s",
-            service_name=cloudLoadBalancers,
-            region=lb_region)
-
     lb_endpoint = public_endpoint_url(service_catalog,
                                       cloudLoadBalancers,
                                       lb_region)
-
-    log.msg("Looking for cloud servers endpoint: %(service_name)s",
-            service_name=cloudServersOpenStack,
-            region=region)
 
     server_endpoint = public_endpoint_url(service_catalog,
                                           cloudServersOpenStack,


### PR DESCRIPTION
instead of `instance_id`. Also removed "Looking for endpoint" messages as they are not really required.
