### PR TITLE
Option to not cancel during timeout (in progress)

### DIFF
--- a/otter/util/deferredutils.py
+++ b/otter/util/deferredutils.py
@@ -52,7 +52,7 @@ class TimedOutError(Exception):
                 desc=deferred_description, timeout=timeout))
 
 
-def timeout_deferred(deferred, timeout, clock, deferred_description=None):
+def timeout_deferred(deferred, timeout, clock, deferred_description=None, cancel=None):
     """
     Time out a deferred - schedule for it to be canceling it after ``timeout``
     seconds from now, as per the clock.
@@ -69,6 +69,7 @@ def timeout_deferred(deferred, timeout, clock, deferred_description=None):
         Deferred's purpose - if not provided, defaults to the ``repr`` of the
         Deferred.  To be passed to :class:`TimedOutError` for a pretty
         Exception string.
+    :param func cancel: Function called when timing out instead of cancelling the deferred
     :param IReactorTime clock: Clock to be used to schedule the timeout -
         used for testing.
 
@@ -80,7 +81,10 @@ def timeout_deferred(deferred, timeout, clock, deferred_description=None):
 
     def time_it_out():
         timed_out[0] = True
-        deferred.cancel()
+        if cancel:
+            cancel()
+        else:
+            deferred.cancel()
 
     delayed_call = clock.callLater(timeout, time_it_out)
 
@@ -105,23 +109,16 @@ def timeout_deferred(deferred, timeout, clock, deferred_description=None):
 
 def _retry_without_cancel(do_work, timeout, can_retry, next_interval, clock,
                           deferred_description):
+    """
+    Similar to `retry_and_timeout` except that it does not cancel currently
+    running work if timeout occurs. It waits for that to complete
+    """
 
     retrier = _Retrier(do_work, can_retry, next_interval, clock)
     deferred = retrier.start()
-
-    stop_d = Deferred(retrier.stop)
-    timeout_deferred(stop_d)
-
-    deferred.chainDeferred(stop_d)
-
-    def convert_timeout(f):
-        # if we timed it out, convert it to a TimedOutError.
-        # Otherwise, propagate it.
-        f.trap(CancelledError)
-        raise TimedOutError(timeout, deferred_description)
-
-    stop_d.addErrback(convert_timeout)
-    return stop_d
+    timeout_deferred(deferred, timeout, clock=clock,
+                     deferred_description=deferred_description, cancel=retrier.stop)
+    return deferred
 
 
 def retry_and_timeout(do_work, timeout, can_retry=None, next_interval=None,

--- a/otter/util/retry.py
+++ b/otter/util/retry.py
@@ -115,7 +115,9 @@ class _Retrier(object):
 
     def stop(self):
         """
-        Stop retrying by cancelling next schedule
+        Stop retrying by cancelling next schedule but will not disturb currently
+        running operation. Use start()'s deferred.cancel() to stop retrying and stop
+        currently running operation
         """
         self.cancelled = True
         if self.delayed_call is not None:


### PR DESCRIPTION
Added option to not cancel currently running operation during timeout in `retry_and_timeout` method. This is needed since without it doing LB add/remove using this method can be dangerous. This is because It is possible that add/remove can get cancelled and otter will think that operation did not complete whereas request might've reached LB and operation could've taken place. 

This solution may not be correct. Yet to write tests and confirm. Would love if @wirehead or @cyli can take a look at it.
