### PR TITLE
All deletes are finished before shutdown

### DIFF
--- a/otter/supervisor.py
+++ b/otter/supervisor.py
@@ -154,6 +154,7 @@ class SupervisorService(object, Service):
         d = self.auth_function(scaling_group.tenant_id)
         log.msg("Authenticating for tenant")
         d.addCallback(when_authenticated)
+        self.deferred_pool.add(d)
 
         return d
 

--- a/otter/test/test_supervisor.py
+++ b/otter/test/test_supervisor.py
@@ -237,6 +237,15 @@ class DeleteServerTests(SupervisorTests):
             self.auth_token,
             (self.fake_server['id'], self.fake_server['lb_info']))
 
+    def test_execute_delete_added_to_pool(self):
+        """
+        `execute_delete_server` returned deferred is added to the pool
+        """
+        self.delete_server.return_value = Deferred()
+        d = self.supervisor.execute_delete_server(
+            self.log, 'transaction-id', self.group, self.fake_server)
+        self.assertIn(d, self.supervisor.deferred_pool._pool)
+
     def test_execute_delete_auths(self):
         """
         ``execute_delete_server`` asks the provided authentication function for


### PR DESCRIPTION
so that otter does not shutdown until delete jobs are finished
