### PR TITLE
AUTO-859: partition.finish() called only when it is allocated (please review)

### DIFF
--- a/otter/scheduler.py
+++ b/otter/scheduler.py
@@ -60,7 +60,8 @@ class SchedulerService(TimerService):
         Stop this service. This will release buckets partitions it holds
         """
         TimerService.stopService(self)
-        return self.kz_partition.finish()
+        if self.kz_partition.allocated:
+            return self.kz_partition.finish()
 
     def check_events(self, batchsize):
         """

--- a/otter/test/test_scheduler.py
+++ b/otter/test/test_scheduler.py
@@ -78,13 +78,24 @@ class SchedulerServiceTests(SchedulerTests):
 
     def test_stop_service(self):
         """
-        stopService() calls super's stopService() and stops the allocation
+        stopService() calls super's stopService() and stops the allocation if it
+        is already allocated
         """
         self.scheduler_service.startService()
+        self.kz_partition.allocated = True
         d = self.scheduler_service.stopService()
         self.timer_service.stopService.assert_called_once_with(self.scheduler_service)
         self.kz_partition.finish.assert_called_once_with()
         self.assertEqual(self.kz_partition.finish.return_value, d)
+
+    def test_stop_service_allocating(self):
+        """
+        stopService() does not stop the allocation (i.e. call finish) if it is not allocated
+        """
+        self.scheduler_service.startService()
+        d = self.scheduler_service.stopService()
+        self.assertFalse(self.kz_partition.finish.called)
+        self.assertIsNone(d)
 
     def test_check_events_allocating(self):
         """


### PR DESCRIPTION
`SetPartitioner.finish()` is expected to call only when it is allocated. The `SetPartitioner` code does not handle allocating case during finish. Not calling finish while allocating will also release the partition when otter shuts down since its session will be lost and all ephemeral nodes related to the partition will be deleted. 

Earlier at some situations `SetPartitioner.finish` was called at same time the `time_boundary` while allocating got over. This caused exception in allocating code eventually not allowing otter to shutdown gracefully. This PR will avoid that situation.
