### PR TITLE
Call treq.content on a 404 to avoid triggering a twisted bug

### DIFF
--- a/otter/worker/launch_server_v1.py
+++ b/otter/worker/launch_server_v1.py
@@ -556,6 +556,7 @@ def verified_delete(log,
     def delete():
         del_d = treq.delete(path, headers=headers(auth_token), log=serv_log)
         del_d.addCallback(check_success, [404])
+        del_d.addCallback(treq.content)
         return del_d
 
     start_time = clock.seconds()


### PR DESCRIPTION
If there is a body in the 404, this may cause an issue.
