### PR TITLE
Oops, forgot about logging authenticator now.  :|  (ready for review)

### DIFF
--- a/otter/auth.py
+++ b/otter/auth.py
@@ -56,7 +56,7 @@ class IAuthenticator(Interface):
     """
     Authenticators know how to authenticate tenants.
     """
-    def authenticate_tenant(tenant_id):
+    def authenticate_tenant(tenant_id, log=None):
         """
         :param tenant_id: A keystone tenant ID to authenticate as.
 
@@ -78,14 +78,15 @@ class RetryingAuthenticator(object):
         self._max_retries = max_retries
         self._retry_interval = retry_interval
 
-    def authenticate_tenant(self, tenant_id):
+    def authenticate_tenant(self, tenant_id, log=None):
         """
         see :meth:`IAuthenticator.authenticate_tenant`
         """
-        return retry(partial(self._authenticator.authenticate_tenant, tenant_id),
-                     can_retry=retry_times(self._max_retries),
-                     next_interval=repeating_interval(self._retry_interval),
-                     clock=self._reactor)
+        return retry(
+            partial(self._authenticator.authenticate_tenant, tenant_id, log=log),
+            can_retry=retry_times(self._max_retries),
+            next_interval=repeating_interval(self._retry_interval),
+            clock=self._reactor)
 
 
 @implementer(IAuthenticator)

--- a/otter/test/test_auth.py
+++ b/otter/test/test_auth.py
@@ -573,23 +573,23 @@ class RetryingAuthenticatorTests(TestCase):
         self.mock_auth.authenticate_tenant.return_value = succeed('result')
         d = self.authenticator.authenticate_tenant(23)
         self.assertEqual(self.successResultOf(d), 'result')
-        self.mock_auth.authenticate_tenant.assert_called_once_with(23)
+        self.mock_auth.authenticate_tenant.assert_called_once_with(23, log=None)
 
     def test_retries(self):
         """
         `RetryingAuthenticator` retries internal authenticator if it fails
         """
-        self.mock_auth.authenticate_tenant.side_effect = lambda _: fail(APIError(500, '2'))
+        self.mock_auth.authenticate_tenant.side_effect = lambda *a, **kw: fail(APIError(500, '2'))
         d = self.authenticator.authenticate_tenant(23)
         # mock_auth is called and there is no result
         self.assertNoResult(d)
-        self.mock_auth.authenticate_tenant.assert_called_once_with(23)
+        self.mock_auth.authenticate_tenant.assert_called_once_with(23, log=None)
         # Advance clock and mock_auth is called again
         self.clock.advance(4)
         self.assertEqual(self.mock_auth.authenticate_tenant.call_count, 2)
         self.assertNoResult(d)
         # advance clock and mock_auth's success return is propogated
-        self.mock_auth.authenticate_tenant.side_effect = lambda _: succeed('result')
+        self.mock_auth.authenticate_tenant.side_effect = lambda *a, **kw: succeed('result')
         self.clock.advance(4)
         self.assertEqual(self.successResultOf(d), 'result')
 
@@ -598,7 +598,7 @@ class RetryingAuthenticatorTests(TestCase):
         `RetryingAuthenticator` retries internal authenticator and times out if it
         keeps failing for certain period of time
         """
-        self.mock_auth.authenticate_tenant.side_effect = lambda _: fail(APIError(500, '2'))
+        self.mock_auth.authenticate_tenant.side_effect = lambda *a, **kw: fail(APIError(500, '2'))
         d = self.authenticator.authenticate_tenant(23)
         self.assertNoResult(d)
         self.clock.pump([4] * 4)


### PR DESCRIPTION
I fail at looking at code.  Log keyword needs to be able to be passed to authenticate.
