### PR TITLE
Auto 877 marshalling desired capacity (reviewed, pending merge)

### DIFF
--- a/otter/models/cass.py
+++ b/otter/models/cass.py
@@ -65,7 +65,7 @@ _cql_create_group = ('INSERT INTO {cf}("tenantId", "groupId", group_config, laun
                      'VALUES (:tenantId, :groupId, :group_config, :launch_config, :active, '
                      ':pending, :policyTouched, :paused, :desired, :created_at)')
 _cql_view_manifest = ('SELECT "tenantId", "groupId", group_config, launch_config, active, '
-                      'pending, "groupTouched", "policyTouched", paused, created_at '
+                      'pending, "groupTouched", "policyTouched", paused, desired, created_at '
                       'FROM {cf} WHERE "tenantId" = :tenantId AND "groupId" = :groupId')
 _cql_insert_policy = (
     'INSERT INTO {cf}("tenantId", "groupId", "policyId", data, version) '

--- a/otter/test/models/test_cass_models.py
+++ b/otter/test/models/test_cass_models.py
@@ -1466,7 +1466,7 @@ class CassScalingGroupTests(CassScalingGroupTestCase):
         self.group._naive_list_policies.assert_called_once_with(limit=10)
 
         view_cql = ('SELECT "tenantId", "groupId", group_config, launch_config, active, '
-                    'pending, "groupTouched", "policyTouched", paused, created_at '
+                    'pending, "groupTouched", "policyTouched", paused, desired, created_at '
                     'FROM scaling_group WHERE "tenantId" = :tenantId AND "groupId" = :groupId')
         del_cql = 'DELETE FROM scaling_group WHERE "tenantId" = :tenantId AND "groupId" = :groupId'
         exp_data = {'tenantId': self.tenant_id, 'groupId': self.group_id}
@@ -1504,7 +1504,7 @@ class CassScalingGroupTests(CassScalingGroupTestCase):
         r = self.group.view_manifest()
         self.failureResultOf(r, NoSuchScalingGroupError)
         view_cql = ('SELECT "tenantId", "groupId", group_config, launch_config, active, '
-                    'pending, "groupTouched", "policyTouched", paused, created_at '
+                    'pending, "groupTouched", "policyTouched", paused, desired, created_at '
                     'FROM scaling_group WHERE "tenantId" = :tenantId AND "groupId" = :groupId')
         del_cql = 'DELETE FROM scaling_group WHERE "tenantId" = :tenantId AND "groupId" = :groupId'
         exp_data = {'tenantId': self.tenant_id, 'groupId': self.group_id}


### PR DESCRIPTION
https://github.com/rackerlabs/otter/pull/541 has been merged.  Tested against that DB schema and it seems to store the desired capacity ok (at least, some number that is not always 0 is stored :))
