### PR TITLE
Up the default polling frequency for polling nova server status to mitigate a user getting 413 (ready for review)

### DIFF
--- a/otter/test/worker/test_launch_server_v1.py
+++ b/otter/test/worker/test_launch_server_v1.py
@@ -732,7 +732,7 @@ class ServerTests(TestCase):
 
         d = wait_for_active(self.log,
                             'http://url/', 'my-auth-token', 'serverId',
-                            clock=clock)
+                            interval=5, clock=clock)
 
         server_details.assert_called_with('http://url/', 'my-auth-token',
                                           'serverId', log=mock.ANY)
@@ -767,7 +767,7 @@ class ServerTests(TestCase):
 
         d = wait_for_active(self.log,
                             'http://url/', 'my-auth-token', 'serverId',
-                            clock=clock)
+                            interval=5, clock=clock)
 
         clock.advance(5)
 
@@ -793,7 +793,7 @@ class ServerTests(TestCase):
 
         d = wait_for_active(self.log,
                             'http://url/', 'my-auth-token', 'serverId',
-                            clock=clock)
+                            interval=5, clock=clock)
 
         # This gets called once immediately then every 5 seconds.
         self.assertEqual(server_details.call_count, 1)
@@ -825,7 +825,7 @@ class ServerTests(TestCase):
 
         d = wait_for_active(self.log,
                             'http://url/', 'my-auth-token', 'serverId',
-                            clock=clock)
+                            interval=5, clock=clock)
 
         # This gets called once immediately then every 5 seconds.
         self.assertEqual(server_details.call_count, 1)

--- a/otter/worker/launch_server_v1.py
+++ b/otter/worker/launch_server_v1.py
@@ -78,7 +78,7 @@ def wait_for_active(log,
                     server_endpoint,
                     auth_token,
                     server_id,
-                    interval=5,
+                    interval=20,
                     timeout=3600,
                     clock=None):
     """


### PR DESCRIPTION
... when spinning up too many servers.
