### PR TITLE
Upgrade silverberg to 0.1.7, which correctly unmarshalls 32-bit integers (ready for review)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ yunomi==0.2.2
 iso8601==0.1.4
 lxml==3.0.1
 treq==0.2.0
-silverberg==0.1.6
+silverberg==0.1.7
 pyOpenSSL==0.13
 jsonfig==0.1.1
 testtools==0.9.32


### PR DESCRIPTION
Functional tests all pass for me with mimic.
