### PR TITLE
Request logging normalization (reviewed, pending merge)

### DIFF
--- a/otter/rest/decorators.py
+++ b/otter/rest/decorators.py
@@ -40,7 +40,7 @@ def fails_with(mapping):
                         'details': getattr(failure.value, 'details', '')
                     }
                     self.log.msg("Request failed: {message}", uri=request.uri,
-                                 **errorObj)
+                                 request_status="failed", **errorObj)
                 else:
                     errorObj = {
                         'type': 'InternalError',
@@ -49,7 +49,8 @@ def fails_with(mapping):
                         'details': ''
                     }
                     self.log.err(failure, 'Request failed: Unhandled Error',
-                                 uri=request.uri, code=code)
+                                 uri=request.uri, code=code,
+                                 request_status="failed")
                 request.setResponseCode(code)
                 return json.dumps({'error': errorObj})
 
@@ -86,10 +87,8 @@ def succeeds_with(success_code):
                 # is 200, then it is the default and can be overriden
                 if request.code == 200:
                     request.setResponseCode(success_code)
-                self.log.bind(
-                    uri=request.uri,
-                    code=request.code
-                ).msg('Request succeeded')
+                self.log.msg('Request succeeded', uri=request.uri,
+                             code=request.code, request_status="succeeded")
                 return result
 
             d = defer.maybeDeferred(f, self, request, *args, **kwargs)
@@ -150,13 +149,14 @@ def with_transaction_id():
             self.log = self.log.bind(
                 system=reflect.fullyQualifiedName(f),
                 transaction_id=transaction_id)
-            self.log.bind(
+            self.log.msg(
+                "Received request",
                 method=request.method,
                 uri=request.uri,
                 clientproto=request.clientproto,
                 referer=request.getHeader("referer"),
-                useragent=request.getHeader("user-agent")
-            ).msg("Received request")
+                useragent=request.getHeader("user-agent"),
+                request_status="received")
             return f(self, request, *args, **kwargs)
         return _
     return decorator

--- a/otter/test/rest/test_webhooks.py
+++ b/otter/test/rest/test_webhooks.py
@@ -467,15 +467,14 @@ class OneWebhookTestCase(RestAPITestMixin, TestCase):
             202, '/v1.0/execute/1/11111/', 'POST')
 
         self.mock_store.get_scaling_group.assert_called_once_with(
-            log.bind(), self.tenant_id, self.group_id)
+            log.bind.return_value, self.tenant_id, self.group_id)
 
-        self.assertEqual(log.bind.call_args_list[1],
-                         mock.call(tenant_id=self.tenant_id,
-                                   scaling_group_id=self.group_id,
-                                   policy_id=self.policy_id))
+        log.bind.assert_called_once_with(tenant_id=self.tenant_id,
+                                         scaling_group_id=self.group_id,
+                                         policy_id=self.policy_id)
 
         self.mock_controller.maybe_execute_scaling_policy.assert_called_once_with(
-            log.bind(),
+            log.bind.return_value,
             'transaction-id',
             self.mock_group,
             self.mock_state,


### PR DESCRIPTION
Functional tests pass locally with mimic.

On receipt:

```
{
   "@timestamp": "2014-02-03T14:31:30.372355", 
   "@version": 1, 
   "clientproto": "HTTP/1.1", 
   "host": "ubuntu", 
   "level": 6, 
   "message": "Received request", 
   "method": "GET", 
   "otter_facility": "otter.rest.groups.list_all_scaling_groups", 
   "referer": null, 
   "request_status": "received", 
   "short_message": "Received request", 
   "tenant_id": "11111111", 
   "transaction_id": "6a56ae4c-dfb9-47a3-8994-bdc76eb873c6", 
   "uri": "/v1.0/11111111/groups", 
   "useragent": "curl/7.22.0 (x86_64-pc-linux-gnu) libcurl/7.22.0 OpenSSL/1.0.1 zlib/1.2.3.4 libidn/1.23 librtmp/2.3"
 }
```

On success:

```
 {
   "@timestamp": "2014-02-03T14:31:30.396018", 
   "@version": 1, 
   "code": 200, 
   "host": "ubuntu", 
   "level": 6, 
   "message": "Request succeeded", 
   "otter_facility": "otter.rest.groups.list_all_scaling_groups", 
   "request_status": "succeeded", 
   "short_message": "Request succeeded", 
   "tenant_id": "11111111", 
   "transaction_id": "6a56ae4c-dfb9-47a3-8994-bdc76eb873c6", 
   "uri": "/v1.0/11111111/groups"
 }
```

On failure:

```
{
   "@timestamp": "2014-02-03T14:35:32.431760", 
   "@version": 1, 
   "code": 500, 
   "host": "ubuntu", 
   "level": 3, 
   "message": "Traceback (most recent call last):\nFailure: twisted.internet.error.ConnectionRefusedError: Connection was refused by other side: 111: Connection refused.\n", 
   "otter_facility": "otter.rest.groups.list_all_scaling_groups", 
   "request_status": "failed", 
   "short_message": "Request failed: Unhandled Error: ConnectionRefusedError('Connection refused',)", 
   "tenant_id": "11111111", 
   "transaction_id": "f052f782-e30c-4305-b9a1-7597383ae3bd", 
   "uri": "/v1.0/11111111/groups"
}
```
