### PR TITLE
LB node removal minor refactor

### DIFF
--- a/otter/worker/launch_server_v1.py
+++ b/otter/worker/launch_server_v1.py
@@ -478,6 +478,8 @@ def remove_from_load_balancer(log, endpoint, auth_token, loadbalancer_id,
             if 'load balancer is deleted' not in message:
                 return failure
             lb_log.msg(message)
+        else:
+            return failure
 
     def remove():
         d = treq.delete(path, headers=headers(auth_token), log=lb_log)


### PR DESCRIPTION
Refactored removal of LB node by checking 422 body in errback since content is acquired inside `check_success`. This seems a little more cleaner than earlier
