### PR TITLE
removing extra "Received request" log

### DIFF
--- a/otter/rest/groups.py
+++ b/otter/rest/groups.py
@@ -569,7 +569,6 @@ class OtterGroup(object):
         return OtterConfig(self.store, self.tenant_id, self.group_id).app.resource()
 
     @app.route('/launch/')
-    @with_transaction_id()
     def launch(self, request):
         """
         launch route handled by OtterLaunch
@@ -577,7 +576,6 @@ class OtterGroup(object):
         return OtterLaunch(self.store, self.tenant_id, self.group_id).app.resource()
 
     @app.route('/policies/', branch=True)
-    @with_transaction_id()
     def policies(self, request):
         """
         policies routes handled by OtterPolicies


### PR DESCRIPTION
`with_transaction_id` generates transaction id and binds to the log it passes. This is also there in handlers inside `OtterLaunch` and `OtterPolicies` which is the right place since they are handling request. This caused extra "Received request" message for each message inside `OtterLaunch` and `OtterPolicies`. Hence removing them. 
