### PR TITLE
Better "calculating delta" message

### DIFF
--- a/otter/controller.py
+++ b/otter/controller.py
@@ -287,7 +287,8 @@ def calculate_delta(log, state, config, policy):
     state.desired = max(min(desired, max_entities), config['minEntities'])
     delta = state.desired - current
 
-    log.msg("calculating delta",
+    log.msg(("calculating delta "
+             "{current_active} + {current_pending} -> {constrained_desired_capacity}"),
             unconstrained_desired_capacity=desired,
             constrained_desired_capacity=state.desired,
             max_entities=max_entities, min_entities=config['minEntities'],

--- a/otter/test/test_controller.py
+++ b/otter/test/test_controller.py
@@ -481,7 +481,9 @@ class CalculateDeltaTestCase(TestCase):
                                    fake_policy)
         args, kwargs = self.mock_log.msg.call_args
         self.assertEqual(fake_state.desired, 1)
-        self.assertEqual(args, ('calculating delta',))
+        self.assertEqual(
+            args, (('calculating delta {current_active} + {current_pending}'
+                    ' -> {constrained_desired_capacity}'),))
         self.assertEqual(kwargs, matches(ContainsDict({
             'server_delta': Equals(1),
             'constrained_desired_capacity': Equals(1)})))


### PR DESCRIPTION
This will generate `"Calculating delta 1 + 2 -> 5"` kind of messages where 1 is active, 2 is pending and 5 is the new desired capacity. This will quickly show how the desired capacity is calculated based on current state.
