### PR TITLE
Normalize rest log in rest/configs.py

### DIFF
--- a/otter/rest/configs.py
+++ b/otter/rest/configs.py
@@ -114,7 +114,7 @@ class OtterLaunch(object):
     def __init__(self, store, tenant_id, group_id):
         self.log = log.bind(system='otter.rest.launch',
                             tenant_id=tenant_id,
-                            group_id=group_id)
+                            scaling_group_id=group_id)
         self.store = store
         self.tenant_id = tenant_id
         self.group_id = group_id


### PR DESCRIPTION
All the logs having group_id are bound to scaling_group_id except this one.
