### PR TITLE
Request failure logging fix (reviewed, pending merge)

### DIFF
--- a/otter/rest/decorators.py
+++ b/otter/rest/decorators.py
@@ -39,8 +39,11 @@ def fails_with(mapping):
                         'message': failure.value.message,
                         'details': getattr(failure.value, 'details', '')
                     }
-                    self.log.msg("Request failed: {message}", uri=request.uri,
-                                 request_status="failed", **errorObj)
+                    # format here, because the logger does something special
+                    # with the 'message' key
+                    self.log.msg(
+                        "Request failed: {message}".format(message=errorObj['message']),
+                        uri=request.uri, request_status="failed", **errorObj)
                 else:
                     errorObj = {
                         'type': 'InternalError',

--- a/otter/test/rest/test_decorators.py
+++ b/otter/test/rest/test_decorators.py
@@ -181,7 +181,7 @@ class FaultTestCase(TestCase):
         self.mockRequest.setResponseCode.assert_called_once_with(404)
 
         self.mockLog.msg.assert_called_once_with(
-            "Request failed: {message}", code=404, uri='/', details='',
+            "Request failed: fail", code=404, uri='/', details='',
             message='fail', type='BlahError', request_status="failed")
 
         faultDoc = json.loads(r)
@@ -213,7 +213,7 @@ class FaultTestCase(TestCase):
         self.mockRequest.setResponseCode.assert_called_once_with(404)
 
         self.mockLog.msg.assert_called_once_with(
-            "Request failed: {message}", code=404, uri='/',
+            "Request failed: fail", code=404, uri='/',
             details='this is a detail', message='fail', type='DetailsError',
             request_status="failed")
 
@@ -289,7 +289,7 @@ class FaultTestCase(TestCase):
         self.mockRequest.setResponseCode.assert_called_once_with(400)
 
         self.mockLog.msg.assert_called_once_with(
-            "Request failed: {message}", code=400, uri='/', details='',
+            "Request failed: fail", code=400, uri='/', details='',
             message='fail', type='BlahError', request_status="failed")
 
         faultDoc = json.loads(r)


### PR DESCRIPTION
The formatter does something special with the 'message' param, so we end up with inception-ed messages like: `Request failed: ('Request failed: {message}',)`.

So when logging request failures, just interpolate it into the request failure message immediately.
