### PR TITLE
Moved params before <representation>

### DIFF
--- a/docbook/src/wadl/autoscale.wadl
+++ b/docbook/src/wadl/autoscale.wadl
@@ -17,7 +17,6 @@
     xmlns:raxapi="http://docs.rackspace.com/volume/api/v1"
     xmlns:wadl="http://wadl.dev.java.net/2009/02"
     xmlns:osapi="http://docs.openstack.org/compute/api/v1.1"
-    xmlns:csapi="http://docs.openstack.org/compute/api/v2"
     xmlns:xlink="http://www.w3.org/1999/xlink"
     xmlns:xsd="http://www.w3.org/2001/XMLSchema"
     xmlns:rax="http://docs.rackspace.com/api"
@@ -27,7 +26,7 @@
     <!-- ======================================================================================= -->
     <resources
         base="https://{region}.autoscale.api.rackspacecloud.com/"
-        xml:id="autoscale-v1.0">
+        xml:id="autoscale-v1">
         <resource id="version" path="v1.0/"
             rax:roles="admin autoscale:admin autoscale:service-admin">
             <!-- GROUPS resource -->
@@ -152,6 +151,312 @@
                 includes an ID and links for the group.</para>
         </wadl:doc>
         <request>
+            <param style="plain" name="launchConfiguration"
+                required="true" type="object"
+                path="$.launchConfiguration">
+                <wadl:doc xmlns="http://docbook.org/ns/docbook"
+                    xml:lang="EN">
+                    <para>A launch configuration.</para>
+                    <para>A launch configuration defines what to do
+                        when a new server is created, including
+                        information about the server image, the flavor
+                        of the server image, and the load balancer to
+                        which to connect. You must set the
+                            <code>type</code> parameter to
+                            <code>launch_server</code>.
+                    </para></wadl:doc>
+            </param>
+            <param style="plain" name="loadBalancers" required="false"
+                type="array"
+                path="$.launchConfiguration.args.loadBalancers">
+                <wadl:doc xmlns="http://docbook.org/ns/docbook"
+                    xml:lang="EN">
+                    <para>One or more load balancers to which to add
+                        new servers. All servers are added to these
+                        load balancers with the IP addresses of their
+                        ServiceNet network. All servers are enabled
+                        and equally weighted. Any new servers that are
+                        not connected to the ServiceNet network are
+                        not added to any load
+                    balancers.</para></wadl:doc>
+            </param>
+            <param style="plain" name="port" required="true"
+                type="integer"
+                path="$.launchConfiguration.args.loadBalancers.[*].port">
+                <wadl:doc xmlns="http://docbook.org/ns/docbook"
+                    xml:lang="EN"><para>The port number of the service
+                        (on the new servers) to use for this
+                        particular load balancer. In most cases, this
+                        port number is 80.</para></wadl:doc>
+            </param>
+            <param style="plain" name="loadBalancerId" required="true"
+                type="integer"
+                path="$.launchConfiguration.args.loadBalancers.[*].loadBalancerId">
+                <wadl:doc xmlns="http://docbook.org/ns/docbook"
+                    xml:lang="EN"><para>The ID of the load balancer to
+                        which to add new servers.</para></wadl:doc>
+            </param>
+            <param style="plain" name="server" required="true"
+                type="object" path="$.launchConfiguration.args.server">
+                <wadl:doc xmlns="http://docbook.org/ns/docbook"
+                    xml:lang="EN"><para>The attributes that Auto Scale
+                        uses to create a new server. For more
+                        information, see <link
+                            xlink:href="http://docs.rackspace.com/servers/api/v2/cs-devguide/content/CreateServers.html"
+                            >Create Server</link>. The attributes that
+                        you specify for the server entity apply to all
+                        new servers in the scaling group, including
+                        the server name.</para></wadl:doc>
+            </param>
+            <param style="plain" name="flavorRef" required="true"
+                type="string"
+                path="$.launchConfiguration.args.server.flavorRef">
+                <wadl:doc xmlns="http://docbook.org/ns/docbook"
+                    xml:lang="EN"><para>The flavor of the server
+                        image. Specifies the flavor ID for the
+                        server.</para><para>A flavor is a resource
+                        configuration for a server. For more
+                        information, see Server Flavors<olink
+                            targetdoc="autoscale-devguide"
+                            targetptr="server-flavors">“Server
+                            Flavors”</olink>
+                    section.</para></wadl:doc>
+            </param>
+            <param style="plain" name="imageRef" required="true"
+                type="string"
+                path="$.launchConfiguration.args.server.imageRef">
+                <wadl:doc xmlns="http://docbook.org/ns/docbook"
+                    xml:lang="EN"><para>The ID of the cloud server
+                        image, after which new server images are
+                        created.</para></wadl:doc>
+            </param>
+            <param style="plain" name="personality" required="false"
+                type="array"
+                path="$.launchConfiguration.args.server.personality">
+                <wadl:doc xmlns="http://docbook.org/ns/docbook"
+                    xml:lang="EN"><para>The file path and/or the
+                        content that you want to inject into a server
+                        image. For more information, see the <link
+                            xlink:href="http://docs.rackspace.com/servers/api/v2/cs-devguide/content/Server_Personality-d1e2543.html"
+                            >Server Personality</link> documentation
+                        for Rackspace Cloud Servers.</para></wadl:doc>
+            </param>
+            <param style="plain" name="path" required="true"
+                type="string"
+                path="$.launchConfiguration.args.server.personality.[*].path">
+                <wadl:doc xmlns="http://docbook.org/ns/docbook"
+                    xml:lang="EN"><para>The path to the file that
+                        contains data that is injected into the file
+                        system of the new cloud server
+                    image.</para></wadl:doc>
+            </param>
+            <param style="plain" name="contents" required="true"
+                type="string"
+                path="$.launchConfiguration.args.server.personality.[*].contents">
+                <wadl:doc xmlns="http://docbook.org/ns/docbook"
+                    xml:lang="EN"><para>The content items that is
+                        injected into the file system of the new cloud
+                        server image.</para>
+                </wadl:doc>
+            </param>
+            <param style="plain" name="args" required="true"
+                type="object" path="$.launchConfiguration.args">
+                <wadl:doc xmlns="http://docbook.org/ns/docbook"
+                    xml:lang="EN"><para>The item to be configured.
+                        Must be "server" or "load balancer." Most
+                        launch configurations have both a server and a
+                        load balancer configured.</para></wadl:doc>
+            </param>
+            <param style="plain" name="type" required="true"
+                type="string" path="$.launchConfiguration.type">
+                <wadl:doc xmlns="http://docbook.org/ns/docbook"
+                    xml:lang="EN"><para>The type of the launch
+                        configuration. For this release, this
+                        parameter must be set to
+                            <code>launch_server</code>.</para></wadl:doc>
+            </param>
+            <param style="plain" name="groupConfiguration"
+                required="true" type="object"
+                path="$.groupConfiguration">
+                <wadl:doc xmlns="http://docbook.org/ns/docbook"
+                    xml:lang="EN"><para>The configuration options for
+                        the scaling group. The scaling group
+                        configuration specifies the basic elements of
+                        the Auto Scale configuration. It manages how
+                        many servers can participate in the scaling
+                        group. It specifies information related to
+                        load balancers.</para></wadl:doc>
+            </param>
+            <param style="plain" name="maxEntities" required="false"
+                type="object" path="$.groupConfiguration.maxEntities">
+                <wadl:doc xmlns="http://docbook.org/ns/docbook"
+                    xml:lang="EN"><para>The maximum amount of
+                        identities that are allowed in the scaling
+                        group. This number defaults to null. If this
+                        value is provided it must be set to an integer
+                        between 0 and 1000.</para>
+                </wadl:doc>
+            </param>
+            <param style="plain" name="name" required="true"
+                type="string" path="$.groupConfiguration.name">
+                <wadl:doc xmlns="http://docbook.org/ns/docbook"
+                    xml:lang="EN"><para>The name of the scaling group.
+                        This name does not need to be
+                    unique.</para></wadl:doc>
+            </param>
+            <param style="plain" name="cooldown" required="true"
+                type="integer" path="$.groupConfiguration.cooldown">
+                <wadl:doc xmlns="http://docbook.org/ns/docbook"
+                    xml:lang="EN"><para>The cool-down period before
+                        more entities are added, in seconds. This
+                        number must be an integer between 0 and 86400
+                        (24 hrs).</para>
+                </wadl:doc>
+            </param>
+            <param style="plain" name="minEntities" required="true"
+                type="integer" path="$.groupConfiguration.minEntities">
+                <wadl:doc xmlns="http://docbook.org/ns/docbook"
+                    xml:lang="EN"><para>The minimum number of entities
+                        in the scaling group. This number must be an
+                        integer between 0 and 1000.</para></wadl:doc>
+            </param>
+            <param style="plain" name="metadata" required="false"
+                type="object" path="$.groupConfiguration.metadata">
+                <wadl:doc xmlns="http://docbook.org/ns/docbook"
+                    xml:lang="EN"><para>Optional. Custom metadata for
+                        your group configuration. You can use the
+                        metadata parameter for customer automation,
+                        but it does not change any functionality in
+                        Auto Scale. There currently is no limitation
+                        on depth.</para></wadl:doc>
+            </param>
+            <param style="plain" name="scalingPolicies"
+                required="true" type="array" path="$.scalingPolicies">
+                <wadl:doc xmlns="http://docbook.org/ns/docbook">This
+                    parameter group specifies configuration
+                    information for your scaling policies. Scaling
+                    policies specify how to modify the scaling group
+                    and its behavior. You can specify multiple
+                    policies to manage a scaling group. </wadl:doc>
+            </param>
+            <param style="plain" name="array" required="true"
+                type="array" path="$.scalingPolicies.[*]">
+                <wadl:doc xmlns="http://docbook.org/ns/docbook"
+                    xml:lang="EN"><para>An array of scaling
+                        policies.</para></wadl:doc>
+            </param>
+            <param style="plain" name="name" required="true"
+                type="string" path="$.scalingPolicies.[*].name">
+                <wadl:doc xmlns="http://docbook.org/ns/docbook"
+                    xml:lang="EN"><para>A name for the scaling policy.
+                        This name must be unique for each scaling
+                        policy.</para></wadl:doc>
+            </param>
+            <param style="plain" name="args" required="false"
+                type="object" path="$.scalingPolicies.[*].args">
+                <wadl:doc xmlns="http://docbook.org/ns/docbook"
+                    xml:lang="EN"><para>Additional configuration
+                        information for policies of type "schedule."
+                        This parameter is not required for policies of
+                        type "webhook." This parameter must be set to
+                        either "at" or <code>cron</code>. Both "at"
+                        and <code>cron</code> are mutually
+                        exclusive.</para>
+                </wadl:doc>
+            </param>
+            <param style="plain" name="cron" required="false"
+                type="string" path="$.scalingPolicies.[*].args.cron">
+                <wadl:doc xmlns="http://docbook.org/ns/docbook"
+                    xml:lang="EN"><para>The recurring time when the
+                        policy runs as a cron entry. For example, if
+                        you set this parameter to <code>1 0 * *
+                            *</code>, the policy runs at one minute
+                        past midnight (00:01) every day of the month,
+                        and every day of the week. For more
+                        information about cron, see <link
+                            xlink:href="http://en.wikipedia.org/wiki/Cron"
+                            >http://en.wikipedia.org/wiki/Cron</link>.</para></wadl:doc>
+            </param>
+            <param style="plain" name="at" required="false"
+                type="string" path="$.scalingPolicies.[*].args.at">
+                <wadl:doc xmlns="http://docbook.org/ns/docbook"
+                    xml:lang="EN"><para>The time when this policy
+                        runs. This property is mutually exclusive with
+                        the <code>cron</code> parameter. You must
+                        specify seconds when using "at". For example,
+                            <code>"at": "2013-12-05T03:12:00Z"</code>.
+                        If seconds are not specified, a 400 error is
+                        returned. Note, the policy is triggered within
+                        a 10-second range of the time specified by
+                            <code>at</code>.</para></wadl:doc>
+            </param>
+            <param style="plain" name="changePercent" required="false"
+                type="number"
+                path="$.scalingPolicies.[*].changePercent">
+                <wadl:doc xmlns="http://docbook.org/ns/docbook"
+                    xml:lang="EN"><para>The percent change to make in
+                        the number of servers in the scaling group. If
+                        this number is positive, the number of servers
+                        will increase by the given percentage. If this
+                        parameter is set to a negative number, the
+                        number of servers decreases by the given
+                        percentage. The absolute change in the number
+                        of servers will be rounded to the nearest
+                        integer. This means that if -X% of the current
+                        number of servers translates to -0.5 or -0.25
+                        or -0.75 servers, the actual number of servers
+                        that will be shut down is 1. If X% of the
+                        current number of servers translates to 1.2 or
+                        1.5 or 1.7 servers, the actual number of
+                        servers that will be launched is
+                    2.</para></wadl:doc>
+            </param>
+            <param style="plain" name="cooldown" required="true"
+                type="number" path="$.scalingPolicies.[*].cooldown">
+                <wadl:doc xmlns="http://docbook.org/ns/docbook"
+                    xml:lang="EN"><para>The cool-down period, in
+                        seconds, before this particular scaling policy
+                        can run again. The cool-down period does not
+                        affect the global scaling group cool-down. The
+                        minimum value for this parameter is 0 seconds,
+                        the maximum value is 86400 seconds (24
+                        hrs).</para>
+                </wadl:doc>
+            </param>
+            <param style="plain" name="type" required="true"
+                type="enum" path="$.scalingPolicies.[*].type">
+                <wadl:doc xmlns="http://docbook.org/ns/docbook"
+                    xml:lang="EN"><para>The type of policy that runs
+                        for the current release, this value can be
+                        either <code>webhook</code> for webhook-based
+                        policies or <code>schedule</code> for
+                        schedule-based policies.</para></wadl:doc>
+            </param>
+            <param style="plain" name="change" required="false"
+                type="integer" path="$.scalingPolicies.[*].change">
+                <wadl:doc xmlns="http://docbook.org/ns/docbook"
+                    xml:lang="EN"><para>The change to make in the
+                        number of servers in the scaling group. This
+                        parameter must be an integer. If the value is
+                        a positive integer, the number of servers
+                        increases. If the value is a negative integer,
+                        the number of servers
+                    decreases.</para></wadl:doc>
+            </param>
+            <param style="plain" name="desiredCapacity"
+                required="false" type="integer"
+                path="$.scalingPolicies.[*].desiredCapacity">
+                <wadl:doc xmlns="http://docbook.org/ns/docbook"
+                    xml:lang="EN"><para>The desired server capacity of
+                        the scaling the group. For example, how many
+                        servers should be in the scaling group. This
+                        value must be an absolute number. For example,
+                        if this parameter is set to 10 and the
+                        executing policy with this will bring the
+                        number of servers to 10. The minimum allowed
+                        value is 0.</para>
+                </wadl:doc>
+            </param>
             <representation mediaType="application/json">
                 <wadl:doc xmlns="http://docbook.org/ns/docbook"
                     xml:lang="EN">
@@ -160,332 +465,7 @@
                     <xsdxt:code
                         href="../docbkx/samples/reqCreateGroup.json"/>
                 </wadl:doc>
-                <param style="plain" name="launchConfiguration"
-                    required="true" type="object"
-                    path="$.launchConfiguration">
-                    <wadl:doc xmlns="http://docbook.org/ns/docbook"
-                        xml:lang="EN">
-                        <para>A launch configuration.</para><para>A
-                            launch configuration defines what to do
-                            when a new server is created, including
-                            information about the server image, the
-                            flavor of the server image, and the load
-                            balancer to which to connect. You must set
-                            the <code>type</code> parameter to
-                                <code>launch_server</code>.</para></wadl:doc>
-                </param>
-                <param style="plain" name="loadBalancers"
-                    required="false" type="array"
-                    path="$.launchConfiguration.args.loadBalancers">
-                    <wadl:doc xmlns="http://docbook.org/ns/docbook"
-                        xml:lang="EN">
-                        <para>One or more load balancers to which to
-                            add new servers. All servers are added to these load
-                            balancers with the IP addresses of their
-                            ServiceNet network. All servers are
-                            enabled and equally weighted. Any new
-                            servers that are not connected to the
-                            ServiceNet network are not added to any
-                            load balancers.</para></wadl:doc>
-                </param>
-                <param style="plain" name="port" required="true"
-                    type="integer"
-                    path="$.launchConfiguration.args.loadBalancers.[*].port">
-                    <wadl:doc xmlns="http://docbook.org/ns/docbook"
-                        xml:lang="EN"><para>The port number of the
-                            service (on the new servers) to use for
-                            this particular load balancer. In most
-                            cases, this port number is
-                        80.</para></wadl:doc>
-                </param>
-                <param style="plain" name="loadBalancerId"
-                    required="true" type="integer"
-                    path="$.launchConfiguration.args.loadBalancers.[*].loadBalancerId">
-                    <wadl:doc xmlns="http://docbook.org/ns/docbook"
-                        xml:lang="EN"><para>The ID of the load
-                            balancer to which to add new
-                            servers.</para></wadl:doc>
-                </param>
-                <param style="plain" name="server" required="true"
-                    type="object"
-                    path="$.launchConfiguration.args.server">
-                    <wadl:doc xmlns="http://docbook.org/ns/docbook"
-                        xml:lang="EN"><para>The attributes that Auto
-                            Scale uses to create a new server. For
-                            more information, see <link
-                                xlink:href="http://docs.rackspace.com/servers/api/v2/cs-devguide/content/CreateServers.html"
-                                >Create Server</link>. The attributes
-                            that you specify for the server entity
-                            apply to all new servers in the scaling
-                            group, including the server
-                        name.</para></wadl:doc>
-                </param>
-                <param style="plain" name="flavorRef" required="true"
-                    type="string"
-                    path="$.launchConfiguration.args.server.flavorRef">
-                    <wadl:doc xmlns="http://docbook.org/ns/docbook"
-                        xml:lang="EN"><para>The flavor of the server
-                            image. Specifies the flavor ID for the
-                            server.</para><para>A flavor is a resource
-                            configuration for a server. For more
-                            information, see Server Flavors<olink
-                                targetdoc="autoscale-devguide"
-                                targetptr="server-flavors">“Server
-                                Flavors”</olink>
-                        section.</para></wadl:doc>
-                </param>
-                <param style="plain" name="imageRef" required="true"
-                    type="string"
-                    path="$.launchConfiguration.args.server.imageRef">
-                    <wadl:doc xmlns="http://docbook.org/ns/docbook"
-                        xml:lang="EN"><para>The ID of the cloud server
-                            image, after which new server images are
-                            created.</para></wadl:doc>
-                </param>
-                <param style="plain" name="personality"
-                    required="false" type="array"
-                    path="$.launchConfiguration.args.server.personality">
-                    <wadl:doc xmlns="http://docbook.org/ns/docbook"
-                        xml:lang="EN"><para>The file path and/or the
-                            content that you want to inject into a
-                            server image. For more information, see
-                            the <link
-                                xlink:href="http://docs.rackspace.com/servers/api/v2/cs-devguide/content/Server_Personality-d1e2543.html"
-                                >Server Personality</link>
-                            documentation for Rackspace Cloud
-                            Servers.</para></wadl:doc>
-                </param>
-                <param style="plain" name="path" required="true"
-                    type="string"
-                    path="$.launchConfiguration.args.server.personality.[*].path">
-                    <wadl:doc xmlns="http://docbook.org/ns/docbook"
-                        xml:lang="EN"><para>The path to the file that
-                            contains data that is injected into the
-                            file system of the new cloud server
-                            image.</para></wadl:doc>
-                </param>
-                <param style="plain" name="contents" required="true"
-                    type="string"
-                    path="$.launchConfiguration.args.server.personality.[*].contents">
-                    <wadl:doc xmlns="http://docbook.org/ns/docbook"
-                        xml:lang="EN"><para>The content items that is
-                            injected into the file system of the new
-                            cloud server image.</para>
-                    </wadl:doc>
-                </param>
-                <param style="plain" name="args" required="true"
-                    type="object" path="$.launchConfiguration.args">
-                    <wadl:doc xmlns="http://docbook.org/ns/docbook"
-                        xml:lang="EN"><para>The item to be configured.
-                            Must be "server" or "load balancer." Most
-                            launch configurations have both a server
-                            and a load balancer
-                        configured.</para></wadl:doc>
-                </param>
-                <param style="plain" name="type" required="true"
-                    type="string" path="$.launchConfiguration.type">
-                    <wadl:doc xmlns="http://docbook.org/ns/docbook"
-                        xml:lang="EN"><para>The type of the launch
-                            configuration. For this release, this
-                            parameter must be set to
-                                <code>launch_server</code>.</para></wadl:doc>
-                </param>
-                <param style="plain" name="groupConfiguration"
-                    required="true" type="object"
-                    path="$.groupConfiguration">
-                    <wadl:doc xmlns="http://docbook.org/ns/docbook"
-                        xml:lang="EN"><para>The configuration options
-                            for the scaling group. The scaling group
-                            configuration specifies the basic elements
-                            of the Auto Scale configuration. It
-                            manages how many servers can participate
-                            in the scaling group. It specifies
-                            information related to load
-                            balancers.</para></wadl:doc>
-                </param>
-                <param style="plain" name="maxEntities"
-                    required="false" type="object"
-                    path="$.groupConfiguration.maxEntities">
-                    <wadl:doc xmlns="http://docbook.org/ns/docbook"
-                        xml:lang="EN"><para>The maximum amount of
-                            identities that are allowed in the scaling
-                            group. This number defaults to null. If
-                            this value is provided it must be set to
-                            an integer between 0 and 1000.</para>
-                    </wadl:doc>
-                </param>
-                <param style="plain" name="name" required="true"
-                    type="string" path="$.groupConfiguration.name">
-                    <wadl:doc xmlns="http://docbook.org/ns/docbook"
-                        xml:lang="EN"><para>The name of the scaling
-                            group. This name does not need to be
-                            unique.</para></wadl:doc>
-                </param>
-                <param style="plain" name="cooldown" required="true"
-                    type="integer"
-                    path="$.groupConfiguration.cooldown">
-                    <wadl:doc xmlns="http://docbook.org/ns/docbook"
-                        xml:lang="EN"><para>The cool-down period
-                            before more entities are added, in
-                            seconds. This number must be an integer
-                            between 0 and 86400 (24 hrs).</para>
-                    </wadl:doc>
-                </param>
-                <param style="plain" name="minEntities"
-                    required="true" type="integer"
-                    path="$.groupConfiguration.minEntities">
-                    <wadl:doc xmlns="http://docbook.org/ns/docbook"
-                        xml:lang="EN"><para>The minimum number of
-                            entities in the scaling group. This number
-                            must be an integer between 0 and
-                            1000.</para></wadl:doc>
-                </param>
-                <param style="plain" name="metadata" required="false"
-                    type="object" path="$.groupConfiguration.metadata">
-                    <wadl:doc xmlns="http://docbook.org/ns/docbook"
-                        xml:lang="EN"><para>Optional. Custom metadata
-                            for your group configuration. You can use
-                            the metadata parameter for customer
-                            automation, but it does not change any
-                            functionality in Auto Scale. There
-                            currently is no limitation on
-                            depth.</para></wadl:doc>
-                </param>
-                <param style="plain" name="scalingPolicies"
-                    required="true" type="array"
-                    path="$.scalingPolicies">
-                    <wadl:doc xmlns="http://docbook.org/ns/docbook"
-                        >This parameter group specifies configuration
-                        information for your scaling policies. Scaling
-                        policies specify how to modify the scaling
-                        group and its behavior. You can specify
-                        multiple policies to manage a scaling group.
-                    </wadl:doc>
-                </param>
-                <param style="plain" name="array" required="true"
-                    type="array" path="$.scalingPolicies.[*]">
-                    <wadl:doc xmlns="http://docbook.org/ns/docbook"
-                        xml:lang="EN"><para>An array of scaling
-                            policies.</para></wadl:doc>
-                </param>
-                <param style="plain" name="name" required="true"
-                    type="string" path="$.scalingPolicies.[*].name">
-                    <wadl:doc xmlns="http://docbook.org/ns/docbook"
-                        xml:lang="EN"><para>A name for the scaling
-                            policy. This name must be unique for each
-                            scaling policy.</para></wadl:doc>
-                </param>
-                <param style="plain" name="args" required="false"
-                    type="object" path="$.scalingPolicies.[*].args">
-                    <wadl:doc xmlns="http://docbook.org/ns/docbook"
-                        xml:lang="EN"><para>Additional configuration
-                            information for policies of type
-                            "schedule." This parameter is not required
-                            for policies of type "webhook." This
-                            parameter must be set to either "at" or
-                                <code>cron</code>. Both "at" and
-                                <code>cron</code> are mutually
-                            exclusive.</para>
-                    </wadl:doc>
-                </param>
-                <param style="plain" name="cron" required="false"
-                    type="string"
-                    path="$.scalingPolicies.[*].args.cron">
-                    <wadl:doc xmlns="http://docbook.org/ns/docbook"
-                        xml:lang="EN"><para>The recurring time when
-                            the policy runs as a cron entry. For
-                            example, if you set this parameter to
-                                <code>1 0 * * *</code>, the policy
-                            runs at one minute past midnight (00:01)
-                            every day of the month, and every day of
-                            the week. For more information about cron,
-                            see <link
-                                xlink:href="http://en.wikipedia.org/wiki/Cron"
-                                >http://en.wikipedia.org/wiki/Cron</link>.</para></wadl:doc>
-                </param>
-                <param style="plain" name="at" required="false"
-                    type="string" path="$.scalingPolicies.[*].args.at">
-                    <wadl:doc xmlns="http://docbook.org/ns/docbook"
-                        xml:lang="EN"><para>The time when this policy
-                            runs. This property is mutually exclusive
-                            with the <code>cron</code> parameter. You
-                            must specify seconds when using "at". For example, 
-                            <code>"at": "2013-12-05T03:12:00Z"</code>. 
-                            If seconds are not specified, a 400 error is
-                            returned. Note, the policy is triggered within a 
-                            10-second range of the time specified by <code>at</code>.</para></wadl:doc>
-                </param>
-                <param style="plain" name="changePercent"
-                    required="false" type="number"
-                    path="$.scalingPolicies.[*].changePercent">
-                    <wadl:doc xmlns="http://docbook.org/ns/docbook"
-                        xml:lang="EN"><para>The percent change to make
-                            in the number of servers in the scaling
-                            group. If this number is positive, the
-                            number of servers will increase by the
-                            given percentage. If this parameter is set
-                            to a negative number, the number of
-                            servers decreases by the given percentage.
-                            The absolute change in the number of
-                            servers will be rounded to the nearest
-                            integer. This means that if -X% of the
-                            current number of servers translates to
-                            -0.5 or -0.25 or -0.75 servers, the actual
-                            number of servers that will be shut down
-                            is 1. If X% of the current number of
-                            servers translates to 1.2 or 1.5 or 1.7
-                            servers, the actual number of servers that
-                            will be launched is 2.</para></wadl:doc>
-                </param>
-                <param style="plain" name="cooldown" required="true"
-                    type="number"
-                    path="$.scalingPolicies.[*].cooldown">
-                    <wadl:doc xmlns="http://docbook.org/ns/docbook"
-                        xml:lang="EN"><para>The cool-down period, in
-                            seconds, before this particular scaling
-                            policy can run again. The cool-down period
-                            does not affect the global scaling group
-                            cool-down. The minimum value for this
-                            parameter is 0 seconds, the maximum value
-                            is 86400 seconds (24 hrs).</para>
-                    </wadl:doc>
-                </param>
-                <param style="plain" name="type" required="true"
-                    type="enum" path="$.scalingPolicies.[*].type">
-                    <wadl:doc xmlns="http://docbook.org/ns/docbook"
-                        xml:lang="EN"><para>The type of policy that
-                            runs for the current release, this value
-                            can be either <code>webhook</code> for
-                            webhook-based policies or
-                                <code>schedule</code> for
-                            schedule-based policies.</para></wadl:doc>
-                </param>
-                <param style="plain" name="change" required="false"
-                    type="integer" path="$.scalingPolicies.[*].change">
-                    <wadl:doc xmlns="http://docbook.org/ns/docbook"
-                        xml:lang="EN"><para>The change to make in the
-                            number of servers in the scaling group.
-                            This parameter must be an integer. If the
-                            value is a positive integer, the number of
-                            servers increases. If the value is a
-                            negative integer, the number of servers
-                            decreases.</para></wadl:doc>
-                </param>
-                <param style="plain" name="desiredCapacity"
-                    required="false" type="integer"
-                    path="$.scalingPolicies.[*].desiredCapacity">
-                    <wadl:doc xmlns="http://docbook.org/ns/docbook"
-                        xml:lang="EN"><para>The desired server
-                            capacity of the scaling the group. For
-                            example, how many servers should be in the
-                            scaling group. This value must be an
-                            absolute number. For example, if this
-                            parameter is set to 10 and the executing
-                            policy with this will bring the number of
-                            servers to 10. The minimum allowed value
-                            is 0.</para>
-                    </wadl:doc>
-                </param>
+
             </representation>
         </request>
         <response status="201">
@@ -657,6 +637,48 @@
                 successful, no response body is returned.</para>
         </wadl:doc>
         <request>
+            <param style="plain" name="maxEntities" required="true"
+                type="object" path="$.maxEntities">
+                <wadl:doc xmlns="http://docbook.org/ns/docbook"
+                    xml:lang="EN"><para>The maximum amount of
+                        identities that are allowed in the scaling
+                        group. This number defaults to null. If this
+                        value is provided it must be set to an integer
+                        between 0 and 1000.</para>
+                </wadl:doc>
+            </param>
+            <param style="plain" name="cooldown" required="true"
+                type="integer" path="$.cooldown">
+                <wadl:doc xmlns="http://docbook.org/ns/docbook"
+                    xml:lang="EN"><para>The cool-down period before
+                        more entities are added, in seconds. This
+                        number must be an integer between 0 and 86400
+                        (24 hrs).</para>
+                </wadl:doc>
+            </param>
+            <param style="plain" name="name" required="true"
+                type="string" path="$.name">
+                <wadl:doc xmlns="http://docbook.org/ns/docbook"
+                    xml:lang="EN"><para>The name of the scaling group.
+                        This name cannot be unique.</para></wadl:doc>
+            </param>
+            <param style="plain" name="minEntities" required="true"
+                type="integer" path="$.minEntities">
+                <wadl:doc xmlns="http://docbook.org/ns/docbook"
+                    xml:lang="EN"><para>The minimum number of entities
+                        in the scaling group. This number must be an
+                        integer between 0 and 1000.</para></wadl:doc>
+            </param>
+            <param style="plain" name="metadata" required="true"
+                type="object" path="$.metadata">
+                <wadl:doc xmlns="http://docbook.org/ns/docbook"
+                    xml:lang="EN"><para>Optional. Custom metadata for
+                        your group configuration. You can use the
+                        metadata parameter for customer automation,
+                        but it does not change any functionality in
+                        Auto Scale. There currently is no limitation
+                        on depth.</para></wadl:doc>
+            </param>
             <representation mediaType="application/json">
                 <wadl:doc xmlns="http://docbook.org/ns/docbook"
                     xml:lang="EN">
@@ -664,52 +686,7 @@
                         href="../docbkx/samples/reqPutGroupConfig.json"
                     />
                 </wadl:doc>
-                <param style="plain" name="maxEntities"
-                    required="true" type="object" path="$.maxEntities">
-                    <wadl:doc xmlns="http://docbook.org/ns/docbook"
-                        xml:lang="EN"><para>The maximum amount of
-                            identities that are allowed in the scaling
-                            group. This number defaults to null. If
-                            this value is provided it must be set to
-                            an integer between 0 and 1000.</para>
-                    </wadl:doc>
-                </param>
-                <param style="plain" name="cooldown" required="true"
-                    type="integer" path="$.cooldown">
-                    <wadl:doc xmlns="http://docbook.org/ns/docbook"
-                        xml:lang="EN"><para>The cool-down period
-                            before more entities are added, in
-                            seconds. This number must be an integer
-                            between 0 and 86400 (24 hrs).</para>
-                    </wadl:doc>
-                </param>
-                <param style="plain" name="name" required="true"
-                    type="string" path="$.name">
-                    <wadl:doc xmlns="http://docbook.org/ns/docbook"
-                        xml:lang="EN"><para>The name of the scaling
-                            group. This name cannot be
-                        unique.</para></wadl:doc>
-                </param>
-                <param style="plain" name="minEntities"
-                    required="true" type="integer"
-                    path="$.minEntities">
-                    <wadl:doc xmlns="http://docbook.org/ns/docbook"
-                        xml:lang="EN"><para>The minimum number of
-                            entities in the scaling group. This number
-                            must be an integer between 0 and
-                            1000.</para></wadl:doc>
-                </param>
-                <param style="plain" name="metadata" required="true"
-                    type="object" path="$.metadata">
-                    <wadl:doc xmlns="http://docbook.org/ns/docbook"
-                        xml:lang="EN"><para>Optional. Custom metadata
-                            for your group configuration. You can use
-                            the metadata parameter for customer
-                            automation, but it does not change any
-                            functionality in Auto Scale. There
-                            currently is no limitation on
-                            depth.</para></wadl:doc>
-                </param>
+
             </representation>
         </request>
         <response status="204"/> &commonFaults; &getFaults;
@@ -751,6 +728,103 @@
                 successful, no response body is returned.</para>
         </wadl:doc>
         <request>
+            <param style="plain" name="args" required="false"
+                type="object" path="$.args">
+                <wadl:doc xmlns="http://docbook.org/ns/docbook"
+                    xml:lang="EN"><para>The item to be configured.
+                        Must be "server" or "loadbalancer." Most
+                        launch configurations have both a server and a
+                        loadbalancer configured.</para></wadl:doc>
+            </param>
+            <param style="plain" name="loadBalancers" required="false"
+                type="array" path="$.args.loadBalancers">
+                <wadl:doc xmlns="http://docbook.org/ns/docbook"
+                    xml:lang="EN"><para>One or more load balancers to
+                        which to add servers.</para>
+                    <para>All servers are added to these load
+                        balancers with the IP addresses of their
+                        ServiceNet network. All servers are enabled
+                        and equally weighted. Any new servers that are
+                        not connected to the ServiceNet network are
+                        not added to any load
+                    balancers.</para></wadl:doc>
+            </param>
+            <param style="plain" name="port" required="true"
+                type="integer" path="$.args.loadBalancers.[*].port">
+                <wadl:doc xmlns="http://docbook.org/ns/docbook"
+                    xml:lang="EN"><para>The port number of the service
+                        (on the new servers) to use for this
+                        particular load balancer. In most cases, this
+                        port number is 80.</para></wadl:doc>
+            </param>
+            <param style="plain" name="loadBalancerId" required="true"
+                type="integer"
+                path="$.args.loadBalancers.[*].loadBalancerId">
+                <wadl:doc xmlns="http://docbook.org/ns/docbook"
+                    xml:lang="EN"><para>The ID of the load balancer to
+                        which new servers will be
+                    added.</para></wadl:doc>
+            </param>
+            <param style="plain" name="server" required="true"
+                type="object" path="$.args.server">
+                <wadl:doc xmlns="http://docbook.org/ns/docbook"
+                    xml:lang="EN"><para>The attributes that Auto Scale
+                        uses to create a new server. For more
+                        information, see <link
+                            xlink:href="http://docs.rackspace.com/servers/api/v2/cs-devguide/content/CreateServers.html"
+                            >Create Server</link>. The attributes that
+                        are specified for the server entity will apply
+                        to all new servers in the scaling group,
+                        including the server name.</para></wadl:doc>
+            </param>
+            <param style="plain" name="flavorRef" required="true"
+                type="string" path="$.args.server.flavorRef">
+                <wadl:doc xmlns="http://docbook.org/ns/docbook"
+                    xml:lang="EN"><para>The flavor of the server
+                        image. Specifies the flavor Id for the server.
+                        A flavor is a resource configuration for a
+                        server. For more information on available
+                        flavors, see the Server Flavors<olink
+                            targetdoc="autoscale-devguide"
+                            targetptr="server-flavors">“Server
+                            Flavors”</olink>
+                    section.</para></wadl:doc>
+            </param>
+            <param style="plain" name="imageRef" required="true"
+                type="string" path="$.args.server.imageRef">
+                <wadl:doc xmlns="http://docbook.org/ns/docbook"
+                    xml:lang="EN"><para>The ID of the cloud server
+                        image, after which new server images will be
+                        created.</para></wadl:doc>
+            </param>
+            <param style="plain" name="personality" required="false"
+                type="array" path="$.args.server.personality">
+                <wadl:doc xmlns="http://docbook.org/ns/docbook"
+                    xml:lang="EN"><para>The file path and/or the
+                        content that you want to inject into a server
+                        image. For more information, see the <link
+                            xlink:href="http://docs.rackspace.com/servers/api/v2/cs-devguide/content/Server_Personality-d1e2543.html"
+                            >Server Personality</link> documentation
+                        for Rackspace Cloud Servers.</para></wadl:doc>
+            </param>
+            <param style="plain" name="path" required="true"
+                type="string"
+                path="$.args.server.personality.[*].path">
+                <wadl:doc xmlns="http://docbook.org/ns/docbook"
+                    xml:lang="EN"><para>The path to the file that
+                        contains data that will be injected into the
+                        file system of the new cloud server
+                        image.</para></wadl:doc>
+            </param>
+            <param style="plain" name="contents" required="true"
+                type="string"
+                path="$.args.server.personality.[*].contents">
+                <wadl:doc xmlns="http://docbook.org/ns/docbook"
+                    xml:lang="EN"><para>The content items that will be
+                        injected into the file system of the new cloud
+                        server image.</para>
+                </wadl:doc>
+            </param>
             <representation mediaType="application/json">
                 <wadl:doc xmlns="http://docbook.org/ns/docbook"
                     xml:lang="EN">
@@ -758,112 +832,7 @@
                         href="../docbkx/samples/reqPutLaunchConfig.json"
                     />
                 </wadl:doc>
-                <param style="plain" name="args" required="false"
-                    type="object" path="$.args">
-                    <wadl:doc xmlns="http://docbook.org/ns/docbook"
-                        xml:lang="EN"><para>The item to be configured.
-                            Must be "server" or "loadbalancer." Most
-                            launch configurations have both a server
-                            and a loadbalancer
-                        configured.</para></wadl:doc>
-                </param>
-                <param style="plain" name="loadBalancers"
-                    required="false" type="array"
-                    path="$.args.loadBalancers">
-                    <wadl:doc xmlns="http://docbook.org/ns/docbook"
-                        xml:lang="EN"><para>One or more load balancers
-                            to which to add servers.</para>
-                        <para>All servers are added to these load
-                            balancers with the IP addresses of their
-                            ServiceNet network. All servers are
-                            enabled and equally weighted. Any new
-                            servers that are not connected to the
-                            ServiceNet network are not added to any
-                            load balancers.</para></wadl:doc>
-                </param>
-                <param style="plain" name="port" required="true"
-                    type="integer"
-                    path="$.args.loadBalancers.[*].port">
-                    <wadl:doc xmlns="http://docbook.org/ns/docbook"
-                        xml:lang="EN"><para>The port number of the
-                            service (on the new servers) to use for
-                            this particular load balancer. In most
-                            cases, this port number is
-                        80.</para></wadl:doc>
-                </param>
-                <param style="plain" name="loadBalancerId"
-                    required="true" type="integer"
-                    path="$.args.loadBalancers.[*].loadBalancerId">
-                    <wadl:doc xmlns="http://docbook.org/ns/docbook"
-                        xml:lang="EN"><para>The ID of the load
-                            balancer to which new servers will be
-                            added.</para></wadl:doc>
-                </param>
-                <param style="plain" name="server" required="true"
-                    type="object" path="$.args.server">
-                    <wadl:doc xmlns="http://docbook.org/ns/docbook"
-                        xml:lang="EN"><para>The attributes that Auto
-                            Scale uses to create a new server. For
-                            more information, see <link
-                                xlink:href="http://docs.rackspace.com/servers/api/v2/cs-devguide/content/CreateServers.html"
-                                >Create Server</link>. The attributes
-                            that are specified for the server entity
-                            will apply to all new servers in the
-                            scaling group, including the server
-                            name.</para></wadl:doc>
-                </param>
-                <param style="plain" name="flavorRef" required="true"
-                    type="string" path="$.args.server.flavorRef">
-                    <wadl:doc xmlns="http://docbook.org/ns/docbook"
-                        xml:lang="EN"><para>The flavor of the server
-                            image. Specifies the flavor Id for the
-                            server. A flavor is a resource
-                            configuration for a server. For more
-                            information on available flavors, see the
-                            Server Flavors<olink
-                                targetdoc="autoscale-devguide"
-                                targetptr="server-flavors">“Server
-                                Flavors”</olink>
-                        section.</para></wadl:doc>
-                </param>
-                <param style="plain" name="imageRef" required="true"
-                    type="string" path="$.args.server.imageRef">
-                    <wadl:doc xmlns="http://docbook.org/ns/docbook"
-                        xml:lang="EN"><para>The ID of the cloud server
-                            image, after which new server images will
-                            be created.</para></wadl:doc>
-                </param>
-                <param style="plain" name="personality"
-                    required="false" type="array"
-                    path="$.args.server.personality">
-                    <wadl:doc xmlns="http://docbook.org/ns/docbook"
-                        xml:lang="EN"><para>The file path and/or the
-                            content that you want to inject into a
-                            server image. For more information, see
-                            the <link
-                                xlink:href="http://docs.rackspace.com/servers/api/v2/cs-devguide/content/Server_Personality-d1e2543.html"
-                                >Server Personality</link>
-                            documentation for Rackspace Cloud
-                            Servers.</para></wadl:doc>
-                </param>
-                <param style="plain" name="path" required="true"
-                    type="string"
-                    path="$.args.server.personality.[*].path">
-                    <wadl:doc xmlns="http://docbook.org/ns/docbook"
-                        xml:lang="EN"><para>The path to the file that
-                            contains data that will be injected into
-                            the file system of the new cloud server
-                            image.</para></wadl:doc>
-                </param>
-                <param style="plain" name="contents" required="true"
-                    type="string"
-                    path="$.args.server.personality.[*].contents">
-                    <wadl:doc xmlns="http://docbook.org/ns/docbook"
-                        xml:lang="EN"><para>The content items that
-                            will be injected into the file system of
-                            the new cloud server image.</para>
-                    </wadl:doc>
-                </param>
+
             </representation>
         </request>
         <response status="204"/> &commonFaults; &getFaults;
@@ -996,9 +965,10 @@
                         either provide <code>cron</code> or "at" for a
                         given policy, but not both. You must specify
                         seconds when using "at". If seconds are not
-                        specified, a 400 error is
-                        returned. Note, the policy is triggered within a 
-                        10-second range of the time specified by <code>at</code>. </para></wadl:doc>
+                        specified, a 400 error is returned. Note, the
+                        policy is triggered within a 10-second range
+                        of the time specified by <code>at</code>.
+                    </para></wadl:doc>
             </param>
             <param style="plain" name="changePercent" required="false"
                 type="number" path="$.[*].changePercent">
@@ -1160,131 +1130,122 @@
                 no response body is returned.</para>
         </wadl:doc>
         <request>
+            <param style="plain" name="name" required="true"
+                type="string" path="$.scalingPolicies.[*].name">
+                <wadl:doc xmlns="http://docbook.org/ns/docbook"
+                    xml:lang="EN"><para>A name for the scaling policy.
+                        This name must be unique for each scaling
+                        policy.</para></wadl:doc>
+            </param>
+            <param style="plain" name="args" required="false"
+                type="object" path="$.scalingPolicies.[*].args">
+                <wadl:doc xmlns="http://docbook.org/ns/docbook"
+                    xml:lang="EN"><para>Additional configuration
+                        information for policies of type "schedule."
+                        This parameter is not required for policies of
+                        type "webhook." This parameter must be set to
+                        either "at" or <code>cron</code>. Both "at"
+                        and <code>cron</code> are mutually
+                        exclusive.</para>
+                </wadl:doc>
+            </param>
+            <param style="plain" name="cron" required="false"
+                type="string" path="$.scalingPolicies.[*].args.cron">
+                <wadl:doc xmlns="http://docbook.org/ns/docbook"
+                    xml:lang="EN"><para>The recurring time when the
+                        policy runs as a cron entry. For example, if
+                        you set this parameter to <code>1 0 * *
+                            *</code>, the policy will run at one
+                        minute past midnight (00:01) every day of the
+                        month, and every day of the week. For more
+                        information about cron, see <link
+                            xlink:href="http://en.wikipedia.org/wiki/Cron"
+                            >http://en.wikipedia.org/wiki/Cron</link>.</para></wadl:doc>
+            </param>
+            <param style="plain" name="at" required="false"
+                type="string" path="$.scalingPolicies.[*].args.at">
+                <wadl:doc xmlns="http://docbook.org/ns/docbook"
+                    xml:lang="EN"><para>The time at which this policy
+                        runs. This property is mutually exclusive with
+                        the <code>cron</code> parameter. You can
+                        either provide <code>cron</code> or "at" for a
+                        given policy, but not both. You must specify
+                        seconds when using "at". If seconds are not
+                        specified, a 400 error is
+                    returned.</para></wadl:doc>
+            </param>
+            <param style="plain" name="changePercent" required="false"
+                type="number"
+                path="$.scalingPolicies.[*].changePercent">
+                <wadl:doc xmlns="http://docbook.org/ns/docbook"
+                    xml:lang="EN"><para>The percent change to make in
+                        the number of servers in the scaling group. If
+                        this number is positive, the number of servers
+                        will increase by the given percentage. If this
+                        parameter is set to a negative number, the
+                        number of servers decreases by the given
+                        percentage. The absolute change in the number
+                        of servers will be rounded to the nearest
+                        integer. This means that if -X% of the current
+                        number of servers translates to -0.5 or -0.25
+                        or -0.75 servers, the actual number of servers
+                        that will be shut down is 1. If X% of the
+                        current number of servers translates to 1.2 or
+                        1.5 or 1.7 servers, the actual number of
+                        servers that will be launched is
+                    2.</para></wadl:doc>
+            </param>
+            <param style="plain" name="cooldown" required="true"
+                type="number" path="$.scalingPolicies.[*].cooldown">
+                <wadl:doc xmlns="http://docbook.org/ns/docbook"
+                    xml:lang="EN"><para>The cool-down period, in
+                        seconds, before this particular scaling policy
+                        can run again. The cool-down period does not
+                        affect the global scaling group cool-down. The
+                        minimum value for this parameter is 0 seconds.
+                        The maximum value is 86400 seconds (24
+                        hrs).</para></wadl:doc>
+            </param>
+            <param style="plain" name="type" required="true"
+                type="enum" path="$.scalingPolicies.[*].type">
+                <wadl:doc xmlns="http://docbook.org/ns/docbook"
+                    xml:lang="EN"><para>The type of policy that runs
+                        for the current release. This value can be
+                        either <code>webhook</code> for webhook-based
+                        policies or <code>schedule</code> for
+                        schedule-based policies.</para></wadl:doc>
+            </param>
+            <param style="plain" name="change" required="false"
+                type="integer" path="$.scalingPolicies.[*].change">
+                <wadl:doc xmlns="http://docbook.org/ns/docbook"
+                    xml:lang="EN"><para>The change to make in the
+                        number of servers in the scaling group. This
+                        parameter must be an integer. If the value is
+                        a positive integer, the number of servers
+                        increases. If the value is a negative integer,
+                        the number of servers
+                    decreases.</para></wadl:doc>
+            </param>
+            <param style="plain" name="desiredCapacity"
+                required="false" type="integer"
+                path="$.scalingPolicies.[*].desiredCapacity">
+                <wadl:doc xmlns="http://docbook.org/ns/docbook"
+                    xml:lang="EN"><para>The desired server capacity of
+                        the scaling the group, such as how many
+                        servers should be in the scaling group. This
+                        value must be an absolute number. For example,
+                        if this parameter is set to 10, running this
+                        policy brings the number of servers to 10. The
+                        minimum allowed value of this parameter is
+                        0.</para>
+                </wadl:doc>
+            </param>
             <representation mediaType="application/json">
                 <wadl:doc xmlns="http://docbook.org/ns/docbook"
                     xml:lang="EN">
                     <xsdxt:code
                         href="../docbkx/samples/reqPutPolicy.json"/>
                 </wadl:doc>
-                <param style="plain" name="name" required="true"
-                    type="string" path="$.scalingPolicies.[*].name">
-                    <wadl:doc xmlns="http://docbook.org/ns/docbook"
-                        xml:lang="EN"><para>A name for the scaling
-                            policy. This name must be unique for each
-                            scaling policy.</para></wadl:doc>
-                </param>
-                <param style="plain" name="args" required="false"
-                    type="object" path="$.scalingPolicies.[*].args">
-                    <wadl:doc xmlns="http://docbook.org/ns/docbook"
-                        xml:lang="EN"><para>Additional configuration
-                            information for policies of type
-                            "schedule." This parameter is not required
-                            for policies of type "webhook." This
-                            parameter must be set to either "at" or
-                                <code>cron</code>. Both "at" and
-                                <code>cron</code> are mutually
-                            exclusive.</para>
-                    </wadl:doc>
-                </param>
-                <param style="plain" name="cron" required="false"
-                    type="string"
-                    path="$.scalingPolicies.[*].args.cron">
-                    <wadl:doc xmlns="http://docbook.org/ns/docbook"
-                        xml:lang="EN"><para>The recurring time when
-                            the policy runs as a cron entry. For
-                            example, if you set this parameter to
-                                <code>1 0 * * *</code>, the policy
-                            will run at one minute past midnight
-                            (00:01) every day of the month, and every
-                            day of the week. For more information
-                            about cron, see <link
-                                xlink:href="http://en.wikipedia.org/wiki/Cron"
-                                >http://en.wikipedia.org/wiki/Cron</link>.</para></wadl:doc>
-                </param>
-                <param style="plain" name="at" required="false"
-                    type="string" path="$.scalingPolicies.[*].args.at">
-                    <wadl:doc xmlns="http://docbook.org/ns/docbook"
-                        xml:lang="EN"><para>The time at which this
-                            policy runs. This property is mutually
-                            exclusive with the <code>cron</code>
-                            parameter. You can either provide
-                                <code>cron</code> or "at" for a given
-                            policy, but not both. You must specify
-                            seconds when using "at". If seconds are
-                            not specified, a 400 error is
-                            returned.</para></wadl:doc>
-                </param>
-                <param style="plain" name="changePercent"
-                    required="false" type="number"
-                    path="$.scalingPolicies.[*].changePercent">
-                    <wadl:doc xmlns="http://docbook.org/ns/docbook"
-                        xml:lang="EN"><para>The percent change to make
-                            in the number of servers in the scaling
-                            group. If this number is positive, the
-                            number of servers will increase by the
-                            given percentage. If this parameter is set
-                            to a negative number, the number of
-                            servers decreases by the given percentage.
-                            The absolute change in the number of
-                            servers will be rounded to the nearest
-                            integer. This means that if -X% of the
-                            current number of servers translates to
-                            -0.5 or -0.25 or -0.75 servers, the actual
-                            number of servers that will be shut down
-                            is 1. If X% of the current number of
-                            servers translates to 1.2 or 1.5 or 1.7
-                            servers, the actual number of servers that
-                            will be launched is 2.</para></wadl:doc>
-                </param>
-                <param style="plain" name="cooldown" required="true"
-                    type="number"
-                    path="$.scalingPolicies.[*].cooldown">
-                    <wadl:doc xmlns="http://docbook.org/ns/docbook"
-                        xml:lang="EN"><para>The cool-down period, in
-                            seconds, before this particular scaling
-                            policy can run again. The cool-down period
-                            does not affect the global scaling group
-                            cool-down. The minimum value for this
-                            parameter is 0 seconds. The maximum value
-                            is 86400 seconds (24
-                        hrs).</para></wadl:doc>
-                </param>
-                <param style="plain" name="type" required="true"
-                    type="enum" path="$.scalingPolicies.[*].type">
-                    <wadl:doc xmlns="http://docbook.org/ns/docbook"
-                        xml:lang="EN"><para>The type of policy that
-                            runs for the current release. This value
-                            can be either <code>webhook</code> for
-                            webhook-based policies or
-                                <code>schedule</code> for
-                            schedule-based policies.</para></wadl:doc>
-                </param>
-                <param style="plain" name="change" required="false"
-                    type="integer" path="$.scalingPolicies.[*].change">
-                    <wadl:doc xmlns="http://docbook.org/ns/docbook"
-                        xml:lang="EN"><para>The change to make in the
-                            number of servers in the scaling group.
-                            This parameter must be an integer. If the
-                            value is a positive integer, the number of
-                            servers increases. If the value is a
-                            negative integer, the number of servers
-                            decreases.</para></wadl:doc>
-                </param>
-                <param style="plain" name="desiredCapacity"
-                    required="false" type="integer"
-                    path="$.scalingPolicies.[*].desiredCapacity">
-                    <wadl:doc xmlns="http://docbook.org/ns/docbook"
-                        xml:lang="EN"><para>The desired server
-                            capacity of the scaling the group, such as
-                            how many servers should be in the scaling
-                            group. This value must be an absolute
-                            number. For example, if this parameter is
-                            set to 10, running this policy brings the
-                            number of servers to 10. The minimum
-                            allowed value of this parameter is
-                            0.</para>
-                    </wadl:doc>
-                </param>
             </representation>
         </request>
         <response status="204"/> &commonFaults; &getFaults;
@@ -1338,6 +1299,20 @@
                 to the newly created web hooks. This data is provided
                 in the request body in JSON format.</para></wadl:doc>
         <request>
+            <param style="plain" name="name" required="true"
+                type="string" path="$.[*].name">
+                <wadl:doc xmlns="http://docbook.org/ns/docbook"
+                    xml:lang="EN"><para>A name for the webhook for
+                        logging purposes.</para></wadl:doc>
+            </param>
+            <param style="plain" name="metadata" required="false"
+                type="object" path="$.[*].metadata">
+                <wadl:doc xmlns="http://docbook.org/ns/docbook"
+                    xml:lang="EN"><para>User-provided key-value
+                        metadata. Both keys and values should be
+                        strings with a maximum length of 256
+                        characters.</para></wadl:doc>
+            </param>
             <representation mediaType="application/json">
                 <wadl:doc xmlns="http://docbook.org/ns/docbook"
                     xml:lang="EN">
@@ -1347,20 +1322,6 @@
                         href="../docbkx/samples/reqCreateWebhook.json"
                     />
                 </wadl:doc>
-                <param style="plain" name="name" required="true"
-                    type="string" path="$.[*].name">
-                    <wadl:doc xmlns="http://docbook.org/ns/docbook"
-                        xml:lang="EN"><para>A name for the webhook for
-                            logging purposes.</para></wadl:doc>
-                </param>
-                <param style="plain" name="metadata" required="false"
-                    type="object" path="$.[*].metadata">
-                    <wadl:doc xmlns="http://docbook.org/ns/docbook"
-                        xml:lang="EN"><para>User-provided key-value
-                            metadata. Both keys and values should be
-                            strings with a maximum length of 256
-                            characters.</para></wadl:doc>
-                </param>
             </representation>
         </request>
         <response status="201">
@@ -1405,23 +1366,23 @@
                 successful, no response body is returned.</para>
         </wadl:doc>
         <request>
+            <param style="plain" name="name" type="string"
+                required="true" path="$.[*].name">
+                <wadl:doc xmlns="http://docbook.org/ns/docbook"
+                    xml:lang="EN"><para>A name for the webhook for
+                        logging purposes.</para></wadl:doc>
+            </param>
+            <param style="plain" name="metadata" required="false"
+                type="object" path="$.[*].metadata">
+                <wadl:doc xmlns="http://docbook.org/ns/docbook"
+                    xml:lang="EN"><para>User-provided key-value
+                        metadata. Both keys and values should be
+                        strings not exceeding 256 characters in
+                        length.</para></wadl:doc>
+            </param>
             <representation mediaType="application/json">
                 <wadl:doc xmlns="http://docbook.org/ns/docbook"
                     xml:lang="EN"> </wadl:doc>
-                <param style="plain" name="name" type="string"
-                    required="true" path="$.[*].name">
-                    <wadl:doc xmlns="http://docbook.org/ns/docbook"
-                        xml:lang="EN"><para>A name for the webhook for
-                            logging purposes.</para></wadl:doc>
-                </param>
-                <param style="plain" name="metadata" required="false"
-                    type="object" path="$.[*].metadata">
-                    <wadl:doc xmlns="http://docbook.org/ns/docbook"
-                        xml:lang="EN"><para>User-provided key-value
-                            metadata. Both keys and values should be
-                            strings not exceeding 256 characters in
-                            length.</para></wadl:doc>
-                </param>
             </representation>
         </request>
         <response status="204"/> &commonFaults; &getFaults;
@@ -1441,7 +1402,6 @@
             title="Execute anonymous webhook">
             <para role="shortdesc">Runs an anonymous webhook.</para>
         </wadl:doc>
-
         <response status="202"/> &commonFaults; &getFaults;
         &postPutFaults; </method>
 </application>


### PR DESCRIPTION
author: diane fleming

this doesn't fix the problem - david will have to investigate, but the <param> definitions should be after the <request> tag but before the <representation> tag - so I fixed that.
