### PR TITLE
AS-149 Log the image ID when executing a launch config (reviewed, pending merge)

### DIFF
--- a/otter/controller.py
+++ b/otter/controller.py
@@ -424,7 +424,12 @@ class _Job(object):
         except:
             image = 'Unable to pull image ref.'
 
-        self.log = self.log.bind(image_id=image)
+        try:
+            flavor = launch_config['args']['server']['flavorRef']
+        except:
+            flavor = 'Unable to pull flavor ref.'
+
+        self.log = self.log.bind(image_ref=image, flavor_ref=flavor)
 
         deferred = self.supervisor.execute_config(
             self.log, self.transaction_id, self.scaling_group, launch_config)


### PR DESCRIPTION
I know this is not on the sprint - I thought it'd only take 5 seconds since it's a 5-line change in the controller, but fixing the tests took a little longer than I thought.  Anyway...
