### PR TITLE
AS-159: Create server limit (reviewed, pending merge)

### DIFF
--- a/otter/worker/launch_server_v1.py
+++ b/otter/worker/launch_server_v1.py
@@ -20,7 +20,7 @@ import json
 import itertools
 from copy import deepcopy
 
-from twisted.internet.defer import gatherResults, maybeDeferred
+from twisted.internet.defer import gatherResults, maybeDeferred, DeferredSemaphore
 
 from otter.util import logging_treq as treq
 
@@ -151,6 +151,11 @@ def wait_for_active(log,
         deferred_description=timeout_description)
 
 
+# limit on 2 servers to be created simultaneously
+MAX_CREATE_SERVER = 2
+create_server_sem = DeferredSemaphore(MAX_CREATE_SERVER)
+
+
 def create_server(server_endpoint, auth_token, server_config, log=None):
     """
     Create a new server.
@@ -162,8 +167,8 @@ def create_server(server_endpoint, auth_token, server_config, log=None):
     :return: Deferred that fires with the CreateServer response as a dict.
     """
     path = append_segments(server_endpoint, 'servers')
-    d = treq.post(path, headers=headers(auth_token),
-                  data=json.dumps({'server': server_config}), log=log)
+    d = create_server_sem.run(treq.post, path, headers=headers(auth_token),
+                              data=json.dumps({'server': server_config}), log=log)
     d.addCallback(check_success, [202])
     d.addErrback(wrap_request_error, path, 'server_create')
     return d.addCallback(treq.json_content)


### PR DESCRIPTION
Limiting number of servers that can be created at same time to 2. This will reduce load on nova may hopefully reduce errors (timeouts and ERROR state)

https://jira.rax.io/browse/AS-159
