### PR TITLE
Remove the docbook target when cleaning out docs in the Makefile (reviewed, pending merge)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,7 @@ coverage:
 cleandocs:
 	rm -rf _builddoc
 	rm -rf htmldoc
+	rm -rf docbook/target
 
 docs: cleandocs
 	cp -r ${DOCDIR} _builddoc


### PR DESCRIPTION
These weren't getting cleaned out when `make clean` was called before builds, resulting in false failures.
