### PR TITLE
changed timeout for wait_for_expected_group_state from 2 to 3 min

### DIFF
--- a/autoscale_cloudroast/test_repo/autoscale/fixtures.py
+++ b/autoscale_cloudroast/test_repo/autoscale/fixtures.py
@@ -326,7 +326,7 @@ class AutoscaleFixture(BaseTestFixture):
                 "observe the active server list achieving the expected servers count: {2}.".format(
                     timeout, group_id, expected_servers))
 
-    def wait_for_expected_group_state(self, group_id, expected_servers, wait_time=120):
+    def wait_for_expected_group_state(self, group_id, expected_servers, wait_time=180):
         """
         :summary: verify the group state reached the expected servers count.
         :param group_id: Group id
@@ -340,7 +340,7 @@ class AutoscaleFixture(BaseTestFixture):
             time.sleep(self.interval_time)
         else:
             self.fail(
-                "wait_for_exepected_group_state ran for 120 seconds for group {0} and did not "
+                "wait_for_exepected_group_state ran for 180 seconds for group {0} and did not "
                 "observe the active server list achieving the expected servers count: {1}.".format(
                     group_id, expected_servers))
 


### PR DESCRIPTION
The default timeout is being changed since the quick system test "test_system_user_delete_some_servers_out_of_band" has been repeatedly failing due to out of band deletes taking slightly longer than 2 minutes to be registered.
