### PR TITLE
AS-264: using local timestamp when changing group (review)

### DIFF
--- a/otter/test/models/test_cass_models.py
+++ b/otter/test/models/test_cass_models.py
@@ -411,6 +411,31 @@ class CassScalingGroupTests(CassScalingGroupTestCase):
     CassScalingGroup's tests
     """
 
+    def test_with_timestamp(self):
+        """
+        `with_timestamp` calls the decorated function with the timestamp got from
+        `get_client_ts`
+        """
+        self.clock.advance(23.566783)
+
+        @self.group.with_timestamp
+        def f(ts, a, b):
+            "f"
+            self.ts = ts
+            self.a = a
+            self.b = b
+            return 45
+
+        d = f(2, 3)
+        # Wrapped function's return is same
+        self.assertEqual(self.successResultOf(d), 45)
+        # Timestamp and arguments are passed correctly
+        self.assertEqual(self.ts, 23566783)
+        self.assertEqual(self.a, 2)
+        self.assertEqual(self.b, 3)
+        # has same docstring
+        self.assertEqual(f.__doc__, 'f')
+
     def test_view_config(self):
         """
         Test that you can call view and receive a valid parsed response


### PR DESCRIPTION
This should fix https://jira.rax.io/browse/AS-151 but only when one policy execution is happening in one node at a time. This can be a problem if multiple/same policies of same group are getting executing on multiple nodes at same time. 
