### PR TITLE
Minor change - use SynchronousTestCase instead of TestCase

### DIFF
--- a/otter/test/audit_log/test_models.py
+++ b/otter/test/audit_log/test_models.py
@@ -5,7 +5,7 @@ Tests for the Audit Log.
 import mock
 import uuid
 
-from twisted.trial.unittest import TestCase
+from twisted.trial.unittest import SynchronousTestCase
 from twisted.internet.defer import succeed
 
 from zope.interface.verify import verifyObject
@@ -18,7 +18,7 @@ ts1 = uuid.UUID('df3376c7-d86b-11e2-b92c-1040f3e9b720')
 ts2 = uuid.UUID('49825240-de87-11e2-8651-406c8f25a009')
 
 
-class CassandraAuditLogTests(TestCase):
+class CassandraAuditLogTests(SynchronousTestCase):
     """
     Test cassandra backed audit logs.
     """

--- a/otter/test/indexer/test_atom.py
+++ b/otter/test/indexer/test_atom.py
@@ -2,7 +2,7 @@
 Tests for :mod:`otter.indexer.atom`
 """
 
-from twisted.trial.unittest import TestCase
+from twisted.trial.unittest import SynchronousTestCase
 
 from otter.test.utils import fixture
 
@@ -11,7 +11,7 @@ from otter.indexer.atom import (
 )
 
 
-class SimpleAtomTestCase(TestCase):
+class SimpleAtomTestCase(SynchronousTestCase):
     """
     Tests for the public functions in :mod:`otter.indexer.atom` against a
     simple atom feed fixture.

--- a/otter/test/indexer/test_poller.py
+++ b/otter/test/indexer/test_poller.py
@@ -6,7 +6,7 @@ import mock
 
 from zope.interface import implements
 
-from twisted.trial.unittest import TestCase
+from twisted.trial.unittest import SynchronousTestCase
 
 from twisted.internet.defer import succeed
 from twisted.internet.task import Cooperator
@@ -54,7 +54,7 @@ def feed_response(fixture_name):
         fixture(fixture_name)))
 
 
-class FeedPollerServiceTests(TestCase):
+class FeedPollerServiceTests(SynchronousTestCase):
     """
     Tests for :class:`otter.indexer.poller.FeedPollerService`
     """

--- a/otter/test/json_schema/test_schemas.py
+++ b/otter/test/json_schema/test_schemas.py
@@ -4,7 +4,7 @@ Tests for :mod:`otter.jsonschema.group_schemas`
 from copy import deepcopy
 from datetime import datetime, timedelta
 
-from twisted.trial.unittest import TestCase
+from twisted.trial.unittest import SynchronousTestCase
 from jsonschema import Draft3Validator, ValidationError
 
 from otter.json_schema import validate
@@ -12,7 +12,7 @@ from otter.json_schema import group_schemas, group_examples, rest_schemas
 from otter.util.config import set_config_data
 
 
-class ScalingGroupConfigTestCase(TestCase):
+class ScalingGroupConfigTestCase(SynchronousTestCase):
     """
     Simple verification that the JSON schema for scaling groups is correct.
     """
@@ -123,7 +123,7 @@ class ScalingGroupConfigTestCase(TestCase):
                                 validate, invalid, group_schemas.config)
 
 
-class GeneralLaunchConfigTestCase(TestCase):
+class GeneralLaunchConfigTestCase(SynchronousTestCase):
     """
     Verification that the general JSON schema for launch configs is correct.
     """
@@ -178,7 +178,7 @@ class GeneralLaunchConfigTestCase(TestCase):
                  schema)
 
 
-class ServerLaunchConfigTestCase(TestCase):
+class ServerLaunchConfigTestCase(SynchronousTestCase):
     """
     Simple verification that the JSON schema for launch server launch configs
     is correct.
@@ -273,7 +273,7 @@ class ServerLaunchConfigTestCase(TestCase):
                                 validate, invalid, group_schemas.launch_config)
 
 
-class LaunchConfigServerPayloadValidationTests(TestCase):
+class LaunchConfigServerPayloadValidationTests(SynchronousTestCase):
     """
     Tests to verify json schema of 'server' attribute used to create servers
     Valid tests are already done in ServerLaunchConfigTestCase.test_valid_examples_validate
@@ -381,7 +381,7 @@ class LaunchConfigServerPayloadValidationTests(TestCase):
                                 validate, self.server, group_schemas.server)
 
 
-class ScalingPolicyTestCase(TestCase):
+class ScalingPolicyTestCase(SynchronousTestCase):
     """
     Simple verification that the JSON schema for scaling policies is correct.
     """
@@ -712,7 +712,7 @@ class ScalingPolicyTestCase(TestCase):
                                 group_schemas.validate_cron, invalid_cron)
 
 
-class CreateScalingPoliciesTestCase(TestCase):
+class CreateScalingPoliciesTestCase(SynchronousTestCase):
     """
     Verification that the JSON schema for creating scaling policies is correct
     """
@@ -760,7 +760,7 @@ class CreateScalingPoliciesTestCase(TestCase):
                           rest_schemas.create_policies_request)
 
 
-class CreateScalingGroupTestCase(TestCase):
+class CreateScalingGroupTestCase(SynchronousTestCase):
     """
     Simple verification that the JSON schema for creating a scaling group is
     correct.
@@ -906,7 +906,7 @@ class CreateScalingGroupTestCase(TestCase):
                 }, rest_schemas.create_group_request)
 
 
-class SingleWebhookTestCase(TestCase):
+class SingleWebhookTestCase(SynchronousTestCase):
     """
     Verify the webhook schema.
     """
@@ -930,7 +930,7 @@ class SingleWebhookTestCase(TestCase):
         validate({'name': 'foo'}, group_schemas.webhook)
 
 
-class CreateWebhooksTestCase(TestCase):
+class CreateWebhooksTestCase(SynchronousTestCase):
     """
     Verification that the JSON schema for creating scaling policies is correct
     """
@@ -978,7 +978,7 @@ class CreateWebhooksTestCase(TestCase):
                           rest_schemas.create_policies_request)
 
 
-class UpdateWebhookTestCase(TestCase):
+class UpdateWebhookTestCase(SynchronousTestCase):
     """
     Verify the update webhook schemas.
     """

--- a/otter/test/models/test_cass_models.py
+++ b/otter/test/models/test_cass_models.py
@@ -8,7 +8,7 @@ from datetime import datetime
 import itertools
 from copy import deepcopy
 
-from twisted.trial.unittest import TestCase
+from twisted.trial.unittest import SynchronousTestCase
 from jsonschema import ValidationError
 
 from otter.json_schema import group_examples
@@ -91,7 +91,7 @@ def _cassandrify_data(list_of_dicts):
     return _de_identify(list_of_dicts)
 
 
-class SerialJsonDataTestCase(TestCase):
+class SerialJsonDataTestCase(SynchronousTestCase):
     """
     Serializing json data to be put into cassandra should append a version
     """
@@ -104,7 +104,7 @@ class SerialJsonDataTestCase(TestCase):
                          json.dumps({'_ver': 'version'}))
 
 
-class GetConsistencyTests(TestCase):
+class GetConsistencyTests(SynchronousTestCase):
     """
     Tests for `get_consistency_level`
     """
@@ -151,7 +151,7 @@ class GetConsistencyTests(TestCase):
         self.assertEqual(level, ConsistencyLevel.QUORUM)
 
 
-class AssembleWebhooksTests(TestCase):
+class AssembleWebhooksTests(SynchronousTestCase):
     """
     Tests for `assemble_webhooks_in_policies`
     """
@@ -239,7 +239,7 @@ class AssembleWebhooksTests(TestCase):
         self.assertEqual(policies[9]['webhooks'], ['9w91'])
 
 
-class VerifiedViewTests(TestCase):
+class VerifiedViewTests(SynchronousTestCase):
     """
     Tests for `verified_view`
     """
@@ -303,7 +303,7 @@ class VerifiedViewTests(TestCase):
         self.assertFalse(self.log.msg.called)
 
 
-class WeakLocksTests(TestCase):
+class WeakLocksTests(SynchronousTestCase):
     """
     Tests for `WeakLocks`
     """
@@ -333,7 +333,7 @@ class WeakLocksTests(TestCase):
         self.assertIsNot(self.locks.get_lock('a'), self.locks.get_lock('b'))
 
 
-class CassScalingGroupTestCase(IScalingGroupProviderMixin, LockMixin, TestCase):
+class CassScalingGroupTestCase(IScalingGroupProviderMixin, LockMixin, SynchronousTestCase):
     """
     Tests for :class:`MockScalingGroup`
     """
@@ -2184,7 +2184,7 @@ class ScalingGroupAddPoliciesTests(CassScalingGroupTestCase):
 
 
 class CassScalingScheduleCollectionTestCase(IScalingScheduleCollectionProviderMixin,
-                                            TestCase):
+                                            SynchronousTestCase):
     """
     Tests for :class:`CassScalingScheduleCollection`
     """
@@ -2301,7 +2301,7 @@ class CassScalingScheduleCollectionTestCase(IScalingScheduleCollectionProviderMi
 
 
 class CassScalingGroupsCollectionTestCase(IScalingGroupCollectionProviderMixin,
-                                          TestCase):
+                                          SynchronousTestCase):
     """
     Tests for :class:`CassScalingGroupCollection`
     """
@@ -2866,7 +2866,7 @@ class CassScalingGroupsCollectionTestCase(IScalingGroupCollectionProviderMixin,
 
 
 class CassScalingGroupsCollectionHealthCheckTestCase(
-        IScalingGroupCollectionProviderMixin, LockMixin, TestCase):
+        IScalingGroupCollectionProviderMixin, LockMixin, SynchronousTestCase):
     """
     Tests for `health_check` and `kazoo_health_check` in
     :class:`CassScalingGroupCollection`
@@ -2960,7 +2960,7 @@ class CassScalingGroupsCollectionHealthCheckTestCase(
             (True, {'cassandra_time': 0}))
 
 
-class CassAdminTestCase(TestCase):
+class CassAdminTestCase(SynchronousTestCase):
     """
     Tests for :class:`CassAdmin`
     """

--- a/otter/test/models/test_interface.py
+++ b/otter/test/models/test_interface.py
@@ -9,7 +9,7 @@ import mock
 from zope.interface.verify import verifyObject
 
 from twisted.internet import defer
-from twisted.trial.unittest import TestCase
+from twisted.trial.unittest import SynchronousTestCase
 
 from otter.models.interface import (
     GroupState, IScalingGroup, IScalingGroupCollection, IScalingScheduleCollection,
@@ -18,7 +18,7 @@ from otter.json_schema.group_schemas import launch_config
 from otter.json_schema import model_schemas, validate
 
 
-class GroupStateTestCase(TestCase):
+class GroupStateTestCase(SynchronousTestCase):
     """
     Tests the state object `otter.mode.s
     """

--- a/otter/test/rest/test_admin.py
+++ b/otter/test/rest/test_admin.py
@@ -4,12 +4,12 @@ Tests for the OtterAdmin application.
 import json
 
 from twisted.internet import defer
-from twisted.trial.unittest import TestCase
+from twisted.trial.unittest import SynchronousTestCase
 
 from otter.test.rest.request import AdminRestAPITestMixin
 
 
-class AdminEndpointsTestCase(AdminRestAPITestMixin, TestCase):
+class AdminEndpointsTestCase(AdminRestAPITestMixin, SynchronousTestCase):
     """
     Tests against the OtterAdmin endpoints.
     """

--- a/otter/test/rest/test_configs.py
+++ b/otter/test/rest/test_configs.py
@@ -10,7 +10,7 @@ from jsonschema import ValidationError
 import mock
 
 from twisted.internet import defer
-from twisted.trial.unittest import TestCase
+from twisted.trial.unittest import SynchronousTestCase
 
 from otter.json_schema.group_examples import (
     config as config_examples,
@@ -24,7 +24,7 @@ from otter.worker.validate_config import InvalidLaunchConfiguration
 from otter.test.rest.request import DummyException, RestAPITestMixin
 
 
-class GroupConfigTestCase(RestAPITestMixin, TestCase):
+class GroupConfigTestCase(RestAPITestMixin, SynchronousTestCase):
     """
     Tests for ``/{tenantId}/groups/{groupId}/config`` endpoint, which updates
     and views the config part of a scaling group (having to do with the min,
@@ -283,7 +283,7 @@ class GroupConfigTestCase(RestAPITestMixin, TestCase):
         self.assert_status_code(204, method='PUT', body=json.dumps(invalid))
 
 
-class LaunchConfigTestCase(RestAPITestMixin, TestCase):
+class LaunchConfigTestCase(RestAPITestMixin, SynchronousTestCase):
     """
     Tests for ``/{tenantId}/groups/{groupId}/launch`` endpoint, which updates
     and views the launch config part of a scaling group (having to do with

--- a/otter/test/rest/test_decorators.py
+++ b/otter/test/rest/test_decorators.py
@@ -8,7 +8,7 @@ import mock
 
 from jsonschema import ValidationError
 
-from twisted.trial.unittest import TestCase
+from twisted.trial.unittest import SynchronousTestCase
 from twisted.internet import defer
 from twisted.python.failure import Failure
 
@@ -30,7 +30,7 @@ class DetailsError(Exception):
     details = 'this is a detail'
 
 
-class TransactionIdTestCase(TestCase):
+class TransactionIdTestCase(SynchronousTestCase):
     """Test case for the transaction ID"""
     def setUp(self):
         """ Basic Setup and patch the log """
@@ -104,7 +104,7 @@ class TransactionIdTestCase(TestCase):
         self.mock_log.bind().bind.assert_called_with(arg1='a1', arg2='a2')
 
 
-class FaultTestCase(TestCase):
+class FaultTestCase(SynchronousTestCase):
     """Test case for the fault system"""
     def setUp(self):
         """ Basic Setup and patch the log """
@@ -348,7 +348,7 @@ class FaultTestCase(TestCase):
         self.flushLoggedErrors(BlahError)
 
 
-class ValidateBodyTestCase(TestCase):
+class ValidateBodyTestCase(SynchronousTestCase):
     """
     Tests for the `validate_body` decorator
     """
@@ -432,7 +432,7 @@ class ValidateBodyTestCase(TestCase):
         self.failureResultOf(FakeApp().handle_body(self.request), ValidationError)
 
 
-class LogArgumentsTestCase(TestCase):
+class LogArgumentsTestCase(SynchronousTestCase):
     """
     Tests for the `log_arguments` decorator
     """
@@ -482,7 +482,7 @@ class LogArgumentsTestCase(TestCase):
         self.mockLog.bind.assert_called_once_with(**kwargs)
 
 
-class PaginatableTestCase(TestCase):
+class PaginatableTestCase(SynchronousTestCase):
     """
     Tests for the `paginatable` decorator
     """
@@ -564,7 +564,7 @@ class PaginatableTestCase(TestCase):
                          {'marker': '1234', 'limit': 10})
 
 
-class AuditLoggerTestCase(TestCase):
+class AuditLoggerTestCase(SynchronousTestCase):
     """
     Tests for AuditLogger
     """
@@ -604,7 +604,7 @@ class AuditLoggerTestCase(TestCase):
         self.assertFalse(log_a.msg.called)
 
 
-class AuditableTestCase(TestCase):
+class AuditableTestCase(SynchronousTestCase):
     """
     Tests for auditable decorator
     """

--- a/otter/test/rest/test_groups.py
+++ b/otter/test/rest/test_groups.py
@@ -9,7 +9,7 @@ from copy import deepcopy
 import mock
 
 from twisted.internet import defer
-from twisted.trial.unittest import TestCase
+from twisted.trial.unittest import SynchronousTestCase
 
 from otter.json_schema.group_examples import (
     launch_server_config as launch_examples,
@@ -37,7 +37,7 @@ from otter.worker.validate_config import InvalidLaunchConfiguration
 from otter.util.config import set_config_data
 
 
-class FormatterHelpers(TestCase):
+class FormatterHelpers(SynchronousTestCase):
     """
     Tests for formatting helpers in :mod:`otter.rest.groups`
     """
@@ -85,7 +85,7 @@ class FormatterHelpers(TestCase):
         })
 
 
-class AllGroupsEndpointTestCase(RestAPITestMixin, TestCase):
+class AllGroupsEndpointTestCase(RestAPITestMixin, SynchronousTestCase):
     """
     Tests for ``/{tenantId}/groups/`` endpoints (create, list)
     """
@@ -493,7 +493,7 @@ class AllGroupsEndpointTestCase(RestAPITestMixin, TestCase):
         self.flushLoggedErrors(AssertionError)
 
 
-class AllGroupsBobbyEndpointTestCase(RestAPITestMixin, TestCase):
+class AllGroupsBobbyEndpointTestCase(RestAPITestMixin, SynchronousTestCase):
     """
     Tests for ``/{tenantId}/groups/`` endpoints (create, list) with Bobby
 
@@ -568,7 +568,7 @@ class AllGroupsBobbyEndpointTestCase(RestAPITestMixin, TestCase):
         create_group.assert_called_once_with('11111', '1')
 
 
-class OneGroupTestCase(RestAPITestMixin, TestCase):
+class OneGroupTestCase(RestAPITestMixin, SynchronousTestCase):
     """
     Tests for ``/{tenantId}/groups/{groupId}/`` endpoints (view manifest,
     view state, delete)
@@ -845,7 +845,7 @@ class OneGroupTestCase(RestAPITestMixin, TestCase):
         self.flushLoggedErrors(GroupNotEmptyError)
 
 
-class GroupStateTestCase(RestAPITestMixin, TestCase):
+class GroupStateTestCase(RestAPITestMixin, SynchronousTestCase):
     """
     Tests for ``/{tenantId}/groups/{groupId}/state/`` endpoint
     """
@@ -907,7 +907,7 @@ class GroupStateTestCase(RestAPITestMixin, TestCase):
         mock_format.assert_called_once_with('group_state')
 
 
-class GroupPauseTestCase(RestAPITestMixin, TestCase):
+class GroupPauseTestCase(RestAPITestMixin, SynchronousTestCase):
     """
     Tests for ``/{tenantId}/groups/{groupId}/pause/`` endpoint
     """
@@ -934,7 +934,7 @@ class GroupPauseTestCase(RestAPITestMixin, TestCase):
         self.assert_status_code(501, method="POST")
 
 
-class GroupResumeTestCase(RestAPITestMixin, TestCase):
+class GroupResumeTestCase(RestAPITestMixin, SynchronousTestCase):
     """
     Tests for ``/{tenantId}/groups/{groupId}/resume/`` endpoint
     """

--- a/otter/test/rest/test_history.py
+++ b/otter/test/rest/test_history.py
@@ -3,12 +3,12 @@ Tests for `otter.rest.history`
 """
 import json
 
-from twisted.trial.unittest import TestCase
+from twisted.trial.unittest import SynchronousTestCase
 
 from otter.test.rest.request import RestAPITestMixin, request
 
 
-class OtterHistoryTestCase(RestAPITestMixin, TestCase):
+class OtterHistoryTestCase(RestAPITestMixin, SynchronousTestCase):
     """
     Tests for ``/{tenantId}/history``
     """

--- a/otter/test/rest/test_limits.py
+++ b/otter/test/rest/test_limits.py
@@ -4,13 +4,13 @@ group limits
 """
 
 import json
-from twisted.trial.unittest import TestCase
+from twisted.trial.unittest import SynchronousTestCase
 
 from otter.test.rest.request import RestAPITestMixin, request
 from otter.util.config import set_config_data
 
 
-class OtterLimitsTestCase(RestAPITestMixin, TestCase):
+class OtterLimitsTestCase(RestAPITestMixin, SynchronousTestCase):
     """
     Tests for ``/{tenantId}/limits``
     """

--- a/otter/test/rest/test_metrics.py
+++ b/otter/test/rest/test_metrics.py
@@ -5,12 +5,12 @@ import json
 import mock
 
 from twisted.internet import defer
-from twisted.trial.unittest import TestCase
+from twisted.trial.unittest import SynchronousTestCase
 
 from otter.test.rest.request import AdminRestAPITestMixin
 
 
-class MetricsEndpointsTestCase(AdminRestAPITestMixin, TestCase):
+class MetricsEndpointsTestCase(AdminRestAPITestMixin, SynchronousTestCase):
     """
     Tests for '/metrics' endpoint, which contains metrics regarding the
     Otter system as a whole.

--- a/otter/test/rest/test_policies.py
+++ b/otter/test/rest/test_policies.py
@@ -10,7 +10,7 @@ from jsonschema import ValidationError
 import mock
 
 from twisted.internet import defer
-from twisted.trial.unittest import TestCase
+from twisted.trial.unittest import SynchronousTestCase
 
 from otter.controller import CannotExecutePolicyError
 from otter.json_schema.group_examples import policy as policy_examples
@@ -25,7 +25,7 @@ from otter.rest.bobby import set_bobby
 from otter.bobby import BobbyClient
 
 
-class AllPoliciesTestCase(RestAPITestMixin, TestCase):
+class AllPoliciesTestCase(RestAPITestMixin, SynchronousTestCase):
     """
     Tests for ``/{tenantId}/groups/{group_id}/policies`` endpoints (create, list)
     """
@@ -263,7 +263,7 @@ class AllPoliciesTestCase(RestAPITestMixin, TestCase):
             system=mock.ANY)
 
 
-class AllBobbyPoliciesTestCase(RestAPITestMixin, TestCase):
+class AllBobbyPoliciesTestCase(RestAPITestMixin, SynchronousTestCase):
     """
     Tests for ``/{tenantId}/groups/{group_id}/policies`` endpoints (create, list)
     """
@@ -395,7 +395,7 @@ class AllBobbyPoliciesTestCase(RestAPITestMixin, TestCase):
         self.assertEqual(resp, {"policies": [expected_policy]})
 
 
-class OnePolicyTestCase(RestAPITestMixin, TestCase):
+class OnePolicyTestCase(RestAPITestMixin, SynchronousTestCase):
     """
     Tests for ``/{tenantId}/groups/{groupId}/policies`` endpoint, which updates
     and views the policy part of a scaling group.

--- a/otter/test/rest/test_webhooks.py
+++ b/otter/test/rest/test_webhooks.py
@@ -9,7 +9,7 @@ from jsonschema import ValidationError
 import mock
 
 from twisted.internet import defer
-from twisted.trial.unittest import TestCase
+from twisted.trial.unittest import SynchronousTestCase
 
 from otter.json_schema import rest_schemas, validate
 from otter.models.interface import (
@@ -22,7 +22,7 @@ from otter.test.rest.request import DummyException, RestAPITestMixin
 from otter.controller import CannotExecutePolicyError
 
 
-class WebhookCollectionTestCase(RestAPITestMixin, TestCase):
+class WebhookCollectionTestCase(RestAPITestMixin, SynchronousTestCase):
     """
     Tests for ``/{tenantId}/groups/{groupId}/policies/{policyId}/webhooks``
     endpoints (create, list)
@@ -242,7 +242,7 @@ class WebhookCollectionTestCase(RestAPITestMixin, TestCase):
         })
 
 
-class OneWebhookTestCase(RestAPITestMixin, TestCase):
+class OneWebhookTestCase(RestAPITestMixin, SynchronousTestCase):
     """
     Tests for
     ``/{tenantId}/groups/{groupId}/policies/{policyId}/webhooks/{webhookId}``

--- a/otter/test/tap/test_api.py
+++ b/otter/test/tap/test_api.py
@@ -11,7 +11,7 @@ from twisted.internet import defer
 from twisted.internet.task import Clock
 
 from twisted.application.service import MultiService
-from twisted.trial.unittest import TestCase
+from twisted.trial.unittest import SynchronousTestCase
 
 from otter.supervisor import get_supervisor, set_supervisor, SupervisorService
 from otter.tap.api import (
@@ -32,7 +32,7 @@ test_config = {
 }
 
 
-class APIOptionsTests(TestCase):
+class APIOptionsTests(SynchronousTestCase):
     """
     Test the various command line options.
     """
@@ -63,7 +63,7 @@ class APIOptionsTests(TestCase):
         self.assertEqual(config['port'], 'tcp:9999')
 
 
-class HealthCheckerTests(TestCase):
+class HealthCheckerTests(SynchronousTestCase):
     """
     Tests for the HealthChecker object
     """
@@ -204,7 +204,7 @@ class HealthCheckerTests(TestCase):
         self.assertIn('a health check timed out', r['a']['details']['reason'])
 
 
-class CallAfterSupervisorTests(TestCase):
+class CallAfterSupervisorTests(SynchronousTestCase):
     """
     Tests for `call_after_supervisor`
     """
@@ -231,7 +231,7 @@ class CallAfterSupervisorTests(TestCase):
         self.assertEqual(self.successResultOf(d), 2)
 
 
-class APIMakeServiceTests(TestCase):
+class APIMakeServiceTests(SynchronousTestCase):
     """
     Test creation of the API service heirarchy.
     """
@@ -510,7 +510,7 @@ class APIMakeServiceTests(TestCase):
         self.assertTrue(kz_client.stop.called)
 
 
-class SchedulerSetupTests(TestCase):
+class SchedulerSetupTests(SynchronousTestCase):
     """
     Tests for `setup_scheduler`
     """

--- a/otter/test/test_auth.py
+++ b/otter/test/test_auth.py
@@ -3,7 +3,7 @@ Test authentication functions.
 """
 import mock
 
-from twisted.trial.unittest import TestCase
+from twisted.trial.unittest import SynchronousTestCase
 from twisted.internet.defer import succeed, fail, Deferred
 from twisted.internet.task import Clock
 
@@ -33,7 +33,7 @@ expected_headers = {'accept': ['application/json'],
                     'User-Agent': ['OtterScale/0.0']}
 
 
-class HelperTests(TestCase):
+class HelperTests(SynchronousTestCase):
     """
     Test misc helpers for authentication.
     """
@@ -260,7 +260,7 @@ class HelperTests(TestCase):
         self.assertEqual(real_failure.value.body, 'error_body')
 
 
-class ImpersonatingAuthenticatorTests(TestCase):
+class ImpersonatingAuthenticatorTests(SynchronousTestCase):
     """
     Tests for the end-to-end impersonation workflow.
     """
@@ -413,7 +413,7 @@ class ImpersonatingAuthenticatorTests(TestCase):
         self.assertTrue(failure.check(APIError))
 
 
-class CachingAuthenticatorTests(TestCase):
+class CachingAuthenticatorTests(SynchronousTestCase):
     """
     Test the in memory cache of authentication tokens.
     """
@@ -554,7 +554,7 @@ class CachingAuthenticatorTests(TestCase):
         self.assertTrue(failure.check(APIError))
 
 
-class RetryingAuthenticatorTests(TestCase):
+class RetryingAuthenticatorTests(SynchronousTestCase):
     """
     Tests for `RetryingAuthenticator`
     """

--- a/otter/test/test_bobby.py
+++ b/otter/test/test_bobby.py
@@ -5,13 +5,13 @@ Unit tests for the Bobby interface
 import mock
 import json
 
-from twisted.trial.unittest import TestCase
+from twisted.trial.unittest import SynchronousTestCase
 from twisted.internet.defer import succeed
 
 from otter.bobby import BobbyClient
 
 
-class BobbyTests(TestCase):
+class BobbyTests(SynchronousTestCase):
     """
     Bobby tests
     """

--- a/otter/test/test_controller.py
+++ b/otter/test/test_controller.py
@@ -8,7 +8,7 @@ import mock
 from testtools.matchers import ContainsDict, Equals
 
 from twisted.internet import defer
-from twisted.trial.unittest import TestCase
+from twisted.trial.unittest import SynchronousTestCase
 
 from otter import controller
 
@@ -18,7 +18,7 @@ from otter.util.timestamp import MIN
 from otter.test.utils import iMock, matches, patch, mock_log
 
 
-class CalculateDeltaTestCase(TestCase):
+class CalculateDeltaTestCase(SynchronousTestCase):
     """
     Tests for :func:`otter.controller.calculate_delta`
     """
@@ -485,7 +485,7 @@ class CalculateDeltaTestCase(TestCase):
             'constrained_desired_capacity': Equals(1)})))
 
 
-class CheckCooldownsTestCase(TestCase):
+class CheckCooldownsTestCase(SynchronousTestCase):
     """
     Tests for :func:`otter.controller.check_cooldowns`
     """
@@ -582,7 +582,7 @@ class CheckCooldownsTestCase(TestCase):
                                                     'pol'))
 
 
-class ObeyConfigChangeTestCase(TestCase):
+class ObeyConfigChangeTestCase(SynchronousTestCase):
     """
     Tests for :func:`otter.controller.obey_config_change`
     """
@@ -720,7 +720,7 @@ class ObeyConfigChangeTestCase(TestCase):
             webhook_id=None)
 
 
-class MaybeExecuteScalingPolicyTestCase(TestCase):
+class MaybeExecuteScalingPolicyTestCase(SynchronousTestCase):
     """
     Tests for :func:`otter.controller.maybe_execute_scaling_policy`
     """

--- a/otter/test/test_cqlbatch.py
+++ b/otter/test/test_cqlbatch.py
@@ -1,5 +1,5 @@
 """ CQL Batch wrapper test """
-from twisted.trial.unittest import TestCase
+from twisted.trial.unittest import SynchronousTestCase
 from otter.util.cqlbatch import Batch
 import mock
 from twisted.internet import defer
@@ -7,7 +7,7 @@ from twisted.internet import defer
 from silverberg.client import ConsistencyLevel
 
 
-class CqlBatchTestCase(TestCase):
+class CqlBatchTestCase(SynchronousTestCase):
     """
     CQL Batch wrapper test case
     """

--- a/otter/test/test_deferredutils.py
+++ b/otter/test/test_deferredutils.py
@@ -5,14 +5,14 @@ import mock
 
 from twisted.internet.task import Clock
 from twisted.internet.defer import CancelledError, Deferred
-from twisted.trial.unittest import TestCase
+from twisted.trial.unittest import SynchronousTestCase
 
 from otter.util.deferredutils import (
     timeout_deferred, retry_and_timeout, TimedOutError, DeferredPool)
 from otter.test.utils import DummyException, patch
 
 
-class TimeoutDeferredTests(TestCase):
+class TimeoutDeferredTests(SynchronousTestCase):
     """
     Tests for the method method ``timeout_deferred``
     """
@@ -124,7 +124,7 @@ class TimeoutDeferredTests(TestCase):
         self.assertIn("It'sa ME! timed out after 5.3 seconds", str(f))
 
 
-class RetryAndTimeoutTests(TestCase):
+class RetryAndTimeoutTests(SynchronousTestCase):
     """
     Tests for ``retry_and_timeout``.  Since this is just a composition of two
     already tested functions, just ensure that the arguments passed
@@ -167,7 +167,7 @@ class RetryAndTimeoutTests(TestCase):
         self.assertIs(retry_clock, timeout_clock)
 
 
-class DeferredPoolTests(TestCase):
+class DeferredPoolTests(SynchronousTestCase):
     """
     Tests for :class:`DeferredPool`
     """

--- a/otter/test/test_log.py
+++ b/otter/test/test_log.py
@@ -7,7 +7,7 @@ import mock
 from datetime import datetime
 
 from twisted.python.failure import Failure
-from twisted.trial.unittest import TestCase
+from twisted.trial.unittest import SynchronousTestCase
 
 from testtools.matchers import Contains, ContainsDict, Equals
 
@@ -21,7 +21,7 @@ from otter.log.formatters import (
 from otter.test.utils import SameJSON, matches
 
 
-class BoundLogTests(TestCase):
+class BoundLogTests(SynchronousTestCase):
     """
     Test the BoundLog utility.
     """
@@ -55,7 +55,7 @@ class BoundLogTests(TestCase):
         self.err.assert_called_once_with(exc, system='hello')
 
 
-class AuditLoggerTests(TestCase):
+class AuditLoggerTests(SynchronousTestCase):
     """
     Test the method that binds the audit log
     """
@@ -85,7 +85,7 @@ class AuditLoggerTests(TestCase):
         self.err.assert_called_once_with(exc, audit_log=True)
 
 
-class JSONObserverWrapperTests(TestCase):
+class JSONObserverWrapperTests(SynchronousTestCase):
     """
     Test the JSON observer wrapper.
     """
@@ -156,7 +156,7 @@ class JSONObserverWrapperTests(TestCase):
             {'message': (SameJSON({'foo': str(failure)}),)})
 
 
-class StreamObserverWrapperTests(TestCase):
+class StreamObserverWrapperTests(SynchronousTestCase):
     """
     Test the StreamObserverWrapper.
     """
@@ -215,7 +215,7 @@ class StreamObserverWrapperTests(TestCase):
              mock.call('bar')])
 
 
-class SystemFilterWrapperTests(TestCase):
+class SystemFilterWrapperTests(SynchronousTestCase):
     """
     Test the SystemFilterWrapper
     """
@@ -252,7 +252,7 @@ class SystemFilterWrapperTests(TestCase):
             {'system': 'otter.rest.blah.blargh'})
 
 
-class PEP3101FormattingWrapperTests(TestCase):
+class PEP3101FormattingWrapperTests(SynchronousTestCase):
     """
     Test the PEP3101 Formatting.
     """
@@ -307,7 +307,7 @@ class PEP3101FormattingWrapperTests(TestCase):
         })
 
 
-class ObserverWrapperTests(TestCase):
+class ObserverWrapperTests(SynchronousTestCase):
     """
     Test the ObserverWrapper.
     """
@@ -430,7 +430,7 @@ class ObserverWrapperTests(TestCase):
         ])
 
 
-class AuditLogFormatterTests(TestCase):
+class AuditLogFormatterTests(SynchronousTestCase):
     """
     Tests the audit log formatter
     """

--- a/otter/test/test_logging_treq.py
+++ b/otter/test/test_logging_treq.py
@@ -7,14 +7,14 @@ import treq
 from twisted.internet.defer import Deferred
 from twisted.internet.task import Clock
 from twisted.python.failure import Failure
-from twisted.trial.unittest import TestCase
+from twisted.trial.unittest import SynchronousTestCase
 
 from otter.util import logging_treq
 from otter.util.deferredutils import TimedOutError
 from otter.test.utils import CheckFailure, DummyException, mock_log, patch
 
 
-class LoggingTreqTest(TestCase):
+class LoggingTreqTest(SynchronousTestCase):
     """
     Test to make sure all treq methods are supported and all requests are
     logged.

--- a/otter/test/test_retry.py
+++ b/otter/test/test_retry.py
@@ -6,14 +6,14 @@ import mock
 from twisted.internet.task import Clock
 from twisted.internet.defer import CancelledError, Deferred, succeed
 from twisted.python.failure import Failure
-from twisted.trial.unittest import TestCase
+from twisted.trial.unittest import SynchronousTestCase
 
 from otter.util.retry import (retry, repeating_interval, random_interval,
                               transient_errors_except, retry_times, compose_retries)
 from otter.test.utils import CheckFailure, DummyException
 
 
-class RetryTests(TestCase):
+class RetryTests(SynchronousTestCase):
     """
     Tests for the helper method method ``retry``
     """
@@ -284,7 +284,7 @@ class RetryTests(TestCase):
         self.assertNoResult(d)
 
 
-class CanRetryHelperTests(TestCase):
+class CanRetryHelperTests(SynchronousTestCase):
     """
     Tests for ``can_retry`` implementations such as ``transient_errors_except``
     """
@@ -330,7 +330,7 @@ class CanRetryHelperTests(TestCase):
         self.assertFalse(can_retry(3))
 
 
-class NextIntervalHelperTests(TestCase):
+class NextIntervalHelperTests(SynchronousTestCase):
     """
     Tests for ``next_interval`` implementations such as ``repeating_interval``
     """

--- a/otter/test/test_scheduler.py
+++ b/otter/test/test_scheduler.py
@@ -2,7 +2,7 @@
 Tests for :mod:`otter.scheduler`
 """
 
-from twisted.trial.unittest import TestCase
+from twisted.trial.unittest import SynchronousTestCase
 from twisted.internet import defer
 from twisted.internet.task import Clock
 
@@ -18,7 +18,7 @@ from otter.models.interface import NoSuchPolicyError, NoSuchScalingGroupError
 from otter.controller import CannotExecutePolicyError
 
 
-class SchedulerTests(TestCase):
+class SchedulerTests(SynchronousTestCase):
     """
     Tests for `scheduler.py`
     """

--- a/otter/test/test_supervisor.py
+++ b/otter/test/test_supervisor.py
@@ -6,7 +6,7 @@ import mock
 from testtools.matchers import ContainsDict, Equals, IsInstance
 
 from twisted.python.failure import Failure
-from twisted.trial.unittest import TestCase
+from twisted.trial.unittest import SynchronousTestCase
 from twisted.internet.defer import succeed, fail, Deferred, maybeDeferred
 from twisted.internet.task import Cooperator
 
@@ -21,7 +21,7 @@ from otter.util.config import set_config_data
 from otter.util.deferredutils import DeferredPool
 
 
-class SupervisorTests(TestCase):
+class SupervisorTests(SynchronousTestCase):
     """
     Common stuff for tests in SupervisorService
     """
@@ -368,7 +368,7 @@ class ValidateLaunchConfigTests(SupervisorTests):
                                   mock.call('Validating launch server config')])
 
 
-class FindPendingJobsToCancelTests(TestCase):
+class FindPendingJobsToCancelTests(SynchronousTestCase):
     """
     Tests for :func:`otter.supervisor.find_pending_jobs_to_cancel`
     """
@@ -409,7 +409,7 @@ class FindPendingJobsToCancelTests(TestCase):
             ['1', '2', '3', '4', '5'])
 
 
-class FindServersToEvictTests(TestCase):
+class FindServersToEvictTests(SynchronousTestCase):
     """
     Tests for :func:`otter.supervisor.find_servers_to_evict`
     """
@@ -452,7 +452,7 @@ class FindServersToEvictTests(TestCase):
             sorted(self.data.values()))
 
 
-class DeleteActiveServersTests(TestCase):
+class DeleteActiveServersTests(SynchronousTestCase):
     """
     Tests for :func:`otter.supervisor.delete_active_servers`
     """
@@ -515,7 +515,7 @@ class DeleteActiveServersTests(TestCase):
         self.assertTrue(all([job.start.called for job in self.jobs]))
 
 
-class DeleteJobTests(TestCase):
+class DeleteJobTests(SynchronousTestCase):
     """
     Tests for :class:`supervisor._DeleteJob`
     """
@@ -563,7 +563,7 @@ class DeleteJobTests(TestCase):
                                              'Server deletion job failed')
 
 
-class ExecScaleDownTests(TestCase):
+class ExecScaleDownTests(SynchronousTestCase):
     """
     Tests for :func:`otter.supervisor.exec_scale_down`
     """
@@ -625,7 +625,7 @@ class ExecScaleDownTests(TestCase):
         self.assertFalse(self.del_active_servers.called)
 
 
-class ExecuteLaunchConfigTestCase(TestCase):
+class ExecuteLaunchConfigTestCase(SynchronousTestCase):
     """
     Tests for :func:`otter.supervisor.execute_launch_config`
     """
@@ -825,7 +825,7 @@ class DummyException(Exception):
     """
 
 
-class PrivateJobHelperTestCase(TestCase):
+class PrivateJobHelperTestCase(SynchronousTestCase):
     """
     Tests for the private helper class `_Job`
     """

--- a/otter/test/test_undo.py
+++ b/otter/test/test_undo.py
@@ -4,7 +4,7 @@ Tests for undo stacks.
 
 from zope.interface.verify import verifyObject
 
-from twisted.trial.unittest import TestCase
+from twisted.trial.unittest import SynchronousTestCase
 from twisted.internet.defer import Deferred
 from twisted.internet.task import Cooperator
 
@@ -12,7 +12,7 @@ from otter.undo import IUndoStack
 from otter.undo import InMemoryUndoStack
 
 
-class InMemoryUndoStackTests(TestCase):
+class InMemoryUndoStackTests(SynchronousTestCase):
     """
     Tests for the in memory undo stack.
     """

--- a/otter/test/test_util.py
+++ b/otter/test/test_util.py
@@ -4,7 +4,7 @@ Tests for ``otter.util``
 from datetime import datetime
 import mock
 
-from twisted.trial.unittest import TestCase
+from twisted.trial.unittest import SynchronousTestCase
 from twisted.internet.defer import succeed, fail, Deferred
 from twisted.internet.task import Clock
 from twisted.python.failure import Failure
@@ -20,7 +20,7 @@ from otter.util.deferredutils import with_lock, delay
 from otter.test.utils import patch, LockMixin, mock_log, DummyException
 
 
-class HTTPUtilityTests(TestCase):
+class HTTPUtilityTests(SynchronousTestCase):
     """
     Tests for ``otter.util.http``
     """
@@ -217,7 +217,7 @@ class HTTPUtilityTests(TestCase):
                           failure, 'url')
 
 
-class CapabilityTests(TestCase):
+class CapabilityTests(SynchronousTestCase):
     """
     Test capability generation.
     """
@@ -247,7 +247,7 @@ class CapabilityTests(TestCase):
         self.assertEqual(v, "1")
 
 
-class TimestampTests(TestCase):
+class TimestampTests(SynchronousTestCase):
     """
     Test timestamp utilities
     """
@@ -306,7 +306,7 @@ class TimestampTests(TestCase):
         self.assertEqual(parsed.replace(tzinfo=None), datetime.min)
 
 
-class ConfigTest(TestCase):
+class ConfigTest(SynchronousTestCase):
     """
     Test the simple configuration API.
     """
@@ -339,7 +339,7 @@ class ConfigTest(TestCase):
         self.assertIdentical(config.config_value('baz.blah'), None)
 
 
-class WithLockTests(TestCase):
+class WithLockTests(SynchronousTestCase):
     """
     Tests for `with_lock`
     """
@@ -422,7 +422,7 @@ class WithLockTests(TestCase):
         self.failureResultOf(d, ValueError)
 
 
-class DelayTests(TestCase):
+class DelayTests(SynchronousTestCase):
     """
     Tests for `delay`
     """

--- a/otter/test/worker/test_heat_client.py
+++ b/otter/test/worker/test_heat_client.py
@@ -3,14 +3,14 @@
 import json
 import mock
 
-from twisted.trial.unittest import TestCase
+from twisted.trial.unittest import SynchronousTestCase
 
 from otter.util.http import APIError
 from otter.worker.heat_client import HeatClient
 from otter.test.utils import mock_treq, mock_log, patch
 
 
-class HeatClientTests(TestCase):
+class HeatClientTests(SynchronousTestCase):
     """Tests for HeatClient."""
 
     def _assert_bound(self, orig_log, log, **kwargs):

--- a/otter/test/worker/test_launch_server_v1.py
+++ b/otter/test/worker/test_launch_server_v1.py
@@ -4,7 +4,7 @@ Unittests for the launch_server_v1 launch config.
 import mock
 import json
 
-from twisted.trial.unittest import TestCase
+from twisted.trial.unittest import SynchronousTestCase
 from twisted.internet.defer import Deferred, fail, succeed
 from twisted.internet.task import Clock
 from twisted.python.failure import Failure
@@ -60,7 +60,7 @@ fake_service_catalog = [
 ]
 
 
-class UtilityTests(TestCase):
+class UtilityTests(SynchronousTestCase):
     """
     Tests for non-specific utilities that should be refactored out of the
     worker implementation eventually.
@@ -117,7 +117,7 @@ expected_headers = {
 error_body = '{"code": 500, "message": "Internal Server Error"}'
 
 
-class LoadBalancersTests(TestCase):
+class LoadBalancersTests(SynchronousTestCase):
     """
     Test adding to one or more load balancers.
     """
@@ -642,7 +642,7 @@ class LoadBalancersTests(TestCase):
     test_removelb_retries_logs_unexpected_errors.skip = 'Lets log all errors for now'
 
 
-class ServerTests(TestCase):
+class ServerTests(SynchronousTestCase):
     """
     Test server manipulation functions.
     """
@@ -1414,7 +1414,7 @@ class ServerTests(TestCase):
         self.assertFalse(mock_addlb.called)
 
 
-class ConfigPreparationTests(TestCase):
+class ConfigPreparationTests(SynchronousTestCase):
     """
     Test config preparation.
     """
@@ -1538,7 +1538,7 @@ instance_details = (
      (54321, {'nodes': [{'id': 2}]})])
 
 
-class DeleteServerTests(TestCase):
+class DeleteServerTests(SynchronousTestCase):
     """
     Test the delete server worker.
     """

--- a/otter/test/worker/test_validate_config.py
+++ b/otter/test/worker/test_validate_config.py
@@ -5,7 +5,7 @@ Tests for `worker.validate_config.py`
 import mock
 import base64
 from twisted.internet import defer
-from twisted.trial.unittest import TestCase
+from twisted.trial.unittest import SynchronousTestCase
 
 from otter.test.utils import mock_log, patch, mock_treq, CheckFailure
 from otter.util.config import set_config_data
@@ -19,7 +19,7 @@ from otter.worker.validate_config import (
     InvalidFileContentSize)
 
 
-class ValidateLaunchServerConfigTests(TestCase):
+class ValidateLaunchServerConfigTests(SynchronousTestCase):
     """
     Tests for `validate_launch_server_config`
     """
@@ -144,7 +144,7 @@ class ValidateLaunchServerConfigTests(TestCase):
         self.assertFalse(self.validate_flavor.called)
 
 
-class ShortenTests(TestCase):
+class ShortenTests(SynchronousTestCase):
     """
     Tests for `worker.shorten`
     """
@@ -169,7 +169,7 @@ class ShortenTests(TestCase):
         self.assertEqual(shorten(s, len(s)), s)
 
 
-class ValidateImageTests(TestCase):
+class ValidateImageTests(SynchronousTestCase):
     """
     Tests for `validate_image`
     """
@@ -223,7 +223,7 @@ class ValidateImageTests(TestCase):
         self.failureResultOf(d)
 
 
-class ValidateFlavorTests(TestCase):
+class ValidateFlavorTests(SynchronousTestCase):
     """
     Tests for `validate_flavor`
     """
@@ -267,7 +267,7 @@ class ValidateFlavorTests(TestCase):
         self.failureResultOf(d)
 
 
-class ValidatePersonalityTests(TestCase):
+class ValidatePersonalityTests(SynchronousTestCase):
     """
     Tests for `validate_personality`
     """
@@ -357,7 +357,7 @@ class ValidatePersonalityTests(TestCase):
             'File "/etc/banner.txt" content\'s size exceeds maximum size "35"')
 
 
-class GetServiceEndpointTests(TestCase):
+class GetServiceEndpointTests(SynchronousTestCase):
     """
     Tests for `get_service_endpoint`
     """


### PR DESCRIPTION
Except in the unitgration tests which are asynchronous.

Low priority, just a useful search/replace cleanup @lvh pointed out.
