### PR TITLE
AS-218 - Modify verify delete so that it bails if the task_state is 'deleting' (ready for review)

### DIFF
--- a/otter/test/worker/test_launch_server_v1.py
+++ b/otter/test/worker/test_launch_server_v1.py
@@ -1749,7 +1749,10 @@ class DeleteServerTests(SynchronousTestCase):
 
         delete_and_verify.side_effect = lambda *a, **kw: None
         self.clock.pump([5])
-        self.assertEqual(delete_and_verify.call_count, 2)
+        self.assertEqual(
+            delete_and_verify.mock_calls,
+            [mock.call(matches(IsInstance(self.log.__class__)), 'http://url/',
+                       'my-auth-token', 'serverId')] * 2)
         self.successResultOf(d)
 
         # the loop has stopped
@@ -1775,7 +1778,10 @@ class DeleteServerTests(SynchronousTestCase):
         self.assertNoResult(d)
 
         self.clock.pump([5] * 4)
-        self.assertEqual(delete_and_verify.call_count, 4)
+        self.assertEqual(
+            delete_and_verify.mock_calls,
+            [mock.call(matches(IsInstance(self.log.__class__)), 'http://url/',
+                       'my-auth-token', 'serverId')] * 4)
         self.log.err.assert_called_once_with(CheckFailure(TimedOutError),
                                              server_id='serverId')
 

--- a/otter/worker/launch_server_v1.py
+++ b/otter/worker/launch_server_v1.py
@@ -575,7 +575,7 @@ def delete_and_verify(log, server_endpoint, auth_token, server_id):
     to be deleted (task_state = "deleted").
 
     Note that ``task_state`` is in the server details key
-    ``OS-EXT-STS:task_state``, which is supported by openstack but available
+    ``OS-EXT-STS:task_state``, which is supported by Openstack but available
     only when looking at the extended status of a server.
     """
     path = append_segments(server_endpoint, 'servers', server_id)


### PR DESCRIPTION
Instead of retrying over and over.  Once task_state is in "deleting", it is assumed that nova knows about it and will clean it up.
