### PR TITLE
BoundLog matcher implemented

### DIFF
--- a/otter/test/test_util.py
+++ b/otter/test/test_util.py
@@ -474,9 +474,8 @@ class IsBoundWithTests(SynchronousTestCase):
         Returns mismatch on non-matching kwargs
         """
         log = BoundLog(lambda: None, lambda: None).bind(a=10, b=2)
-        m = self.bound.match(log)
         self.assertEqual(
-            m.describe(),
+            self.bound.match(log).describe(),
             'Expected kwargs {} but got {} instead'.format(dict(a=10, b=20), dict(a=10, b=2)))
 
     def test_nested_match(self):
@@ -485,6 +484,14 @@ class IsBoundWithTests(SynchronousTestCase):
         """
         log = BoundLog(lambda: None, lambda: None).bind(a=10, b=20).bind(c=3)
         self.assertIsNone(IsBoundWith(a=10, b=20, c=3).match(log))
+
+    def test_kwargs_order(self):
+        """
+        kwargs bound in order, i.e. next bound overriding previous bound should
+        retain the value
+        """
+        log = BoundLog(lambda: None, lambda: None).bind(a=10, b=20).bind(a=3)
+        self.assertIsNone(IsBoundWith(a=3, b=20).match(log))
 
     def test_str(self):
         """

--- a/otter/test/utils.py
+++ b/otter/test/utils.py
@@ -72,16 +72,20 @@ class IsBoundWith(object):
         """
         if not isinstance(log, BoundLog):
             return Mismatch('log is not a BoundLog')
-        # Extract kwargs
+        # Collect kwargs
         f = log.msg
-        kwargs = {}
+        kwargs_list = []
         while True:
             try:
-                kwargs.update(f.keywords)
+                kwargs_list.append(f.keywords)
             except AttributeError:
                 break
             else:
                 f = f.func
+        # combine them in order they were bound
+        kwargs = {}
+        [kwargs.update(kwa) for kwa in reversed(kwargs_list)]
+        # Compare and return accordingly
         if self.kwargs == kwargs:
             return None
         else:


### PR DESCRIPTION
Based on discussion in #633, `BoundLog` matcher has been implemented that can be used in tests by calling 

``` python
self.assertEqual(self.log, matches(IsBoundWith(a=2, b=3))
```

This is based on http://testtools.readthedocs.org/en/latest/for-test-authors.html#writing-your-own-matchers.

Thanks to @lvh for providing the awesome partial kwargs extraction code :)
