### PR TITLE
Checking deleting task_state in cloudcafe

### DIFF
--- a/autoscale_cloudroast/test_repo/autoscale/fixtures.py
+++ b/autoscale_cloudroast/test_repo/autoscale/fixtures.py
@@ -264,7 +264,6 @@ class AutoscaleFixture(BaseTestFixture):
             params = launch_config.server.name
         elif server_name:
             params = server_name
-        list_server_resp = self.server_client.list_servers_with_detail(name=params)
         return [server.id for server in self.get_non_deleting_servers(params)]
 
     def verify_server_count_using_server_metadata(self, group_id, expected_count):


### PR DESCRIPTION
Many of our prod tests fail because nova doesn't completely delete servers within 15 mins even though otter issued delete. Otter has recently started checking if `OS-EXT-STS:task_state` is `deleting` after deleting server. If so, it assumes that nova will eventually delete it. This PR does the same in tests. This should reduce tests that fail with following message: `"Servers on the tenant with name test_sg_bhv_srv410275 were not deleted even after waiting 15 mins"`
