### PR TITLE
Bump txkazoo to 0.0.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,4 @@ pyOpenSSL==0.13
 jsonfig==0.1.1
 testtools==0.9.32
 croniter==0.3.3
-txkazoo==0.0.4
+txkazoo==0.0.5


### PR DESCRIPTION
This is a cleanup release. It is also available from the public PyPI
now, so local testing is a little easier.
