### PR TITLE
IP address logged while adding node to CLB

### DIFF
--- a/otter/test/worker/test_launch_server_v1.py
+++ b/otter/test/worker/test_launch_server_v1.py
@@ -179,6 +179,10 @@ class LoadBalancersTests(SynchronousTestCase):
 
         self.treq.json_content.assert_called_once_with(mock.ANY)
 
+        self.log.msg.assert_called_with(
+            'Added to load balancer', loadbalancer_id=12345,
+            ip_address='192.168.1.1', node_id=1)
+
     def test_add_lb_retries(self):
         """
         add_to_load_balancer will retry again until it succeeds
@@ -271,7 +275,8 @@ class LoadBalancersTests(SynchronousTestCase):
         self.successResultOf(d)
         self.log.msg.assert_has_calls(
             [mock.call('Got LB error while {m}: {e}', loadbalancer_id=12345,
-                       m='add_node', e=matches(IsInstance(RequestError)))] * bad_codes_len)
+                       ip_address='192.168.1.1', m='add_node',
+                       e=matches(IsInstance(RequestError)))] * bad_codes_len)
 
     def test_add_lb_retries_logs_unexpected_errors(self):
         """

--- a/otter/worker/launch_server_v1.py
+++ b/otter/worker/launch_server_v1.py
@@ -223,7 +223,7 @@ def add_to_load_balancer(log, endpoint, auth_token, lb_config, ip_address, undo,
     lb_id = lb_config['loadBalancerId']
     port = lb_config['port']
     path = append_segments(endpoint, 'loadbalancers', str(lb_id), 'nodes')
-    lb_log = log.bind(loadbalancer_id=lb_id)
+    lb_log = log.bind(loadbalancer_id=lb_id, ip_address=ip_address)
 
     def add():
         d = treq.post(path, headers=headers(auth_token),
@@ -244,7 +244,7 @@ def add_to_load_balancer(log, endpoint, auth_token, lb_config, ip_address, undo,
         clock=clock)
 
     def when_done(result):
-        lb_log.msg('Added to load balancer')
+        lb_log.msg('Added to load balancer', node_id=result['nodes'][0]['id'])
         undo.push(remove_from_load_balancer,
                   lb_log,
                   endpoint,


### PR DESCRIPTION
I've seen some rare situations when node is still hanging around in CLB but has no logs. This adds `node_id` and `ip_address` in the logs while adding node so that we can debug that. 
