### PR TITLE
Delete lock znode after group delete

### DIFF
--- a/otter/models/cass.py
+++ b/otter/models/cass.py
@@ -1114,7 +1114,6 @@ class CassScalingGroup(object):
         return d
 
 
-
 @implementer(IScalingGroupCollection, IScalingScheduleCollection)
 class CassScalingGroupCollection:
     """

--- a/otter/test/models/test_cass_models.py
+++ b/otter/test/models/test_cass_models.py
@@ -1932,7 +1932,6 @@ class CassScalingGroupTests(CassScalingGroupTestCase):
         # locks znode is not deleted
         self.assertFalse(self.kz_client.delete.called)
 
-
     @mock.patch('otter.models.cass.CassScalingGroup.view_state')
     def test_delete_lock_with_log_category_locking(self, mock_view_state):
         """


### PR DESCRIPTION
After the group is deleted, `/locks/<groupID>` znode in Zookeeper remains wasting space as group is never going to be locked. Hence, deleting the znode and its children (if any) after successful group delete. You would wonder if this can cause problem when a server becomes active after the group is deleted and lock is acquired. This is fine since kazoo locking recipe will just re-create the znode. Unfortunately, the newly created znode will become orphaned when all the servers related the group become active. This in reality should be less number assuming not many customers will do this. However, many tests do this. But it is still better than all orphaned znodes. 

There are currently many orphaned znodes in all DCs because of this. ORD `zkCli.sh` is not able to display the list complaining the packet to too large :/ (`java.io.IOException: Packet len4449193 is out of range!`). I'll probably have to write a separate script that checks the znodes with all groups in CASS and delete unwanted ones. This script can be run again sometime later. 
