### PR TITLE
AS-203 - if the user doesn't have load balancers configured, don't fail with KeyError

### DIFF
--- a/otter/worker/launch_server_v1.py
+++ b/otter/worker/launch_server_v1.py
@@ -541,11 +541,14 @@ def launch_server(log, region, scaling_group, service_catalog, auth_token,
             server_id)
 
     def add_lb(server):
-        ip_address = private_ip_addresses(server)[0]
-        lbd = add_to_load_balancers(
-            ilog[0], lb_endpoint, auth_token, lb_config, ip_address, undo)
-        lbd.addCallback(lambda lb_response: (server, lb_response))
-        return lbd
+        if lb_config:
+            ip_address = private_ip_addresses(server)[0]
+            lbd = add_to_load_balancers(
+                ilog[0], lb_endpoint, auth_token, lb_config, ip_address, undo)
+            lbd.addCallback(lambda lb_response: (server, lb_response))
+            return lbd
+
+        return (server, [])
 
     def _create_server():
         d = create_server(server_endpoint, auth_token, server_config, log=log)


### PR DESCRIPTION
If there are no load balancers in the launch config, do not require the server to have servicenet configured

Thinking about, in another PR, verifying the launch config has servicenet configured if one or more LBs are configured.
