### PR TITLE
Limit the number of load balancers to 5

### DIFF
--- a/otter/json_schema/group_schemas.py
+++ b/otter/json_schema/group_schemas.py
@@ -146,6 +146,7 @@ launch_server = {
                     # doesn't seem like a good idea.
                     "required": False,
                     "minItems": 0,
+                    "maxItems": 5,
                     "uniqueItems": True,
                     "items": {
                         "type": "object",

--- a/otter/test/json_schema/test_schemas.py
+++ b/otter/test/json_schema/test_schemas.py
@@ -214,6 +214,28 @@ class ServerLaunchConfigTestCase(SynchronousTestCase):
             self.assertRaisesRegexp(ValidationError, 'not of type', validate,
                                     base, group_schemas.launch_config)
 
+    def test_too_many_load_balancers_do_not_validate(self):
+        """
+        If more than 5 load balancers are provided, the launch config fails to
+        validate.
+        """
+        invalid = {
+            "type": "launch_server",
+            "args": {
+                "server": {},
+                "loadBalancers": [{'loadBalancerId': i, 'port': 80}
+                                  for i in range(6)]
+            }
+        }
+
+        # the type fails ot valdiate because the load balancer list is too long
+        self.assertRaisesRegexp(ValidationError, 'is too long',
+                                validate, invalid, group_schemas.launch_server)
+        # because the type schema fails to validate, the config schema
+        # fails to validate because it is not the given type
+        self.assertRaisesRegexp(ValidationError, 'not of type',
+                                validate, invalid, group_schemas.launch_config)
+
     def test_duplicate_load_balancers_do_not_validate(self):
         """
         If the same load balancer config appears twice, the launch config


### PR DESCRIPTION
Why 5?  Because it seems like the max number we have a launch config for so far is 4.  (maybe we should go lower)

But we want to establish a limit if we want to use server metadata to store the load balancers the server should be attached to.
