### PR TITLE
Initial lbinfo in server metadata

### DIFF
--- a/otter/worker/launch_server_v1.py
+++ b/otter/worker/launch_server_v1.py
@@ -669,7 +669,7 @@ def launch_server(log, region, scaling_group, service_catalog, auth_token,
         result = server['server'].get('metadata')
         if  result != expected:
             ilog[0].msg('Server metadata has changed.',
-                        metadata_check=True,
+                        sanity_check=True,
                         expected_metadata=expected,
                         nova_metadata=result)
         return server


### PR DESCRIPTION
This puts the load balancers a server needs to be added to into the server metadata when it's created.

The data will look like:

```
{
    "rax:auto_scaling_group_id": "11111-11111....",
    "rax:auto_scaling_lbids": "[1234, 4567]",
    "rax:auto_scaling:lb:1234": "{\"port\": 80}",
    "rax:auto_scaling:lb:4567": "{\"port\": 81}"
}
```

If the metadata has changed, a message is also logged - not sure if this is useful but might be good for us to see if this ever happens.
