### PR TITLE
Some functional goodies for Otter, for use in convergence

### DIFF
--- a/otter/test/util/test_fp.py
+++ b/otter/test/util/test_fp.py
@@ -1,0 +1,96 @@
+"""Tests for otter.util.fp"""
+
+from pyrsistent import m, v
+
+from twisted.trial.unittest import SynchronousTestCase
+
+from otter.util.fp import freeze, unfreeze
+from otter.test.utils import matches
+
+from testtools.matchers import Mismatch
+
+
+class IsTypeAndValue(object):
+    """testtools matcher that checks the type and the value."""
+
+    def __init__(self, value):
+        self.type = type(value)
+        self.value = value
+
+    def __str__(self):
+        return 'IsTypeAndValue {} {}'.format(self.type, self.value)
+
+    def match(self, value):
+        """Ensure that matches type and equality."""
+        if self.type is not type(value):
+            return Mismatch("{} is not of type {}".format(
+                type(value), self.type))
+        if self.value != value:
+            return Mismatch("expected {}, got {}".format(self.value, value))
+
+
+def eqtype(v):
+    """Return a 'matches' instance around IsTypeAndValue."""
+    return matches(IsTypeAndValue(v))
+
+
+class FreezeTests(SynchronousTestCase):
+    """Tests for :obj:`freeze`."""
+
+    def test_freeze_basic(self):
+        """Non-dict and non-list objects are frozen to themselves."""
+        self.assertEqual(freeze(1), 1)
+        self.assertEqual(freeze('foo'), 'foo')
+
+    def test_freeze_list(self):
+        """Lists are frozen to :obj:`pyrsistent.PVector`s."""
+        self.assertEqual(freeze([1, 2]), eqtype(v(1, 2)))
+
+    def test_freeze_dict(self):
+        """Dicts are frozen to :obj:`pyrsistent.PMap`s."""
+        self.assertEqual(freeze({'a': 'b'}), eqtype(m(a='b')))
+
+    def test_recurse_in_dictionary_values(self):
+        """Dictionary values are recursively frozen."""
+        self.assertEqual(freeze({'a': [1]}), eqtype(m(a=eqtype(v(1)))))
+
+    def test_recurse_in_lists(self):
+        """Values in lists are recursively frozen."""
+        self.assertEqual(
+            freeze(['a', {'b': 3}]),
+            eqtype(v('a', eqtype(m(b=3)))))
+
+    def test_recurse_in_tuples(self):
+        """Values in tuples are recursively frozen."""
+        self.assertEqual(freeze(('a', {})), ('a', eqtype(m())))
+
+
+class UnfreezeTests(SynchronousTestCase):
+    """Tests for :obj:`unfreeze`."""
+
+    def test_unfreeze_basic(self):
+        """Non-dict and non-list objects are unfrozen to themselves."""
+        self.assertEqual(unfreeze(1), 1)
+        self.assertEqual(unfreeze('foo'), 'foo')
+
+    def test_unfreeze_list(self):
+        """:obj:`pyrsistent.PVector`s are unfrozen to lists."""
+        self.assertEqual(unfreeze(v(1, 2)), eqtype([1, 2]))
+
+    def test_unfreeze_dict(self):
+        """:obj:`pyrsistent.PMap`s are unfrozen to dicts."""
+        self.assertEqual(unfreeze(m(a='b')), eqtype({'a': 'b'}))
+
+    def test_recurse_in_dictionary_values(self):
+        """PMap values are recursively unfrozen."""
+        self.assertEqual(unfreeze(m(a=v(1))), eqtype({'a': eqtype([1])}))
+
+    def test_recurse_in_lists(self):
+        """Values in PVectors are recursively unfrozen."""
+        self.assertEqual(
+            unfreeze(v('a', m(b=3))),
+            eqtype(['a', eqtype({'b': 3})]))
+
+    def test_recurse_in_tuples(self):
+        """Values in tuples are recursively unfrozen."""
+        self.assertEqual(unfreeze(('a', m())), ('a', eqtype({})))

--- a/otter/util/fp.py
+++ b/otter/util/fp.py
@@ -1,5 +1,12 @@
 # coding: utf-8
 
+"""Functional programming utilities."""
+
+
+from pyrsistent import pvector, pmap
+from toolz.itertoolz import groupby
+
+
 """Functional programming helpers."""
 
 
@@ -30,3 +37,63 @@ def wrappers(*stuff):
     All functions after the first should take a callable as their first argument.
     """
     return reduce(wrap, stuff)
+
+
+def freeze(o):
+    """
+    Recursively convert a simple Python data structure (lists, tuples,
+    dictionaries) into pyrsistent versions of those data structures.
+    """
+    typ = type(o)
+    if typ is dict:
+        return pmap({k: freeze(v) for k, v in o.iteritems()})
+    elif typ is list:
+        return pvector(map(freeze, o))
+    elif typ is tuple:
+        return tuple(map(freeze, o))
+    else:
+        return o
+
+
+def unfreeze(o):
+    """
+    Recursively convert pyrsistent data structures into basic Python types.
+    """
+    typ = type(o)
+    if typ is type(pvector()):
+        return map(unfreeze, o)
+    if typ is type(pmap()):
+        return {k: unfreeze(v) for k, v in o.iteritems()}
+    if typ is tuple:
+        return tuple(map(unfreeze, o))
+    else:
+        return o
+
+
+def partition_groups(grouper, seq, keys):
+    """
+    Partition a sequence based on a grouping function. This is like groupby,
+    but it returns a tuple of fixed length instead of a dict of arbitrary
+    length.
+
+    :param callable grouper: A function which returns a key for an item.
+    :param seq: A sequence of items.
+    :param keys: A sequence of key names to expect.
+    :return: A tuple of lists for which the grouper returned each key, in the
+        same order as this keys argument.
+    """
+    groups = groupby(grouper, seq)
+    return tuple(groups.get(key, []) for key in keys)
+
+
+def partition_bool(pred, seq):
+    """
+    Partition a sequence based on a predicate.
+
+    :param callable pred: Function that will be passed items from seq and
+        must return a bool.
+    :param seq: sequence of items.
+    :returns: 2-tuple of lists, first the elements for which the predicate is
+        True, second the elements for which the predicate is False.
+    """
+    return partition_groups(pred, seq, (True, False))

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ txkazoo==0.0.5
 effect==0.1a6
 characteristic==0.1.0
 toolz==0.6.0
+pyrsistent==0.3.1
 
 # pinning dependencies of dependencies
 


### PR DESCRIPTION
- depend on pyrsistent
- add freeze and unfreeze functions to otter.util.fp
  (to be contributed to pyrsistent)
- add "partition_bool" and "partition_group" functions to otter.util.fp
  (to be used by convergence)
