### PR TITLE
Clean up the requirements

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -6,7 +6,6 @@ coverage==3.5.3
 docutils==0.9.1
 sphinx==1.1.3
 repoze.sphinx.autointerface==0.7.1
-terrarium==1.0.0rc4
 python-subunit==0.0.8
 junitxml==0.7
 paramiko==1.10.0
@@ -16,3 +15,12 @@ unittest2==0.5.1
 git+https://github.com/stackforge/opencafe.git@b971070b28d07c0b19f8809e18950f2d6cf0e466#egg=opencafe
 git+https://github.com/stackforge/cloudcafe.git@4dc2227b4b0140158ceab286dfa127384886f5b7#egg=cloudcafe
 IPy==0.81
+# mock==1.0.1
+
+# pin deps of deps
+
+httpretty==0.6.0
+pymongo==2.5.2
+argparse==1.2.1
+Pygments==1.5
+Jinja2==2.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,6 +25,7 @@ kazoo==2.0b1
 mock==1.0.1
 pyasn1==0.1.7
 pyasn1-modules==0.0.5
+pycrypto==2.6
 python-dateutil==2.1
 python-mimeparse==0.1.4
 six==1.7.3


### PR DESCRIPTION
We don't actually use tryfer (for tracing) or yunomi (for stats) yet, so remove those dependencies and their corresponding pinned dependencies.  Also mock is in both requirements files, which can cause issues with terrarium, so remove that duplicate.

(partially I am running into terrarium issues, wondering if this will fix it - this will take a bit)
