### PR TITLE
TxKazoo client will keep trying to connect forever

### DIFF
--- a/otter/tap/api.py
+++ b/otter/tap/api.py
@@ -278,8 +278,12 @@ def makeService(config):
     if config_value('zookeeper'):
         threads = config_value('zookeeper.threads') or 10
         kz_client = TxKazooClient(hosts=config_value('zookeeper.hosts'),
+                                  # Keep trying to connect until the end of time with
+                                  # max interval of 10 minutes
+                                  connection_retry=dict(max_tries=-1, max_delay=600),
                                   threads=threads, txlog=log.bind(system='kazoo'))
-        d = kz_client.start()
+        # Don't timeout. Keep trying to connect forever
+        d = kz_client.start(timeout=None)
 
         def on_client_ready(_):
             # Setup scheduler service after starting

--- a/otter/test/tap/test_api.py
+++ b/otter/test/tap/test_api.py
@@ -482,8 +482,10 @@ class APIMakeServiceTests(SynchronousTestCase):
 
         self.log.bind.assert_called_with(system='kazoo')
         mock_txkz.assert_called_once_with(
-            hosts='zk_hosts', threads=20, txlog=self.log.bind.return_value)
-        kz_client.start.assert_called_once_with()
+            hosts='zk_hosts', threads=20,
+            connection_retry=dict(max_tries=-1, max_delay=600),
+            txlog=self.log.bind.return_value)
+        kz_client.start.assert_called_once_with(timeout=None)
 
         # setup_scheduler and store.kz_client is not called yet, and nothing
         # added to the health checker
@@ -514,8 +516,9 @@ class APIMakeServiceTests(SynchronousTestCase):
         makeService(config)
 
         mock_txkz.assert_called_once_with(
-            hosts='zk_hosts', threads=20, txlog=mock.ANY)
-        kz_client.start.assert_called_once_with()
+            hosts='zk_hosts', threads=20,
+            connection_retry=dict(max_tries=-1, max_delay=600), txlog=mock.ANY)
+        kz_client.start.assert_called_once_with(timeout=None)
         self.assertFalse(mock_setup_scheduler.called)
         self.log.err.assert_called_once_with(CheckFailure(ValueError),
                                              'Could not start TxKazooClient')


### PR DESCRIPTION
When zookeeper servers are not reachable, otter gives up connecting after some 10 seconds or so. After that no group change / policy execution can work from that API node even if zookeeper nodes are come back up. Eventually, someone has to manually restart the server. This change will ensure kazoo keeps trying to connect forever. Please realize that this fixes only _startup_ connection issue. If kazoo loses connection when otter is running, it may never recover when zk comes back. 
