### PR TITLE
Allow empty image refs for boot-from-volume

### DIFF
--- a/otter/json_schema/group_schemas.py
+++ b/otter/json_schema/group_schemas.py
@@ -82,9 +82,8 @@ server = {
                     "all new servers (including the name attribute)."),
     "properties": {
         "imageRef": {
-            "type": "string",
-            "required": True,
-            "pattern": "^\S*$"  # must contain non-whitespace
+            "type": ["string", "null"],
+            "pattern": "^\S*$"  # must contain non-whitespace, if it's there
         },
         "flavorRef": {
             "type": "string",

--- a/otter/test/json_schema/test_schemas.py
+++ b/otter/test/json_schema/test_schemas.py
@@ -361,6 +361,20 @@ class LaunchConfigServerPayloadValidationTests(SynchronousTestCase):
         self.server['imageRef'] = ''
         validate(self.server, group_schemas.server)
 
+    def test_null_image(self):
+        """
+        Null for ``imageRef`` is valid.
+        """
+        self.server['imageRef'] = None
+        validate(self.server, group_schemas.server)
+
+    def test_no_image(self):
+        """
+        Not providing ``imageRef`` is valid.
+        """
+        self.server.pop('imageRef')
+        validate(self.server, group_schemas.server)
+
     def test_blank_image(self):
         """
         invalidates if imageRef is just whitespace

--- a/otter/test/worker/test_validate_config.py
+++ b/otter/test/worker/test_validate_config.py
@@ -90,6 +90,30 @@ class ValidateLaunchServerConfigTests(SynchronousTestCase):
 
         self.assertFalse(self.validate_image.called)
 
+    def test_null_image(self):
+        """
+        None in the image param means that Nova will use boot-from-volume.
+        The ``None`` ``imageRef`` still validates.
+        """
+        self.launch_config['server']['imageRef'] = None
+
+        d = validate_launch_server_config(self.log, 'dfw', 'catalog', 'token', self.launch_config)
+        self.successResultOf(d)
+
+        self.assertFalse(self.validate_image.called)
+
+    def test_no_image(self):
+        """
+        Not providing an ``imageRef`` param means that Nova will use
+        boot-from-volume.  The server args still validate.
+        """
+        self.launch_config['server'].pop('imageRef')
+
+        d = validate_launch_server_config(self.log, 'dfw', 'catalog', 'token', self.launch_config)
+        self.successResultOf(d)
+
+        self.assertFalse(self.validate_image.called)
+
     def test_invalid_flavor(self):
         """
         Invalid flavor causes InvalidLaunchConfiguration

--- a/otter/worker/launch_server_v1.py
+++ b/otter/worker/launch_server_v1.py
@@ -191,10 +191,14 @@ def find_server(server_endpoint, auth_token, server_config, log=None):
     :raises: :class:`ServerCreationRetryError`
     """
     query_params = {
-        'image': server_config['imageRef'],
+        'image': server_config.get('imageRef', ''),
         'flavor': server_config['flavorRef'],
         'name': '^{0}$'.format(re.escape(server_config['name']))
     }
+
+    if query_params['image'] is None:
+        query_params['image'] = ''
+
     url = '{path}?{query}'.format(
         path=append_segments(server_endpoint, 'servers', 'detail'),
         query=urlencode(query_params))


### PR DESCRIPTION
Pretty much most of our code handled this just fine, except for the json schema.

This is mostly a PR adding tests for the case we want to support.

Future task that should be added:
- Empty image ID can only be submitted as a request along with `block_device_mapping`, else Nova returns 400.  Add block device volume ID validation, and validation that ensures that the blank image ref must be accompanied by some block device mappings.

TODO:
- [x] Actually nova seems to also accept null, or no image.  This PR needs to be modified to do so.

Integration tests are in https://github.com/rackerlabs/otter/pull/712
