### PR TITLE
Draining attributes in structures

### DIFF
--- a/otter/convergence.py
+++ b/otter/convergence.py
@@ -156,7 +156,8 @@ class NovaServer(object):
                        instance_of=NamedConstant),
              Attribute("type", default_value=NodeType.PRIMARY,
                        instance_of=NamedConstant),
-             Attribute("draining_timeout", default_value=0, instance_of=float)])
+             Attribute("draining_timeout", default_value=0.0, instance_of=float,
+                       exclude_from_cmp=True)])
 class LBConfig(object):
     """
     Information representing a load balancer port mapping; how a particular
@@ -170,12 +171,19 @@ class LBConfig(object):
     :ivar str condition: One of ``ENABLED``, ``DISABLED``, or ``DRAINING`` -
         the default is ``ENABLED``
     :ivar str type: One of ``PRIMARY`` or ``SECONDARY`` - default is ``PRIMARY``
+
+    TODO: this is not the ideal place for ``draining_timeout``, since
+    :class:`LBConfig` is more about what node on a CLB should look like.
+    And :class:`LBConfig` may not be applicable to a hardware LB.
+    So `draining_timeout` is here until other load balancer requirements are
+    understood and a better place is found for it.
     :ivar float draining_timeout: Number of seconds node should be in DRAINING
         state before being removed
     """
 
 
-@attributes(["lb_id", "node_id", "address", "drained_at", "config"])
+@attributes(["lb_id", "node_id", "address",
+             Attribute("drained_at", default_value=0.0, instance_of=float), "config"])
 class LBNode(object):
     """
     Information representing an actual node on a load balancer, which is

--- a/otter/test/test_convergence.py
+++ b/otter/test/test_convergence.py
@@ -160,6 +160,7 @@ class ObjectStorageTests(SynchronousTestCase):
     """
     Tests for objects that store data such as :class:`LBConfig`
     """
+
     def test_lbconfig_default_weight_condition_and_type(self):
         """
         :obj:`LBConfig` only requires a port.  The other attributes have
@@ -169,6 +170,13 @@ class ObjectStorageTests(SynchronousTestCase):
         self.assertEqual(lb.weight, 1)
         self.assertEqual(lb.condition, NodeCondition.ENABLED)
         self.assertEqual(lb.type, NodeType.PRIMARY)
+
+    def test_lbconfig_not_cmp_draining(self):
+        """
+        :obj:`LBConfig.draining_timeout` is excluded from comparison
+        """
+        self.assertEqual(LBConfig(port=80, draining_timeout=2.4),
+                         LBConfig(port=80, draining_timeout=5.4))
 
 
 class ConvergeLBStateTests(SynchronousTestCase):


### PR DESCRIPTION
This is so that @cyli can work independently on implementing the algorithm while I work on filling these structures.
