### PR TITLE
Require sets for the converge function

### DIFF
--- a/otter/convergence.py
+++ b/otter/convergence.py
@@ -266,10 +266,10 @@ def converge(desired_state, servers_with_cheese, load_balancer_contents, now,
     by ``desired_state``.
 
     :param DesiredGroupState desired_state: The desired group state.
-    :param list servers_with_cheese: a list of :obj:`NovaServer` instances.
+    :param set servers_with_cheese: a list of :obj:`NovaServer` instances.
         This must only contain servers that are being managed for the specified
         group.
-    :param load_balancer_contents: a list of :obj:`LBNode` instances.  This must
+    :param load_balancer_contents: a set of :obj:`LBNode` instances.  This must
         contain all the load balancer mappings for all the load balancers on the
         tenant.
     :param float now: number of seconds since the POSIX epoch indicating the

--- a/otter/test/test_convergence.py
+++ b/otter/test/test_convergence.py
@@ -301,8 +301,8 @@ class ConvergeTests(SynchronousTestCase):
         self.assertEqual(
             converge(
                 DesiredGroupState(launch_config={}, desired=1),
-                [],
-                [],
+                set(),
+                set(),
                 0),
             Convergence(
                 steps=pbag([CreateServer(launch_config=pmap())])))
@@ -315,8 +315,8 @@ class ConvergeTests(SynchronousTestCase):
         self.assertEqual(
             converge(
                 DesiredGroupState(launch_config={}, desired=2),
-                [],
-                [],
+                set(),
+                set(),
                 0),
             Convergence(
                 steps=pbag([
@@ -331,8 +331,8 @@ class ConvergeTests(SynchronousTestCase):
         self.assertEqual(
             converge(
                 DesiredGroupState(launch_config={}, desired=1),
-                [server('abc', ServerState.BUILD)],
-                [],
+                set([server('abc', ServerState.BUILD)]),
+                set(),
                 0),
             Convergence(steps=pbag([])))
 
@@ -344,8 +344,8 @@ class ConvergeTests(SynchronousTestCase):
         self.assertEqual(
             converge(
                 DesiredGroupState(launch_config={}, desired=1),
-                [server('abc', ServerState.ERROR)],
-                [],
+                set([server('abc', ServerState.ERROR)]),
+                set(),
                 0),
             Convergence(
                 steps=pbag([
@@ -362,11 +362,11 @@ class ConvergeTests(SynchronousTestCase):
         self.assertEqual(
             converge(
                 DesiredGroupState(launch_config={}, desired=1),
-                [server('abc', ServerState.ERROR, servicenet_address='1.1.1.1')],
-                [LBNode(lb_id=5, address='1.1.1.1', node_id=3,
-                        config=LBConfig(port=80)),
-                 LBNode(lb_id=5, address='1.1.1.1', node_id=5,
-                        config=LBConfig(port=8080))],
+                set([server('abc', ServerState.ERROR, servicenet_address='1.1.1.1')]),
+                set([LBNode(lb_id=5, address='1.1.1.1', node_id=3,
+                            config=LBConfig(port=80)),
+                     LBNode(lb_id=5, address='1.1.1.1', node_id=5,
+                            config=LBConfig(port=8080))]),
                 0),
             Convergence(
                 steps=pbag([
@@ -381,9 +381,9 @@ class ConvergeTests(SynchronousTestCase):
         self.assertEqual(
             converge(
                 DesiredGroupState(launch_config={}, desired=1),
-                [server('abc', ServerState.ACTIVE, created=0),
-                 server('def', ServerState.ACTIVE, created=1)],
-                [],
+                set([server('abc', ServerState.ACTIVE, created=0),
+                     server('def', ServerState.ACTIVE, created=1)]),
+                set(),
                 0),
             Convergence(steps=pbag([DeleteServer(server_id='abc')])))
 
@@ -396,9 +396,10 @@ class ConvergeTests(SynchronousTestCase):
         self.assertEqual(
             converge(
                 DesiredGroupState(launch_config={}, desired=0),
-                [server('abc', ServerState.ACTIVE, servicenet_address='1.1.1.1', created=0)],
-                [LBNode(lb_id=5, address='1.1.1.1', node_id=3,
-                        config=LBConfig(port=80))],
+                set([server('abc', ServerState.ACTIVE,
+                            servicenet_address='1.1.1.1', created=0)]),
+                set([LBNode(lb_id=5, address='1.1.1.1', node_id=3,
+                            config=LBConfig(port=80))]),
                 0),
             Convergence(steps=pbag([
                 DeleteServer(server_id='abc'),
@@ -413,10 +414,10 @@ class ConvergeTests(SynchronousTestCase):
         self.assertEqual(
             converge(
                 DesiredGroupState(launch_config={}, desired=2),
-                [server('abc', ServerState.ACTIVE, created=0),
-                 server('def', ServerState.BUILD, created=1),
-                 server('ghi', ServerState.ACTIVE, created=2)],
-                [],
+                set([server('abc', ServerState.ACTIVE, created=0),
+                     server('def', ServerState.BUILD, created=1),
+                     server('ghi', ServerState.ACTIVE, created=2)]),
+                set(),
                 0),
             Convergence(
                 steps=pbag([DeleteServer(server_id='def')])))
@@ -429,9 +430,9 @@ class ConvergeTests(SynchronousTestCase):
         self.assertEqual(
             converge(
                 DesiredGroupState(launch_config={}, desired=2),
-                [server('slowpoke', ServerState.BUILD, created=0),
-                 server('ok', ServerState.ACTIVE, created=0)],
-                [],
+                set([server('slowpoke', ServerState.BUILD, created=0),
+                     server('ok', ServerState.ACTIVE, created=0)]),
+                set(),
                 3600),
             Convergence(
                 steps=pbag([
@@ -446,10 +447,10 @@ class ConvergeTests(SynchronousTestCase):
         self.assertEqual(
             converge(
                 DesiredGroupState(launch_config={}, desired=2),
-                [server('slowpoke', ServerState.BUILD, created=0),
-                 server('old-ok', ServerState.ACTIVE, created=0),
-                 server('new-ok', ServerState.ACTIVE, created=3600)],
-                [],
+                set([server('slowpoke', ServerState.BUILD, created=0),
+                     server('old-ok', ServerState.ACTIVE, created=0),
+                     server('new-ok', ServerState.ACTIVE, created=3600)]),
+                set(),
                 3600),
             Convergence(steps=pbag([DeleteServer(server_id='slowpoke')])))
 
@@ -462,9 +463,11 @@ class ConvergeTests(SynchronousTestCase):
         self.assertEqual(
             converge(
                 DesiredGroupState(launch_config={}, desired=1, desired_lbs=desired_lbs),
-                [server('abc', ServerState.ACTIVE, servicenet_address='1.1.1.1', created=0),
-                 server('bcd', ServerState.ACTIVE, servicenet_address='2.2.2.2', created=1)],
-                [],
+                set([server('abc', ServerState.ACTIVE,
+                            servicenet_address='1.1.1.1', created=0),
+                     server('bcd', ServerState.ACTIVE,
+                            servicenet_address='2.2.2.2', created=1)]),
+                set(),
                 0),
             Convergence(steps=pbag([
                 DeleteServer(server_id='abc'),


### PR DESCRIPTION
To guarantee unique servers and unique LB Nodes.
