### PR TITLE
Pass authenticator to SupervisorService

### DIFF
--- a/otter/tap/api.py
+++ b/otter/tap/api.py
@@ -240,8 +240,7 @@ def makeService(config):
         set_bobby(BobbyClient(bobby_url))
 
     authenticator = generate_authenticator(reactor)
-    supervisor = SupervisorService(authenticator.authenticate_tenant,
-                                   region, coiterate)
+    supervisor = SupervisorService(authenticator, region, coiterate)
     supervisor.setServiceParent(s)
 
     set_supervisor(supervisor)

--- a/otter/test/tap/test_api.py
+++ b/otter/test/tap/test_api.py
@@ -431,8 +431,8 @@ class APIMakeServiceTests(SynchronousTestCase):
         self.addCleanup(lambda: set_supervisor(None))
         makeService(test_config)
         mock_ga.assert_called_once_with(mock_reactor)
-        self.assertIdentical(get_supervisor().auth_function,
-                             mock_ga.return_value.authenticate_tenant)
+        self.assertIdentical(get_supervisor().authenticator,
+                             mock_ga.return_value)
 
     @mock.patch('otter.tap.api.SupervisorService', wraps=SupervisorService)
     def test_health_checker_no_zookeeper(self, supervisor):

--- a/otter/test/test_supervisor.py
+++ b/otter/test/test_supervisor.py
@@ -51,8 +51,10 @@ class SupervisorTests(SynchronousTestCase):
 
         self.auth_token = 'auth-token'
         self.service_catalog = {}
-        self.auth_function = mock.Mock(
-            return_value=succeed((self.auth_token, self.service_catalog)))
+        self.authenticator = mock.Mock()
+        self.auth_function = self.authenticator.authenticate_tenant
+        self.auth_function.return_value = succeed((self.auth_token,
+                                                   self.service_catalog))
 
         self.fake_server_details = {
             'server': {'id': 'server_id', 'links': ['links'], 'name': 'meh',
@@ -62,7 +64,7 @@ class SupervisorTests(SynchronousTestCase):
         self.cooperator = mock.Mock(spec=Cooperator)
 
         self.supervisor = SupervisorService(
-            self.auth_function, 'ORD', self.cooperator.coiterate)
+            self.authenticator, 'ORD', self.cooperator.coiterate)
 
         self.InMemoryUndoStack = patch(self, 'otter.supervisor.InMemoryUndoStack')
         self.undo = self.InMemoryUndoStack.return_value


### PR DESCRIPTION
This is part of a bigger project to pass a `request_fn` around in worker (hence the branch name). Step one: give the supervisor access to the authenticator. This is necessary because `otter.http.get_request_func` wants the authenticator object, not just an authentication function. (We could re-synthesize it, but that'd be a little silly.)
