### PR TITLE
Use equality semantics for compiler tests

### DIFF
--- a/otter/test/test_convergence.py
+++ b/otter/test/test_convergence.py
@@ -27,7 +27,7 @@ from otter.convergence import (
 
 from pyrsistent import pmap, pbag, pset, s
 
-from effect import ConstantIntent, Effect
+from effect import ConstantIntent, Effect, parallel
 from effect.testing import StubIntent, resolve_stubs
 
 
@@ -1207,28 +1207,14 @@ class RequestsToEffectTests(SynchronousTestCase):
     """
     Tests for converting :class:`Request` into effects.
     """
-    def _reqs_to_effect(self, conv_requests):
-        """
-        Helper function to call :func:`_reqs_to_effect`.
 
-        Uses :class:`_PureRequestStub` test double for easy introspection.
-
-        :param conv_requests: The convergence requests to be turned into an
-            effect.
-        :type conv_requests: iterable of :class:`Request`
-        :return: The return value of :func:`_reqs_to_effect`.
+    def assertCompileTo(self, conv_requests, expected_effects):
         """
-        return _reqs_to_effect(_PureRequestStub, conv_requests)
-
-    def assertCompilesTo(self, conv_requests, expected_effects):
-        """
-        Assert that the given convergence requests, compile down to a parallel
+        Assert that the given convergence requests compile down to a parallel
         effect comprised of the given effects.
         """
-        effect = self._reqs_to_effect(conv_requests)
-        self.assertTrue(isinstance(effect, Effect))
-        individual_effects = effect.intent.effects
-        self.assertEqual(expected_effects, set(individual_effects))
+        effect = _reqs_to_effect(_PureRequestStub, conv_requests)
+        self.assertEqual(effect, parallel(expected_effects))
 
     def test_single_request(self):
         """
@@ -1239,14 +1225,14 @@ class RequestsToEffectTests(SynchronousTestCase):
                     method="GET",
                     path="/whatever",
                     success_codes=(999,))]
-        expected_effects = set([
+        expected_effects = [
             _PureRequestStub(service_type=ServiceType.CLOUD_LOAD_BALANCERS,
                              method="GET",
                              url="/whatever",
                              headers=None,
                              data=None,
-                             success_codes=(999,))])
-        self.assertCompilesTo(conv_requests, expected_effects)
+                             success_codes=(999,))]
+        self.assertCompileTo(conv_requests, expected_effects)
 
     def test_multiple_requests(self):
         """
@@ -1261,7 +1247,7 @@ class RequestsToEffectTests(SynchronousTestCase):
                     method="GET",
                     path="/whatever/something/else",
                     success_codes=(231,))]
-        expected_effects = set([
+        expected_effects = [
             _PureRequestStub(service_type=ServiceType.CLOUD_LOAD_BALANCERS,
                              method="GET",
                              url="/whatever",
@@ -1272,8 +1258,8 @@ class RequestsToEffectTests(SynchronousTestCase):
                              url="/whatever/something/else",
                              headers=None,
                              data=None,
-                             success_codes=(231,))])
-        self.assertCompilesTo(conv_requests, expected_effects)
+                             success_codes=(231,))]
+        self.assertCompileTo(conv_requests, expected_effects)
 
     def test_multiple_requests_of_different_type(self):
         """
@@ -1293,7 +1279,7 @@ class RequestsToEffectTests(SynchronousTestCase):
                     method="POST",
                     path="/xyzzy",
                     data=data_sentinel)]
-        expected_effects = set([
+        expected_effects = [
             _PureRequestStub(service_type=ServiceType.CLOUD_LOAD_BALANCERS,
                              method="GET",
                              url="/whatever",
@@ -1309,5 +1295,5 @@ class RequestsToEffectTests(SynchronousTestCase):
                              method="POST",
                              url="/xyzzy",
                              headers=None,
-                             data=data_sentinel)])
-        self.assertCompilesTo(conv_requests, expected_effects)
+                             data=data_sentinel)]
+        self.assertCompileTo(conv_requests, expected_effects)


### PR DESCRIPTION
Closes #776.

This follows the spirit of #776, but not quite the letter. `assertCompilesTo` lives (named `assertCompileTo` since it takes a collection of things), but uses equality semantics. That still seemed like an entirely reasonable helper method to keep, so I kept it :)

Thanks, @radix!
