### PR TITLE
add_bind_root does not quote url

### DIFF
--- a/otter/test/util/test_pure_http.py
+++ b/otter/test/util/test_pure_http.py
@@ -226,6 +226,22 @@ class BindRootTests(TestCase):
         self.assertEqual(request_("get", "foo~").intent.url,
                          "http://slashdot.org/foo~")
 
+    def test_root_unicode(self):
+        """
+        If root is unicode, it is encoded as ascii before appending
+        """
+        request_ = add_bind_root(u'http://example.com', request)
+        self.assertEqual(request_("get", "foo").intent.url,
+                         "http://example.com/foo")
+
+    def test_url_unicode(self):
+        """
+        If url is unicode, it is encoded as utf-8 before appending
+        """
+        request_ = add_bind_root('http://example.com', request)
+        self.assertEqual(request_("get", u"foo\u0100").intent.url,
+                         "http://example.com/foo\xc4\x80")
+
 
 class ContentOnlyTests(TestCase):
     """Tests for :func:`add_content_only`"""

--- a/otter/util/pure_http.py
+++ b/otter/util/pure_http.py
@@ -180,8 +180,15 @@ def add_json_request_data(request_func):
 def add_bind_root(root, request_func):
     """
     Decorate a request function so that it's URL is appended to a common root.
-    The URL given is expected to be quoted. This decorator does not quote the URL.
+    The URL given is expected to be quoted if required. This decorator does not quote the URL.
     """
-    request = lambda method, url, *args, **kwargs: (
-        request_func(method, '{}/{}'.format(root.rstrip('/'), url), *args, **kwargs))
-    return wraps(request_func)(request)
+    @wraps(request_func)
+    def request(method, url, *args, **kwargs):
+        _root = root
+        if isinstance(_root, unicode):
+            _root = _root.encode('ascii')
+        if isinstance(url, unicode):
+            url = url.encode('utf-8')
+        return request_func(method, '{}/{}'.format(_root.rstrip('/'), url), *args, **kwargs)
+
+    return request


### PR DESCRIPTION
This was causing problem when calling `get_all_server_details` on #789 branch. That function appends limit and marker as query string and `add_bind_root` was quoting it resulting in `GET ../servers/detail%3Flimit%3D100` resulting in 404 from Nova for all requests. Since this function binds base to a full URL it is best if the caller does the quoting before passing the URL.
