### PR TITLE
removing service default names

### DIFF
--- a/otter/metrics.py
+++ b/otter/metrics.py
@@ -300,9 +300,6 @@ class Options(usage.Options):
         Parse config file and add nova service name
         """
         self.open = getattr(self, 'open', None) or open  # For testing
-        # TODO: This is hard-coded here and in tap/api.py. Should be there in
-        # Inject nova service name in case it is not there in config
-        self.update({'cloudServersOpenStack': 'cloudServersOpenStack'})
         self.update(json.load(self.open(self['config'])))
 
 
@@ -355,7 +352,5 @@ def makeService(config):
 
 if __name__ == '__main__':
     config = json.load(open(sys.argv[1]))
-    # TODO: This should come from config only
-    config['cloudServersOpenStack'] = 'cloudServersOpenStack'
     # TODO: Take _print as cmd-line arg and pass it.
     task.react(collect_metrics, (config, None, None, True))

--- a/otter/tap/api.py
+++ b/otter/tap/api.py
@@ -64,14 +64,6 @@ class Options(usage.Options):
         """
         self.update(jsonfig.from_path(self['config']))
 
-        # TODO: #846
-        # The staging service catalog has some unfortunate differences
-        # from the production one, so these are here to hint at the
-        # correct ocnfiguration for staging.
-        if self.get('environment') == 'staging':
-            self['cloudServersOpenStack'] = 'cloudServersPreprod'
-            self['regionOverrides']['cloudLoadBalancers'] = 'STAGING'
-
 
 class FunctionalService(Service, object):
     """

--- a/otter/tap/api.py
+++ b/otter/tap/api.py
@@ -62,17 +62,9 @@ class Options(usage.Options):
         """
         Merge our commandline arguments with our config file.
         """
-        # Inject some default values into the config.  Right now this is
-        # only used to support distinguishing between staging and production.
-        self.update({
-            'regionOverrides': {},
-            'cloudServersOpenStack': 'cloudServersOpenStack',
-            'cloudLoadBalancers': 'cloudLoadBalancers',
-            'rackconnect': 'rackconnect'
-        })
-
         self.update(jsonfig.from_path(self['config']))
 
+        # TODO: #846
         # The staging service catalog has some unfortunate differences
         # from the production one, so these are here to hint at the
         # correct ocnfiguration for staging.

--- a/otter/test/tap/test_api.py
+++ b/otter/test/tap/test_api.py
@@ -73,16 +73,6 @@ class APIOptionsTests(SynchronousTestCase):
         config.parseOptions(['-p', 'tcp:9999'])
         self.assertEqual(config['port'], 'tcp:9999')
 
-    def test_hardcoded_service_names(self):
-        """
-        Several hardcoded service names are injected.
-        """
-        config = Options()
-        config.parseOptions([])
-        self.assertEqual(config['cloudLoadBalancers'], 'cloudLoadBalancers')
-        self.assertEqual(config['cloudServersOpenStack'], 'cloudServersOpenStack')
-        self.assertEqual(config['rackconnect'], 'rackconnect')
-
 
 class HealthCheckerTests(SynchronousTestCase):
     """

--- a/otter/test/test_metrics.py
+++ b/otter/test/test_metrics.py
@@ -439,8 +439,7 @@ class APIOptionsTests(SynchronousTestCase):
         config = Options()
         config.open = mock.Mock(return_value=StringIO(u'{"a": "b"}'))
         config.parseOptions(['--config=file.json'])
-        self.assertEqual(config, {'a': 'b', 'config': 'file.json',
-                                  'cloudServersOpenStack': 'cloudServersOpenStack'})
+        self.assertEqual(config, {'a': 'b', 'config': 'file.json'})
 
 
 class ServiceTests(SynchronousTestCase):


### PR DESCRIPTION
They are expected to come from config file only. Implements #846. This should be merged after https://github.com/rackerlabs/autoscaling-chef/pull/573. 