### PR TITLE
Generic LB model (interfaces) for converger (mergable without queuing).

### DIFF
--- a/otter/convergence/model.py
+++ b/otter/convergence/model.py
@@ -102,7 +102,7 @@ class NovaServer(object):
 
 
 @attributes(['launch_config', 'desired',
-             Attribute('desired_lbs', default_value=(), instance_of=tuple),
+             Attribute('desired_lbs', default_factory=dict, instance_of=dict),
              Attribute('draining_timeout', default_value=0.0, instance_of=float)])
 class DesiredGroupState(object):
     """
@@ -110,7 +110,8 @@ class DesiredGroupState(object):
 
     :ivar dict launch_config: nova launch config.
     :ivar int desired: the number of desired servers within the group.
-    :ivar tuple desired_lbs: A tuple of :class:`ILBDescription` providers.
+    :ivar dict desired_lbs: A mapping of load balancer IDs to lists of
+        :class:`LBConfig` instances.
     :ivar float draining_timeout: If greater than zero, when the server is
         scaled down it will be put into draining condition.  It will remain
         in draining condition for a maximum of ``draining_timeout`` seconds

--- a/otter/convergence/model.py
+++ b/otter/convergence/model.py
@@ -9,6 +9,9 @@ from pyrsistent import freeze
 
 from twisted.python.constants import Names, NamedConstant
 
+from zope.interface import implementer, Interface
+from zope.interface import Attribute as IAttribute
+
 
 class CLBNodeCondition(Names):
     """Constants representing the condition a load balancer node can be in"""
@@ -34,53 +37,6 @@ class ServerState(Names):
     DRAINING = NamedConstant()  # Autoscale is deleting the server
 
 
-@attributes(["lb_id", "node_id", "address",
-             Attribute("drained_at", default_value=0.0, instance_of=float),
-             Attribute("connections", default_value=None),
-             "config"])
-class LBNode(object):
-    """
-    Information representing an actual node on a load balancer, which is
-    an actual, existing, specific port mapping on a load balancer.
-
-    :ivar int lb_id: The Load Balancer ID.
-    :ivar int node_id: The ID of the node, which is represents a unique
-        combination of IP and port number, on the load balancer.
-    :ivar str address: The IP address of the node.  The IP and port form a
-        unique mapping on the load balancer, which is assigned a node ID.  Two
-        nodes with the same IP and port cannot exist on a single load balancer.
-    :ivar float drained_at: EPOCH at which this node was put in DRAINING.
-        Will be 0 if node is not DRAINING
-    :ivar int connections: The number of active connections on the node - this
-        is None by default (the stat is not available yet)
-
-    :ivar config: The configuration for the port mapping
-    :type config: :class:`LBConfig`
-    """
-
-
-@attributes(["port",
-             Attribute("weight", default_value=1, instance_of=int),
-             Attribute("condition", default_value=CLBNodeCondition.ENABLED,
-                       instance_of=NamedConstant),
-             Attribute("type", default_value=CLBNodeType.PRIMARY,
-                       instance_of=NamedConstant)])
-class LBConfig(object):
-    """
-    Information representing a load balancer port mapping; how a particular
-    server *should* be port-mapped to a load balancer.
-
-    :ivar int port: The port, which together with the server's IP, specifies
-        the service that should be load-balanced by the load balancer.
-    :ivar int weight: The weight to be used for certain load-balancing
-        algorithms if configured on the load balancer.  Defaults to 1,
-        the max is 100.
-    :ivar str condition: One of ``ENABLED``, ``DISABLED``, or ``DRAINING`` -
-        the default is ``ENABLED``
-    :ivar str type: One of ``PRIMARY`` or ``SECONDARY`` - default is ``PRIMARY``
-    """
-
-
 @attributes(['id', 'state', 'created',
              Attribute('servicenet_address', default_value='', instance_of=str)])
 class NovaServer(object):
@@ -96,7 +52,7 @@ class NovaServer(object):
 
 
 @attributes(['launch_config', 'desired',
-             Attribute('desired_lbs', default_factory=dict, instance_of=dict),
+             Attribute('desired_lbs', default_value=(), instance_of=tuple),
              Attribute('draining_timeout', default_value=0.0, instance_of=float)])
 class DesiredGroupState(object):
     """
@@ -104,13 +60,125 @@ class DesiredGroupState(object):
 
     :ivar dict launch_config: nova launch config.
     :ivar int desired: the number of desired servers within the group.
-    :ivar dict desired_lbs: A mapping of load balancer IDs to lists of
-        :class:`LBConfig` instances.
+    :ivar tuple desired_lbs: A tuple of :class:`ILBDescription` providers.
     :ivar float draining_timeout: If greater than zero, when the server is
         scaled down it will be put into draining condition.  It will remain
         in draining condition for a maximum of ``draining_timeout`` seconds
         before being removed from the load balancer and then deleted.
     """
-
     def __init__(self):
+        """
+        Make attributes immutable.
+        """
         self.launch_config = freeze(self.launch_config)
+
+
+class ILBDescription(Interface):
+    """
+    A description of how to create a node on a load balancing entity.
+
+    A load balancing entity can be a cloud load balancer or some kind of load
+    balancer pool - anything that load balances.
+
+    Implementers should have immutable attributes.
+    """
+    def equivalent_definition(other_description):
+        """
+        Checks whether two description have the same definitions.
+
+        A definition is anything non-server specific information that describes
+        how to add a node to a particular load balancing entity.  For instance,
+        the type of load balancer, the load balancer ID, and/or the port.
+
+        :param ILBDescription other_description: the other description to
+            compare against
+        :return: whether the definitions are equivalent
+        :rtype: `bool`
+        """
+
+
+class ILBNode(Interface):
+    """
+    A node, which is a mapping between a server and a :class:`ILBDescription`.
+
+    :ivar ILBDescription description: The description of how the server is
+        mapped to the load balancer.
+    :ivar str node_id: The ID of the node, which is represents a unique
+        mapping of a server to a load balancer (possibly one of many).
+    :ivar NovaServer: The server corresponding to this node.
+    """
+    server = IAttribute("The server that corresponds to this node.")
+    node_id = IAttribute("The ID of this node.")
+    description = IAttribute("The LB Description for how this server is "
+                             "attached to the load balancer.")
+
+
+class IDrainable(Interface):
+    """
+    The drainability part of a LB Node.  If a node is drainable, it should
+    also provide this interface.
+    """
+    def currently_draining():
+        """
+        Is this node currently in draining mode?
+        """
+
+    def is_done_draining(now, timeout):
+        """
+        Given the current time and the draining timeout, can this node be
+        done draining?
+        """
+
+
+@implementer(ILBDescription)
+@attributes([Attribute("lb_id", instance_of=str),
+             Attribute("port", instance_of=int),
+             Attribute("weight", default_value=1, instance_of=int),
+             Attribute("condition", default_value=CLBNodeCondition.ENABLED,
+                       instance_of=NamedConstant),
+             Attribute("type", default_value=CLBNodeType.PRIMARY,
+                       instance_of=NamedConstant)])
+class CLBDescription(object):
+    """
+    Information representing a Rackspace CLB port mapping; how a particular
+    server *should* be port-mapped to a Rackspace Cloud Load Balancer.
+
+    :ivar int lb_id: The Load Balancer ID.
+    :ivar int port: The port, which together with the server's IP, specifies
+        the service that should be load-balanced by the load balancer.
+    :ivar int weight: The weight to be used for certain load-balancing
+        algorithms if configured on the load balancer.  Defaults to 1,
+        the max is 100.
+    :ivar str condition: One of ``ENABLED``, ``DISABLED``, or ``DRAINING`` -
+        the default is ``ENABLED``
+    :ivar str type: One of ``PRIMARY`` or ``SECONDARY`` - default is ``PRIMARY``
+    """
+    def equivalent_definition(self, other_description):
+        """
+        Whether the other description is also a :class:`CLBDescription` and
+        whether it has the same load balancer ID and port.
+
+        See :func:`ILBDescription.equivalent_definition`.
+        """
+        return (isinstance(other_description, CLBDescription) and
+                other_description.lb_id == self.lb_id and
+                other_description.port == self.port)
+
+
+@implementer(ILBDescription)
+@attributes([Attribute("pool_id", instance_of=str)])
+class RCv3Description(object):
+    """
+    Information representing a Rackspace RackConnect v3 load balancer.
+
+    :ivar int lb_id: The Load Balancer Pool ID.
+    """
+    def equivalent_definition(self, other_description):
+        """
+        Whether the other description is also a :class:`RCv3Description` and
+        whether it has the same load balancer pool ID.
+
+        See :func:`ILBDescription.equivalent_definition`.
+        """
+        return (isinstance(other_description, RCv3Description) and
+                other_description.pool_id == self.pool_id)

--- a/otter/test/convergence/test_model.py
+++ b/otter/test/convergence/test_model.py
@@ -1,0 +1,179 @@
+"""
+Tests for convergence models.
+"""
+from characteristic import attributes
+from twisted.trial.unittest import SynchronousTestCase
+from zope.interface import implementer
+
+from otter.convergence.model import (
+    IDrainable, ILBDescription, ILBNode, NovaServer, ServerState,
+    CLBNodeCondition, CLBNodeType, CLBNode, CLBDescription)
+
+
+@implementer(ILBDescription)
+class DummyLBDescription(object):
+    """
+    Fake LB description to be use for equality testing.
+    """
+    def equivalent_definition(self, other):
+        """Just always return True"""
+        return True
+
+
+@attributes(["servicenet_address"])
+class DummyServer(object):
+    """
+    Fake Server object to be used for tesitng.
+    """
+
+
+class CLBDescriptionTests(SynchronousTestCase):
+    """
+    Tests for :class:`CLBDescription`.
+    """
+    def test_provides_ILBDescription(self):
+        """
+        An instance of :class:`CLBDescription` provides :class:`ILBDescription`.
+        """
+        desc = CLBDescription(lb_id='12345', port=80)
+        self.assertTrue(ILBDescription.providedBy(desc))
+
+    def test_only_eq_and_equivalent_definition_to_other_CLBDescriptions(self):
+        """
+        :func:`CLBDescriptionTest.__eq__` and
+        :func:`CLBDescriptionTest.equivalent_definition` return false if
+        compared to a non-:class:`CLBDescription` :class:`ILBDescription`
+        provider.
+        """
+        desc = CLBDescription(lb_id='12345', port=80)
+        fake = DummyLBDescription()
+        self.assertNotEqual(desc, fake)
+        self.assertFalse(desc.equivalent_definition(fake))
+
+    def test_equivalent_definition_but_not_eq(self):
+        """
+        Even if weight, etc. are different, so long as the ``lb_id`` and ``port``
+        are identical, :func:`CLBDescription.equivalent_definition` will
+        return `True`.  :func:`CLBDescription.__eq__` will not, however.
+        """
+        desc1 = CLBDescription(lb_id='12345', port=80)
+        desc2 = CLBDescription(lb_id='12345', port=80, weight=2,
+                               condition=CLBNodeCondition.DISABLED,
+                               type=CLBNodeType.SECONDARY)
+        self.assertTrue(desc1.equivalent_definition(desc2))
+        self.assertNotEqual(desc1, desc2)
+
+    def test_neither_equivalent_definition_or_eq(self):
+        """
+        If ``lb_id`` and ``port`` are different, even if everything else are
+        the same, neither :func:`CLBDescription.equivalent_definition` nor
+        :func:`CLBDescription.__eq__` will return `True`.
+        """
+        desc1 = CLBDescription(lb_id='12345', port=80)
+        desc2 = CLBDescription(lb_id='12345', port=8080)
+        self.assertFalse(desc1.equivalent_definition(desc2))
+        self.assertNotEqual(desc1, desc2)
+
+    def test_equivalent_definition_and_eq(self):
+        """
+        If every attribute is the same, both :func:`CLBDescription.__eq__` and
+        :func:`CLBDescription.equivalent_definition` will return `True`.
+        """
+        desc1 = CLBDescription(lb_id='12345', port=80)
+        desc2 = CLBDescription(lb_id='12345', port=80)
+        self.assertTrue(desc1.equivalent_definition(desc2))
+        self.assertEquals(desc1, desc2)
+
+
+class CLBNodeTests(SynchronousTestCase):
+    """
+    Tests for :class:`CLBNode`.
+    """
+    desc = CLBDescription(lb_id='12345', port=80)
+    drain_desc = CLBDescription(lb_id='12345', port=80,
+                                condition=CLBNodeCondition.DRAINING)
+
+    def test_provides_ILBDescription_and_IDrainable(self):
+        """
+        An instance of :class:`CLBNode` provides :class:`ILBNode` and
+        :class:`IDrainable`.
+        """
+        node = CLBNode(node_id='1234', description=self.desc, address='10.1.1.1')
+        self.assertTrue(ILBNode.providedBy(node))
+        self.assertTrue(IDrainable.providedBy(node))
+
+    def test_matches_only_works_with_NovaServers(self):
+        """
+        :func:`CLBNode.matches` returns false if the server is not an instance
+        of :class:`NovaServer`.
+        """
+        node = CLBNode(node_id='1234', description=self.desc, address='10.1.1.1')
+        self.assertFalse(node.matches(DummyServer(servicenet_address="10.1.1.1")))
+
+    def test_matches_only_if_NovaServer_address_matches_node_address(self):
+        """
+        :func:`CLBNode.matches` returns True only if the :class:`NovaServer` has
+        the same ServiceNet address as the node address
+        """
+        node = CLBNode(node_id='1234', description=self.desc, address='10.1.1.1')
+        self.assertFalse(node.matches(
+            NovaServer(id='1', state=ServerState.ACTIVE, created=0.0,
+                       servicenet_address="10.1.1.2")))
+        self.assertTrue(node.matches(
+            NovaServer(id='1', state=ServerState.ACTIVE, created=0.0,
+                       servicenet_address="10.1.1.1")))
+
+    def test_current_draining_true_if_description_is_draining(self):
+        """
+        :func:`CLBNode.currently_draining` returns `True` if
+        `CLBNode.description.condition` is :obj:`CLBNodeCondition.DRAINING`
+        """
+        node = CLBNode(node_id='1234', description=self.drain_desc,
+                       address='10.1.1.1')
+        self.assertTrue(node.currently_draining())
+
+    def test_current_draining_false_if_description_not_draining(self):
+        """
+        :func:`CLBNode.currently_draining` returns `False` if
+        `CLBNode.description.condition` is not :obj:`CLBNodeCondition.DRAINING`
+        """
+        node = CLBNode(node_id='1234', description=self.desc, address='10.1.1.1')
+        self.assertFalse(node.currently_draining())
+
+    def test_done_draining_past_timeout_even_if_there_are_connections(self):
+        """
+        If there are still connections, but the node has been in draining past
+        the timeout, :func:`CLBNode.is_done_draining` returns `True`.
+        """
+        node = CLBNode(node_id='1234', description=self.drain_desc,
+                       address='10.1.1.1', drained_at=0.0, connections=1)
+        self.assertTrue(node.is_done_draining(now=30, timeout=15))
+
+    def test_done_draining_past_timeout_even_if_no_connection_info(self):
+        """
+        If connection information is not provided, and the node has been in
+        draining past the timeout, :func:`CLBNode.is_done_draining` returns
+        `True`.
+        """
+        node = CLBNode(node_id='1234', description=self.drain_desc,
+                       address='10.1.1.1', drained_at=0.0)
+        self.assertTrue(node.is_done_draining(now=30, timeout=15))
+
+    def test_done_draining_before_timeout_if_there_are_no_connections(self):
+        """
+        If there are zero connections, but the node has been in draining less
+        than the timeout, :func:`CLBNode.is_done_draining` returns `True`.
+        """
+        node = CLBNode(node_id='1234', description=self.drain_desc,
+                       address='10.1.1.1', drained_at=0.0, connections=0)
+        self.assertTrue(node.is_done_draining(now=15, timeout=30))
+
+    def test_not_done_draining_before_timeout_if_no_connection_info(self):
+        """
+        If connection information is not provided, and the node has been in
+        draining less than the timeout, :func:`CLBNode.is_done_draining`
+        returns `False`.
+        """
+        node = CLBNode(node_id='1234', description=self.drain_desc,
+                       address='10.1.1.1', drained_at=0.0)
+        self.assertFalse(node.is_done_draining(now=15, timeout=30))


### PR DESCRIPTION
Some generic LB model interfaces (and specific CLB interface providers) so that the converge logic can operate on general LBs (part of fixing #821).

Here is [a sketch of what planning will look like (not full changes, no tests)](https://github.com/rackerlabs/otter/blob/a70fc77f226905422eaac91d0c8412394a18273f/otter/convergence/planning.py) - mainly, look at [_remove_from_lb_with_draining](https://github.com/rackerlabs/otter/blob/a70fc77f226905422eaac91d0c8412394a18273f/otter/convergence/planning.py#L20) and [_converge_lb_state](https://github.com/rackerlabs/otter/blob/a70fc77f226905422eaac91d0c8412394a18273f/otter/convergence/planning.py#L68).  (Will be separate PRs)

There will also be specific RCv3 implementations of ILBDescription and ILBNode (the RCv3 version may not be drainable). (Again, future PRs.)

Also looking to implement `AddToLoadBalancing` etc. as a function which checks what the types are and produces the right specific steps (in future PR).  Something like:

    def AddServerToLoadBalancing(server, description):
        if isinstance(description, CLBDescription):
            return AddNodesToLoadBalancer(description.lb_id, (server.servicenet_address, description))

Naming corrections/feedback about above welcome and requested :)