### PR TITLE
Pin setuptools to < 10.0 to fix terrarium

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,25 @@
+# pin this up here because terrarium
+setuptools<10.0
+
+
+# pinning dependencies of dependencies
+Werkzeug==0.9.3
+cql==1.4.0
+extras==0.0.3
+kazoo==2.0b1
+mock==1.0.1
+pyasn1==0.1.7
+pyasn1-modules==0.0.5
+pycrypto==2.6
+python-dateutil==2.1
+python-mimeparse==0.1.4
+six==1.7.3
+thrift==0.9.0
+wsgiref==0.1.2
+zope.interface==4.0.5
+
+
+# Actual requirements
 klein==0.2.1
 twisted==14.0
 service_identity==0.2
@@ -15,21 +37,3 @@ effect==0.1a11
 characteristic==14.1.0
 toolz==0.6.0
 pyrsistent==0.5.0
-
-# pinning dependencies of dependencies
-
-Werkzeug==0.9.3
-cql==1.4.0
-extras==0.0.3
-kazoo==2.0b1
-mock==1.0.1
-pyasn1==0.1.7
-pyasn1-modules==0.0.5
-pycrypto==2.6
-python-dateutil==2.1
-python-mimeparse==0.1.4
-six==1.7.3
-thrift==0.9.0
-wsgiref==0.1.2
-zope.interface==4.0.5
-setuptools<10.0


### PR DESCRIPTION
Since setuptools==10.0.1 was just released.  Does this fix builds?
