### PR TITLE
Accept string CLB ID in loadBalancerId in launch config

### DIFF
--- a/autoscale_cloudroast/test_repo/autoscale/functional/launch_config/test_update_launch_config.py
+++ b/autoscale_cloudroast/test_repo/autoscale/functional/launch_config/test_update_launch_config.py
@@ -29,7 +29,8 @@ class UpdateLaunchConfigTest(AutoscaleFixture):
         lc_name = rand_name('upd_server_name')
         lc_image_ref = self.lc_image_ref_alt
         lc_flavor_ref = '4'
-        lc_load_balancers = [{'loadBalancerId': 1234, 'port': 8181}]
+        lc_load_balancers = [{'loadBalancerId': 1234, 'port': 8181},
+                             {'loadBalancerId': '3245', 'port': 8181}]
         lc_disk_config = 'AUTO'
         lc_personality = [{'path': '/root/.ssh/authorized_keys',
                            'contents': ('DQoiQSBjbG91ZCBkb2VzIG5vdCBrbm93IHdoeSBp')}]

--- a/autoscale_cloudroast/test_repo/autoscale/functional/scaling_group/test_create_scaling_group.py
+++ b/autoscale_cloudroast/test_repo/autoscale/functional/scaling_group/test_create_scaling_group.py
@@ -30,7 +30,8 @@ class CreateScalingGroupTest(AutoscaleFixture):
         self.lc_disk_config = 'AUTO'
         self.lc_networks = [{'uuid': '11111111-1111-1111-1111-111111111111'},
                             {'uuid': '00000000-0000-0000-0000-000000000000'}]
-        self.lc_load_balancers = [{'loadBalancerId': 9099, 'port': 8080}]
+        self.lc_load_balancers = [{'loadBalancerId': 9099, 'port': 8080},
+                                  {'loadBalancerId': '8315', 'port': 80}]
         self.sp_list = [{
             'name': 'scale up by 1',
             'change': 1,

--- a/otter/json_schema/group_examples.py
+++ b/otter/json_schema/group_examples.py
@@ -104,6 +104,39 @@ def launch_server_config():
                 "server": {
                     "flavorRef": "2",
                     "name": "worker",
+                    "imageRef": "a09e7493-7429-41e1-8d3f-384d7ece09c0"
+                },
+                "loadBalancers": [
+                    {
+                        "loadBalancerId": "2200",
+                        "port": 8081,
+                        "type": "CloudLoadBalancer"
+                    }
+                ]
+            }
+        },
+        {
+            "type": "launch_server",
+            "args": {
+                "server": {
+                    "flavorRef": "2",
+                    "name": "worker",
+                    "imageRef": "a09e7493-7429-41e1-8d3f-384d7ece09c0"
+                },
+                "loadBalancers": [
+                    {
+                        "loadBalancerId": "441",
+                        "port": 80
+                    }
+                ]
+            }
+        },
+        {
+            "type": "launch_server",
+            "args": {
+                "server": {
+                    "flavorRef": "2",
+                    "name": "worker",
                     "imageRef": "a09e7493-7429-41e1-8d3f-384d7ece09c0",
                     "personality": [
                         {

--- a/otter/json_schema/group_schemas.py
+++ b/otter/json_schema/group_schemas.py
@@ -125,7 +125,8 @@ _clb_lb = {
         "One load balancer all new servers should be "
         "added to."),
     "properties": {
-        # load balancer id's are NOT uuid's.  just an int.
+        # Cloud load balancer id's are NOT uuid's, just ints.  But accept
+        # strings also for backwards compatibility reasons.
         "loadBalancerId": {
             "type": ["integer", "string"],
             "description": (
@@ -138,7 +139,7 @@ _clb_lb = {
             "description": (
                 "The port number of the service (on the "
                 "new servers) to load balance on for this "
-                "particular load balancer."),
+                "particular Cloud Load Balancer."),
             "required": True
         },
         "type": {

--- a/otter/json_schema/group_schemas.py
+++ b/otter/json_schema/group_schemas.py
@@ -127,7 +127,7 @@ _clb_lb = {
     "properties": {
         # load balancer id's are NOT uuid's.  just an int.
         "loadBalancerId": {
-            "type": "integer",
+            "type": ["integer", "string"],
             "description": (
                 "The ID of the load balancer to which new "
                 "servers will be added."),


### PR DESCRIPTION
Launch config's `loadBalancerId` has been taking int before RCv3 since it only took ID of CLB which is an integer. Now it is also taking RCv3 LB pool ID in the same field which is a UUID. This change of types broke Reach. So, otter should accept CLB ID in `loadBalancerId` as string. But also allow int to keep it backwards compatible. 