### PR TITLE
Validate launch config to require servicenet with CLBs

### DIFF
--- a/autoscale_cloudroast/test_repo/autoscale/functional/launch_config/test_launch_config_negative.py
+++ b/autoscale_cloudroast/test_repo/autoscale/functional/launch_config/test_launch_config_negative.py
@@ -141,6 +141,53 @@ class LaunchConfigNegtaiveTest(AutoscaleFixture):
                               msg='Create group with invalid flavor id was successsful with'
                               ' response {0}'.format(create_group_response.status_code))
 
+    def test_create_scaling_group_with_CLBs_but_no_ServiceNet(self):
+        """
+        Scaling group creation fails with a 400 when a launch config has one or
+        more CLBs configured, but no ServiceNet configured.
+        """
+        create_group_response = self.autoscale_client.create_scaling_group(
+            gc_name='test_no_servicenet',
+            gc_cooldown=self.gc_cooldown,
+            gc_min_entities=self.gc_min_entities,
+            lc_name=self.lc_name,
+            lc_image_ref=self.lc_image_ref,
+            lc_flavor_ref=self.lc_flavor_ref,
+            lc_networks=[
+                {"uuid": "4ebd35cf-bfe7-4d93-b0d8-eb468ce2245a"},
+                {"uuid": "00000000-0000-0000-0000-000000000000"}
+            ],
+            lc_load_balancers=[{'loadBalancerId': '1234', 'port': 80,
+                                'type': 'CloudLoadBalancer'}])
+        self.assertEquals(
+            create_group_response.status_code, 400,
+            msg=('Create group with no CLBs but no ServiceNet was successsful '
+                 'with response {0}'.format(create_group_response.status_code)))
+
+    def test_update_scaling_group_with_CLBs_but_no_ServiceNet(self):
+        """
+        Update scaling group fails with a 400 when a launch config has one or
+        more CLBs configured, but no ServiceNet configured.
+        """
+        group = self._create_group()
+        update_launch_config_response = self.autoscale_client.update_launch_config(
+            group_id=group.id,
+            name=self.lc_name,
+            image_ref=self.lc_image_ref,
+            flavor_ref=self.lc_flavor_ref,
+            networks=[
+                {"uuid": "4ebd35cf-bfe7-4d93-b0d8-eb468ce2245a"},
+                {"uuid": "00000000-0000-0000-0000-000000000000"}
+            ],
+            load_balancers=[{'loadBalancerId': '1234', 'port': 80,
+                             'type': 'CloudLoadBalancer'}])
+
+        status = update_launch_config_response.status_code
+        self.assertEquals(
+            status, 400,
+            msg=('Create group with no CLBs but no ServiceNet was successsful '
+                 'with response {0}'.format(status)))
+
     def _create_group(self):
         """
         Create a group

--- a/autoscale_cloudroast/test_repo/autoscale/functional/launch_config/test_launch_config_negative.py
+++ b/autoscale_cloudroast/test_repo/autoscale/functional/launch_config/test_launch_config_negative.py
@@ -161,7 +161,7 @@ class LaunchConfigNegtaiveTest(AutoscaleFixture):
                                 'type': 'CloudLoadBalancer'}])
         self.assertEquals(
             create_group_response.status_code, 400,
-            msg=('Create group with no CLBs but no ServiceNet was successsful '
+            msg=('Create group with CLBs but no ServiceNet was successsful '
                  'with response {0}'.format(create_group_response.status_code)))
 
     def test_update_scaling_group_with_CLBs_but_no_ServiceNet(self):
@@ -185,7 +185,7 @@ class LaunchConfigNegtaiveTest(AutoscaleFixture):
         status = update_launch_config_response.status_code
         self.assertEquals(
             status, 400,
-            msg=('Create group with no CLBs but no ServiceNet was successsful '
+            msg=('Updating a group to have CLBs but no ServiceNet was successsful '
                  'with response {0}'.format(status)))
 
     def _create_group(self):

--- a/otter/json_schema/group_schemas.py
+++ b/otter/json_schema/group_schemas.py
@@ -8,6 +8,7 @@ from datetime import datetime
 import calendar
 
 from croniter import croniter
+from toolz import get_in
 
 from otter.util.timestamp import from_timestamp
 from otter.json_schema import format_checker
@@ -319,6 +320,21 @@ zero = {
     "minimum": 0,
     "maximum": 0
 }
+
+
+def validate_launch_config_servicenet(lc):
+    """
+    Validate that if CLBs are provided, ServiceNet is also provided.
+    """
+    clb = any([lb.get('type', 'CloudLoadBalancer') == 'CloudLoadBalancer'
+               for lb in get_in(('args', 'loadBalancers'), lc, default=())])
+    servicenet = get_in(('args', 'server', 'networks'), lc, default=None)
+
+    if (clb and
+            servicenet is not None and
+            {'uuid': '11111111-1111-1111-1111-111111111111'} not in servicenet):
+        raise ValidationError("ServiceNet network must be present if one or "
+                              "more Cloud Load Balancers are configured.")
 
 
 # Datetime validator. Allow only zulu-based UTC timestamp

--- a/otter/json_schema/group_schemas.py
+++ b/otter/json_schema/group_schemas.py
@@ -328,11 +328,11 @@ def validate_launch_config_servicenet(lc):
     """
     clb = any([lb.get('type', 'CloudLoadBalancer') == 'CloudLoadBalancer'
                for lb in get_in(('args', 'loadBalancers'), lc, default=())])
-    servicenet = get_in(('args', 'server', 'networks'), lc, default=None)
+    networks = get_in(('args', 'server', 'networks'), lc, default=None)
 
     if (clb and
-            servicenet is not None and
-            {'uuid': '11111111-1111-1111-1111-111111111111'} not in servicenet):
+            networks is not None and
+            {'uuid': '11111111-1111-1111-1111-111111111111'} not in networks):
         raise ValidationError("ServiceNet network must be present if one or "
                               "more Cloud Load Balancers are configured.")
 

--- a/otter/rest/configs.py
+++ b/otter/rest/configs.py
@@ -243,6 +243,7 @@ class OtterLaunch(object):
         """
         rec = self.store.get_scaling_group(self.log, self.tenant_id, self.group_id)
         data = normalize_launch_config(data)
+        group_schemas.validate_launch_config_servicenet(data)
         deferred = get_supervisor().validate_launch_config(self.log, self.tenant_id, data)
         deferred.addCallback(lambda _: rec.update_launch_config(data))
         return deferred

--- a/otter/rest/groups.py
+++ b/otter/rest/groups.py
@@ -11,7 +11,8 @@ from otter import controller
 from otter.supervisor import get_supervisor, remove_server_from_group
 
 from otter.json_schema.rest_schemas import create_group_request
-from otter.json_schema.group_schemas import MAX_ENTITIES
+from otter.json_schema.group_schemas import (
+    MAX_ENTITIES, validate_launch_config_servicenet)
 from otter.log import log
 from otter.rest.configs import OtterConfig, OtterLaunch, normalize_launch_config
 from otter.rest.decorators import (validate_body, fails_with, succeeds_with,
@@ -334,6 +335,8 @@ class OtterGroups(object):
 
         if data['groupConfiguration']['minEntities'] > data['groupConfiguration']['maxEntities']:
             raise InvalidMinEntities("minEntities must be less than or equal to maxEntities")
+
+        validate_launch_config_servicenet(data['launchConfiguration'])
 
         deferred = get_supervisor().validate_launch_config(
             self.log, self.tenant_id, data['launchConfiguration'])


### PR DESCRIPTION
This is part of addressing #868, to prevent users from putting in bad data in the first place.

I am not sure it's worth splitting the json schema into different versions (CLB and no CLB), since our schema is getting pretty complicated already, so I made this a function.  Also, this makes for a nicer user error message.