### PR TITLE
Force group delete fails sometimes

### DIFF
--- a/otter/models/cass.py
+++ b/otter/models/cass.py
@@ -217,7 +217,8 @@ _consistency_levels = {'event': {'fetch': ConsistencyLevel.QUORUM,
                                  'insert': ConsistencyLevel.ONE,
                                  'delete': ConsistencyLevel.QUORUM},
                        'group': {'create': ConsistencyLevel.QUORUM},
-                       'state': {'update': ConsistencyLevel.QUORUM}}
+                       'state': {'update': ConsistencyLevel.QUORUM},
+                       'partial': {'update': ConsistencyLevel.QUORUM}}
 
 
 def get_consistency_level(operation_name, resource_name,

--- a/otter/test/models/test_cass_models.py
+++ b/otter/test/models/test_cass_models.py
@@ -857,6 +857,8 @@ class CassScalingGroupTests(CassScalingGroupTestCase):
         Test that you can update a config, and if its successful the return
         value is None
         """
+        self.group.get_consistency = get_consistency_level  # test defaults
+
         self.clock.advance(10.345)
         d = self.group.update_config({"b": "lah"})
         self.assertIsNone(self.successResultOf(d))  # update returns None
@@ -868,7 +870,7 @@ class CassScalingGroupTests(CassScalingGroupTestCase):
                         "groupId": '12345678g',
                         "tenantId": '11111', 'ts': 10345000}
         self.connection.execute.assert_called_with(
-            expectedCql, expectedData, ConsistencyLevel.TWO)
+            expectedCql, expectedData, ConsistencyLevel.QUORUM)
 
     @mock.patch('otter.models.cass.CassScalingGroup.view_config',
                 return_value=defer.succeed({}))
@@ -877,6 +879,8 @@ class CassScalingGroupTests(CassScalingGroupTestCase):
         Test that you can update a launch config, and if successful the return
         value is None
         """
+        self.group.get_consistency = get_consistency_level  # test defaults
+
         self.clock.advance(10.345)
         d = self.group.update_launch_config({"b": "lah"})
         self.assertIsNone(self.successResultOf(d))  # update returns None
@@ -888,7 +892,7 @@ class CassScalingGroupTests(CassScalingGroupTestCase):
                         "groupId": '12345678g',
                         "tenantId": '11111', 'ts': 10345000}
         self.connection.execute.assert_called_with(
-            expectedCql, expectedData, ConsistencyLevel.TWO)
+            expectedCql, expectedData, ConsistencyLevel.QUORUM)
 
     @mock.patch('otter.models.cass.CassScalingGroup.view_config')
     def test_update_configs_call_view_first(self, view_config):


### PR DESCRIPTION
Test `test_system_force_delete_group_with_minentities_over_zero` in https://as-jenkins.rax.io/job/otter-cloudcafe-prod-dfw-slow-system-tests/507/ failed because `DELETE ...groups/<groupId>/?force=TRUE` returned 403 instead of 204. This should never happen. It should always succeed. The most likely reason is that `update_config` to set min/max to 0 is done with consistency ONE and `obey_config_change` after that didn't notice config change group deletion. I think the right solution would be to change default consistency to QUORUM. There is already facility to do that.