### PR TITLE
Increase build timeout from 1 to 2 hours

### DIFF
--- a/otter/test/convergence/test_effecting.py
+++ b/otter/test/convergence/test_effecting.py
@@ -7,6 +7,7 @@ from otter.constants import ServiceType
 from otter.convergence.effecting import _reqs_to_effect
 from otter.convergence.steps import Request
 from otter.http import get_request_func
+from otter.test.utils import defaults_by_name
 from otter.util.pure_http import has_code
 from twisted.trial.unittest import SynchronousTestCase
 
@@ -35,14 +36,14 @@ class PureRequestStubTests(SynchronousTestCase):
         """
         authenticator, log, = object(), object()
         request_func = get_request_func(authenticator, 1234, log, {}, "XYZ")
-        args, _, _, defaults = getargspec(request_func)
+        args = getargspec(request_func).args
         characteristic_attrs = _PureRequestStub.characteristic_attributes
         self.assertEqual(set(a.name for a in characteristic_attrs), set(args))
         characteristic_defaults = {a.name: a.default_value
                                    for a in characteristic_attrs
                                    if a.default_value is not NOTHING}
-        defaults_by_name = dict(zip(reversed(args), reversed(defaults)))
-        self.assertEqual(characteristic_defaults, defaults_by_name)
+        self.assertEqual(characteristic_defaults,
+                         defaults_by_name(request_func))
 
 
 class RequestsToEffectTests(SynchronousTestCase):

--- a/otter/test/utils.py
+++ b/otter/test/utils.py
@@ -2,6 +2,7 @@
 Mixins and utilities to be used for testing.
 """
 from functools import partial
+from inspect import getargspec
 import json
 import mock
 import os
@@ -601,3 +602,9 @@ def resolve_retry_stubs(eff):
     assert type(eff.intent) is Retry
     is_error, intermediate_result = guard(resolve_stubs, eff.intent.effect)
     return resolve_effect(eff, intermediate_result, is_error=is_error)
+
+
+def defaults_by_name(fn):
+    """Returns a mapping of args of fn to their default values."""
+    args, _, _, defaults = getargspec(fn)
+    return dict(zip(reversed(args), reversed(defaults)))

--- a/otter/test/worker/test_launch_server_v1.py
+++ b/otter/test/worker/test_launch_server_v1.py
@@ -1469,12 +1469,10 @@ class ServerTests(SynchronousTestCase):
         clock.advance(5)
         self.assertEqual(server_details.call_count, 2)
 
-
     def test_wait_for_active_default_timeout(self):
         """:func`wait_for_active` waits for 2 hours by default."""
         self.assertEqual(defaults_by_name(wait_for_active)["timeout"],
                          2 * 60 * 60)
-
 
     def _launch_server(self, launch_config, log=None, clock=None):
         """

--- a/otter/test/worker/test_launch_server_v1.py
+++ b/otter/test/worker/test_launch_server_v1.py
@@ -42,9 +42,9 @@ from otter.worker.launch_server_v1 import (
 )
 
 
-from otter.test.utils import (mock_log, patch, CheckFailure, mock_treq,
-                              matches, DummyException, IsBoundWith,
-                              StubTreq, StubTreq2, StubResponse)
+from otter.test.utils import (mock_log, patch, CheckFailure, mock_treq, matches,
+                              DummyException, IsBoundWith, StubTreq, StubTreq2,
+                              StubResponse, defaults_by_name)
 from otter.test.worker.test_rcv3 import _rcv3_add_response
 from testtools.matchers import IsInstance, StartsWith, MatchesRegex
 
@@ -1468,6 +1468,13 @@ class ServerTests(SynchronousTestCase):
         # the loop has stopped
         clock.advance(5)
         self.assertEqual(server_details.call_count, 2)
+
+
+    def test_wait_for_active_default_timeout(self):
+        """:func`wait_for_active` waits for 2 hours by default."""
+        self.assertEqual(defaults_by_name(wait_for_active)["timeout"],
+                         2 * 60 * 60)
+
 
     def _launch_server(self, launch_config, log=None, clock=None):
         """

--- a/otter/worker/launch_server_v1.py
+++ b/otter/worker/launch_server_v1.py
@@ -103,7 +103,7 @@ def wait_for_active(log,
                     auth_token,
                     server_id,
                     interval=20,
-                    timeout=3600,
+                    timeout=7200,
                     clock=None):
     """
     Wait until the server specified by server_id's status is 'ACTIVE'
@@ -114,7 +114,7 @@ def wait_for_active(log,
     :param str server_id: Opaque nova server id.
     :param int interval: Polling interval in seconds.  Default: 20.
     :param int timeout: timeout to poll for the server status in seconds.
-        Default 3600 (1 hour)
+        Default 7200 (2 hours).
 
     :return: Deferred that fires when the expected status has been seen.
     """

--- a/otter/worker/launch_server_v1.py
+++ b/otter/worker/launch_server_v1.py
@@ -112,7 +112,7 @@ def wait_for_active(log,
     :param str server_endpoint: Server endpoint URI.
     :param str auth_token: Keystone Auth token.
     :param str server_id: Opaque nova server id.
-    :param int interval: Polling interval in seconds.  Default: 5.
+    :param int interval: Polling interval in seconds.  Default: 20.
     :param int timeout: timeout to poll for the server status in seconds.
         Default 3600 (1 hour)
 


### PR DESCRIPTION
I also refactored the "get defaults from a function by name" behavior, since there are now 2 tests that use it.