### PR TITLE
Allow tests to pass autoscale client a list of networks on creating a group.

### DIFF
--- a/autoscale_cloudcafe/autoscale/client.py
+++ b/autoscale_cloudcafe/autoscale/client.py
@@ -110,25 +110,29 @@ class AutoscalingAPIClient(AutoMarshallingRestClient):
             lc_metadata['build_config'] = 'core'
         else:
             lc_metadata = dict(build_config='core')
+
         # Setting netowrk type for servers to be private by default.
-        lc_networks = [{'uuid': '11111111-1111-1111-1111-111111111111'}]
-        if network_type is 'public':
-            lc_networks.append({'uuid': '00000000-0000-0000-0000-000000000000'})
-        scaling_group = ScalingGroup_Request(gc_name=gc_name,
-                                             gc_cooldown=gc_cooldown,
-                                             gc_min_entities=gc_min_entities,
-                                             gc_max_entities=gc_max_entities,
-                                             gc_metadata=gc_metadata,
-                                             lc_name=lc_name,
-                                             lc_image_ref=lc_image_ref,
-                                             lc_flavor_ref=lc_flavor_ref,
-                                             lc_personality=lc_personality,
-                                             lc_metadata=lc_metadata,
-                                             lc_disk_config=lc_disk_config,
-                                             lc_networks=lc_networks,
-                                             lc_block_device_mapping=lc_block_device_mapping,
-                                             lc_load_balancers=lc_load_balancers,
-                                             sp_list=sp_list)
+        if lc_networks is None:
+            lc_networks = [{'uuid': '11111111-1111-1111-1111-111111111111'}]
+            if network_type is 'public':
+                lc_networks.append(
+                    {'uuid': '00000000-0000-0000-0000-000000000000'})
+        scaling_group = ScalingGroup_Request(
+            gc_name=gc_name,
+            gc_cooldown=gc_cooldown,
+            gc_min_entities=gc_min_entities,
+            gc_max_entities=gc_max_entities,
+            gc_metadata=gc_metadata,
+            lc_name=lc_name,
+            lc_image_ref=lc_image_ref,
+            lc_flavor_ref=lc_flavor_ref,
+            lc_personality=lc_personality,
+            lc_metadata=lc_metadata,
+            lc_disk_config=lc_disk_config,
+            lc_networks=lc_networks,
+            lc_block_device_mapping=lc_block_device_mapping,
+            lc_load_balancers=lc_load_balancers,
+            sp_list=sp_list)
         return self.request('POST', url,
                             request_entity=scaling_group,
                             requestslib_kwargs=requestslib_kwargs,

--- a/autoscale_cloudcafe/autoscale/client.py
+++ b/autoscale_cloudcafe/autoscale/client.py
@@ -111,12 +111,15 @@ class AutoscalingAPIClient(AutoMarshallingRestClient):
         else:
             lc_metadata = dict(build_config='core')
 
-        # Setting netowrk type for servers to be private by default.
+        # Setting network type for servers to be private by default so that
+        # when testing against production, by default public IPs are not
+        # used up.
         if lc_networks is None:
             lc_networks = [{'uuid': '11111111-1111-1111-1111-111111111111'}]
             if network_type is 'public':
                 lc_networks.append(
                     {'uuid': '00000000-0000-0000-0000-000000000000'})
+
         scaling_group = ScalingGroup_Request(
             gc_name=gc_name,
             gc_cooldown=gc_cooldown,


### PR DESCRIPTION
Just provide default networks if none are listed - do not overwrite the networks in the cloudcafe autoscale client if networks are provided.