### PR TITLE
Improve flake8-based linting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ flake8diff:
 	git diff --patch --no-prefix ${DIFF_TARGET} | flake8 --diff
 
 flake8full:
-	flake8 --max-complexity=10 ${PYDIRS}
+	flake8 ${PYDIRS}
 
 unit:
 ifneq ($(JENKINS_URL), )

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ ifneq ($(JENKINS_URL), )
 # On Jenkins, HEAD will be a Github-created merge commit. Hence, diffing
 # against HEAD^1 gives you the diff introduced by the PR, which is what we're
 # trying to test.
-DIFF_TARGET = "HEAD^1"
+DIFF_TARGET = HEAD^1
 else
 # On not-Jenkins, we find the current branch's branch-off point from master,
 # and diff against that.

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -4,7 +4,6 @@ flake8-blind-except==0.1.0
 flake8-debugger==1.3.2
 flake8-import-order==0.5.3
 flake8-print==1.5.0
-pep8-naming==0.2.2
 coverage==3.7.1
 
 # Docs

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[flake8]
+application-import-names = otter,test_repo,autoscale,bobby

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,3 @@
 [flake8]
-application-import-names = otter,test_repo,autoscale,bobby
+max-complexity = 10
+application-import-names = otter,test_repo,autoscale


### PR DESCRIPTION
- Previously didn't work on Jenkins, because it pulls the weird Github-created PR ref. The new code diffs against `HEAD^1` on Jenkins (which is the diff produced by the PR), and against the merge-base of the current branch vs master.
- flake8 configuration moved to setup.cfg.
- application-import-names added so that otter imports go separately from others.
- removed pep8 naming because it doesn't support the few camelCaseMethods we have (notably setUp, a bunch of Twisted methods, and probably some logger stuff in the tests).