### PR TITLE
fix the Retry performer to actually conform to the performer interface

### DIFF
--- a/otter/test/test_retry.py
+++ b/otter/test/test_retry.py
@@ -16,7 +16,7 @@ from twisted.python.failure import Failure
 from twisted.trial.unittest import SynchronousTestCase
 
 from otter.test.utils import (
-    CheckFailure, CheckFailureValue, DummyException, resolve_stubs)
+    CheckFailure, CheckFailureValue, DummyException)
 from otter.util.retry import (
     Retry,
     ShouldDelayAndRetry,

--- a/otter/test/test_retry.py
+++ b/otter/test/test_retry.py
@@ -459,6 +459,7 @@ class EffectfulRetryTests(SynchronousTestCase):
     # attributes, I guess...
 
     def setUp(self):
+        """Save common objects."""
         self.dispatcher = ComposedDispatcher([
             base_dispatcher,
             TypeDispatcher({Retry: perform_retry})])

--- a/otter/util/retry.py
+++ b/otter/util/retry.py
@@ -6,7 +6,7 @@ import random
 
 from characteristic import Attribute, attributes
 
-from effect import Delay, Effect, Func
+from effect import Delay, Effect, Func, sync_performer
 from effect.retry import retry as effect_retry
 
 from twisted.internet import defer
@@ -342,6 +342,7 @@ class Retry(object):
     """
 
 
+@sync_performer
 def perform_retry(dispatcher, intent):
     """
     Invoke :func:`effect.retry.retry` with the effect and the


### PR DESCRIPTION
There was a bug with perform_retry -- it didn't take the box argument and deal with it properly. Fix by using @sync_performer.

This wasn't caught in integration tests because none of our integration tests exercise Retries yet.