### PR TITLE
Bring back full pyflakes coverage in "make lint"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ env:
 	./scripts/bootstrap-virtualenv.sh
 
 lint: listoutdated flake8diff
-	pyflakes otter
+	pyflakes ${PYDIRS}
 
 listoutdated:
 	pip list --outdated --allow-external=cafe,cloudcafe

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ env:
 	./scripts/bootstrap-virtualenv.sh
 
 lint: listoutdated flake8diff
+	pyflakes otter
 
 listoutdated:
 	pip list --outdated --allow-external=cafe,cloudcafe

--- a/otter/test/models/test_cass_models.py
+++ b/otter/test/models/test_cass_models.py
@@ -2,7 +2,6 @@
 Tests for :mod:`otter.models.mock`
 """
 from collections import namedtuple
-from functools import partial
 import json
 import mock
 from datetime import datetime

--- a/otter/test/tap/test_api.py
+++ b/otter/test/tap/test_api.py
@@ -5,8 +5,6 @@ Tests for the otter-api tap plugin.
 import json
 import mock
 
-from silverberg.client import ConsistencyLevel
-
 from testtools.matchers import Contains
 
 from twisted.internet import defer


### PR DESCRIPTION
The linting changes recently switched everything to diff-based linting, but we were already at 100% pyflakes coverage. This PR brings back full coverage for pyflakes and makes it a mandatory part of "make lint".