### PR TITLE
Convergence prepares launch config

### DIFF
--- a/otter/convergence/composition.py
+++ b/otter/convergence/composition.py
@@ -2,10 +2,10 @@
 Code for composing all of the convergence functionality together.
 """
 
+import itertools
+import time
 from collections import defaultdict
 from functools import partial
-import time
-import itertools
 
 from otter.convergence.effecting import steps_to_effect
 from otter.convergence.gathering import get_all_convergence_data

--- a/otter/convergence/composition.py
+++ b/otter/convergence/composition.py
@@ -5,11 +5,13 @@ Code for composing all of the convergence functionality together.
 from collections import defaultdict
 from functools import partial
 import time
+import itertools
 
 from otter.convergence.effecting import steps_to_effect
 from otter.convergence.gathering import get_all_convergence_data
 from otter.convergence.model import DesiredGroupState, CLBDescription
 from otter.convergence.planning import plan
+from otter.worker.launch_server_v1 import prepare_launch_config
 
 
 def execute_convergence(request_func, group_id, desired_group_state,
@@ -66,17 +68,23 @@ def json_to_LBConfigs(lbs_json):
     return lbd
 
 
-def get_desired_group_state(launch_config, desired):
+def get_desired_group_state(group_id, launch_config, desired,
+                            _prepare_lc=prepare_launch_config):
     """
     Create a :obj:`DesiredGroupState` from a launch config and desired
     number of servers.
 
+    :param str group_id: Scaling group ID
     :param dict launch_config: Group's launch config as per
         :obj:`otter.json_schema.group_schemas.launch_config`
     :param int desired: Group's desired capacity
+    :param callable _prepare_lc: Optional implementation of
+        `prepare_launch_config` useful for testing
     """
     lbs = json_to_LBConfigs(launch_config['args']['loadBalancers'])
+    server_lc = {'server': launch_config['args']['server']}
     desired_state = DesiredGroupState(
-        launch_config={'server': launch_config['args']['server']},
+        launch_configs=(_prepare_lc(group_id, server_lc)
+                        for _ in itertools.count()),
         desired=desired, desired_lbs=lbs)
     return desired_state

--- a/otter/convergence/model.py
+++ b/otter/convergence/model.py
@@ -5,8 +5,6 @@ representation across the different phases of convergence.
 
 from characteristic import attributes, Attribute
 
-from pyrsistent import freeze
-
 from twisted.python.constants import Names, NamedConstant
 
 from zope.interface import implementer, Interface
@@ -55,8 +53,10 @@ class NovaServer(object):
 
 
 @attributes(['launch_configs', 'desired',
-             Attribute('desired_lbs', default_factory=dict, instance_of=dict),
-             Attribute('draining_timeout', default_value=0.0, instance_of=float)])
+             Attribute('desired_lbs', default_factory=dict,
+                       instance_of=dict),
+             Attribute('draining_timeout', default_value=0.0,
+                       instance_of=float)])
 class DesiredGroupState(object):
     """
     The desired state for a scaling group.

--- a/otter/convergence/model.py
+++ b/otter/convergence/model.py
@@ -61,7 +61,7 @@ class DesiredGroupState(object):
     """
     The desired state for a scaling group.
 
-    :ivar generator launch_configs: Generates nova launch configs
+    :ivar iterable launch_configs: Nova launch configs
     :ivar int desired: the number of desired servers within the group.
     :ivar dict desired_lbs: A mapping of load balancer IDs to lists of
         :class:`CLBDescription` instances.

--- a/otter/convergence/model.py
+++ b/otter/convergence/model.py
@@ -54,14 +54,14 @@ class NovaServer(object):
     """
 
 
-@attributes(['launch_config', 'desired',
+@attributes(['launch_configs', 'desired',
              Attribute('desired_lbs', default_factory=dict, instance_of=dict),
              Attribute('draining_timeout', default_value=0.0, instance_of=float)])
 class DesiredGroupState(object):
     """
     The desired state for a scaling group.
 
-    :ivar dict launch_config: nova launch config.
+    :ivar generator launch_configs: Generates nova launch configs
     :ivar int desired: the number of desired servers within the group.
     :ivar dict desired_lbs: A mapping of load balancer IDs to lists of
         :class:`CLBDescription` instances.
@@ -70,11 +70,6 @@ class DesiredGroupState(object):
         in draining condition for a maximum of ``draining_timeout`` seconds
         before being removed from the load balancer and then deleted.
     """
-    def __init__(self):
-        """
-        Make attributes immutable.
-        """
-        self.launch_config = freeze(self.launch_config)
 
 
 class ILBDescription(Interface):

--- a/otter/convergence/planning.py
+++ b/otter/convergence/planning.py
@@ -190,16 +190,17 @@ def converge(desired_state, servers_with_cheese, load_balancer_contents, now,
         lambda server: now - server.created >= timeout,
         servers_in_build)
 
-    create_server = CreateServer(launch_config=desired_state.launch_config)
-
     # delete any servers that have been building for too long
     delete_timeout_steps = [DeleteServer(server_id=server.id)
                             for server in building_too_long]
 
     # create servers
-    create_steps = [create_server] * (desired_state.desired
-                                      - (len(servers_in_active)
-                                         + len(waiting_for_build)))
+    servers_to_create = (
+        desired_state.desired - (len(servers_in_active) +
+                                 len(waiting_for_build)))
+    create_steps = [
+        CreateServer(launch_config=next(desired_state.launch_configs))
+        for i in range(servers_to_create)]
 
     # Scale down over capacity, starting with building, then active,
     # preferring older.  Also, finish draining/deleting servers already in

--- a/otter/test/convergence/test_composition.py
+++ b/otter/test/convergence/test_composition.py
@@ -108,7 +108,7 @@ class ExecConvergenceTests(SynchronousTestCase):
         get_all_convergence_data = self._get_gacd_func(
             self.servers, 'gid', reqfunc)
         desired = DesiredGroupState(
-            launch_config={'server': {'name': 'test', 'flavorRef': 'f'}},
+            launch_configs=range(2),
             desired_lbs={23: [CLBDescription(lb_id='23', port=80)]},
             desired=2)
 
@@ -144,7 +144,7 @@ class ExecConvergenceTests(SynchronousTestCase):
         If state of world matches desired, no steps are executed and False is returned
         """
         desired = DesiredGroupState(
-            launch_config={'server': {'name': 'test', 'flavorRef': 'f'}},
+            launch_configs=range(2),
             desired_lbs={},
             desired=2)
         reqfunc = lambda **k: 1 / 0

--- a/otter/test/convergence/test_composition.py
+++ b/otter/test/convergence/test_composition.py
@@ -101,8 +101,8 @@ class ExecConvergenceTests(SynchronousTestCase):
 
     def test_success(self):
         """
-        Executes optimized steps if state of world does not match desired and returns
-        True to be called again
+        Executes optimized steps if state of world does not match desired
+        and returns True to be called again
         """
         reqfunc = lambda **k: Effect(k)
         get_all_convergence_data = self._get_gacd_func(
@@ -141,7 +141,8 @@ class ExecConvergenceTests(SynchronousTestCase):
 
     def test_no_steps(self):
         """
-        If state of world matches desired, no steps are executed and False is returned
+        If state of world matches desired, no steps are executed
+        and False is returned
         """
         desired = DesiredGroupState(
             launch_configs=range(2),

--- a/otter/test/convergence/test_composition.py
+++ b/otter/test/convergence/test_composition.py
@@ -51,15 +51,23 @@ class JsonToLBConfigTests(SynchronousTestCase):
 class GetDesiredGroupStateTests(SynchronousTestCase):
     """Tests for :func:`get_desired_group_state`."""
     def test_convert(self):
-        """An Otter launch config is converted into a :obj:`DesiredGroupState`."""
+        """An Otter launch config is converted into a
+        :obj:`DesiredGroupState`."""
         server_config = {'name': 'test', 'flavorRef': 'f'}
         lc = {'args': {'server': server_config,
                        'loadBalancers': [{'loadBalancerId': 23, 'port': 80}]}}
-        state = get_desired_group_state(lc, 2)
+
+        twice = iter(range(2))
+        prepare_lc = lambda gid, sc: (
+            gid + sc['server']['name'] + str(next(twice)))
+
+        state = get_desired_group_state('gid', lc, 2, _prepare_lc=prepare_lc)
+
+        state.launch_configs = list(state.launch_configs)
         self.assertEqual(
             state,
             DesiredGroupState(
-                launch_config={'server': server_config},
+                launch_configs=['gidtest0', 'gidtest1'],
                 desired=2,
                 desired_lbs={23: [CLBDescription(lb_id='23', port=80)]}))
 

--- a/otter/test/convergence/test_planning.py
+++ b/otter/test/convergence/test_planning.py
@@ -1,5 +1,7 @@
 """Tests for convergence planning."""
 
+import itertools
+
 from pyrsistent import pmap, pbag, pset, s
 
 from twisted.trial.unittest import SynchronousTestCase
@@ -462,6 +464,9 @@ class DrainAndDeleteServerTests(SynchronousTestCase):
 class ConvergeTests(SynchronousTestCase):
     """Tests for :func:`converge`."""
 
+    def setUp(self):
+        self.lcs = itertools.count(0)
+
     def test_converge_give_me_a_server(self):
         """
         A server is added if there are not enough servers to meet
@@ -469,11 +474,11 @@ class ConvergeTests(SynchronousTestCase):
         """
         self.assertEqual(
             converge(
-                DesiredGroupState(launch_config={}, desired=1),
+                DesiredGroupState(launch_configs=self.lcs, desired=1),
                 set(),
                 set(),
                 0),
-            pbag([CreateServer(launch_config=pmap())]))
+            pbag([CreateServer(launch_config=0)]))
 
     def test_converge_give_me_multiple_servers(self):
         """
@@ -482,13 +487,13 @@ class ConvergeTests(SynchronousTestCase):
         """
         self.assertEqual(
             converge(
-                DesiredGroupState(launch_config={}, desired=2),
+                DesiredGroupState(launch_configs=self.lcs, desired=2),
                 set(),
                 set(),
                 0),
             pbag([
-                CreateServer(launch_config=pmap()),
-                CreateServer(launch_config=pmap())]))
+                CreateServer(launch_config=0),
+                CreateServer(launch_config=1)]))
 
     def test_count_building_as_meeting_capacity(self):
         """

--- a/otter/test/convergence/test_planning.py
+++ b/otter/test/convergence/test_planning.py
@@ -537,11 +537,13 @@ class ConvergeTests(SynchronousTestCase):
         self.assertEqual(
             converge(
                 DesiredGroupState(launch_configs=sample_lcs(), desired=1),
-                set([server('abc', ServerState.ERROR, servicenet_address='1.1.1.1')]),
+                set([server('abc', ServerState.ERROR,
+                            servicenet_address='1.1.1.1')]),
                 set([CLBNode(address='1.1.1.1', node_id='3',
                              description=CLBDescription(lb_id='5', port=80)),
                      CLBNode(address='1.1.1.1', node_id='5',
-                             description=CLBDescription(lb_id='5', port=8080))]),
+                             description=CLBDescription(lb_id='5',
+                                                        port=8080))]),
                 0),
             pbag([
                 DeleteServer(server_id='abc'),

--- a/otter/test/convergence/test_planning.py
+++ b/otter/test/convergence/test_planning.py
@@ -31,6 +31,13 @@ from otter.convergence.steps import (
     SetMetadataItemOnServer)
 
 
+def sample_lcs():
+    """
+    Sample launch configs
+    """
+    return itertools.count(0)
+
+
 class RemoveFromLBWithDrainingTests(SynchronousTestCase):
     """
     Tests for :func:`_remove_from_lb_with_draining`
@@ -321,7 +328,7 @@ class DrainAndDeleteServerTests(SynchronousTestCase):
         """
         self.assertEqual(
             converge(
-                DesiredGroupState(launch_config={}, desired=0,
+                DesiredGroupState(launch_configs=sample_lcs(), desired=0,
                                   draining_timeout=10.0),
                 set([server('abc', state=ServerState.ACTIVE)]),
                 set(),
@@ -336,7 +343,7 @@ class DrainAndDeleteServerTests(SynchronousTestCase):
         """
         self.assertEqual(
             converge(
-                DesiredGroupState(launch_config={}, desired=0),
+                DesiredGroupState(launch_configs=sample_lcs(), desired=0),
                 set([server('abc', state=ServerState.ACTIVE,
                             servicenet_address='1.1.1.1')]),
                 set([CLBNode(node_id='1', address='1.1.1.1',
@@ -354,7 +361,7 @@ class DrainAndDeleteServerTests(SynchronousTestCase):
         """
         self.assertEqual(
             converge(
-                DesiredGroupState(launch_config={}, desired=0),
+                DesiredGroupState(launch_configs=sample_lcs(), desired=0),
                 set([server('abc', state=ServerState.DRAINING,
                             servicenet_address='1.1.1.1')]),
                 set([CLBNode(node_id='1', address='1.1.1.1',
@@ -373,7 +380,7 @@ class DrainAndDeleteServerTests(SynchronousTestCase):
         """
         self.assertEqual(
             converge(
-                DesiredGroupState(launch_config={}, desired=0,
+                DesiredGroupState(launch_configs=sample_lcs(), desired=0,
                                   draining_timeout=10.0),
                 set([server('abc', state=ServerState.DRAINING,
                             servicenet_address='1.1.1.1')]),
@@ -392,7 +399,7 @@ class DrainAndDeleteServerTests(SynchronousTestCase):
         """
         self.assertEqual(
             converge(
-                DesiredGroupState(launch_config={}, desired=0,
+                DesiredGroupState(launch_configs=sample_lcs(), desired=0,
                                   draining_timeout=10.0),
                 set([server('abc', state=ServerState.ACTIVE,
                             servicenet_address='1.1.1.1')]),
@@ -420,7 +427,7 @@ class DrainAndDeleteServerTests(SynchronousTestCase):
         """
         self.assertEqual(
             converge(
-                DesiredGroupState(launch_config={}, desired=0,
+                DesiredGroupState(launch_configs=sample_lcs(), desired=0,
                                   draining_timeout=10.0),
                 set([server('abc', state=ServerState.ACTIVE,
                             servicenet_address='1.1.1.1')]),
@@ -447,7 +454,7 @@ class DrainAndDeleteServerTests(SynchronousTestCase):
         """
         self.assertEqual(
             converge(
-                DesiredGroupState(launch_config={}, desired=0,
+                DesiredGroupState(launch_configs=sample_lcs(), desired=0,
                                   draining_timeout=10.0),
                 set([server('abc', state=ServerState.DRAINING,
                             servicenet_address='1.1.1.1')]),
@@ -464,9 +471,6 @@ class DrainAndDeleteServerTests(SynchronousTestCase):
 class ConvergeTests(SynchronousTestCase):
     """Tests for :func:`converge`."""
 
-    def setUp(self):
-        self.lcs = itertools.count(0)
-
     def test_converge_give_me_a_server(self):
         """
         A server is added if there are not enough servers to meet
@@ -474,7 +478,7 @@ class ConvergeTests(SynchronousTestCase):
         """
         self.assertEqual(
             converge(
-                DesiredGroupState(launch_configs=self.lcs, desired=1),
+                DesiredGroupState(launch_configs=sample_lcs(), desired=1),
                 set(),
                 set(),
                 0),
@@ -487,7 +491,7 @@ class ConvergeTests(SynchronousTestCase):
         """
         self.assertEqual(
             converge(
-                DesiredGroupState(launch_configs=self.lcs, desired=2),
+                DesiredGroupState(launch_configs=sample_lcs(), desired=2),
                 set(),
                 set(),
                 0),
@@ -502,7 +506,7 @@ class ConvergeTests(SynchronousTestCase):
         """
         self.assertEqual(
             converge(
-                DesiredGroupState(launch_config={}, desired=1),
+                DesiredGroupState(launch_configs=sample_lcs(), desired=1),
                 set([server('abc', ServerState.BUILD)]),
                 set(),
                 0),
@@ -515,13 +519,13 @@ class ConvergeTests(SynchronousTestCase):
         """
         self.assertEqual(
             converge(
-                DesiredGroupState(launch_config={}, desired=1),
+                DesiredGroupState(launch_configs=sample_lcs(), desired=1),
                 set([server('abc', ServerState.ERROR)]),
                 set(),
                 0),
             pbag([
                 DeleteServer(server_id='abc'),
-                CreateServer(launch_config=pmap()),
+                CreateServer(launch_config=0),
             ]))
 
     def test_delete_error_state_servers_with_lb_nodes(self):
@@ -532,7 +536,7 @@ class ConvergeTests(SynchronousTestCase):
         """
         self.assertEqual(
             converge(
-                DesiredGroupState(launch_config={}, desired=1),
+                DesiredGroupState(launch_configs=sample_lcs(), desired=1),
                 set([server('abc', ServerState.ERROR, servicenet_address='1.1.1.1')]),
                 set([CLBNode(address='1.1.1.1', node_id='3',
                              description=CLBDescription(lb_id='5', port=80)),
@@ -543,14 +547,14 @@ class ConvergeTests(SynchronousTestCase):
                 DeleteServer(server_id='abc'),
                 RemoveFromCLB(lb_id='5', node_id='3'),
                 RemoveFromCLB(lb_id='5', node_id='5'),
-                CreateServer(launch_config=pmap()),
+                CreateServer(launch_config=0),
             ]))
 
     def test_scale_down(self):
         """If we have more servers than desired, we delete the oldest."""
         self.assertEqual(
             converge(
-                DesiredGroupState(launch_config={}, desired=1),
+                DesiredGroupState(launch_configs=sample_lcs(), desired=1),
                 set([server('abc', ServerState.ACTIVE, created=0),
                      server('def', ServerState.ACTIVE, created=1)]),
                 set(),
@@ -565,7 +569,7 @@ class ConvergeTests(SynchronousTestCase):
         """
         self.assertEqual(
             converge(
-                DesiredGroupState(launch_config={}, desired=0),
+                DesiredGroupState(launch_configs=sample_lcs(), desired=0),
                 set([server('abc', ServerState.ACTIVE,
                             servicenet_address='1.1.1.1', created=0)]),
                 set([CLBNode(address='1.1.1.1', node_id='3',
@@ -583,7 +587,7 @@ class ConvergeTests(SynchronousTestCase):
         """
         self.assertEqual(
             converge(
-                DesiredGroupState(launch_config={}, desired=2),
+                DesiredGroupState(launch_configs=sample_lcs(), desired=2),
                 set([server('abc', ServerState.ACTIVE, created=0),
                      server('def', ServerState.BUILD, created=1),
                      server('ghi', ServerState.ACTIVE, created=2)]),
@@ -598,14 +602,14 @@ class ConvergeTests(SynchronousTestCase):
         """
         self.assertEqual(
             converge(
-                DesiredGroupState(launch_config={}, desired=2),
+                DesiredGroupState(launch_configs=sample_lcs(), desired=2),
                 set([server('slowpoke', ServerState.BUILD, created=0),
                      server('ok', ServerState.ACTIVE, created=0)]),
                 set(),
                 3600),
             pbag([
                 DeleteServer(server_id='slowpoke'),
-                CreateServer(launch_config=pmap())]))
+                CreateServer(launch_config=0)]))
 
     def test_timeout_replace_only_when_necessary(self):
         """
@@ -614,7 +618,7 @@ class ConvergeTests(SynchronousTestCase):
         """
         self.assertEqual(
             converge(
-                DesiredGroupState(launch_config={}, desired=2),
+                DesiredGroupState(launch_configs=sample_lcs(), desired=2),
                 set([server('slowpoke', ServerState.BUILD, created=0),
                      server('old-ok', ServerState.ACTIVE, created=0),
                      server('new-ok', ServerState.ACTIVE, created=3600)]),
@@ -630,7 +634,8 @@ class ConvergeTests(SynchronousTestCase):
         desired_lbs = {'5': [CLBDescription(lb_id='5', port=80)]}
         self.assertEqual(
             converge(
-                DesiredGroupState(launch_config={}, desired=1, desired_lbs=desired_lbs),
+                DesiredGroupState(launch_configs=sample_lcs(),
+                                  desired=1, desired_lbs=desired_lbs),
                 set([server('abc', ServerState.ACTIVE,
                             servicenet_address='1.1.1.1', created=0),
                      server('bcd', ServerState.ACTIVE,
@@ -788,7 +793,7 @@ class PlanTests(SynchronousTestCase):
 
         desired_lbs = {5: [CLBDescription(lb_id='5', port=80)]}
         desired_group_state = DesiredGroupState(
-            launch_config={}, desired=2, desired_lbs=desired_lbs)
+            launch_configs=sample_lcs(), desired=2, desired_lbs=desired_lbs)
 
         result = plan(
             desired_group_state,


### PR DESCRIPTION
Implements #883. `DesiredGroupState` has iterable of launch configs instead of one fixed launch config. This iterable is generated on the fly using `prepare_launch_config`.