### PR TITLE
allow per-service region configuration.

### DIFF
--- a/otter/constants.py
+++ b/otter/constants.py
@@ -11,17 +11,32 @@ class ServiceType(Names):
     CLOUD_METRICS_INGEST = NamedConstant()
 
 
-def get_service_mapping(config):
+def get_service_configs(config):
     """
-    Return a mapping of :class:`ServiceType` members to the actual configured
-    service names to look up in tenant catalogs.
+    Return service configurations for all services based on the config data.
+
+    Returns a dict, where keys are :obj:`ServiceType` members, and values are
+    service configs. A service config is a dict with ``name`` and ``region``
+    keys.
 
     :param dict config: Config from file containing service names that will be
         there in service catalog
     """
     return {
-        ServiceType.CLOUD_SERVERS: config['cloudServersOpenStack'],
-        ServiceType.CLOUD_LOAD_BALANCERS: config["cloudLoadBalancers"],
-        ServiceType.RACKCONNECT_V3: config['rackconnect'],
-        ServiceType.CLOUD_METRICS_INGEST: config['metrics']['service']
+        ServiceType.CLOUD_SERVERS: {
+            'name': config['cloudServersOpenStack'],
+            'region': config['region'],
+        },
+        ServiceType.CLOUD_LOAD_BALANCERS: {
+            'name': config['cloudLoadBalancers'],
+            'region': config['region'],
+        },
+        ServiceType.RACKCONNECT_V3: {
+            'name': config['rackconnect'],
+            'region': config['region'],
+        },
+        ServiceType.CLOUD_METRICS_INGEST: {
+            'name': config['metrics']['service'],
+            'region': config['metrics']['region'],
+        },
     }

--- a/otter/effect_dispatcher.py
+++ b/otter/effect_dispatcher.py
@@ -38,13 +38,13 @@ def get_simple_dispatcher(reactor):
     ])
 
 
-def get_full_dispatcher(reactor, authenticator, log, service_mapping, region):
+def get_full_dispatcher(reactor, authenticator, log, service_config):
     """
     Return a dispatcher that can perform all of Otter's effects.
     """
     return ComposedDispatcher([
         TypeDispatcher({
             TenantScope: partial(perform_tenant_scope, authenticator, log,
-                                 service_mapping, region)}),
+                                 service_config)}),
         get_simple_dispatcher(reactor),
     ])

--- a/otter/http.py
+++ b/otter/http.py
@@ -81,7 +81,7 @@ def get_request_func(authenticator, tenant_id, log, service_mapping, region):
         def got_auth((token, catalog)):
             request_ = add_bind_service(
                 catalog,
-                service_mapping[service_type],
+                service_mapping[service_type]['name'],
                 region,
                 log,
                 add_json_request_data(
@@ -197,7 +197,7 @@ class TenantScope(object):
 
 
 def concretize_service_request(
-        authenticator, log, service_mapping, region,
+        authenticator, log, service_configs,
         tenant_id,
         service_request):
     """
@@ -208,20 +208,22 @@ def concretize_service_request(
     :param ICachingAuthenticator authenticator: the caching authenticator
     :param tenant_id: tenant ID.
     :param BoundLog log: info about requests will be logged to this.
-    :param dict service_mapping: A mapping of otter.constants.ServiceType
-        constants to real service names as found in a tenant's catalog.
-    :param region: The region of the Rackspace services which requests will
-        be made to.
+    :param dict service_configs: As returned by
+        :func:`otter.constants.get_service_configs`.
     """
     auth_eff = Effect(Authenticate(authenticator, tenant_id, log))
     invalidate_eff = Effect(InvalidateToken(authenticator, tenant_id))
     if service_request.log is not None:
         log = service_request.log
 
+    service_config = service_configs[service_request.service_type]
+    region = service_config['region']
+    service_name = service_config['name']
+
     def got_auth((token, catalog)):
         request_ = add_bind_service(
             catalog,
-            service_mapping[service_request.service_type],
+            service_name,
             region,
             log,
             add_json_request_data(
@@ -244,7 +246,7 @@ def concretize_service_request(
 
 
 def perform_tenant_scope(
-        authenticator, log, service_mapping, region,
+        authenticator, log, service_configs,
         dispatcher, tenant_scope, box,
         _concretize=concretize_service_request):
     """
@@ -260,7 +262,7 @@ def perform_tenant_scope(
     @sync_performer
     def scoped_performer(dispatcher, service_request):
         return _concretize(
-            authenticator, log, service_mapping, region,
+            authenticator, log, service_configs,
             tenant_scope.tenant_id, service_request)
     new_disp = ComposedDispatcher([
         TypeDispatcher({ServiceRequest: scoped_performer}),

--- a/otter/tap/api.py
+++ b/otter/tap/api.py
@@ -29,7 +29,7 @@ from otter.scheduler import SchedulerService
 
 from otter.supervisor import SupervisorService, set_supervisor
 from otter.auth import generate_authenticator
-from otter.constants import get_service_mapping
+from otter.constants import get_service_configs
 
 from otter.log import log
 from silverberg.cluster import RoundRobinCassandraCluster
@@ -190,7 +190,7 @@ def makeService(config):
 
     authenticator = generate_authenticator(reactor, config['identity'])
     supervisor = SupervisorService(authenticator, region, coiterate,
-                                   get_service_mapping(config))
+                                   get_service_configs(config))
     supervisor.setServiceParent(s)
 
     set_supervisor(supervisor)

--- a/otter/test/tap/test_api.py
+++ b/otter/test/tap/test_api.py
@@ -38,7 +38,8 @@ test_config = {
     'cloudServersOpenStack': 'cloudServersOpenStack',
     'cloudLoadBalancers': 'cloudLoadBalancers',
     'rackconnect': 'rackconnect',
-    'metrics': {'service': 'cloudMetricsIngest'}
+    'metrics': {'service': 'cloudMetricsIngest',
+                'region': 'IAD'}
 }
 
 

--- a/otter/test/test_constants.py
+++ b/otter/test/test_constants.py
@@ -2,12 +2,12 @@
 
 from twisted.trial.unittest import SynchronousTestCase
 
-from otter.constants import ServiceType, get_service_mapping
+from otter.constants import ServiceType, get_service_configs
 
 
 class GetServiceMappingTests(SynchronousTestCase):
     """
-    Tests for :func:`get_service_mapping`.
+    Tests for :func:`get_service_configs`.
     """
 
     def setUp(self):
@@ -17,13 +17,31 @@ class GetServiceMappingTests(SynchronousTestCase):
         self.config = {'cloudServersOpenStack': 'nova',
                        'cloudLoadBalancers': 'clb',
                        'rackconnect': 'rc',
-                       'metrics': {'service': 'm'}}
+                       'region': 'DFW',
+                       'metrics': {'service': 'm',
+                                   'region': 'IAD'}}
 
     def test_takes_from_config(self):
         """
         Returns mapping based on info from config
         """
         self.assertEqual(
-            get_service_mapping(self.config),
-            {ServiceType.CLOUD_SERVERS: 'nova', ServiceType.CLOUD_LOAD_BALANCERS: 'clb',
-             ServiceType.RACKCONNECT_V3: 'rc', ServiceType.CLOUD_METRICS_INGEST: 'm'})
+            get_service_configs(self.config),
+            {
+                ServiceType.CLOUD_SERVERS: {
+                    'name': 'nova',
+                    'region': 'DFW',
+                },
+                ServiceType.CLOUD_LOAD_BALANCERS: {
+                    'name': 'clb',
+                    'region': 'DFW',
+                },
+                ServiceType.RACKCONNECT_V3: {
+                    'name': 'rc',
+                    'region': 'DFW',
+                },
+                ServiceType.CLOUD_METRICS_INGEST: {
+                    'name': 'm',
+                    'region': 'IAD',
+                },
+            })

--- a/otter/test/test_effect_dispatcher.py
+++ b/otter/test/test_effect_dispatcher.py
@@ -43,7 +43,7 @@ class FullDispatcherTests(SynchronousTestCase):
 
     def test_intent_support(self):
         """All intents are supported by the dispatcher."""
-        dispatcher = get_full_dispatcher(None, None, None, None, None)
+        dispatcher = get_full_dispatcher(None, None, None, None)
         for intent in all_intents():
             self.assertIsNot(dispatcher(intent), None)
 
@@ -52,7 +52,7 @@ class FullDispatcherTests(SynchronousTestCase):
         # This is not testing much, but at least that it calls
         # perform_tenant_scope in a vaguely working manner. There are
         # more specific TenantScope performer tests in otter.test.test_http
-        dispatcher = get_full_dispatcher(None, None, None, None, None)
+        dispatcher = get_full_dispatcher(None, None, None, None)
         scope = TenantScope(Effect(Constant('foo')), 1)
         eff = Effect(scope)
         self.assertEqual(sync_perform(dispatcher, eff), 'foo')


### PR DESCRIPTION
This should resolve issue #896.

This repurposes the `service_mapping` into a more general `service_configs`, where each value is a dict of `name` and `region`, instead of just being the name. This means that each service can be configured with its own region, though in practice it's only the metrics service that uses anything other than the default `config['region']`. The logic about how to calculate the regions based on the config file remains in `get_service_configs` (renamed from `get_service_mapping`).

All in all, a pretty simple change to solve this problem. 

Notes for reviewers: 

- the main change here is in `otter/http.py`'s `concretize_service_request`, which pulls the region out of `service_config[service_type]['region']`
- `metrics.py`, in `collect_metrics`, now creates a more general dispatcher, with no *specific* region being passed to it, just the `service_configs` mapping. (note that we could now refactor the two different creations of dispatchers in metrics.py, but I'll wait until after #921 is done to avoid too many conflicts.)
- there was a lot of renaming of `service_mapping` to `service_configs`, but I didn't do it in code which should be deleted Real Soon Now.
