### PR TITLE
added back missing API ref chapter

### DIFF
--- a/docbook/src/docbkx/autoscale-devguide.xml
+++ b/docbook/src/docbkx/autoscale-devguide.xml
@@ -3654,6 +3654,7 @@ config at https://github.com/rackerlabs/autoscaling-chef/blob/master/site-cookbo
                 the scaling policy is executed.</para>
         </section>
     </chapter>
+        <xi:include href="chapters/apiref.xml"/>
     <chapter xml:id="Glossary">
         <title>Glossary</title>
         <!-- Glossary section, defining basic terms, is external so it's handy for Getting Started to share. -->


### PR DESCRIPTION
somehow the include to the API chapter got deleted. i am adding it back now
