### PR TITLE
use service_request in convergence.effecting

### DIFF
--- a/otter/convergence/composition.py
+++ b/otter/convergence/composition.py
@@ -12,7 +12,7 @@ from otter.convergence.model import DesiredGroupState, CLBDescription
 from otter.convergence.planning import plan
 
 
-def execute_convergence(request_func, group_id, desired_group_state,
+def execute_convergence(group_id, desired_group_state,
                         get_all_convergence_data=get_all_convergence_data):
     """
     Execute convergence. This function will do following:
@@ -23,7 +23,6 @@ def execute_convergence(request_func, group_id, desired_group_state,
     This is in effect single cycle execution. A layer above this is expected
     to keep calling this until this function returns False
 
-    :param request_func: Tenant bound request function
     :param bytes group_id: Tenant's group
     :param DesiredGroupState desired_group_state: the desired state
 
@@ -34,7 +33,7 @@ def execute_convergence(request_func, group_id, desired_group_state,
     conv_eff = eff.on(
         lambda (servers, lb_nodes): plan(desired_group_state, servers,
                                          lb_nodes, time.time()))
-    return conv_eff.on(partial(steps_to_effect, request_func)).on(bool)
+    return conv_eff.on(steps_to_effect).on(bool)
 
 
 def tenant_is_enabled(tenant_id, get_config_value):

--- a/otter/convergence/effecting.py
+++ b/otter/convergence/effecting.py
@@ -2,26 +2,28 @@
 
 from effect import parallel
 
+from otter.http import service_request
 
-def _reqs_to_effect(request_func, conv_requests):
+
+def _reqs_to_effect(conv_requests):
     """Turns a collection of :class:`Request` objects into an effect.
 
-    :param request_func: A pure-http request function, as produced by
-        :func:`otter.http.get_request_func`.
     :param conv_requests: Convergence requests to turn into effects.
     :return: An effect which will perform all the requests in parallel.
     :rtype: :class:`Effect`
     """
-    effects = [request_func(service_type=r.service,
-                            method=r.method,
-                            url=r.path,
-                            headers=r.headers,
-                            data=r.data,
-                            success_pred=r.success_pred)
-               for r in conv_requests]
+    effects = [
+        service_request(
+            service_type=r.service,
+            method=r.method,
+            url=r.path,
+            headers=r.headers,
+            data=r.data,
+            success_pred=r.success_pred)
+        for r in conv_requests]
     return parallel(effects)
 
 
-def steps_to_effect(request_func, steps):
+def steps_to_effect(steps):
     """Turns a collection of :class:`IStep` providers into an effect."""
-    return _reqs_to_effect(request_func, [s.as_request() for s in steps])
+    return _reqs_to_effect([s.as_request() for s in steps])

--- a/otter/supervisor.py
+++ b/otter/supervisor.py
@@ -11,15 +11,15 @@ from twisted.internet.defer import succeed
 from zope.interface import Interface, implementer
 
 from otter.effect_dispatcher import get_full_dispatcher
-from otter.models.interface import NoSuchScalingGroupError
 from otter.http import get_request_func
 from otter.log import audit
+from otter.models.interface import NoSuchScalingGroupError
+from otter.undo import InMemoryUndoStack
 from otter.util.config import config_value
 from otter.util.deferredutils import DeferredPool
 from otter.util.hashkey import generate_job_id
 from otter.util.timestamp import from_timestamp
 from otter.worker import launch_server_v1, validate_config
-from otter.undo import InMemoryUndoStack
 
 
 class ISupervisor(Interface):
@@ -107,6 +107,7 @@ class SupervisorService(object, Service):
         request_func.lb_region = lb_region or self.region
         request_func.region = self.region
         request_func.dispatcher = dispatcher
+        request_func.tenant_id = tenant_id
 
         log.msg("Authenticating for tenant")
         d = self.authenticator.authenticate_tenant(tenant_id, log=log)

--- a/otter/supervisor.py
+++ b/otter/supervisor.py
@@ -5,10 +5,12 @@ This code is specific to the launch_server_v1 worker.
 """
 
 from twisted.application.service import Service
+from twisted.internet import reactor
 from twisted.internet.defer import succeed
 
 from zope.interface import Interface, implementer
 
+from otter.effect_dispatcher import get_full_dispatcher
 from otter.models.interface import NoSuchScalingGroupError
 from otter.http import get_request_func
 from otter.log import audit
@@ -82,12 +84,12 @@ class SupervisorService(object, Service):
     """
     name = "supervisor"
 
-    def __init__(self, authenticator, region, coiterate, service_mapping):
+    def __init__(self, authenticator, region, coiterate, service_configs):
         self.authenticator = authenticator
         self.region = region
         self.coiterate = coiterate
         self.deferred_pool = DeferredPool()
-        self.service_mapping = service_mapping
+        self.service_configs = service_configs
 
     def _get_request_func(self, log, scaling_group):
         """
@@ -95,12 +97,16 @@ class SupervisorService(object, Service):
         some attributes for backwards compatibility.
         """
         tenant_id = scaling_group.tenant_id
+        dispatcher = get_full_dispatcher(reactor, self.authenticator, log,
+                                         self.service_configs)
+
         request_func = get_request_func(self.authenticator, tenant_id,
-                                        log, self.service_mapping,
+                                        log, self.service_configs,
                                         self.region)
         lb_region = config_value('regionOverrides.cloudLoadBalancers')
         request_func.lb_region = lb_region or self.region
         request_func.region = self.region
+        request_func.dispatcher = dispatcher
 
         log.msg("Authenticating for tenant")
         d = self.authenticator.authenticate_tenant(tenant_id, log=log)

--- a/otter/test/convergence/test_composition.py
+++ b/otter/test/convergence/test_composition.py
@@ -5,7 +5,7 @@ from effect.testing import Stub, resolve_effect
 
 import mock
 
-from pyrsistent import pmap
+from pyrsistent import freeze, pmap
 
 from twisted.trial.unittest import SynchronousTestCase
 
@@ -17,8 +17,8 @@ from otter.convergence.composition import (
     tenant_is_enabled)
 from otter.convergence.model import (
     CLBDescription, DesiredGroupState, NovaServer, ServerState)
+from otter.http import service_request
 from otter.test.utils import resolve_stubs
-from otter.util.pure_http import has_code
 
 
 class JsonToLBConfigTests(SynchronousTestCase):
@@ -92,10 +92,9 @@ class ExecConvergenceTests(SynchronousTestCase):
 
     def test_success(self):
         """
-        Executes optimized steps if state of world does not match desired and returns
-        True to be called again
+        Executes optimized steps if state of world does not match desired and
+        returns True to be called again
         """
-        reqfunc = lambda **k: Effect(k)
         get_all_convergence_data = self._get_gacd_func('gid')
         desired = DesiredGroupState(
             launch_config={'server': {'name': 'test', 'flavorRef': 'f'}},
@@ -103,23 +102,23 @@ class ExecConvergenceTests(SynchronousTestCase):
             desired=2)
 
         eff = execute_convergence(
-            reqfunc, 'gid', desired,
-            get_all_convergence_data=get_all_convergence_data)
+            'gid', desired, get_all_convergence_data=get_all_convergence_data)
 
         eff = resolve_stubs(eff)
         # The steps are optimized
         self.assertIsInstance(eff.intent, ParallelEffects)
         self.assertEqual(len(eff.intent.effects), 1)
+        expected_req = service_request(
+            ServiceType.CLOUD_LOAD_BALANCERS,
+            'POST',
+            'loadbalancers/23',
+            data=mock.ANY)
+        got_req = eff.intent.effects[0].intent
+        self.assertEqual(got_req, expected_req.intent)
+        # separate check for nodes as it can be in any order but content is
+        # unique
         self.assertEqual(
-            eff.intent.effects[0].intent,
-            {'url': 'loadbalancers/23', 'headers': None,
-             'service_type': ServiceType.CLOUD_LOAD_BALANCERS,
-             'data': {'nodes': mock.ANY},
-             'method': 'POST',
-             'success_pred': has_code(200)})
-        # separate check for nodes as it can be in any order but content is unique
-        self.assertEqual(
-            set(map(pmap, eff.intent.effects[0].intent['data']['nodes'])),
+            set(freeze(got_req.data['nodes'])),
             set([pmap({'weight': 1, 'type': 'PRIMARY', 'port': 80,
                        'condition': 'ENABLED', 'address': '10.0.0.2'}),
                  pmap({'weight': 1, 'type': 'PRIMARY', 'port': 80,
@@ -137,10 +136,9 @@ class ExecConvergenceTests(SynchronousTestCase):
             launch_config={'server': {'name': 'test', 'flavorRef': 'f'}},
             desired_lbs={},
             desired=2)
-        reqfunc = lambda **k: 1 / 0
         get_all_convergence_data = self._get_gacd_func('gid')
         eff = execute_convergence(
-            reqfunc, 'gid', desired,
+            'gid', desired,
             get_all_convergence_data=get_all_convergence_data)
         self.assertIs(resolve_stubs(eff), False)
 

--- a/otter/test/test_supervisor.py
+++ b/otter/test/test_supervisor.py
@@ -2,7 +2,7 @@
 Tests for the worker supervisor.
 """
 
-from effect import Effect, Constant
+from effect import Constant, Effect
 
 import mock
 
@@ -18,13 +18,14 @@ from otter import supervisor
 from otter.constants import ServiceType
 from otter.http import TenantScope
 from otter.models.interface import (
-    IScalingGroup, GroupState, NoSuchScalingGroupError)
+    GroupState, IScalingGroup, NoSuchScalingGroupError)
 from otter.supervisor import (
-    ISupervisor, SupervisorService, set_supervisor, remove_server_from_group,
-    execute_launch_config, CannotDeleteServerBelowMinError, ServerNotFoundError)
+    CannotDeleteServerBelowMinError, ISupervisor, ServerNotFoundError,
+    SupervisorService, execute_launch_config, remove_server_from_group,
+    set_supervisor)
 from otter.test.utils import (
-    iMock, patch, mock_log, CheckFailure, matches, FakeSupervisor, IsBoundWith,
-    DummyException, mock_group)
+    CheckFailure, DummyException, FakeSupervisor, IsBoundWith, iMock, matches,
+    mock_group, mock_log, patch)
 from otter.util.deferredutils import DeferredPool
 
 

--- a/otter/test/test_supervisor.py
+++ b/otter/test/test_supervisor.py
@@ -1,6 +1,9 @@
 """
 Tests for the worker supervisor.
 """
+
+from effect import Effect, Constant
+
 import mock
 
 from testtools.matchers import ContainsDict, Equals, IsInstance
@@ -13,6 +16,7 @@ from zope.interface.verify import verifyObject
 
 from otter import supervisor
 from otter.constants import ServiceType
+from otter.http import TenantScope
 from otter.models.interface import (
     IScalingGroup, GroupState, NoSuchScalingGroupError)
 from otter.supervisor import (
@@ -111,6 +115,11 @@ class SupervisorTests(SynchronousTestCase):
         self.assertEqual(request_func.service_catalog, self.service_catalog)
         self.assertEqual(request_func.region, "ORD")
         self.assertEqual(request_func.lb_region, "ORD")
+        self.assertEqual(request_func.tenant_id, self.group.tenant_id)
+        # make sure the dispatcher supports some interesting intent that is
+        # only provided by the full dispatcher
+        tscope = TenantScope(Effect(Constant(1)), 'tenant_id')
+        self.assertIsNot(request_func.dispatcher(tscope), None)
 
 
 class HealthCheckTests(SupervisorTests):

--- a/otter/test/worker/test_rcv3.py
+++ b/otter/test/worker/test_rcv3.py
@@ -9,7 +9,6 @@ from twisted.internet.defer import succeed
 from twisted.trial.unittest import SynchronousTestCase
 
 from otter.constants import ServiceType
-from otter.test.convergence.test_effecting import _PureRequestStub
 from otter.util.pure_http import has_code
 from otter.worker import _rcv3
 
@@ -30,6 +29,15 @@ def _rcv3_add_response(lb_id, server_id):
     }]
 
 
+class _RequestBag(object):
+    """
+    Something like the ``request_func`` (lol) that gets passed around from the
+    supervisor, at least as far as _rcv3.py is concerned.
+    """
+    def __init__(self, dispatcher):
+        self.dispatcher = dispatcher
+
+
 class RCv3Tests(SynchronousTestCase):
     """
     Tests for RCv3-specific worker logic.
@@ -40,6 +48,8 @@ class RCv3Tests(SynchronousTestCase):
         """
         self.reactor = object()
         self.patch(_rcv3, "perform", self._fake_perform)
+        self.dispatcher = object()
+        self.request_bag = _RequestBag(self.dispatcher)
 
     def _fake_perform(self, dispatcher, effect):
         """
@@ -48,31 +58,27 @@ class RCv3Tests(SynchronousTestCase):
         :param dispatcher: The Effect dispatcher.
         :param effect: The effect to "execute".
         """
-        self.assertTrue(isinstance(dispatcher, ComposedDispatcher))
+        self.assertIdentical(dispatcher, self.dispatcher)
 
-        self.effect = effect
         self.assertTrue(isinstance(effect, Effect))
         (sub_effect,) = effect.intent.effects
+        req = sub_effect.intent
 
-        self.assertEqual(sub_effect.service_type, ServiceType.RACKCONNECT_V3)
-        self.assertEqual(sub_effect.data,
+        self.assertEqual(req.service_type, ServiceType.RACKCONNECT_V3)
+        self.assertEqual(req.data,
                          [{'load_balancer_pool': {'id': 'lb_id'},
                            'cloud_server': {'id': 'server_id'}}])
-        # The URL is actually a relative URL path. This is intentional,
-        # because the real request_func is service-bound.
-        self.assertEqual(sub_effect.url, 'load_balancer_pools/nodes')
-        # The headers are None (== unspecified). This is intentional,
-        # because the real request func injects auth headers.
-        self.assertEqual(sub_effect.headers, None)
+        self.assertEqual(req.url, 'load_balancer_pools/nodes')
+        self.assertEqual(req.headers, None)
         # The method is either POST (add) or DELETE (remove).
-        self.assertIn(sub_effect.method, ["POST", "DELETE"])
+        self.assertIn(req.method, ["POST", "DELETE"])
 
-        if sub_effect.method == "POST":
-            self.assertEqual(sub_effect.success_pred, has_code(201))
+        if req.method == "POST":
+            self.assertEqual(req.success_pred, has_code(201))
             # http://docs.rcv3.apiary.io/#post-%2Fv3%2F{tenant_id}%2Fload_balancer_pools%2Fnodes
             response = _rcv3_add_response("lb_id", "server_id")
-        elif sub_effect.method == "DELETE":
-            self.assertEqual(sub_effect.success_pred, has_code(204))
+        elif req.method == "DELETE":
+            self.assertEqual(req.success_pred, has_code(204))
             # http://docs.rcv3.apiary.io/#delete-%2Fv3%2F{tenant_id}%2Fload_balancer_pools%2Fnodes
             response = None
 
@@ -82,8 +88,7 @@ class RCv3Tests(SynchronousTestCase):
         """
         :func:`_rcv3.add_to_rcv3` attempts to perform the correct effect.
         """
-        d = _rcv3.add_to_rcv3(_PureRequestStub, "lb_id", "server_id",
-                              _reactor=self.reactor)
+        d = _rcv3.add_to_rcv3(self.request_bag, "lb_id", "server_id")
         (add_result,) = self.successResultOf(d)
         self.assertEqual(add_result["cloud_server"], {"id": "server_id"})
         self.assertEqual(add_result["load_balancer_pool"], {"id": "lb_id"})
@@ -92,6 +97,5 @@ class RCv3Tests(SynchronousTestCase):
         """
         :func:`_rcv3.add_to_rcv3` attempts to perform the correct effect.
         """
-        d = _rcv3.remove_from_rcv3(_PureRequestStub, "lb_id", "server_id",
-                                   _reactor=self.reactor)
+        d = _rcv3.remove_from_rcv3(self.request_bag, "lb_id", "server_id")
         self.assertIdentical(self.successResultOf(d), None)

--- a/otter/worker/_rcv3.py
+++ b/otter/worker/_rcv3.py
@@ -15,29 +15,28 @@ from otter.convergence.steps import BulkAddToRCv3, BulkRemoveFromRCv3
 from otter.effect_dispatcher import get_simple_dispatcher
 
 
-def _generic_rcv3_request(step_class, request_func, lb_id, server_id,
-                          _reactor=reactor):
+def _generic_rcv3_request(step_class, request_bag, lb_id, server_id):
     """
     Perform a generic RCv3 bulk step on a single (lb, server) pair.
 
     :param IStep step_class: The step class to perform the action.
-    :param callable request_func: A request function.
+    :param request_bag: An object with a bunch of useful data on it. Called
+        a ``request_func`` by other worker/supervisor code.
     :param str lb_id: The id of the RCv3 load balancer to act on.
     :param str server_id: The Nova server id to act on.
-    :param _reactor: The reactor used to perform the effects.
     :return: A deferred that will fire when the request has been performed,
         firing with the parsed result of the request, or :data:`None` if the
         request has no body.
     """
     step = step_class(lb_node_pairs=[(lb_id, server_id)])
-    effect = steps_to_effect(request_func, [step])
+    effect = steps_to_effect([step])
     # The result will be a list (added by ParallelEffects) of
     # results. In this code, we're only performing one request, so we
     # know there will only be one element in that list. Our contract
     # is that we return the result of the request, so we discard the
     # outer list.
-    dispatcher = get_simple_dispatcher(_reactor)
-    return perform(dispatcher, effect).addCallback(itemgetter(0))
+    # TODO: TenantScope!
+    return perform(request_bag.dispatcher, effect).addCallback(itemgetter(0))
 
 
 add_to_rcv3 = partial(_generic_rcv3_request, BulkAddToRCv3)

--- a/otter/worker/_rcv3.py
+++ b/otter/worker/_rcv3.py
@@ -6,13 +6,12 @@ At some point, this should just be moved into that module.
 from functools import partial
 from operator import itemgetter
 
+from effect import Effect
 from effect.twisted import perform
-
-from twisted.internet import reactor
 
 from otter.convergence.effecting import steps_to_effect
 from otter.convergence.steps import BulkAddToRCv3, BulkRemoveFromRCv3
-from otter.effect_dispatcher import get_simple_dispatcher
+from otter.http import TenantScope
 
 
 def _generic_rcv3_request(step_class, request_bag, lb_id, server_id):
@@ -30,13 +29,15 @@ def _generic_rcv3_request(step_class, request_bag, lb_id, server_id):
     """
     step = step_class(lb_node_pairs=[(lb_id, server_id)])
     effect = steps_to_effect([step])
-    # The result will be a list (added by ParallelEffects) of
-    # results. In this code, we're only performing one request, so we
-    # know there will only be one element in that list. Our contract
-    # is that we return the result of the request, so we discard the
-    # outer list.
-    # TODO: TenantScope!
-    return perform(request_bag.dispatcher, effect).addCallback(itemgetter(0))
+    # Unfortunate that we have to TenantScope here, but here's where we're
+    # performing.
+    scoped = Effect(TenantScope(effect, request_bag.tenant_id))
+
+    # The result of steps_to_effect will be a list (added by ParallelEffects)
+    # of results. In this code, we're only performing one request, so we know
+    # there will only be one element in that list. Our contract is that we
+    # return the result of the request, so we discard the outer list.
+    return perform(request_bag.dispatcher, scoped).addCallback(itemgetter(0))
 
 
 add_to_rcv3 = partial(_generic_rcv3_request, BulkAddToRCv3)


### PR DESCRIPTION
This has a couple of fallouts:

- now no convergence code has request_func in it any more, most notably up through execute_convergence
- the RCv3 worker code had to be updated to apply a TenantScope, and use the full dispatcher.
- I decided to put the dispatcher in the "request bag" (aka the "request_func" object that supervisor passes around), since the supervisor has access to all the data necessary for creating a dispatcher when it's creating the request_func.
- I also had to put the tenant_id in the "request bag" so that the RCv3 worker code could wrap the effect in a TenantScope.

