### PR TITLE
Re-enable linter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ DIFF_TARGET = $(shell git merge-base master HEAD)
 endif
 
 flake8diff:
-	git diff --patch --no-prefix ${DIFF_TARGET} | flake8 --diff; true
+	git diff --patch --no-prefix ${DIFF_TARGET} | flake8 --diff
 
 flake8full:
 	flake8 ${PYDIRS}

--- a/otter/convergence/composition.py
+++ b/otter/convergence/composition.py
@@ -4,7 +4,6 @@ Code for composing all of the convergence functionality together.
 import time
 
 from collections import defaultdict
-from functools import partial
 
 from otter.convergence.effecting import steps_to_effect
 from otter.convergence.gathering import get_all_convergence_data

--- a/otter/test/test_metrics.py
+++ b/otter/test/test_metrics.py
@@ -5,8 +5,7 @@ Tests for `metrics.py`
 import operator
 from io import StringIO
 
-from effect import (
-    ComposedDispatcher, Constant, Effect, TypeDispatcher, base_dispatcher)
+from effect import Constant, Effect, base_dispatcher
 from effect.testing import resolve_effect
 
 import mock
@@ -48,8 +47,7 @@ from otter.test.utils import (
     Provides,
     matches,
     mock_log,
-    patch,
-    resolve_stubs,
+    patch
 )
 
 


### PR DESCRIPTION
A lot of lint is fixed now, so leaving this disabled is probably doing more harm than good.  Example:

https://github.com/rackerlabs/otter/pull/939#issuecomment-70904875

Closes #912.