### PR TITLE
make CreateServer generate a random server name

### DIFF
--- a/otter/convergence/steps.py
+++ b/otter/convergence/steps.py
@@ -2,10 +2,13 @@
 
 from characteristic import attributes
 
+from effect import Effect, Func
+
 from zope.interface import Interface, implementer
 
 from otter.constants import ServiceType
 from otter.http import has_code, service_request
+from otter.util.hashkey import generate_server_name
 from otter.util.http import append_segments
 
 
@@ -30,11 +33,22 @@ class CreateServer(object):
 
     def as_effect(self):
         """Produce a :obj:`Request` to create a server."""
-        return service_request(
-            ServiceType.CLOUD_SERVERS,
-            'POST',
-            'servers',
-            data=self.launch_config)
+        eff = Effect(Func(generate_server_name))
+
+        def got_name(random_name):
+            server_name = self.launch_config['server'].get('name')
+            if server_name is not None:
+                server_name = '{}-{}'.format(server_name, random_name)
+            else:
+                server_name = random_name
+            launch_config = self.launch_config['server'].set('name',
+                                                             server_name)
+            return service_request(
+                ServiceType.CLOUD_SERVERS,
+                'POST',
+                'servers',
+                data=launch_config)
+        return eff.on(got_name)
 
 
 @implementer(IStep)

--- a/otter/test/convergence/test_steps.py
+++ b/otter/test/convergence/test_steps.py
@@ -43,6 +43,24 @@ class StepAsRequestTests(SynchronousTestCase):
                 'servers',
                 data=pmap({'name': 'myserver-random-name', 'flavorRef': '1'})))
 
+    def test_create_server_noname(self):
+        """
+        When no name is provided in the launch config, the name will be
+        generated from scratch.
+        """
+        create = CreateServer(
+            launch_config=freeze({'server': {'flavorRef': '1'}}))
+        eff = create.as_effect()
+        self.assertEqual(eff.intent, Func(generate_server_name))
+        eff = resolve_effect(eff, 'random-name')
+        self.assertEqual(
+            eff,
+            service_request(
+                ServiceType.CLOUD_SERVERS,
+                'POST',
+                'servers',
+                data=pmap({'name': 'random-name', 'flavorRef': '1'})))
+
     def test_delete_server(self):
         """
         :obj:`DeleteServer.as_effect` produces a request for deleting a server.

--- a/otter/test/convergence/test_steps.py
+++ b/otter/test/convergence/test_steps.py
@@ -1,6 +1,9 @@
 """Tests for convergence steps."""
 
-from pyrsistent import pmap, pset
+from effect import Func
+from effect.testing import resolve_effect
+
+from pyrsistent import freeze, pmap, pset
 
 from twisted.trial.unittest import SynchronousTestCase
 
@@ -14,6 +17,7 @@ from otter.convergence.steps import (
     RemoveFromCLB,
     SetMetadataItemOnServer)
 from otter.http import has_code, service_request
+from otter.util.hashkey import generate_server_name
 
 
 class StepAsRequestTests(SynchronousTestCase):
@@ -26,14 +30,18 @@ class StepAsRequestTests(SynchronousTestCase):
         :obj:`CreateServer.as_effect` produces a request for creating a server.
         """
         create = CreateServer(
-            launch_config=pmap({'name': 'myserver', 'flavorRef': '1'}))
+            launch_config=freeze({'server': {'name': 'myserver',
+                                             'flavorRef': '1'}}))
+        eff = create.as_effect()
+        self.assertEqual(eff.intent, Func(generate_server_name))
+        eff = resolve_effect(eff, 'random-name')
         self.assertEqual(
-            create.as_effect(),
+            eff,
             service_request(
                 ServiceType.CLOUD_SERVERS,
                 'POST',
                 'servers',
-                data=pmap({'name': 'myserver', 'flavorRef': '1'})))
+                data=pmap({'name': 'myserver-random-name', 'flavorRef': '1'})))
 
     def test_delete_server(self):
         """


### PR DESCRIPTION
EDIT: *really* in progress -- need to make sure LB metadata gets the server name too.

Depends on #943, fixes #930.

CreateServer.as_effect generates a random name to put into the launch config.

I have some more stuff coming to do the rest of the "preparation" of launch configs (i.e. adding metadata), so don't worry :)

