### PR TITLE
Support RCv3 out-of-band delete

### DIFF
--- a/otter/convergence/steps.py
+++ b/otter/convergence/steps.py
@@ -200,3 +200,16 @@ class BulkRemoveFromRCv3(object):
         return _rackconnect_bulk_request(
             self.lb_node_pairs, "DELETE",
             success_pred=has_code(204))
+
+
+def _rcv3_delete_successful(lb_node_pairs, response):
+    """
+    Checks if the RCv3 bulk deletion command was successful.
+
+    This means either the response code indicated unambiguous success
+    """
+    if response.code == 204:
+        return True
+
+    fatal_errors = []
+    return bool(fatal_errors)

--- a/otter/test/convergence/test_steps.py
+++ b/otter/test/convergence/test_steps.py
@@ -185,7 +185,8 @@ class RCv3DeleteSuccessfulTests(SynchronousTestCase):
 
     def _rcv3_delete_successful(self, resp, body):
         """
-        Calls :func:`_rcv3_delete_successful`, partially applied with test data.
+        Calls :func:`_rcv3_delete_successful`, partially applied with test
+        data.
         """
         return _rcv3_delete_successful(self.LB_NODE_PAIRS, resp, body)
 

--- a/otter/test/convergence/test_steps.py
+++ b/otter/test/convergence/test_steps.py
@@ -6,14 +6,14 @@ from twisted.trial.unittest import SynchronousTestCase
 
 from otter.constants import ServiceType
 from otter.convergence.steps import (
-    _rcv3_delete_successful,
     BulkAddToRCv3,
     BulkRemoveFromRCv3,
     ChangeCLBNode,
     CreateServer,
     DeleteServer,
     RemoveFromCLB,
-    SetMetadataItemOnServer)
+    SetMetadataItemOnServer,
+    _rcv3_delete_successful)
 from otter.http import has_code, service_request
 from otter.test.utils import StubResponse
 


### PR DESCRIPTION
Closes #820.

This is currently blocked on RCv3 getting back to us re: atomicity semantics of bulk operations.