### PR TITLE
Change 'status' in LB message to 'status_code'

### DIFF
--- a/otter/test/worker/test_launch_server_v1.py
+++ b/otter/test/worker/test_launch_server_v1.py
@@ -324,9 +324,12 @@ class AddToCLBTests(LoadBalancersTestsMixin, SynchronousTestCase):
         self.successResultOf(d)
         self.assertEqual(
             self.log.msg.mock_calls[:len(bad_codes)],
-            [mock.call('Got unexpected LB status {status} while {msg}: {error}',
-                       status=bad_code, loadbalancer_id=12345, ip_address='192.168.1.1', msg='add_node',
-                       error=matches(IsInstance(APIError))) for bad_code in bad_codes])
+            [mock.call(
+                'Got unexpected LB status {status_code} while {msg}: {error}',
+                status_code=bad_code, loadbalancer_id=12345,
+                ip_address='192.168.1.1', msg='add_node',
+                error=matches(IsInstance(APIError)))
+             for bad_code in bad_codes])
 
     def test_pushes_remove_onto_undo_stack(self):
         """
@@ -770,10 +773,11 @@ class RemoveFromCLBTests(LoadBalancersTestsMixin, SynchronousTestCase):
         self.clock.pump([self.retry_interval] * 6)
         self.successResultOf(d)
         self.log.msg.assert_has_calls(
-            [mock.call('Got unexpected LB status {status} while {msg}: {error}',
-                       status=code, msg='remove_node',
-                       error=matches(IsInstance(APIError)), loadbalancer_id=12345,
-                       node_id="a")
+            [mock.call(
+                'Got unexpected LB status {status_code} while {msg}: {error}',
+                status_code=code, msg='remove_node',
+                error=matches(IsInstance(APIError)), loadbalancer_id=12345,
+                node_id="a")
              for code in bad_codes])
 
 

--- a/otter/worker/launch_server_v1.py
+++ b/otter/worker/launch_server_v1.py
@@ -383,8 +383,8 @@ def log_lb_unexpected_errors(f, log, msg):
         log.err(f, 'Unknown error while ' + msg)
     elif not (f.value.code == 404 or
               f.value.code == 422 and 'PENDING_UPDATE' in f.value.body):
-        log.msg('Got unexpected LB status {status} while {msg}: {error}',
-                status=f.value.code, msg=msg, error=f.value)
+        log.msg('Got unexpected LB status {status_code} while {msg}: {error}',
+                status_code=f.value.code, msg=msg, error=f.value)
     return f
 
 


### PR DESCRIPTION
This is breaking the elasticsearch mappings, since this is a number and I guess group status or something is logged now as a string.

We should improve our ES practices/setup, but this is less work for now and a sufficient stopgap measure.