### PR TITLE
Rename desired to capacity in DesiredGroupState

### DIFF
--- a/otter/convergence/composition.py
+++ b/otter/convergence/composition.py
@@ -82,7 +82,7 @@ def get_desired_group_state(group_id, launch_config, desired):
     lbs = json_to_LBConfigs(launch_config['args']['loadBalancers'])
     desired_state = DesiredGroupState(
         launch_config=server_lc,
-        desired=desired, desired_lbs=lbs)
+        capacity=desired, desired_lbs=lbs)
     return desired_state
 
 

--- a/otter/convergence/model.py
+++ b/otter/convergence/model.py
@@ -56,7 +56,8 @@ class NovaServer(object):
 
 @attributes(['launch_config', 'capacity',
              Attribute('desired_lbs', default_factory=dict, instance_of=dict),
-             Attribute('draining_timeout', default_value=0.0, instance_of=float)])
+             Attribute('draining_timeout', default_value=0.0,
+                       instance_of=float)])
 class DesiredGroupState(object):
     """
     The desired state for a scaling group.

--- a/otter/convergence/model.py
+++ b/otter/convergence/model.py
@@ -54,7 +54,7 @@ class NovaServer(object):
     """
 
 
-@attributes(['launch_config', 'desired',
+@attributes(['launch_config', 'capacity',
              Attribute('desired_lbs', default_factory=dict, instance_of=dict),
              Attribute('draining_timeout', default_value=0.0, instance_of=float)])
 class DesiredGroupState(object):
@@ -62,7 +62,7 @@ class DesiredGroupState(object):
     The desired state for a scaling group.
 
     :ivar dict launch_config: nova launch config.
-    :ivar int desired: the number of desired servers within the group.
+    :ivar int capacity: the number of desired servers within the group.
     :ivar dict desired_lbs: A mapping of load balancer IDs to lists of
         :class:`CLBDescription` instances.
     :ivar float draining_timeout: If greater than zero, when the server is

--- a/otter/convergence/planning.py
+++ b/otter/convergence/planning.py
@@ -199,7 +199,7 @@ def converge(desired_state, servers_with_cheese, load_balancer_contents, now,
                             for server in building_too_long]
 
     # create servers
-    create_steps = [create_server] * (desired_state.desired
+    create_steps = [create_server] * (desired_state.capacity
                                       - (len(servers_in_active)
                                          + len(waiting_for_build)))
 
@@ -207,7 +207,7 @@ def converge(desired_state, servers_with_cheese, load_balancer_contents, now,
     # preferring older.  Also, finish draining/deleting servers already in
     # draining state
     servers_in_preferred_order = servers_in_active + waiting_for_build
-    servers_to_delete = servers_in_preferred_order[desired_state.desired:]
+    servers_to_delete = servers_in_preferred_order[desired_state.capacity:]
 
     def drain_and_delete_a_server(server):
         return _drain_and_delete(

--- a/otter/test/convergence/test_composition.py
+++ b/otter/test/convergence/test_composition.py
@@ -71,7 +71,7 @@ class GetDesiredGroupStateTests(SynchronousTestCase):
             state,
             DesiredGroupState(
                 launch_config=expected_server_config,
-                desired=2,
+                capacity=2,
                 desired_lbs={23: [CLBDescription(lb_id='23', port=80)]}))
 
 
@@ -110,7 +110,7 @@ class ExecConvergenceTests(SynchronousTestCase):
         desired = DesiredGroupState(
             launch_config={'server': {'name': 'test', 'flavorRef': 'f'}},
             desired_lbs={23: [CLBDescription(lb_id='23', port=80)]},
-            desired=2)
+            capacity=2)
 
         eff = execute_convergence(
             'gid', desired, get_all_convergence_data=get_all_convergence_data)
@@ -146,7 +146,7 @@ class ExecConvergenceTests(SynchronousTestCase):
         desired = DesiredGroupState(
             launch_config={'server': {'name': 'test', 'flavorRef': 'f'}},
             desired_lbs={},
-            desired=2)
+            capacity=2)
         get_all_convergence_data = self._get_gacd_func('gid')
         eff = execute_convergence(
             'gid', desired,

--- a/otter/test/convergence/test_planning.py
+++ b/otter/test/convergence/test_planning.py
@@ -341,7 +341,7 @@ class DrainAndDeleteServerTests(SynchronousTestCase):
         """
         self.assertEqual(
             converge(
-                DesiredGroupState(launch_config={}, desired=0,
+                DesiredGroupState(launch_config={}, capacity=0,
                                   draining_timeout=10.0),
                 set([server('abc', state=ServerState.ACTIVE)]),
                 set(),
@@ -356,7 +356,7 @@ class DrainAndDeleteServerTests(SynchronousTestCase):
         """
         self.assertEqual(
             converge(
-                DesiredGroupState(launch_config={}, desired=0),
+                DesiredGroupState(launch_config={}, capacity=0),
                 set([server('abc', state=ServerState.ACTIVE,
                             servicenet_address='1.1.1.1')]),
                 set([CLBNode(node_id='1', address='1.1.1.1',
@@ -374,7 +374,7 @@ class DrainAndDeleteServerTests(SynchronousTestCase):
         """
         self.assertEqual(
             converge(
-                DesiredGroupState(launch_config={}, desired=0),
+                DesiredGroupState(launch_config={}, capacity=0),
                 set([server('abc', state=ServerState.DRAINING,
                             servicenet_address='1.1.1.1')]),
                 set([CLBNode(node_id='1', address='1.1.1.1',
@@ -394,7 +394,7 @@ class DrainAndDeleteServerTests(SynchronousTestCase):
         """
         self.assertEqual(
             converge(
-                DesiredGroupState(launch_config={}, desired=0,
+                DesiredGroupState(launch_config={}, capacity=0,
                                   draining_timeout=10.0),
                 set([server('abc', state=ServerState.DRAINING,
                             servicenet_address='1.1.1.1')]),
@@ -414,7 +414,7 @@ class DrainAndDeleteServerTests(SynchronousTestCase):
         """
         self.assertEqual(
             converge(
-                DesiredGroupState(launch_config={}, desired=0,
+                DesiredGroupState(launch_config={}, capacity=0,
                                   draining_timeout=10.0),
                 set([server('abc', state=ServerState.ACTIVE,
                             servicenet_address='1.1.1.1')]),
@@ -442,7 +442,7 @@ class DrainAndDeleteServerTests(SynchronousTestCase):
         """
         self.assertEqual(
             converge(
-                DesiredGroupState(launch_config={}, desired=0,
+                DesiredGroupState(launch_config={}, capacity=0,
                                   draining_timeout=10.0),
                 set([server('abc', state=ServerState.ACTIVE,
                             servicenet_address='1.1.1.1')]),
@@ -470,7 +470,7 @@ class DrainAndDeleteServerTests(SynchronousTestCase):
         """
         self.assertEqual(
             converge(
-                DesiredGroupState(launch_config={}, desired=0,
+                DesiredGroupState(launch_config={}, capacity=0,
                                   draining_timeout=10.0),
                 set([server('abc', state=ServerState.DRAINING,
                             servicenet_address='1.1.1.1')]),
@@ -494,7 +494,7 @@ class ConvergeTests(SynchronousTestCase):
         """
         self.assertEqual(
             converge(
-                DesiredGroupState(launch_config={}, desired=1),
+                DesiredGroupState(launch_config={}, capacity=1),
                 set(),
                 set(),
                 0),
@@ -507,7 +507,7 @@ class ConvergeTests(SynchronousTestCase):
         """
         self.assertEqual(
             converge(
-                DesiredGroupState(launch_config={}, desired=2),
+                DesiredGroupState(launch_config={}, capacity=2),
                 set(),
                 set(),
                 0),
@@ -522,7 +522,7 @@ class ConvergeTests(SynchronousTestCase):
         """
         self.assertEqual(
             converge(
-                DesiredGroupState(launch_config={}, desired=1),
+                DesiredGroupState(launch_config={}, capacity=1),
                 set([server('abc', ServerState.BUILD)]),
                 set(),
                 0),
@@ -535,7 +535,7 @@ class ConvergeTests(SynchronousTestCase):
         """
         self.assertEqual(
             converge(
-                DesiredGroupState(launch_config={}, desired=1),
+                DesiredGroupState(launch_config={}, capacity=1),
                 set([server('abc', ServerState.ERROR)]),
                 set(),
                 0),
@@ -552,7 +552,7 @@ class ConvergeTests(SynchronousTestCase):
         """
         self.assertEqual(
             converge(
-                DesiredGroupState(launch_config={}, desired=1),
+                DesiredGroupState(launch_config={}, capacity=1),
                 set([server('abc', ServerState.ERROR,
                             servicenet_address='1.1.1.1')]),
                 set([CLBNode(address='1.1.1.1', node_id='3',
@@ -573,7 +573,7 @@ class ConvergeTests(SynchronousTestCase):
         """If we have more servers than desired, we delete the oldest."""
         self.assertEqual(
             converge(
-                DesiredGroupState(launch_config={}, desired=1),
+                DesiredGroupState(launch_config={}, capacity=1),
                 set([server('abc', ServerState.ACTIVE, created=0),
                      server('def', ServerState.ACTIVE, created=1)]),
                 set(),
@@ -588,7 +588,7 @@ class ConvergeTests(SynchronousTestCase):
         """
         self.assertEqual(
             converge(
-                DesiredGroupState(launch_config={}, desired=0),
+                DesiredGroupState(launch_config={}, capacity=0),
                 set([server('abc', ServerState.ACTIVE,
                             servicenet_address='1.1.1.1', created=0)]),
                 set([CLBNode(address='1.1.1.1', node_id='3',
@@ -606,7 +606,7 @@ class ConvergeTests(SynchronousTestCase):
         """
         self.assertEqual(
             converge(
-                DesiredGroupState(launch_config={}, desired=2),
+                DesiredGroupState(launch_config={}, capacity=2),
                 set([server('abc', ServerState.ACTIVE, created=0),
                      server('def', ServerState.BUILD, created=1),
                      server('ghi', ServerState.ACTIVE, created=2)]),
@@ -621,7 +621,7 @@ class ConvergeTests(SynchronousTestCase):
         """
         self.assertEqual(
             converge(
-                DesiredGroupState(launch_config={}, desired=2),
+                DesiredGroupState(launch_config={}, capacity=2),
                 set([server('slowpoke', ServerState.BUILD, created=0),
                      server('ok', ServerState.ACTIVE, created=0)]),
                 set(),
@@ -637,7 +637,7 @@ class ConvergeTests(SynchronousTestCase):
         """
         self.assertEqual(
             converge(
-                DesiredGroupState(launch_config={}, desired=2),
+                DesiredGroupState(launch_config={}, capacity=2),
                 set([server('slowpoke', ServerState.BUILD, created=0),
                      server('old-ok', ServerState.ACTIVE, created=0),
                      server('new-ok', ServerState.ACTIVE, created=3600)]),
@@ -653,7 +653,7 @@ class ConvergeTests(SynchronousTestCase):
         desired_lbs = {'5': [CLBDescription(lb_id='5', port=80)]}
         self.assertEqual(
             converge(
-                DesiredGroupState(launch_config={}, desired=1,
+                DesiredGroupState(launch_config={}, capacity=1,
                                   desired_lbs=desired_lbs),
                 set([server('abc', ServerState.ACTIVE,
                             servicenet_address='1.1.1.1', created=0),
@@ -899,7 +899,7 @@ class PlanTests(SynchronousTestCase):
 
         desired_lbs = {5: [CLBDescription(lb_id='5', port=80)]}
         desired_group_state = DesiredGroupState(
-            launch_config={}, desired=8, desired_lbs=desired_lbs)
+            launch_config={}, capacity=8, desired_lbs=desired_lbs)
 
         result = plan(
             desired_group_state,

--- a/otter/test/integration/test_utils.py
+++ b/otter/test/integration/test_utils.py
@@ -46,7 +46,7 @@ class MeasureProgressTests(SynchronousTestCase):
         )
         desired_state = DesiredGroupState(
             launch_config=pmap(),
-            desired=5,
+            capacity=5,
         )
         progress = measure_progress(
             previous_state, current_state, desired_state)
@@ -67,7 +67,7 @@ class MeasureProgressTests(SynchronousTestCase):
         )
         desired_state = DesiredGroupState(
             launch_config=pmap(),
-            desired=1,
+            capacity=1,
         )
         progress = measure_progress(
             previous_state, current_state, desired_state)
@@ -88,7 +88,7 @@ class MeasureProgressTests(SynchronousTestCase):
         )
         desired_state = DesiredGroupState(
             launch_config=pmap(),
-            desired=5,
+            capacity=5,
         )
         self.assertRaises(
             OvershootError,
@@ -109,7 +109,7 @@ class MeasureProgressTests(SynchronousTestCase):
         )
         desired_state = DesiredGroupState(
             launch_config=pmap(),
-            desired=5,
+            capacity=5,
         )
         self.assertRaises(
             UndershootError,
@@ -131,7 +131,7 @@ class MeasureProgressTests(SynchronousTestCase):
         )
         desired_state = DesiredGroupState(
             launch_config=pmap(),
-            desired=5,
+            capacity=5,
         )
         progress = measure_progress(
             previous_state, current_state, desired_state)
@@ -152,7 +152,7 @@ class MeasureProgressTests(SynchronousTestCase):
         )
         desired_state = DesiredGroupState(
             launch_config=pmap(),
-            desired=5,
+            capacity=5,
         )
         progress = measure_progress(
             previous_state, current_state, desired_state)
@@ -175,7 +175,7 @@ class MeasureProgressTests(SynchronousTestCase):
         )
         desired_state = DesiredGroupState(
             launch_config=pmap(),
-            desired=5,
+            capacity=5,
         )
         progress = measure_progress(
             previous_state, current_state, desired_state)
@@ -196,7 +196,7 @@ class MeasureProgressTests(SynchronousTestCase):
         )
         desired_state = DesiredGroupState(
             launch_config=pmap(),
-            desired=5,
+            capacity=5,
         )
         progress = measure_progress(
             previous_state, current_state, desired_state)

--- a/otter/test/integration/utils.py
+++ b/otter/test/integration/utils.py
@@ -55,7 +55,7 @@ def measure_progress(prev_state, curr_state, desired_state):
     prev_capacity = _count_live_servers(prev_state.servers)
     curr_capacity = _count_live_servers(curr_state.servers)
     capacity_delta = curr_capacity - prev_capacity
-    desired = desired_state.desired
+    desired = desired_state.capacity
 
     if prev_capacity > desired and curr_capacity < desired:
         msg = "Undershoot: prev capacity = %d, desired = %d, current = %d"


### PR DESCRIPTION
Fixes #960.

One of two renaming PRs - we seem to be using the name 'launch_config' interchangably with the actual launch config that a user submits, with both server and load balancer args, and the server part of the launch config.

I for one am confused, so I'd like to change it so that `launch_config`, `server_config`, and `lb_configs`/`desired_lbs` are  distinct and separate.  :)  (I am also not tied to those exact names)