### PR TITLE
Disambiguate launch_config and server_config

### DIFF
--- a/otter/convergence/composition.py
+++ b/otter/convergence/composition.py
@@ -81,13 +81,16 @@ def get_desired_group_state(group_id, launch_config, desired):
         freeze({'server': launch_config['args']['server']}))
     lbs = json_to_LBConfigs(launch_config['args']['loadBalancers'])
     desired_state = DesiredGroupState(
-        launch_config=server_lc,
+        server_config=server_lc,
         desired=desired, desired_lbs=lbs)
     return desired_state
 
 
-def prepare_server_launch_config(group_id, launch_config):
-    """Prepare a launch config with any necessary dynamic data."""
-    return launch_config.set_in(
+def prepare_server_launch_config(group_id, server_config):
+    """
+    Prepares a server config (the server part of the Group's launch config)
+    with any necessary dynamic data.
+    """
+    return server_config.set_in(
         ('server', 'metadata', 'rax:auto_scaling_group_id'),
         group_id)

--- a/otter/convergence/model.py
+++ b/otter/convergence/model.py
@@ -56,7 +56,8 @@ class NovaServer(object):
 
 @attributes(['server_config', 'desired',
              Attribute('desired_lbs', default_factory=dict, instance_of=dict),
-             Attribute('draining_timeout', default_value=0.0, instance_of=float)])
+             Attribute('draining_timeout', default_value=0.0,
+                       instance_of=float)])
 class DesiredGroupState(object):
     """
     The desired state for a scaling group.

--- a/otter/convergence/model.py
+++ b/otter/convergence/model.py
@@ -54,14 +54,14 @@ class NovaServer(object):
     """
 
 
-@attributes(['launch_config', 'desired',
+@attributes(['server_config', 'desired',
              Attribute('desired_lbs', default_factory=dict, instance_of=dict),
              Attribute('draining_timeout', default_value=0.0, instance_of=float)])
 class DesiredGroupState(object):
     """
     The desired state for a scaling group.
 
-    :ivar dict launch_config: nova launch config.
+    :ivar dict server_config: compute/nova part of the group launch config.
     :ivar int desired: the number of desired servers within the group.
     :ivar dict desired_lbs: A mapping of load balancer IDs to lists of
         :class:`CLBDescription` instances.
@@ -74,7 +74,7 @@ class DesiredGroupState(object):
         """
         Make attributes immutable.
         """
-        self.launch_config = freeze(self.launch_config)
+        self.server_config = freeze(self.server_config)
 
 
 class ILBDescription(Interface):

--- a/otter/convergence/planning.py
+++ b/otter/convergence/planning.py
@@ -192,7 +192,7 @@ def converge(desired_state, servers_with_cheese, load_balancer_contents, now,
         lambda server: now - server.created >= timeout,
         servers_in_build)
 
-    create_server = CreateServer(launch_config=desired_state.launch_config)
+    create_server = CreateServer(server_config=desired_state.server_config)
 
     # delete any servers that have been building for too long
     delete_timeout_steps = [DeleteServer(server_id=server.id)

--- a/otter/convergence/steps.py
+++ b/otter/convergence/steps.py
@@ -24,30 +24,30 @@ class IStep(Interface):
         """Return an Effect which performs this step."""
 
 
-def set_server_name(launch_config_args, name_suffix):
+def set_server_name(server_config_args, name_suffix):
     """
-    Append the given name_suffix to the name of the server in the launch
+    Append the given name_suffix to the name of the server in the server
     config.
 
-    :param launch_config_args: The launch configuration args.
+    :param server_config_args: The server configuration args.
     :param name_suffix: the suffix to append to the server name. If no name was
         specified, it will be used as the name.
     """
-    name = launch_config_args['server'].get('name')
+    name = server_config_args['server'].get('name')
     if name is not None:
         name = '{0}-{1}'.format(name, name_suffix)
     else:
         name = name_suffix
-    return launch_config_args.set_in(('server', 'name'), name)
+    return server_config_args.set_in(('server', 'name'), name)
 
 
 @implementer(IStep)
-@attributes(['launch_config'])
+@attributes(['server_config'])
 class CreateServer(object):
     """
     A server must be created.
 
-    :ivar pmap launch_config: Nova launch configuration.
+    :ivar pmap server_config: Nova launch configuration.
     """
 
     def as_effect(self):
@@ -55,12 +55,12 @@ class CreateServer(object):
         eff = Effect(Func(generate_server_name))
 
         def got_name(random_name):
-            launch_config = set_server_name(self.launch_config, random_name)
+            server_config = set_server_name(self.server_config, random_name)
             return service_request(
                 ServiceType.CLOUD_SERVERS,
                 'POST',
                 'servers',
-                data=thaw(launch_config))
+                data=thaw(server_config))
         return eff.on(got_name)
 
 

--- a/otter/test/convergence/test_composition.py
+++ b/otter/test/convergence/test_composition.py
@@ -70,7 +70,7 @@ class GetDesiredGroupStateTests(SynchronousTestCase):
         self.assertEqual(
             state,
             DesiredGroupState(
-                launch_config=expected_server_config,
+                server_config=expected_server_config,
                 desired=2,
                 desired_lbs={23: [CLBDescription(lb_id='23', port=80)]}))
 
@@ -108,7 +108,7 @@ class ExecConvergenceTests(SynchronousTestCase):
         """
         get_all_convergence_data = self._get_gacd_func('gid')
         desired = DesiredGroupState(
-            launch_config={'server': {'name': 'test', 'flavorRef': 'f'}},
+            server_config={'server': {'name': 'test', 'flavorRef': 'f'}},
             desired_lbs={23: [CLBDescription(lb_id='23', port=80)]},
             desired=2)
 
@@ -144,7 +144,7 @@ class ExecConvergenceTests(SynchronousTestCase):
         is returned.
         """
         desired = DesiredGroupState(
-            launch_config={'server': {'name': 'test', 'flavorRef': 'f'}},
+            server_config={'server': {'name': 'test', 'flavorRef': 'f'}},
             desired_lbs={},
             desired=2)
         get_all_convergence_data = self._get_gacd_func('gid')

--- a/otter/test/convergence/test_planning.py
+++ b/otter/test/convergence/test_planning.py
@@ -341,7 +341,7 @@ class DrainAndDeleteServerTests(SynchronousTestCase):
         """
         self.assertEqual(
             converge(
-                DesiredGroupState(launch_config={}, desired=0,
+                DesiredGroupState(server_config={}, desired=0,
                                   draining_timeout=10.0),
                 set([server('abc', state=ServerState.ACTIVE)]),
                 set(),
@@ -356,7 +356,7 @@ class DrainAndDeleteServerTests(SynchronousTestCase):
         """
         self.assertEqual(
             converge(
-                DesiredGroupState(launch_config={}, desired=0),
+                DesiredGroupState(server_config={}, desired=0),
                 set([server('abc', state=ServerState.ACTIVE,
                             servicenet_address='1.1.1.1')]),
                 set([CLBNode(node_id='1', address='1.1.1.1',
@@ -374,7 +374,7 @@ class DrainAndDeleteServerTests(SynchronousTestCase):
         """
         self.assertEqual(
             converge(
-                DesiredGroupState(launch_config={}, desired=0),
+                DesiredGroupState(server_config={}, desired=0),
                 set([server('abc', state=ServerState.DRAINING,
                             servicenet_address='1.1.1.1')]),
                 set([CLBNode(node_id='1', address='1.1.1.1',
@@ -394,7 +394,7 @@ class DrainAndDeleteServerTests(SynchronousTestCase):
         """
         self.assertEqual(
             converge(
-                DesiredGroupState(launch_config={}, desired=0,
+                DesiredGroupState(server_config={}, desired=0,
                                   draining_timeout=10.0),
                 set([server('abc', state=ServerState.DRAINING,
                             servicenet_address='1.1.1.1')]),
@@ -414,7 +414,7 @@ class DrainAndDeleteServerTests(SynchronousTestCase):
         """
         self.assertEqual(
             converge(
-                DesiredGroupState(launch_config={}, desired=0,
+                DesiredGroupState(server_config={}, desired=0,
                                   draining_timeout=10.0),
                 set([server('abc', state=ServerState.ACTIVE,
                             servicenet_address='1.1.1.1')]),
@@ -442,7 +442,7 @@ class DrainAndDeleteServerTests(SynchronousTestCase):
         """
         self.assertEqual(
             converge(
-                DesiredGroupState(launch_config={}, desired=0,
+                DesiredGroupState(server_config={}, desired=0,
                                   draining_timeout=10.0),
                 set([server('abc', state=ServerState.ACTIVE,
                             servicenet_address='1.1.1.1')]),
@@ -470,7 +470,7 @@ class DrainAndDeleteServerTests(SynchronousTestCase):
         """
         self.assertEqual(
             converge(
-                DesiredGroupState(launch_config={}, desired=0,
+                DesiredGroupState(server_config={}, desired=0,
                                   draining_timeout=10.0),
                 set([server('abc', state=ServerState.DRAINING,
                             servicenet_address='1.1.1.1')]),
@@ -494,11 +494,11 @@ class ConvergeTests(SynchronousTestCase):
         """
         self.assertEqual(
             converge(
-                DesiredGroupState(launch_config={}, desired=1),
+                DesiredGroupState(server_config={}, desired=1),
                 set(),
                 set(),
                 0),
-            pbag([CreateServer(launch_config=pmap())]))
+            pbag([CreateServer(server_config=pmap())]))
 
     def test_converge_give_me_multiple_servers(self):
         """
@@ -507,13 +507,13 @@ class ConvergeTests(SynchronousTestCase):
         """
         self.assertEqual(
             converge(
-                DesiredGroupState(launch_config={}, desired=2),
+                DesiredGroupState(server_config={}, desired=2),
                 set(),
                 set(),
                 0),
             pbag([
-                CreateServer(launch_config=pmap()),
-                CreateServer(launch_config=pmap())]))
+                CreateServer(server_config=pmap()),
+                CreateServer(server_config=pmap())]))
 
     def test_count_building_as_meeting_capacity(self):
         """
@@ -522,7 +522,7 @@ class ConvergeTests(SynchronousTestCase):
         """
         self.assertEqual(
             converge(
-                DesiredGroupState(launch_config={}, desired=1),
+                DesiredGroupState(server_config={}, desired=1),
                 set([server('abc', ServerState.BUILD)]),
                 set(),
                 0),
@@ -535,13 +535,13 @@ class ConvergeTests(SynchronousTestCase):
         """
         self.assertEqual(
             converge(
-                DesiredGroupState(launch_config={}, desired=1),
+                DesiredGroupState(server_config={}, desired=1),
                 set([server('abc', ServerState.ERROR)]),
                 set(),
                 0),
             pbag([
                 DeleteServer(server_id='abc'),
-                CreateServer(launch_config=pmap()),
+                CreateServer(server_config=pmap()),
             ]))
 
     def test_delete_error_state_servers_with_lb_nodes(self):
@@ -552,7 +552,7 @@ class ConvergeTests(SynchronousTestCase):
         """
         self.assertEqual(
             converge(
-                DesiredGroupState(launch_config={}, desired=1),
+                DesiredGroupState(server_config={}, desired=1),
                 set([server('abc', ServerState.ERROR,
                             servicenet_address='1.1.1.1')]),
                 set([CLBNode(address='1.1.1.1', node_id='3',
@@ -566,14 +566,14 @@ class ConvergeTests(SynchronousTestCase):
                 DeleteServer(server_id='abc'),
                 RemoveFromCLB(lb_id='5', node_id='3'),
                 RemoveFromCLB(lb_id='5', node_id='5'),
-                CreateServer(launch_config=pmap()),
+                CreateServer(server_config=pmap()),
             ]))
 
     def test_scale_down(self):
         """If we have more servers than desired, we delete the oldest."""
         self.assertEqual(
             converge(
-                DesiredGroupState(launch_config={}, desired=1),
+                DesiredGroupState(server_config={}, desired=1),
                 set([server('abc', ServerState.ACTIVE, created=0),
                      server('def', ServerState.ACTIVE, created=1)]),
                 set(),
@@ -588,7 +588,7 @@ class ConvergeTests(SynchronousTestCase):
         """
         self.assertEqual(
             converge(
-                DesiredGroupState(launch_config={}, desired=0),
+                DesiredGroupState(server_config={}, desired=0),
                 set([server('abc', ServerState.ACTIVE,
                             servicenet_address='1.1.1.1', created=0)]),
                 set([CLBNode(address='1.1.1.1', node_id='3',
@@ -606,7 +606,7 @@ class ConvergeTests(SynchronousTestCase):
         """
         self.assertEqual(
             converge(
-                DesiredGroupState(launch_config={}, desired=2),
+                DesiredGroupState(server_config={}, desired=2),
                 set([server('abc', ServerState.ACTIVE, created=0),
                      server('def', ServerState.BUILD, created=1),
                      server('ghi', ServerState.ACTIVE, created=2)]),
@@ -621,14 +621,14 @@ class ConvergeTests(SynchronousTestCase):
         """
         self.assertEqual(
             converge(
-                DesiredGroupState(launch_config={}, desired=2),
+                DesiredGroupState(server_config={}, desired=2),
                 set([server('slowpoke', ServerState.BUILD, created=0),
                      server('ok', ServerState.ACTIVE, created=0)]),
                 set(),
                 3600),
             pbag([
                 DeleteServer(server_id='slowpoke'),
-                CreateServer(launch_config=pmap())]))
+                CreateServer(server_config=pmap())]))
 
     def test_timeout_replace_only_when_necessary(self):
         """
@@ -637,7 +637,7 @@ class ConvergeTests(SynchronousTestCase):
         """
         self.assertEqual(
             converge(
-                DesiredGroupState(launch_config={}, desired=2),
+                DesiredGroupState(server_config={}, desired=2),
                 set([server('slowpoke', ServerState.BUILD, created=0),
                      server('old-ok', ServerState.ACTIVE, created=0),
                      server('new-ok', ServerState.ACTIVE, created=3600)]),
@@ -653,7 +653,7 @@ class ConvergeTests(SynchronousTestCase):
         desired_lbs = {'5': [CLBDescription(lb_id='5', port=80)]}
         self.assertEqual(
             converge(
-                DesiredGroupState(launch_config={}, desired=1,
+                DesiredGroupState(server_config={}, desired=1,
                                   desired_lbs=desired_lbs),
                 set([server('abc', ServerState.ACTIVE,
                             servicenet_address='1.1.1.1', created=0),
@@ -766,7 +766,7 @@ class OptimizerTests(SynchronousTestCase):
                 lb_id='5',
                 address_configs=s(('1.1.1.1',
                                    CLBDescription(lb_id='5', port=80)))),
-            CreateServer(launch_config=pmap({})),
+            CreateServer(server_config=pmap({})),
             BulkRemoveFromRCv3(lb_node_pairs=pset([("lb-1", "node-a")])),
             BulkAddToRCv3(lb_node_pairs=pset([("lb-2", "node-b")]))
             # Note that the add & remove pair should not be the same;
@@ -802,7 +802,7 @@ class OptimizerTests(SynchronousTestCase):
                                    CLBDescription(lb_id='6', port=80)))),
 
             # Unoptimizable steps
-            CreateServer(launch_config=pmap({})),
+            CreateServer(server_config=pmap({})),
         ])
 
         self.assertEqual(
@@ -823,7 +823,7 @@ class OptimizerTests(SynchronousTestCase):
                                        CLBDescription(lb_id='6', port=80)))),
 
                 # Unoptimizable steps
-                CreateServer(launch_config=pmap({}))
+                CreateServer(server_config=pmap({}))
             ]))
 
 
@@ -840,7 +840,7 @@ class LimitStepCount(SynchronousTestCase):
             those steps to create. If unspecified, assumed to be zero.
         :return: A pbag of steps.
         """
-        create_servers = [CreateServer(launch_config=pmap({"sentinel": i}))
+        create_servers = [CreateServer(server_config=pmap({"sentinel": i}))
                           for i in xrange(counts.get(CreateServer, 0))]
         delete_servers = [DeleteServer(server_id='abc-' + str(i))
                           for i in xrange(counts.get(DeleteServer, 0))]
@@ -899,7 +899,7 @@ class PlanTests(SynchronousTestCase):
 
         desired_lbs = {5: [CLBDescription(lb_id='5', port=80)]}
         desired_group_state = DesiredGroupState(
-            launch_config={}, desired=8, desired_lbs=desired_lbs)
+            server_config={}, desired=8, desired_lbs=desired_lbs)
 
         result = plan(
             desired_group_state,
@@ -918,4 +918,4 @@ class PlanTests(SynchronousTestCase):
                     address_configs=s(
                         ('1.1.1.1', CLBDescription(lb_id='5', port=80)),
                         ('1.2.3.4', CLBDescription(lb_id='5', port=80)))
-                )] + [CreateServer(launch_config=pmap({}))] * 3))
+                )] + [CreateServer(server_config=pmap({}))] * 3))

--- a/otter/test/convergence/test_steps.py
+++ b/otter/test/convergence/test_steps.py
@@ -30,7 +30,7 @@ class StepAsEffectTests(SynchronousTestCase):
         :obj:`CreateServer.as_effect` produces a request for creating a server.
         """
         create = CreateServer(
-            launch_config=freeze({'server': {'name': 'myserver',
+            server_config=freeze({'server': {'name': 'myserver',
                                              'flavorRef': '1'}}))
         eff = create.as_effect()
         self.assertEqual(eff.intent, Func(generate_server_name))
@@ -50,7 +50,7 @@ class StepAsEffectTests(SynchronousTestCase):
         generated from scratch.
         """
         create = CreateServer(
-            launch_config=freeze({'server': {'flavorRef': '1'}}))
+            server_config=freeze({'server': {'flavorRef': '1'}}))
         eff = create.as_effect()
         self.assertEqual(eff.intent, Func(generate_server_name))
         eff = resolve_effect(eff, 'random-name')

--- a/otter/test/integration/test_utils.py
+++ b/otter/test/integration/test_utils.py
@@ -45,7 +45,7 @@ class MeasureProgressTests(SynchronousTestCase):
             lb_connections=pset([])
         )
         desired_state = DesiredGroupState(
-            launch_config=pmap(),
+            server_config=pmap(),
             desired=5,
         )
         progress = measure_progress(
@@ -66,7 +66,7 @@ class MeasureProgressTests(SynchronousTestCase):
             lb_connections=pset([])
         )
         desired_state = DesiredGroupState(
-            launch_config=pmap(),
+            server_config=pmap(),
             desired=1,
         )
         progress = measure_progress(
@@ -87,7 +87,7 @@ class MeasureProgressTests(SynchronousTestCase):
             lb_connections=pset([])
         )
         desired_state = DesiredGroupState(
-            launch_config=pmap(),
+            server_config=pmap(),
             desired=5,
         )
         self.assertRaises(
@@ -108,7 +108,7 @@ class MeasureProgressTests(SynchronousTestCase):
             lb_connections=pset([])
         )
         desired_state = DesiredGroupState(
-            launch_config=pmap(),
+            server_config=pmap(),
             desired=5,
         )
         self.assertRaises(
@@ -130,7 +130,7 @@ class MeasureProgressTests(SynchronousTestCase):
             lb_connections=pset([])
         )
         desired_state = DesiredGroupState(
-            launch_config=pmap(),
+            server_config=pmap(),
             desired=5,
         )
         progress = measure_progress(
@@ -151,7 +151,7 @@ class MeasureProgressTests(SynchronousTestCase):
             lb_connections=pset([])
         )
         desired_state = DesiredGroupState(
-            launch_config=pmap(),
+            server_config=pmap(),
             desired=5,
         )
         progress = measure_progress(
@@ -174,7 +174,7 @@ class MeasureProgressTests(SynchronousTestCase):
             lb_connections=pset([])
         )
         desired_state = DesiredGroupState(
-            launch_config=pmap(),
+            server_config=pmap(),
             desired=5,
         )
         progress = measure_progress(
@@ -195,7 +195,7 @@ class MeasureProgressTests(SynchronousTestCase):
             lb_connections=pset([])
         )
         desired_state = DesiredGroupState(
-            launch_config=pmap(),
+            server_config=pmap(),
             desired=5,
         )
         progress = measure_progress(


### PR DESCRIPTION
Convert variables that mean 'nova part of launch config' to be named `server_config` instead of `launch_config`