### PR TITLE
Retrieve a server's desired LB state from metadata

### DIFF
--- a/otter/convergence/gathering.py
+++ b/otter/convergence/gathering.py
@@ -190,7 +190,7 @@ def _lb_configs_from_metadata(server):
                     desired_lbs[lbid] = CLBDescription(
                         lb_id=lbid, port=config['port'])
 
-            except Exception:
+            except (KeyError, ValueError, TypeError):
                 pass
 
     return pmap(desired_lbs)

--- a/otter/convergence/gathering.py
+++ b/otter/convergence/gathering.py
@@ -1,9 +1,11 @@
 """Code related to gathering data to inform convergence."""
-
+import json
 from operator import itemgetter
 from urllib import urlencode
 
 from effect import parallel
+
+from pyrsistent import pmap
 
 from toolz.curried import filter, groupby, map
 from toolz.dicttoolz import get_in
@@ -163,19 +165,45 @@ def _private_ipv4_addresses(server):
 
 def _servicenet_address(server):
     """
-    Finds the ServiceNet address for the given server.
+    Find the ServiceNet address for the given server.
     """
     return next((ip for ip in _private_ipv4_addresses(server)
                  if ip.startswith("10.")), "")
 
 
+def _lb_configs_from_metadata(server):
+    """
+    Construct a mapping of load balancer ID to :class:`ILBDescription` based
+    on the server metadata.
+    """
+    key_prefix = 'rax:autoscale:lb:'
+    desired_lbs = {}
+
+    # throw away any value that is malformed
+    for k in server.get('metadata', {}):
+        if k.startswith(key_prefix):
+            try:
+                config = json.loads(server['metadata'][k])
+
+                if config.get('type') != 'RackConnectV3':
+                    lbid = k[len(key_prefix):]
+                    desired_lbs[lbid] = CLBDescription(
+                        lb_id=lbid, port=config['port'])
+
+            except Exception:
+                pass
+
+    return pmap(desired_lbs)
+
+
 def to_nova_server(server_json):
     """
-    Convert from JSON format to :obj:`NovaServer` instance
+    Convert from JSON format to :obj:`NovaServer` instance.
     """
     return NovaServer(id=server_json['id'],
                       state=ServerState.lookupByName(server_json['state']),
                       created=timestamp_to_epoch(server_json['created']),
+                      desired_lbs=_lb_configs_from_metadata(server_json),
                       servicenet_address=_servicenet_address(server_json))
 
 

--- a/otter/convergence/model.py
+++ b/otter/convergence/model.py
@@ -3,14 +3,13 @@ Data classes for representing bits of information that need to share a
 representation across the different phases of convergence.
 """
 
-from characteristic import attributes, Attribute
+from characteristic import Attribute, attributes
 
-from pyrsistent import freeze, pmap, PMap
+from pyrsistent import PMap, freeze, pmap
 
-from twisted.python.constants import Names, NamedConstant
+from twisted.python.constants import NamedConstant, Names
 
-from zope.interface import implementer, Interface
-from zope.interface import Attribute as IAttribute
+from zope.interface import Attribute as IAttribute, Interface, implementer
 
 
 class CLBNodeCondition(Names):

--- a/otter/convergence/model.py
+++ b/otter/convergence/model.py
@@ -5,7 +5,7 @@ representation across the different phases of convergence.
 
 from characteristic import attributes, Attribute
 
-from pyrsistent import freeze
+from pyrsistent import freeze, pmap, PMap
 
 from twisted.python.constants import Names, NamedConstant
 
@@ -38,7 +38,9 @@ class ServerState(Names):
 
 
 @attributes(['id', 'state', 'created',
-             Attribute('servicenet_address', default_value='', instance_of=str)])
+             Attribute('desired_lbs', default_factory=pmap, instance_of=PMap),
+             Attribute('servicenet_address', default_value='',
+                       instance_of=str)])
 class NovaServer(object):
     """
     Information about a server that was retrieved from Nova.
@@ -51,6 +53,9 @@ class NovaServer(object):
     :ivar float created: Timestamp at which the server was created.
     :ivar str servicenet_address: The private ServiceNet IPv4 address, if
         the server is on the ServiceNet network
+
+    :ivar PMap desired_lbs: An immutable mapping of load balancer IDs to lists
+        of :class:`CLBDescription` instances.
     """
 
 

--- a/otter/test/convergence/test_gathering.py
+++ b/otter/test/convergence/test_gathering.py
@@ -6,6 +6,8 @@ from functools import partial
 from effect import Constant, Effect
 from effect.testing import Stub, resolve_effect
 
+from pyrsistent import pmap
+
 from twisted.trial.unittest import SynchronousTestCase
 
 from otter.constants import ServiceType
@@ -384,6 +386,27 @@ class ToNovaServerTests(SynchronousTestCase):
                        state=ServerState.BUILD,
                        created=self.createds[1][1],
                        servicenet_address='10.0.0.1'))
+
+    def test_with_lb_metadata(self):
+        """
+        Create a server that has load balancer config metadata in it.
+        The only desired load balancers created are the ones with valid
+        data.
+        """
+        self.servers[0]['metadata'] = {
+            'rax:autoscale:lb:12345': '{"port": 80}',
+            'rax:autoscale:lb:23456': '{"port": "80"}',
+            'rax:autoscale:lb:34567': 'invalid string'
+        }
+        self.assertEqual(
+            to_nova_server(self.servers[0]),
+            NovaServer(id='a',
+                       state=ServerState.ACTIVE,
+                       created=self.createds[0][1],
+                       desired_lbs=pmap({
+                           '12345': CLBDescription(lb_id='12345', port=80)
+                       }),
+                       servicenet_address=''))
 
 
 class JsonToLBConfigTests(SynchronousTestCase):


### PR DESCRIPTION
When NovaServer is created, parse the server metadata to store that server's desired loadbalancer state.

Second task of #968