### PR TITLE
DeleteServer is successful on 204, not 200

### DIFF
--- a/otter/convergence/steps.py
+++ b/otter/convergence/steps.py
@@ -78,7 +78,8 @@ class DeleteServer(object):
         return service_request(
             ServiceType.CLOUD_SERVERS,
             'DELETE',
-            append_segments('servers', self.server_id))
+            append_segments('servers', self.server_id),
+            success_pred=has_code(204))
 
 
 @implementer(IStep)

--- a/otter/test/convergence/test_steps.py
+++ b/otter/test/convergence/test_steps.py
@@ -72,7 +72,8 @@ class StepAsEffectTests(SynchronousTestCase):
             service_request(
                 ServiceType.CLOUD_SERVERS,
                 'DELETE',
-                'servers/abc123'))
+                'servers/abc123',
+                success_pred=has_code(204)))
 
     def test_set_metadata_item(self):
         """


### PR DESCRIPTION
This was previously just the default. There are more steps with bogus `success_pred` functions because they rely on the default. I'm not sure we should even have the default...