### PR TITLE
Fix lb-configs in metadata so that one LB ID can have multiple LB configurations

### DIFF
--- a/otter/convergence/composition.py
+++ b/otter/convergence/composition.py
@@ -9,6 +9,7 @@ from collections import defaultdict
 from pyrsistent import freeze
 
 from toolz.dicttoolz import keyfilter
+from toolz.itertoolz import groupby
 
 from otter.convergence.effecting import steps_to_effect
 from otter.convergence.gathering import get_all_convergence_data
@@ -93,6 +94,17 @@ def get_desired_group_state(group_id, launch_config, desired):
     return desired_state
 
 
+def _sanitize_lb_metadata(lb_config_json):
+    """
+    Takes load balancer config json, as from :obj:`otter.json_schema._clb_lb`
+    and :obj:`otter.json_schema._rcv3_lb` and normalizes it.
+    """
+    sanitized = keyfilter(lambda k: k in ('type', 'port'), lb_config_json)
+    # provide a default type
+    sanitized.setdefault('type', 'CloudLoadBalancer')
+    return sanitized
+
+
 def prepare_server_launch_config(group_id, server_config, lb_args):
     """
     Prepares a server config (the server part of the Group's launch config)
@@ -114,15 +126,14 @@ def prepare_server_launch_config(group_id, server_config, lb_args):
     server_config = server_config.set_in(
         ('server', 'metadata', 'rax:auto_scaling_group_id'), group_id)
 
-    for config in lb_args:
-        if config.get('type') != 'RackConnectV3':
-            sanitized = keyfilter(lambda k: k in ('type', 'port'), config)
-            # provide a default type
-            sanitized.setdefault('type', 'CloudLoadBalancer')
+    lbs = groupby(lambda conf: conf['loadBalancerId'], lb_args)
 
-            server_config = server_config.set_in(
-                ('server', 'metadata',
-                 'rax:autoscale:lb:{0}'.format(config['loadBalancerId'])),
-                json.dumps(sanitized))
+    for lb_id in lbs:
+        configs = [_sanitize_lb_metadata(config) for config in lbs[lb_id]
+                   if config.get('type') != 'RackConnectV3']
+
+        server_config = server_config.set_in(
+            ('server', 'metadata', 'rax:autoscale:lb:{0}'.format(lb_id)),
+            json.dumps(configs))
 
     return server_config

--- a/otter/test/convergence/test_composition.py
+++ b/otter/test/convergence/test_composition.py
@@ -63,7 +63,8 @@ class GetDesiredGroupStateTests(SynchronousTestCase):
         server_config = {'name': 'test', 'flavorRef': 'f'}
         lc = {'args': {'server': server_config,
                        'loadBalancers': [{'loadBalancerId': 23, 'port': 80,
-                                          'whatsit': 'invalid'}]}}
+                                          'whatsit': 'invalid'},
+                                         {'loadBalancerId': 23, 'port': 90}]}}
 
         expected_server_config = {
             'server': {
@@ -72,7 +73,8 @@ class GetDesiredGroupStateTests(SynchronousTestCase):
                 'metadata': {
                     'rax:auto_scaling_group_id': 'uuid',
                     'rax:autoscale:lb:23': json.dumps(
-                        {"port": 80, "type": "CloudLoadBalancer"})
+                        [{"port": 80, "type": "CloudLoadBalancer"},
+                         {"port": 90, "type": "CloudLoadBalancer"}])
                 }
             }
         }
@@ -82,7 +84,8 @@ class GetDesiredGroupStateTests(SynchronousTestCase):
             DesiredGroupState(
                 server_config=expected_server_config,
                 capacity=2,
-                desired_lbs={23: [CLBDescription(lb_id='23', port=80)]}))
+                desired_lbs={23: [CLBDescription(lb_id='23', port=80),
+                                  CLBDescription(lb_id='23', port=90)]}))
 
 
 class ExecConvergenceTests(SynchronousTestCase):

--- a/otter/test/convergence/test_gathering.py
+++ b/otter/test/convergence/test_gathering.py
@@ -429,9 +429,12 @@ class ToNovaServerTests(SynchronousTestCase):
         data.
         """
         self.servers[0]['metadata'] = {
-            'rax:autoscale:lb:12345': '{"port": 80}',
-            'rax:autoscale:lb:23456': '{"port": "80"}',
-            'rax:autoscale:lb:34567': 'invalid string'
+            # two correct lbconfigs and one incorrect one
+            'rax:autoscale:lb:12345': '[{"port":80},{"bad":"1"},{"port":90}]',
+            # a dictionary instead of a list
+            'rax:autoscale:lb:23456': '{"port": 80}',
+            # not even valid json
+            'rax:autoscale:lb:34567': 'invalid json string'
         }
         self.assertEqual(
             to_nova_server(self.servers[0]),
@@ -441,7 +444,8 @@ class ToNovaServerTests(SynchronousTestCase):
                        flavor_id='valid_flavor',
                        created=self.createds[0][1],
                        desired_lbs=pmap({
-                           '12345': CLBDescription(lb_id='12345', port=80)
+                           '12345': [CLBDescription(lb_id='12345', port=80),
+                                     CLBDescription(lb_id='12345', port=90)]
                        }),
                        servicenet_address=''))
 


### PR DESCRIPTION
In my previous two PRs, I mapped LB ids to one load balancer config.

They should be mapped to a list load balancer configs instead.