### PR TITLE
Fix load balancer list parsing

### DIFF
--- a/otter/convergence/gathering.py
+++ b/otter/convergence/gathering.py
@@ -99,10 +99,12 @@ def get_clb_contents():
                 method, url, json_response=json_response),
             retry_times(5), exponential_backoff_interval(2))
 
-    def fetch_nodes(lbs):
+    def fetch_nodes(result):
+        lbs = result['loadBalancers']
         lb_ids = [lb['id'] for lb in lbs]
         return parallel(
-            [lb_req('GET', append_segments('loadbalancers', str(lb_id), 'nodes'))
+            [lb_req('GET',
+                    append_segments('loadbalancers', str(lb_id), 'nodes'))
              for lb_id in lb_ids]).on(lambda all_nodes: (lb_ids, all_nodes))
 
     def fetch_drained_feeds((ids, all_lb_nodes)):

--- a/otter/test/convergence/test_gathering.py
+++ b/otter/test/convergence/test_gathering.py
@@ -20,7 +20,6 @@ from otter.convergence.gathering import (
     to_nova_server,
     _private_ipv4_addresses,
     _servicenet_address)
-from otter.convergence.composition import json_to_LBConfigs
 from otter.convergence.model import (
     CLBDescription,
     CLBNode,
@@ -203,7 +202,8 @@ class GetLBContentsTests(SynchronousTestCase):
         Stub request function and mock `extract_CLB_drained_at`
         """
         self.reqs = {
-            ('GET', 'loadbalancers', True): [{'id': 1}, {'id': 2}],
+            ('GET', 'loadbalancers', True): {'loadBalancers':
+                                             [{'id': 1}, {'id': 2}]},
             ('GET', 'loadbalancers/1/nodes', True): [
                 {'id': '11', 'port': 20, 'address': 'a11',
                  'weight': 2, 'condition': 'DRAINING', 'type': 'PRIMARY'},
@@ -291,7 +291,7 @@ class GetLBContentsTests(SynchronousTestCase):
         """
         Return empty list if there are no LB
         """
-        self.reqs = {('GET', 'loadbalancers', True): []}
+        self.reqs = {('GET', 'loadbalancers', True): {'loadBalancers': []}}
         eff = get_clb_contents()
         self.assertEqual(self._resolve_lb(eff), [])
 
@@ -300,7 +300,8 @@ class GetLBContentsTests(SynchronousTestCase):
         Return empty if there are LBs but no nodes in them
         """
         self.reqs = {
-            ('GET', 'loadbalancers', True): [{'id': 1}, {'id': 2}],
+            ('GET', 'loadbalancers', True): {'loadBalancers':
+                                             [{'id': 1}, {'id': 2}]},
             ('GET', 'loadbalancers/1/nodes', True): [],
             ('GET', 'loadbalancers/2/nodes', True): []
         }
@@ -312,7 +313,8 @@ class GetLBContentsTests(SynchronousTestCase):
         Doesnt fetch feeds if all nodes are ENABLED
         """
         self.reqs = {
-            ('GET', 'loadbalancers', True): [{'id': 1}, {'id': 2}],
+            ('GET', 'loadbalancers', True): {'loadBalancers':
+                                             [{'id': 1}, {'id': 2}]},
             ('GET', 'loadbalancers/1/nodes', True): [
                 {'id': '11', 'port': 20, 'address': 'a11',
                  'weight': 2, 'condition': 'ENABLED', 'type': 'PRIMARY'}
@@ -444,34 +446,6 @@ class ToNovaServerTests(SynchronousTestCase):
                            '12345': CLBDescription(lb_id='12345', port=80)
                        }),
                        servicenet_address=''))
-
-
-class JsonToLBConfigTests(SynchronousTestCase):
-    """
-    Tests for :func:`json_to_LBConfigs`
-    """
-    def test_without_rackconnect(self):
-        """
-        LB config without rackconnect
-        """
-        self.assertEqual(
-            json_to_LBConfigs([{'loadBalancerId': 20, 'port': 80},
-                               {'loadBalancerId': 20, 'port': 800},
-                               {'loadBalancerId': 21, 'port': 81}]),
-            {20: [CLBDescription(lb_id='20', port=80),
-                  CLBDescription(lb_id='20', port=800)],
-             21: [CLBDescription(lb_id='21', port=81)]})
-
-    def test_with_rackconnect(self):
-        """
-        LB config with rackconnect
-        """
-        self.assertEqual(
-            json_to_LBConfigs([{'loadBalancerId': 20, 'port': 80},
-                               {'loadBalancerId': 200, 'type': 'RackConnectV3'},
-                               {'loadBalancerId': 21, 'port': 81}]),
-            {20: [CLBDescription(lb_id='20', port=80)],
-             21: [CLBDescription(lb_id='21', port=81)]})
 
 
 class IPAddressTests(SynchronousTestCase):


### PR DESCRIPTION
get_clb_contents was dealing with the response from "GET .../loadbalancers" incorrectly, by assuming it was a list, but in fact the response is a dict of the form {"loadBalancers": [...]}.

I've also deleted a redundant copy of the unit tests for json_to_LBConfigs, which were moved to composition.