### PR TITLE
don't blow up during gathering when there are no servers in a group

### DIFF
--- a/otter/convergence/gathering.py
+++ b/otter/convergence/gathering.py
@@ -1,6 +1,5 @@
 """Code related to gathering data to inform convergence."""
 import json
-from operator import itemgetter
 from urllib import urlencode
 
 from effect import parallel
@@ -221,7 +220,7 @@ def get_all_convergence_data(
     """
     eff = parallel(
         [get_scaling_group_servers()
-         .on(itemgetter(group_id))
+         .on(lambda servers: servers.get(group_id, []))
          .on(map(to_nova_server)).on(list),
          get_clb_contents()]
     ).on(tuple)

--- a/otter/test/convergence/test_gathering.py
+++ b/otter/test/convergence/test_gathering.py
@@ -584,3 +584,14 @@ class GetAllConvergenceDataTests(SynchronousTestCase):
                        servicenet_address='10.0.0.2'),
         ]
         self.assertEqual(resolve_stubs(eff), (expected_servers, lb_nodes))
+
+    def test_no_group_servers(self):
+        get_servers = lambda: Effect(Stub(Constant({})))
+        get_lb = lambda: Effect(Stub(Constant([])))
+
+        eff = get_all_convergence_data(
+            'gid',
+            get_scaling_group_servers=get_servers,
+            get_clb_contents=get_lb)
+
+        self.assertEqual(resolve_stubs(eff), ([], []))

--- a/otter/test/convergence/test_gathering.py
+++ b/otter/test/convergence/test_gathering.py
@@ -586,6 +586,10 @@ class GetAllConvergenceDataTests(SynchronousTestCase):
         self.assertEqual(resolve_stubs(eff), (expected_servers, lb_nodes))
 
     def test_no_group_servers(self):
+        """
+        If there are no servers in a group, get_all_convergence_data includes
+        an empty list.
+        """
         get_servers = lambda: Effect(Stub(Constant({})))
         get_lb = lambda: Effect(Stub(Constant([])))
 


### PR DESCRIPTION
If no servers were found for a group, gathering would blow up with a KeyError. 