### PR TITLE
Don't blow up when loadBalancers is not specified in launch config

### DIFF
--- a/otter/convergence/composition.py
+++ b/otter/convergence/composition.py
@@ -67,7 +67,7 @@ def json_to_LBConfigs(lbs_json):
         if lb.get('type') != 'RackConnectV3':
             lbd[lb['loadBalancerId']].append(CLBDescription(
                 lb_id=str(lb['loadBalancerId']), port=lb['port']))
-    return lbd
+    return dict(lbd)
 
 
 def get_desired_group_state(group_id, launch_config, desired):
@@ -82,11 +82,12 @@ def get_desired_group_state(group_id, launch_config, desired):
     NOTE: Currently this ignores draining timeout settings, since it has
     not been added to any schema yet.
     """
+    lbs = launch_config['args'].get('loadBalancers', [])
     server_lc = prepare_server_launch_config(
         group_id,
         freeze({'server': launch_config['args']['server']}),
-        freeze(launch_config['args']['loadBalancers']))
-    lbs = json_to_LBConfigs(launch_config['args']['loadBalancers'])
+        freeze(lbs))
+    lbs = json_to_LBConfigs(lbs)
     desired_state = DesiredGroupState(
         server_config=server_lc,
         capacity=desired, desired_lbs=lbs)

--- a/otter/convergence/composition.py
+++ b/otter/convergence/composition.py
@@ -56,18 +56,18 @@ def json_to_LBConfigs(lbs_json):
     """
     Convert load balancer config from JSON to :obj:`CLBDescription`
 
-    :param list lbs_json: List of load balancer configs
-    :return: `dict` of LBid -> [LBDescription] mapping
+    :param lbs_json: Sequence of load balancer configs
+    :return: mapping of LBid -> Sequence of LBDescription
 
     NOTE: Currently ignores RackConnectV3 configs. Will add them when it gets
     implemented in convergence
     """
-    lbd = defaultdict(list)
+    lbd = defaultdict()
     for lb in lbs_json:
         if lb.get('type') != 'RackConnectV3':
             lbd[lb['loadBalancerId']].append(CLBDescription(
                 lb_id=str(lb['loadBalancerId']), port=lb['port']))
-    return dict(lbd)
+    return freeze(dict(lbd))
 
 
 def get_desired_group_state(group_id, launch_config, desired):
@@ -82,11 +82,11 @@ def get_desired_group_state(group_id, launch_config, desired):
     NOTE: Currently this ignores draining timeout settings, since it has
     not been added to any schema yet.
     """
-    lbs = launch_config['args'].get('loadBalancers', [])
+    lbs = freeze(launch_config['args'].get('loadBalancers', []))
     server_lc = prepare_server_launch_config(
         group_id,
         freeze({'server': launch_config['args']['server']}),
-        freeze(lbs))
+        lbs)
     lbs = json_to_LBConfigs(lbs)
     desired_state = DesiredGroupState(
         server_config=server_lc,

--- a/otter/convergence/composition.py
+++ b/otter/convergence/composition.py
@@ -62,7 +62,7 @@ def json_to_LBConfigs(lbs_json):
     NOTE: Currently ignores RackConnectV3 configs. Will add them when it gets
     implemented in convergence
     """
-    lbd = defaultdict()
+    lbd = defaultdict(list)
     for lb in lbs_json:
         if lb.get('type') != 'RackConnectV3':
             lbd[lb['loadBalancerId']].append(CLBDescription(

--- a/otter/convergence/model.py
+++ b/otter/convergence/model.py
@@ -124,7 +124,7 @@ class NovaServer(object):
 
 
 @attributes(['server_config', 'capacity',
-             Attribute('desired_lbs', default_factory=dict, instance_of=dict),
+             Attribute('desired_lbs', default_factory=dict),
              Attribute('draining_timeout', default_value=0.0,
                        instance_of=float)])
 class DesiredGroupState(object):
@@ -145,6 +145,7 @@ class DesiredGroupState(object):
         Make attributes immutable.
         """
         self.server_config = freeze(self.server_config)
+        self.desired_lbs = freeze(self.desired_lbs)
 
 
 class ILBDescription(Interface):

--- a/otter/convergence/model.py
+++ b/otter/convergence/model.py
@@ -124,7 +124,7 @@ class NovaServer(object):
 
 
 @attributes(['server_config', 'capacity',
-             Attribute('desired_lbs', default_factory=dict),
+             Attribute('desired_lbs', default_factory=pmap, instance_of=PMap),
              Attribute('draining_timeout', default_value=0.0,
                        instance_of=float)])
 class DesiredGroupState(object):
@@ -145,7 +145,6 @@ class DesiredGroupState(object):
         Make attributes immutable.
         """
         self.server_config = freeze(self.server_config)
-        self.desired_lbs = freeze(self.desired_lbs)
 
 
 class ILBDescription(Interface):

--- a/otter/test/convergence/test_composition.py
+++ b/otter/test/convergence/test_composition.py
@@ -82,7 +82,8 @@ class GetDesiredGroupStateTests(SynchronousTestCase):
             DesiredGroupState(
                 server_config=expected_server_config,
                 capacity=2,
-                desired_lbs={23: [CLBDescription(lb_id='23', port=80)]}))
+                desired_lbs=freeze({
+                    23: [CLBDescription(lb_id='23', port=80)]})))
 
     def test_no_lbs(self):
         """
@@ -104,7 +105,7 @@ class GetDesiredGroupStateTests(SynchronousTestCase):
             DesiredGroupState(
                 server_config=expected_server_config,
                 capacity=2,
-                desired_lbs={}))
+                desired_lbs=pmap()))
 
 
 class ExecConvergenceTests(SynchronousTestCase):
@@ -145,7 +146,7 @@ class ExecConvergenceTests(SynchronousTestCase):
         get_all_convergence_data = self._get_gacd_func('gid')
         desired = DesiredGroupState(
             server_config={'server': {'name': 'test', 'flavorRef': 'f'}},
-            desired_lbs={23: [CLBDescription(lb_id='23', port=80)]},
+            desired_lbs=freeze({23: [CLBDescription(lb_id='23', port=80)]}),
             capacity=2)
 
         eff = execute_convergence(
@@ -181,7 +182,7 @@ class ExecConvergenceTests(SynchronousTestCase):
         """
         desired = DesiredGroupState(
             server_config={'server': {'name': 'test', 'flavorRef': 'f'}},
-            desired_lbs={},
+            desired_lbs=pmap(),
             capacity=2)
         get_all_convergence_data = self._get_gacd_func('gid')
         eff = execute_convergence(

--- a/otter/test/convergence/test_composition.py
+++ b/otter/test/convergence/test_composition.py
@@ -84,6 +84,28 @@ class GetDesiredGroupStateTests(SynchronousTestCase):
                 capacity=2,
                 desired_lbs={23: [CLBDescription(lb_id='23', port=80)]}))
 
+    def test_no_lbs(self):
+        """
+        When no loadBalancers are specified, the returned DesiredGroupState has
+        an empty mapping for desired_lbs.
+        """
+        server_config = {'name': 'test', 'flavorRef': 'f'}
+        lc = {'args': {'server': server_config}}
+
+        expected_server_config = {
+            'server': {
+                'name': 'test',
+                'flavorRef': 'f',
+                'metadata': {
+                    'rax:auto_scaling_group_id': 'uuid'}}}
+        state = get_desired_group_state('uuid', lc, 2)
+        self.assertEqual(
+            state,
+            DesiredGroupState(
+                server_config=expected_server_config,
+                capacity=2,
+                desired_lbs={}))
+
 
 class ExecConvergenceTests(SynchronousTestCase):
     """

--- a/otter/test/convergence/test_composition.py
+++ b/otter/test/convergence/test_composition.py
@@ -35,9 +35,9 @@ class JsonToLBConfigTests(SynchronousTestCase):
             json_to_LBConfigs([{'loadBalancerId': 20, 'port': 80},
                                {'loadBalancerId': 20, 'port': 800},
                                {'loadBalancerId': 21, 'port': 81}]),
-            {20: [CLBDescription(lb_id='20', port=80),
-                  CLBDescription(lb_id='20', port=800)],
-             21: [CLBDescription(lb_id='21', port=81)]})
+            freeze({20: [CLBDescription(lb_id='20', port=80),
+                         CLBDescription(lb_id='20', port=800)],
+                    21: [CLBDescription(lb_id='21', port=81)]}))
 
     def test_with_rackconnect(self):
         """
@@ -48,8 +48,8 @@ class JsonToLBConfigTests(SynchronousTestCase):
                 [{'loadBalancerId': 20, 'port': 80},
                  {'loadBalancerId': 200, 'type': 'RackConnectV3'},
                  {'loadBalancerId': 21, 'port': 81}]),
-            {20: [CLBDescription(lb_id='20', port=80)],
-             21: [CLBDescription(lb_id='21', port=81)]})
+            freeze({20: [CLBDescription(lb_id='20', port=80)],
+                    21: [CLBDescription(lb_id='21', port=81)]}))
 
 
 class GetDesiredGroupStateTests(SynchronousTestCase):

--- a/otter/test/convergence/test_planning.py
+++ b/otter/test/convergence/test_planning.py
@@ -1,6 +1,6 @@
 """Tests for convergence planning."""
 
-from pyrsistent import pbag, pmap, pset, s
+from pyrsistent import freeze, pbag, pmap, pset, s
 
 from toolz import groupby
 
@@ -264,7 +264,7 @@ class ConvergeLBStateTests(SynchronousTestCase):
         self.assertEqual(
             converge(
                 DesiredGroupState(server_config={}, capacity=1,
-                                  desired_lbs={'5': [clb_desc]}),
+                                  desired_lbs=freeze({'5': [clb_desc]})),
                 set([server('abc', ServerState.ACTIVE,
                             servicenet_address='1.1.1.1')]),
                 set(),
@@ -288,7 +288,7 @@ class ConvergeLBStateTests(SynchronousTestCase):
         self.assertEqual(
             converge(
                 DesiredGroupState(server_config={}, capacity=1,
-                                  desired_lbs=desired),
+                                  desired_lbs=freeze(desired)),
                 set([server('abc', ServerState.ACTIVE,
                             servicenet_address='1.1.1.1')]),
                 set(current),
@@ -310,7 +310,7 @@ class ConvergeLBStateTests(SynchronousTestCase):
         self.assertEqual(
             converge(
                 DesiredGroupState(server_config={}, capacity=1,
-                                  desired_lbs={}),
+                                  desired_lbs=pmap()),
                 set([server('abc', ServerState.ACTIVE,
                             servicenet_address='1.1.1.1')]),
                 set(current),
@@ -329,7 +329,7 @@ class ConvergeLBStateTests(SynchronousTestCase):
         self.assertEqual(
             converge(
                 DesiredGroupState(server_config={}, capacity=1,
-                                  desired_lbs=desired),
+                                  desired_lbs=freeze(desired)),
                 set([server('abc', ServerState.ACTIVE,
                             servicenet_address='1.1.1.1')]),
                 set(current),
@@ -350,7 +350,7 @@ class ConvergeLBStateTests(SynchronousTestCase):
         self.assertEqual(
             converge(
                 DesiredGroupState(server_config={}, capacity=1,
-                                  desired_lbs=desired),
+                                  desired_lbs=freeze(desired)),
                 set([server('abc', ServerState.ACTIVE,
                             servicenet_address='1.1.1.1')]),
                 set(current),
@@ -380,7 +380,7 @@ class ConvergeLBStateTests(SynchronousTestCase):
         self.assertEqual(
             converge(
                 DesiredGroupState(server_config={}, capacity=1,
-                                  desired_lbs=desired),
+                                  desired_lbs=freeze(desired)),
                 set([server('abc', ServerState.ACTIVE,
                             servicenet_address='1.1.1.1')]),
                 set(current),
@@ -714,7 +714,7 @@ class ConvergeTests(SynchronousTestCase):
         self.assertEqual(
             converge(
                 DesiredGroupState(server_config={}, capacity=1,
-                                  desired_lbs=desired_lbs),
+                                  desired_lbs=freeze(desired_lbs)),
                 set([server('abc', ServerState.ACTIVE,
                             servicenet_address='1.1.1.1', created=0),
                      server('bcd', ServerState.ACTIVE,
@@ -959,7 +959,7 @@ class PlanTests(SynchronousTestCase):
 
         desired_lbs = {5: [CLBDescription(lb_id='5', port=80)]}
         desired_group_state = DesiredGroupState(
-            server_config={}, capacity=8, desired_lbs=desired_lbs)
+            server_config={}, capacity=8, desired_lbs=freeze(desired_lbs))
 
         result = plan(
             desired_group_state,


### PR DESCRIPTION
if launch config doesn't have a `loadBalancers` key in `args`, get_desired_group_state would blow up.

I also changed `DesiredGroupState` to be a persistent data structure in this branch, mostly because otherwise I would have had conflicting branches which would be annoying.