### PR TITLE
Use server desired load balancers rather than the launch config one

### DIFF
--- a/otter/test/convergence/test_composition.py
+++ b/otter/test/convergence/test_composition.py
@@ -7,7 +7,7 @@ from effect.testing import Stub, resolve_effect
 
 import mock
 
-from pyrsistent import freeze, pmap
+from pyrsistent import freeze, pmap, pset
 
 from twisted.trial.unittest import SynchronousTestCase
 
@@ -94,15 +94,18 @@ class ExecConvergenceTests(SynchronousTestCase):
         """
         Sample server json
         """
+        self.desired_lbs = {23: [CLBDescription(lb_id='23', port=80)]}
         self.servers = [
             NovaServer(id='a',
                        state=ServerState.ACTIVE,
                        created=0,
-                       servicenet_address='10.0.0.1'),
+                       servicenet_address='10.0.0.1',
+                       desired_lbs=freeze(self.desired_lbs)),
             NovaServer(id='b',
                        state=ServerState.ACTIVE,
                        created=0,
-                       servicenet_address='10.0.0.2')
+                       servicenet_address='10.0.0.2',
+                       desired_lbs=freeze(self.desired_lbs))
         ]
 
     def _get_gacd_func(self, group_id):
@@ -119,7 +122,7 @@ class ExecConvergenceTests(SynchronousTestCase):
         get_all_convergence_data = self._get_gacd_func('gid')
         desired = DesiredGroupState(
             server_config={'server': {'name': 'test', 'flavorRef': 'f'}},
-            desired_lbs={23: [CLBDescription(lb_id='23', port=80)]},
+            desired_lbs=self.desired_lbs,
             capacity=2)
 
         eff = execute_convergence(
@@ -157,6 +160,10 @@ class ExecConvergenceTests(SynchronousTestCase):
             server_config={'server': {'name': 'test', 'flavorRef': 'f'}},
             desired_lbs={},
             capacity=2)
+
+        for server in self.servers:
+            server.desired_lbs = pmap()
+
         get_all_convergence_data = self._get_gacd_func('gid')
         eff = execute_convergence(
             'gid', desired,

--- a/otter/test/convergence/test_composition.py
+++ b/otter/test/convergence/test_composition.py
@@ -7,7 +7,7 @@ from effect.testing import Stub, resolve_effect
 
 import mock
 
-from pyrsistent import freeze, pmap, pset
+from pyrsistent import freeze, pmap
 
 from twisted.trial.unittest import SynchronousTestCase
 

--- a/otter/test/convergence/test_planning.py
+++ b/otter/test/convergence/test_planning.py
@@ -263,10 +263,10 @@ class ConvergeLBStateTests(SynchronousTestCase):
         clb_desc = CLBDescription(lb_id='5', port=80)
         self.assertEqual(
             converge(
-                DesiredGroupState(server_config={}, capacity=1,
-                                  desired_lbs={'5': [clb_desc]}),
+                DesiredGroupState(server_config={}, capacity=1),
                 set([server('abc', ServerState.ACTIVE,
-                            servicenet_address='1.1.1.1')]),
+                            servicenet_address='1.1.1.1',
+                            desired_lbs=pmap({'5': pset([clb_desc])}))]),
                 set(),
                 0),
             pbag([
@@ -281,16 +281,16 @@ class ConvergeLBStateTests(SynchronousTestCase):
         but the configuration is wrong, `converge_lb_state` returns a
         :class:`ChangeCLBNode` object
         """
-        desired = {'5': [CLBDescription(lb_id='5', port=80)]}
+        desired = pmap({'5': pset([CLBDescription(lb_id='5', port=80)])})
         current = [CLBNode(node_id='123', address='1.1.1.1',
                            description=CLBDescription(
                                lb_id='5', port=80, weight=5))]
         self.assertEqual(
             converge(
-                DesiredGroupState(server_config={}, capacity=1,
-                                  desired_lbs=desired),
+                DesiredGroupState(server_config={}, capacity=1),
                 set([server('abc', ServerState.ACTIVE,
-                            servicenet_address='1.1.1.1')]),
+                            servicenet_address='1.1.1.1',
+                            desired_lbs=desired)]),
                 set(current),
                 0),
             pbag([
@@ -309,10 +309,10 @@ class ConvergeLBStateTests(SynchronousTestCase):
 
         self.assertEqual(
             converge(
-                DesiredGroupState(server_config={}, capacity=1,
-                                  desired_lbs={}),
+                DesiredGroupState(server_config={}, capacity=1),
                 set([server('abc', ServerState.ACTIVE,
-                            servicenet_address='1.1.1.1')]),
+                            servicenet_address='1.1.1.1',
+                            desired_lbs=pmap())]),
                 set(current),
                 0),
             pbag([RemoveFromCLB(lb_id='5', node_id='123')]))
@@ -322,16 +322,16 @@ class ConvergeLBStateTests(SynchronousTestCase):
         If the desired lb state matches the current lb state,
         `converge_lb_state` returns nothing
         """
-        desired = {'5': [CLBDescription(lb_id='5', port=80)]}
+        desired = pmap({'5': pset([CLBDescription(lb_id='5', port=80)])})
         current = [CLBNode(node_id='123', address='1.1.1.1',
                            description=CLBDescription(lb_id='5', port=80))]
 
         self.assertEqual(
             converge(
-                DesiredGroupState(server_config={}, capacity=1,
-                                  desired_lbs=desired),
+                DesiredGroupState(server_config={}, capacity=1),
                 set([server('abc', ServerState.ACTIVE,
-                            servicenet_address='1.1.1.1')]),
+                            servicenet_address='1.1.1.1',
+                            desired_lbs=desired)]),
                 set(current),
                 0),
             pbag([]))
@@ -340,8 +340,9 @@ class ConvergeLBStateTests(SynchronousTestCase):
         """
         Remove, change, and add a node to a load balancer all together
         """
-        desired = {'5': [CLBDescription(lb_id='5', port=80)],
-                   '6': [CLBDescription(lb_id='6', port=80, weight=2)]}
+        desired = pmap({'5': pset([CLBDescription(lb_id='5', port=80)]),
+                        '6': pset([CLBDescription(lb_id='6', port=80,
+                                   weight=2)])})
         current = [CLBNode(node_id='123', address='1.1.1.1',
                            description=CLBDescription(lb_id='5', port=8080)),
                    CLBNode(node_id='234', address='1.1.1.1',
@@ -349,10 +350,10 @@ class ConvergeLBStateTests(SynchronousTestCase):
 
         self.assertEqual(
             converge(
-                DesiredGroupState(server_config={}, capacity=1,
-                                  desired_lbs=desired),
+                DesiredGroupState(server_config={}, capacity=1),
                 set([server('abc', ServerState.ACTIVE,
-                            servicenet_address='1.1.1.1')]),
+                            servicenet_address='1.1.1.1',
+                            desired_lbs=desired)]),
                 set(current),
                 0),
             pbag([
@@ -374,15 +375,15 @@ class ConvergeLBStateTests(SynchronousTestCase):
         (use case: running multiple single-threaded server processes on a
         machine)
         """
-        desired = {'5': [CLBDescription(lb_id='5', port=8080),
-                         CLBDescription(lb_id='5', port=8081)]}
+        desired = pmap({'5': pset([CLBDescription(lb_id='5', port=8080),
+                                   CLBDescription(lb_id='5', port=8081)])})
         current = []
         self.assertEqual(
             converge(
-                DesiredGroupState(server_config={}, capacity=1,
-                                  desired_lbs=desired),
+                DesiredGroupState(server_config={}, capacity=1),
                 set([server('abc', ServerState.ACTIVE,
-                            servicenet_address='1.1.1.1')]),
+                            servicenet_address='1.1.1.1',
+                            desired_lbs=desired)]),
                 set(current),
                 0),
             pbag([


### PR DESCRIPTION
When converging.  This way we don't move old servers to new load balancers.

Last task of #968.