### PR TITLE
Fix the AddNodesToCLB step

### DIFF
--- a/otter/convergence/steps.py
+++ b/otter/convergence/steps.py
@@ -1,5 +1,5 @@
 """Steps for convergence."""
-import json
+
 import re
 
 from functools import partial

--- a/otter/convergence/steps.py
+++ b/otter/convergence/steps.py
@@ -1,5 +1,5 @@
 """Steps for convergence."""
-
+import json
 import re
 
 from functools import partial
@@ -10,10 +10,13 @@ from effect import Effect, Func
 
 from pyrsistent import pset, thaw
 
+from toolz.functoolz import memoize
+
 from zope.interface import Interface, implementer
 
 from otter.constants import ServiceType
 from otter.http import has_code, service_request
+from otter.util.fp import predicate_any
 from otter.util.hashkey import generate_server_name
 from otter.util.http import append_segments
 
@@ -106,6 +109,35 @@ class SetMetadataItemOnServer(object):
             data={'meta': {self.key: self.value}})
 
 
+_CLB_DUPLICATE_NODES_PATTERN = re.compile(
+    "^Duplicate nodes detected. One or more nodes already configured "
+    "on load balancer.$")
+
+
+@memoize
+def _check_clb_422(regex_match):
+    """
+    A success predicate that succeeds if the status code is 422 and the content
+    matches the regex.  Used for detecting duplicate nodes on add to CLB, and
+    the load balancer being deleted or pending delete on remove from CLB.
+
+    It's unfortunate this involves parsing the body.
+    """
+    def check_response(response, content):
+        """
+        Check that the given response has a 422 code and its body matches the
+        regex.
+
+        Expects the content to be JSON, so whatever uses this should make sure
+        that the service request is called with ``json_response=True``,
+        which it should be by default.
+        """
+        return (response.code == 422 and
+                regex_match.search(content.get('message', '')))
+
+    return check_response
+
+
 @implementer(IStep)
 @attributes(['lb_id', 'address_configs'])
 class AddNodesToCLB(object):
@@ -118,6 +150,14 @@ class AddNodesToCLB(object):
 
     :param address_configs: A collection of two-tuples of address and
         :obj:`CLBDescription`.
+
+    Succeed unconditionally on 202 and 413 (over limit, which happens because
+    CLB locks for a few seconds and cannot be changed again after an update -
+    can be fixed next convergence cycle).
+
+    Succeed conditionally on 422 if duplicate nodes are detected - the
+    duplicate codes are not enumerated, so just try again the next convergence
+    cycle.
     """
     def as_effect(self):
         """Produce a :obj:`Effect` to add nodes to CLB"""
@@ -130,10 +170,9 @@ class AddNodesToCLB(object):
                              'weight': lbc.weight,
                              'type': lbc.type.name}
                             for address, lbc in self.address_configs]},
-            # if 413 (overLimit, which happens because CLB locks for a few
-            # seconds and cannot be changed again after an update), do not
-            # fail, just try again the next convegence cycle.
-            success_pred=has_code(202, 413))
+            success_pred=predicate_any(
+                has_code(202, 413),
+                _check_clb_422(_CLB_DUPLICATE_NODES_PATTERN)))
 
 
 @implementer(IStep)

--- a/otter/test/convergence/test_composition.py
+++ b/otter/test/convergence/test_composition.py
@@ -19,7 +19,7 @@ from otter.convergence.composition import (
     tenant_is_enabled)
 from otter.convergence.model import (
     CLBDescription, DesiredGroupState, NovaServer, ServerState)
-from otter.http import has_code, service_request
+from otter.http import service_request
 from otter.test.utils import resolve_stubs
 
 
@@ -164,7 +164,7 @@ class ExecConvergenceTests(SynchronousTestCase):
             'POST',
             'loadbalancers/23/nodes',
             data=mock.ANY,
-            success_pred=has_code(202, 413))
+            success_pred=mock.ANY)
         got_req = eff.intent.effects[0].intent
         self.assertEqual(got_req, expected_req.intent)
         # separate check for nodes; they are unique, but can be in any order

--- a/otter/test/convergence/test_composition.py
+++ b/otter/test/convergence/test_composition.py
@@ -19,7 +19,7 @@ from otter.convergence.composition import (
     tenant_is_enabled)
 from otter.convergence.model import (
     CLBDescription, DesiredGroupState, NovaServer, ServerState)
-from otter.http import service_request
+from otter.http import has_code, service_request
 from otter.test.utils import resolve_stubs
 
 
@@ -162,8 +162,9 @@ class ExecConvergenceTests(SynchronousTestCase):
         expected_req = service_request(
             ServiceType.CLOUD_LOAD_BALANCERS,
             'POST',
-            'loadbalancers/23',
-            data=mock.ANY)
+            'loadbalancers/23/nodes',
+            data=mock.ANY,
+            success_pred=has_code(202, 413))
         got_req = eff.intent.effects[0].intent
         self.assertEqual(got_req, expected_req.intent)
         # separate check for nodes; they are unique, but can be in any order

--- a/otter/test/convergence/test_steps.py
+++ b/otter/test/convergence/test_steps.py
@@ -20,9 +20,9 @@ from otter.convergence.steps import (
     DeleteServer,
     RemoveFromCLB,
     SetMetadataItemOnServer,
-    _rcv3_check_bulk_delete,
     _RCV3_LB_INACTIVE_PATTERN,
-    _RCV3_NODE_NOT_A_MEMBER_PATTERN)
+    _RCV3_NODE_NOT_A_MEMBER_PATTERN,
+    _rcv3_check_bulk_delete)
 from otter.http import has_code, service_request
 from otter.test.utils import StubResponse
 from otter.util.hashkey import generate_server_name

--- a/otter/test/convergence/test_steps.py
+++ b/otter/test/convergence/test_steps.py
@@ -3,12 +3,16 @@
 from effect import Func
 from effect.testing import resolve_effect
 
+from mock import ANY
+
 from pyrsistent import freeze, pset
 
 from twisted.trial.unittest import SynchronousTestCase
 
 from otter.constants import ServiceType
+from otter.convergence.model import CLBDescription
 from otter.convergence.steps import (
+    AddNodesToCLB,
     BulkAddToRCv3,
     BulkRemoveFromRCv3,
     ChangeCLBNode,
@@ -51,8 +55,8 @@ class StepAsEffectTests(SynchronousTestCase):
 
     def test_create_server_noname(self):
         """
-        When no name is provided in the launch config, the name will be
-        generated from scratch.
+        :obj:`CreateServer.as_effect`, when no name is provided in the launch
+        config, will generate the name will from scratch.
         """
         create = CreateServer(
             server_config=freeze({'server': {'flavorRef': '1'}}))
@@ -130,6 +134,48 @@ class StepAsEffectTests(SynchronousTestCase):
                 'loadbalancers/abc123/nodes/node1',
                 data={'condition': 'DRAINING',
                       'weight': 50}))
+
+    def test_add_nodes_to_clb(self):
+        """
+        :obj:`AddNodesToCLB` produces a request for adding any number of nodes
+        to a cloud load balancer.
+        """
+        lb_id = "12345"
+        lb_nodes = pset([
+            ('1.2.3.4', CLBDescription(lb_id=lb_id, port=80)),
+            ('1.2.3.4', CLBDescription(lb_id=lb_id, port=8080)),
+            ('2.3.4.5', CLBDescription(lb_id=lb_id, port=80))
+        ])
+        step = AddNodesToCLB(lb_id=lb_id, address_configs=lb_nodes)
+        request = step.as_effect()
+
+        self.assertEqual(request.intent.service_type,
+                         ServiceType.CLOUD_LOAD_BALANCERS)
+        self.assertEqual(request.intent.method, 'POST')
+        self.assertEqual(request.intent.success_pred, has_code(202, 413))
+        self.assertEqual(request.intent.url, "loadbalancers/12345/nodes")
+        self.assertEqual(request.intent.headers, None)
+
+        self.assertEqual(request.intent.data, {"nodes": ANY})
+        node_data = sorted(request.intent.data['nodes'],
+                           key=lambda n: (n['address'], n['port']))
+        self.assertEqual(node_data, [
+            {'address': '1.2.3.4',
+             'port': 80,
+             'condition': 'ENABLED',
+             'type': 'PRIMARY',
+             'weight': 1},
+            {'address': '1.2.3.4',
+             'port': 8080,
+             'condition': 'ENABLED',
+             'type': 'PRIMARY',
+             'weight': 1},
+            {'address': '2.3.4.5',
+             'port': 80,
+             'condition': 'ENABLED',
+             'type': 'PRIMARY',
+             'weight': 1}
+        ])
 
     def _generic_bulk_rcv3_step_test(self, step_class, expected_method):
         """

--- a/otter/test/convergence/test_steps.py
+++ b/otter/test/convergence/test_steps.py
@@ -3,8 +3,6 @@
 from effect import Func
 from effect.testing import resolve_effect
 
-import json
-
 from mock import ANY
 
 from pyrsistent import freeze, pset
@@ -27,7 +25,6 @@ from otter.convergence.steps import (
     _rcv3_check_bulk_delete)
 from otter.http import has_code, service_request
 from otter.test.utils import StubResponse
-from otter.util.fp import predicate_any
 from otter.util.hashkey import generate_server_name
 
 

--- a/otter/test/util/test_fp.py
+++ b/otter/test/util/test_fp.py
@@ -45,8 +45,9 @@ class PredicateAllTests(SynchronousTestCase):
         Works with multiple keyword argument predicates
         """
         self.assertTrue(
-            predicate_all(lambda **k: k['a'] % 2 == 0 and k['b'] % 2 == 0,
-                          lambda **k: k['a'] % 3 == 0 and k['b'] % 3 == 0)(a=6, b=12))
+            predicate_all(
+                lambda **k: k['a'] % 2 == 0 and k['b'] % 2 == 0,
+                lambda **k: k['a'] % 3 == 0 and k['b'] % 3 == 0)(a=6, b=12))
 
 
 class PredicateAnyTests(SynchronousTestCase):

--- a/otter/test/util/test_fp.py
+++ b/otter/test/util/test_fp.py
@@ -2,7 +2,7 @@
 
 from twisted.trial.unittest import SynchronousTestCase
 
-from otter.util.fp import predicate_all
+from otter.util.fp import predicate_all, predicate_any
 
 
 class PredicateAllTests(SynchronousTestCase):
@@ -47,3 +47,48 @@ class PredicateAllTests(SynchronousTestCase):
         self.assertTrue(
             predicate_all(lambda **k: k['a'] % 2 == 0 and k['b'] % 2 == 0,
                           lambda **k: k['a'] % 3 == 0 and k['b'] % 3 == 0)(a=6, b=12))
+
+
+class PredicateAnyTests(SynchronousTestCase):
+    """
+    Tests for :func:`otter.util.fp.predicate_any`
+    """
+
+    def test_combines_predicates(self):
+        """
+        Combine many predicates and returns another predicate
+        function after applying or operator
+        """
+        p1 = lambda a: a % 2 == 0
+        p2 = lambda a: a % 3 == 0
+        p3 = lambda a: a % 5 == 0
+        p = predicate_any(p1, p2, p3)
+        self.assertTrue(p(2))
+        self.assertTrue(p(3))
+        self.assertTrue(p(5))
+        self.assertTrue(p(30))
+        self.assertFalse(p(7))
+        self.assertFalse(p(11))
+
+    def test_combines_one(self):
+        """
+        Succeed with one arg also.
+        """
+        self.assertTrue(predicate_any(lambda a: a % 2 == 0)(4))
+
+    def test_multiple_args(self):
+        """
+        Succeed with multiple argument predicates.
+        """
+        self.assertTrue(
+            predicate_any(lambda a, b: a % 2 == 0 and b % 2 == 0,
+                          lambda a, b: a % 3 == 0 and b % 3 == 0)(2, 4))
+
+    def test_multiple_kw_args(self):
+        """
+        Succeed with multiple keyword argument predicates.
+        """
+        self.assertTrue(
+            predicate_any(
+                lambda **k: k['a'] % 2 == 0 and k['b'] % 2 == 0,
+                lambda **k: k['a'] % 3 == 0 and k['b'] % 3 == 0)(a=2, b=4))

--- a/otter/util/fp.py
+++ b/otter/util/fp.py
@@ -70,3 +70,11 @@ def predicate_all(*preds):
     with and operator
     """
     return lambda *a, **kw: all(p(*a, **kw) for p in preds)
+
+
+def predicate_any(*preds):
+    """
+    Return a predicate function that combines all the given predicate functions
+    with or operator
+    """
+    return lambda *a, **kw: any(p(*a, **kw) for p in preds)


### PR DESCRIPTION
- the url is `/loadbalancer/<lbid>/nodes`
- succeed on 413 because we want to retry on the next convergence cycle
- succeed on 422 (only duplicate nodes) because we can't figure out which nodes are duplicate - wait for next convergence cycle.
- add tests

Part of #989