### PR TITLE
Makefile improvements for building documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ cleandocs:
 	rm -rf htmldoc
 	rm -rf docbook/target
 
-docs: sphinxdocs
+docs: sphinxdocs docbook
 
 sphinxdocs:
 	cp -r ${DOCDIR} _builddoc

--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,9 @@ cleandocs:
 	rm -rf htmldoc
 	rm -rf docbook/target
 
-docs:
+docs: sphinxdocs
+
+sphinxdocs:
 	cp -r ${DOCDIR} _builddoc
 	sphinx-apidoc -F -T -o _builddoc ${CODEDIR}
 	sphinx-apidoc -F -T -o _builddoc ${TESTDIR2}

--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,6 @@ sphinxdocs:
 	sphinx-apidoc -F -T -o _builddoc ${TESTDIR1}
 	sphinx-apidoc -F -T -o _builddoc ${TESTDIR3}
 	sphinx-build -b html _builddoc htmldoc
-	rm -rf _builddoc
 
 schema: FORCE schema-setup schema-teardown
 

--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,11 @@ sphinxdocs:
 	sphinx-build -b html _builddoc htmldoc
 
 docbook:
+ifneq ($(shell git diff --name-only ${DIFF_TARGET} -- docbook), )
 	cd docbook; mvn -q compile
+else
+	echo "Skipping, nothing changed between working tree and diff target"
+endif
 
 schema: FORCE schema-setup schema-teardown
 

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ CLOUDCAFE ?= $(shell which cafe-runner)
 
 mkfile_dir := $(shell dirname "$(MAKEFILE_LIST)")
 
-.PHONY: targets env-precheck
+.PHONY: targets env-precheck docbook
 
 targets:
 	@cat README.md
@@ -102,6 +102,9 @@ sphinxdocs:
 	sphinx-apidoc -F -T -o _builddoc ${TESTDIR1}
 	sphinx-apidoc -F -T -o _builddoc ${TESTDIR3}
 	sphinx-build -b html _builddoc htmldoc
+
+docbook:
+	cd docbook; mvn -q compile
 
 schema: FORCE schema-setup schema-teardown
 

--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ cleandocs:
 	rm -rf htmldoc
 	rm -rf docbook/target
 
-docs: cleandocs
+docs:
 	cp -r ${DOCDIR} _builddoc
 	sphinx-apidoc -F -T -o _builddoc ${CODEDIR}
 	sphinx-apidoc -F -T -o _builddoc ${TESTDIR2}

--- a/README.md
+++ b/README.md
@@ -63,7 +63,9 @@ Run tests, check code quality:
 
 Build the documentation:
 
-- `make docs` builds customer-facing documentation.
+- `make docs` builds all other documentation targets (listed below).
+- `make sphinxdocs` builds all Sphinx documentation.
+- `make docbook` builds all user-facing Docbook documentation.
 
 ### Deployment
 
@@ -73,7 +75,7 @@ Build the documentation:
 
 ### Cleaning up
 
-- `make cleandocs` removes customer-facing documentation without
+- `make cleandocs` removes all documentation artifacts without
   removing other artifacts.
 - `make clean` removes all build-time artifacts, leaving the
   repository in a distributable state.


### PR DESCRIPTION
This also moves more behavior into the Makefile so that Jenkins can leverage it effectively, while having as little behavior as possible living in Jenkins.