### PR TITLE
Pass query parameters to treq through the Request intent.

### DIFF
--- a/otter/test/rest/test_history.py
+++ b/otter/test/rest/test_history.py
@@ -136,7 +136,7 @@ class OtterHistoryTestCase(RestAPITestMixin, SynchronousTestCase):
             return_value={'tenant_id': 101010})
 
         req = ('GET', 'http://dummy/_search', None,
-               '{"tenant_id": 101010}', {'log': mock.ANY})
+               '{"tenant_id": 101010}', None, {'log': mock.ANY})
         resp = StubResponse(200, {})
 
         self.treq = StubTreq(

--- a/otter/test/util/test_pure_http.py
+++ b/otter/test/util/test_pure_http.py
@@ -49,7 +49,7 @@ class RequestEffectTests(SynchronousTestCase):
         The Request effect dispatches a request to treq, and returns a
         two-tuple of the Twisted Response object and the content as bytes.
         """
-        req = ('GET', 'http://google.com/', None, None,  {'log': None})
+        req = ('GET', 'http://google.com/', None, None, None, {'log': None})
         response = StubResponse(200, {})
         treq = StubTreq(reqs=[(req, response)],
                         contents=[(response, "content")])
@@ -66,7 +66,7 @@ class RequestEffectTests(SynchronousTestCase):
         implementation.
         """
         log = object()
-        req = ('GET', 'http://google.com/', None, None, {'log': log})
+        req = ('GET', 'http://google.com/', None, None, None, {'log': log})
         response = StubResponse(200, {})
         treq = StubTreq(reqs=[(req, response)],
                         contents=[(response, "content")])

--- a/otter/test/utils.py
+++ b/otter/test/utils.py
@@ -369,7 +369,7 @@ class StubTreq(object):
         BoundLog, that's being ignored for now.
         """
         key = (method, url, kwargs.pop('headers', None),
-               kwargs.pop('data', None), kwargs)
+               kwargs.pop('data', None), kwargs.pop('params', None), kwargs)
         return succeed(alist_get(self.reqs, key))
 
     def content(self, response):

--- a/otter/test/worker/test_launch_server_v1.py
+++ b/otter/test/worker/test_launch_server_v1.py
@@ -1084,7 +1084,9 @@ class ServerTests(SynchronousTestCase):
         """
         req = ('POST', 'http://url/servers',
                headers('my-auth-token'),
-               json.dumps({'server': {'some': 'stuff'}}), {'log': mock.ANY})
+               json.dumps({'server': {'some': 'stuff'}}),
+               None,
+               {'log': mock.ANY})
         resp = StubResponse(202, {})
 
         _treq = StubTreq([(req, resp)], [(resp, '{"server": "created"}')])
@@ -1137,7 +1139,9 @@ class ServerTests(SynchronousTestCase):
         """
         req = ('POST', 'http://url/servers',
                headers('my-auth-token'),
-               json.dumps({'server': {}}), {'log': mock.ANY})
+               json.dumps({'server': {}}),
+               None,
+               {'log': mock.ANY})
         resp = StubResponse(500, {})
 
         clock = Clock()
@@ -1167,7 +1171,9 @@ class ServerTests(SynchronousTestCase):
         """
         req = ('POST', 'http://url/servers',
                headers('my-auth-token'),
-               json.dumps({'server': {'some': 'stuff'}}), {'log': mock.ANY})
+               json.dumps({'server': {'some': 'stuff'}}),
+               None,
+               {'log': mock.ANY})
         resp = StubResponse(500, {})
 
         clock = Clock()
@@ -1193,7 +1199,9 @@ class ServerTests(SynchronousTestCase):
         """
         req = ('POST', 'http://url/servers',
                headers('my-auth-token'),
-               json.dumps({'server': {}}), {'log': mock.ANY})
+               json.dumps({'server': {}}),
+               None,
+               {'log': mock.ANY})
         resp = StubResponse(500, {})
 
         clock = Clock()
@@ -1226,7 +1234,9 @@ class ServerTests(SynchronousTestCase):
         """
         req = ('POST', 'http://url/servers',
                headers('my-auth-token'),
-               json.dumps({'server': {}}), {'log': mock.ANY})
+               json.dumps({'server': {}}),
+               None,
+               {'log': mock.ANY})
         resp = StubResponse(500, {})
 
         _treq = StubTreq([(req, resp)], [(resp, error_body)])
@@ -1253,7 +1263,9 @@ class ServerTests(SynchronousTestCase):
         """
         req = ('POST', 'http://url/servers',
                headers('my-auth-token'),
-               json.dumps({'server': {}}), {'log': mock.ANY})
+               json.dumps({'server': {}}),
+               None,
+               {'log': mock.ANY})
         resp = StubResponse(400, {})
 
         _treq = StubTreq([(req, resp)], [(resp, "User error!")])

--- a/otter/util/pure_http.py
+++ b/otter/util/pure_http.py
@@ -20,8 +20,9 @@ from otter.util import logging_treq
 from otter.util.http import APIError
 
 
-@attributes(['method', 'url', 'headers', 'data', 'log'],
-            defaults={'headers': None, 'data': None, 'log': None})
+@attributes(['method', 'url', 'headers', 'data', 'params', 'log'],
+            defaults={'headers': None, 'data': None, 'params': None,
+                      'log': None})
 class Request(object):
     """
     An effect request for performing HTTP requests.
@@ -42,7 +43,9 @@ def perform_request(dispatcher, intent):
     """
     response = yield intent.treq.request(intent.method.upper(), intent.url,
                                          headers=intent.headers,
-                                         data=intent.data, log=intent.log)
+                                         data=intent.data,
+                                         params=intent.params,
+                                         log=intent.log)
     content = yield intent.treq.content(response)
     returnValue((response, content))
 


### PR DESCRIPTION
For bulk CLB deletes.