### PR TITLE
Make mimic put server in building for 3 seconds for one LB test.

### DIFF
--- a/autoscale_cloudroast/test_repo/autoscale/system/integration/test_system_integration_lbaas.py
+++ b/autoscale_cloudroast/test_repo/autoscale/system/integration/test_system_integration_lbaas.py
@@ -356,7 +356,8 @@ class AutoscaleLbaasFixture(AutoscaleFixture):
         """
         load_balancer_list = [self.lb_other_region]
         for each_load_balancer in load_balancer_list:
-            group = self._create_group_given_lbaas_id(each_load_balancer)
+            group = self._create_group_given_lbaas_id(each_load_balancer,
+                                                      server_building="3")
             self._wait_for_servers_to_be_deleted_when_lb_invalid(
                 group.id, group.groupConfiguration.minEntities)
             self.assert_servers_deleted_successfully(


### PR DESCRIPTION
Ensure that `test_negative_scaling_group_with_invalid_load_balancer` creates a server that will remain in building for >0 seconds when running on mimic, since that's what it expects (since it expects the server to show up, and then get deleted when adding to the load balancer fails).

Fixes #1015 