### PR TITLE
On delete success, response is still None, so accept that in _rcv3.

### DIFF
--- a/otter/test/worker/test_rcv3.py
+++ b/otter/test/worker/test_rcv3.py
@@ -53,6 +53,9 @@ class RCv3Tests(SynchronousTestCase):
         self.dispatcher = object()
         self.request_bag = _RequestBag(dispatcher=self.dispatcher,
                                        tenant_id='thetenantid')
+        self.post_response = (StubResponse(201, {}),
+                              _rcv3_add_response_body("lb_id", "server_id"))
+        self.del_response = None
 
     def _fake_perform(self, dispatcher, effect):
         """
@@ -82,14 +85,11 @@ class RCv3Tests(SynchronousTestCase):
         if req.method == "POST":
             self.assertEqual(req.success_pred, has_code(201))
             # http://docs.rcv3.apiary.io/#post-%2Fv3%2F{tenant_id}%2Fload_balancer_pools%2Fnodes
-            response = (StubResponse(201, {}),
-                        _rcv3_add_response_body("lb_id", "server_id"))
+            return succeed([self.post_response])
         elif req.method == "DELETE":
             self.assertEqual(req.success_pred, has_code(204, 409))
             # http://docs.rcv3.apiary.io/#delete-%2Fv3%2F{tenant_id}%2Fload_balancer_pools%2Fnode
-            response = None
-
-        return succeed([response])
+            return succeed([self.del_response])
 
     def test_add_to_rcv3(self):
         """
@@ -99,6 +99,14 @@ class RCv3Tests(SynchronousTestCase):
         (add_result,) = self.successResultOf(d)
         self.assertEqual(add_result["cloud_server"], {"id": "server_id"})
         self.assertEqual(add_result["load_balancer_pool"], {"id": "lb_id"})
+
+    def test_add_to_rcv3_fail_when_body_none(self):
+        """
+        :func:`_rcv3.add_to_rcv3` attempts to perform the correct effect.
+        """
+        self.post_response = None
+        d = _rcv3.add_to_rcv3(self.request_bag, "lb_id", "server_id")
+        self.failureResultOf(d)
 
     def test_remove_from_rcv3(self):
         """

--- a/otter/test/worker/test_rcv3.py
+++ b/otter/test/worker/test_rcv3.py
@@ -13,6 +13,7 @@ from twisted.trial.unittest import SynchronousTestCase
 from otter.constants import ServiceType
 from otter.util.pure_http import has_code
 from otter.worker import _rcv3
+from otter.test.utils import StubResponse
 
 
 def _rcv3_add_response_body(lb_id, server_id):
@@ -81,14 +82,14 @@ class RCv3Tests(SynchronousTestCase):
         if req.method == "POST":
             self.assertEqual(req.success_pred, has_code(201))
             # http://docs.rcv3.apiary.io/#post-%2Fv3%2F{tenant_id}%2Fload_balancer_pools%2Fnodes
-            body = _rcv3_add_response_body("lb_id", "server_id")
+            response = (StubResponse(201, {}),
+                        _rcv3_add_response_body("lb_id", "server_id"))
         elif req.method == "DELETE":
             self.assertEqual(req.success_pred, has_code(204, 409))
             # http://docs.rcv3.apiary.io/#delete-%2Fv3%2F{tenant_id}%2Fload_balancer_pools%2Fnode
-            body = None
+            response = None
 
-        fake_response = object()
-        return succeed([(fake_response, body)])
+        return succeed([response])
 
     def test_add_to_rcv3(self):
         """

--- a/otter/test/worker/test_rcv3.py
+++ b/otter/test/worker/test_rcv3.py
@@ -11,9 +11,9 @@ from twisted.internet.defer import succeed
 from twisted.trial.unittest import SynchronousTestCase
 
 from otter.constants import ServiceType
+from otter.test.utils import StubResponse
 from otter.util.pure_http import has_code
 from otter.worker import _rcv3
-from otter.test.utils import StubResponse
 
 
 def _rcv3_add_response_body(lb_id, server_id):

--- a/otter/worker/_rcv3.py
+++ b/otter/worker/_rcv3.py
@@ -35,7 +35,14 @@ def _generic_rcv3_request(step_class, request_bag, lb_id, server_id):
     d = perform(request_bag.dispatcher, scoped)
 
     def get_response_body(result):
+        # The body must be provided for adding, because that is stored in
+        # the DB so that the worker can delete the server and remove it
+        # from all the load balancers later.  The body is unimportant for
+        # deletes.
+
+        # TODO: when/before #956 lands, this needs refactoring
         if result[0] is None:
+            assert step_class == BulkRemoveFromRCv3
             return None
         else:
             _response, body = result[0]

--- a/otter/worker/_rcv3.py
+++ b/otter/worker/_rcv3.py
@@ -35,8 +35,11 @@ def _generic_rcv3_request(step_class, request_bag, lb_id, server_id):
     d = perform(request_bag.dispatcher, scoped)
 
     def get_response_body(result):
-        _response, body = result[0]
-        return body
+        if result[0] is None:
+            return None
+        else:
+            _response, body = result[0]
+            return body
 
     return d.addCallback(get_response_body)
 


### PR DESCRIPTION
There is still a `'NoneType' object is not iterable` bug, but now it occurs in `_rcv3.py`.

If a delete is successful, `None` is still returned rather than a tuple of (response, body), for instance [here](https://github.com/rackerlabs/otter/blob/master/otter/convergence/steps.py#L386) and also if there is no retry.

I wasn't sure if we wanted the contract for `Step.as_effect()` to always be to return `(response, body)` no matter what, so I made the change just in `_rcv3.py`.  Happy to go the other way.

This fixes the new test fixes introduced in https://github.com/rackerlabs/otter/pull/1027.