### PR TITLE
cloudcafe dev/preprod/ci testing change

### DIFF
--- a/autoscale_cloudcafe/autoscale/config.py
+++ b/autoscale_cloudcafe/autoscale/config.py
@@ -342,3 +342,11 @@ class AutoscaleConfig(ConfigSectionInterface):
         Specify the cloud network to use with RackConnect
         """
         return self.get('rcv3_cloud_network')
+
+    @property
+    def environment(self):
+        """
+        Read the environment for the config.  For example, dev, ci, etc.
+        Default is production.
+        """
+        return self.get('environment', 'production')

--- a/autoscale_cloudcafe/configs/autoscale/dev.config
+++ b/autoscale_cloudcafe/configs/autoscale/dev.config
@@ -45,6 +45,7 @@ lc_uuid=11111111-1111-1111-1111-111111111111
 lc_uuid2=00000000-0000-0000-0000-000000000000
 interval_time=5
 timeout=30
+environment=dev
 
 region=ord
 autoscale_endpoint_name=endpoint_in_service_catalog

--- a/autoscale_cloudroast/test_repo/autoscale/fixtures.py
+++ b/autoscale_cloudroast/test_repo/autoscale/fixtures.py
@@ -71,13 +71,14 @@ class AutoscaleFixture(BaseTestFixture):
 
         cls.tenant_id = cls.autoscale_config.tenant_id
 
-        # If not production or staging, always use the configured server
-        # endpoint instead of what's in the service catalog.
         if cls.autoscale_config.environment in ('production', 'staging'):
             autoscale_service = access_data.get_service(
                 cls.autoscale_config.autoscale_endpoint_name)
             cls.url = autoscale_service.get_endpoint(
                 cls.autoscale_config.region).public_url
+
+        # If not production or staging, always use the configured server
+        # endpoint instead of what's in the service catalog.
         else:
             cls.url = "{0}/{1}".format(
                 cls.autoscale_config.server_endpoint, cls.tenant_id)

--- a/autoscale_cloudroast/test_repo/autoscale/fixtures.py
+++ b/autoscale_cloudroast/test_repo/autoscale/fixtures.py
@@ -5,7 +5,6 @@ from __future__ import print_function
 
 
 import json
-import os
 import time
 from functools import partial
 

--- a/autoscale_cloudroast/test_repo/autoscale/fixtures.py
+++ b/autoscale_cloudroast/test_repo/autoscale/fixtures.py
@@ -72,16 +72,17 @@ class AutoscaleFixture(BaseTestFixture):
 
         cls.tenant_id = cls.autoscale_config.tenant_id
 
-        env = os.environ['OSTNG_CONFIG_FILE']
-        if ('preprod' in env.lower()) or ('dev' in env.lower()):
-            cls.url = str(cls.autoscale_config.server_endpoint) + \
-                '/' + str(cls.tenant_id)
-            print(" ------ Using dev or pre-prod otter --------")
-        else:
+        # If not production or staging, always use the configured server
+        # endpoint instead of what's in the service catalog.
+        if cls.autoscale_config.environment in ('production', 'staging'):
             autoscale_service = access_data.get_service(
                 cls.autoscale_config.autoscale_endpoint_name)
             cls.url = autoscale_service.get_endpoint(
                 cls.autoscale_config.region).public_url
+        else:
+            cls.url = "{0}/{1}".format(
+                cls.autoscale_config.server_endpoint, cls.tenant_id)
+            print(" ------ Using non-production, non-staging otter --------")
 
         cls.autoscale_client = AutoscalingAPIClient(
             cls.url, access_data.token.id_,


### PR DESCRIPTION
For local otter testing, don't get the autoscale endpoint from the service catalog (since we want to test our own version).

Currently this checks the name of the config file (which is stored in an environment variable by cloudcafe) for the word 'dev' or 'preprod'. 

Check an explicit configuration parameter instead for what the environment is, and inject the autoscale endpoint if the environment is not production or staging.

This makes it easier to add new CI environments without having to explicitly change the testing code.

Addresses part of #1028 