### PR TITLE
Skip all of the RCv3 tests if the client is None 

### DIFF
--- a/autoscale_cloudroast/test_repo/autoscale/fixtures.py
+++ b/autoscale_cloudroast/test_repo/autoscale/fixtures.py
@@ -54,6 +54,7 @@ def _make_client(access_data, service_name, region, client_cls, debug_name):
         return client_cls(url, access_data.token.id_, 'json', 'json')
     else:
         print("This account does not support {0}.".format(debug_name))
+        return None
 
 
 def _set_up_clients():
@@ -73,30 +74,30 @@ def _set_up_clients():
             "Unable to authenticate against identity to get auth token and "
             "service catalog.")
 
-    autoscale_client = _make_client(
+    _autoscale_client = _make_client(
         access_data,
         autoscale_config.autoscale_endpoint_name,
         autoscale_config.region,
         AutoscalingAPIClient,
         "Autoscale")
 
-    server_client = _make_client(
+    _server_client = _make_client(
         access_data,
         autoscale_config.server_endpoint_name,
         autoscale_config.server_region_override or autoscale_config.region,
         ServersClient,
         "Nova Compute")
 
-    lbaas_client = _make_client(
+    _lbaas_client = _make_client(
         access_data,
         autoscale_config.load_balancer_endpoint_name,
         autoscale_config.lbaas_region_override or autoscale_config.region,
         LbaasAPIClient,
         "Cloud Load Balancers")
 
-    rcv3_client = None
+    _rcv3_client = None
     if _rcv3_cloud_network and _rcv3_load_balancer_pool:
-        rcv3_client = _make_client(
+        _rcv3_client = _make_client(
             access_data,
             autoscale_config.rcv3_endpoint_name,
             autoscale_config.rcv3_region_override or autoscale_config.region,
@@ -111,7 +112,7 @@ def _set_up_clients():
         raise Exception(
             "Unable to instantiate all necessary clients.")
 
-    return (autoscale_client, server_client, lbaas_client, rcv3_client)
+    return (_autoscale_client, _server_client, _lbaas_client, _rcv3_client)
 
 
 # Global testing state - unfortunate, but only needs to be done once and also

--- a/autoscale_cloudroast/test_repo/autoscale/fixtures.py
+++ b/autoscale_cloudroast/test_repo/autoscale/fixtures.py
@@ -58,7 +58,12 @@ def _make_client(access_data, service_name, region, client_cls, debug_name):
 
 def _set_up_clients():
     """
-    Function
+    Read the user creds from the configuration file in and constructs all the
+    service clients.  If it can't authenticate, or it cannot construct the
+    autoscale/server/lbaas clients, then it fails.
+
+    The RCv3 client is not created if the account does not have access to RCv3
+    or if RCv3 configuration parameters are not present or invalid.
     """
     user_config = UserConfig()
     access_data = AuthProvider.get_access_data(endpoint_config, user_config)

--- a/autoscale_cloudroast/test_repo/autoscale/fixtures.py
+++ b/autoscale_cloudroast/test_repo/autoscale/fixtures.py
@@ -63,6 +63,11 @@ def _set_up_clients():
     user_config = UserConfig()
     access_data = AuthProvider.get_access_data(endpoint_config, user_config)
 
+    if access_data is None:
+        raise Exception(
+            "Unable to authenticate against identity to get auth token and "
+            "service catalog.")
+
     autoscale_client = _make_client(
         access_data,
         autoscale_config.autoscale_endpoint_name,
@@ -92,6 +97,11 @@ def _set_up_clients():
             autoscale_config.rcv3_region_override or autoscale_config.region,
             RackConnectV3APIClient,
             "RackConnect v3")
+
+    if not all([x is not None for x in (autoscale_client, server_client,
+                                        lbaas_client)]):
+        raise Exception(
+            "Unable to instantiate all necessary clients.")
 
     return (autoscale_client, server_client, lbaas_client, rcv3_client)
 

--- a/autoscale_cloudroast/test_repo/autoscale/fixtures.py
+++ b/autoscale_cloudroast/test_repo/autoscale/fixtures.py
@@ -91,6 +91,8 @@ def _set_up_clients():
 
     rcv3_client = None
     if _rcv3_cloud_network and _rcv3_load_balancer_pool:
+        print("Not enough test configuration for RCv3 provided. "
+              "Will not run RCv3 tests.")
         rcv3_client = _make_client(
             access_data,
             autoscale_config.rcv3_endpoint_name,

--- a/autoscale_cloudroast/test_repo/autoscale/fixtures.py
+++ b/autoscale_cloudroast/test_repo/autoscale/fixtures.py
@@ -68,7 +68,6 @@ class AutoscaleFixture(BaseTestFixture):
         except Exception:
             cls.rcv3_client = None
             print("This account does not support rackconnect")
-            # Skip rackconnect test? TO_DO
 
         cls.tenant_id = cls.autoscale_config.tenant_id
 

--- a/autoscale_cloudroast/test_repo/autoscale/fixtures.py
+++ b/autoscale_cloudroast/test_repo/autoscale/fixtures.py
@@ -96,14 +96,15 @@ def _set_up_clients():
 
     rcv3_client = None
     if _rcv3_cloud_network and _rcv3_load_balancer_pool:
-        print("Not enough test configuration for RCv3 provided. "
-              "Will not run RCv3 tests.")
         rcv3_client = _make_client(
             access_data,
             autoscale_config.rcv3_endpoint_name,
             autoscale_config.rcv3_region_override or autoscale_config.region,
             RackConnectV3APIClient,
             "RackConnect v3")
+    else:
+        print("Not enough test configuration for RCv3 provided. "
+              "Will not run RCv3 tests.")
 
     if not all([x is not None for x in (autoscale_client, server_client,
                                         lbaas_client)]):

--- a/autoscale_cloudroast/test_repo/autoscale/system/integration/test_system_integration_lbaas.py
+++ b/autoscale_cloudroast/test_repo/autoscale/system/integration/test_system_integration_lbaas.py
@@ -10,7 +10,7 @@ from cafe.drivers.unittest.decorators import tags
 
 from test_repo.autoscale.fixtures import AutoscaleFixture
 
-from . import common
+from test_repo.autoscale.system.integration import common
 
 
 class AutoscaleLbaasFixture(AutoscaleFixture):

--- a/autoscale_cloudroast/test_repo/autoscale/system/integration/test_system_integration_rcv3.py
+++ b/autoscale_cloudroast/test_repo/autoscale/system/integration/test_system_integration_rcv3.py
@@ -3,7 +3,7 @@ System Integration tests for autoscaling with RackConnect V3 load balancers
 """
 from __future__ import print_function
 
-
+import inspect
 import random
 import time
 import unittest
@@ -56,6 +56,16 @@ class AutoscaleRackConnectFixture(AutoscaleFixture):
         across all tests which can benefit from it.
         """
         super(AutoscaleRackConnectFixture, cls).setUpClass()
+
+        if cls.rcv3_client is None:
+            # don't bother with the rest of the set-up; skip all tests
+            skip = unittest.skip("This account does not support RCv3.")
+
+            for test in inspect.getmembers(cls, predicate=inspect.ismethod):
+                # test is a tuple of name, object
+                if test[0].startswith("test_"):
+                    setattr(cls, test[0], skip(test[1]))
+            return
 
         cls.common = common.CommonTestUtilities(cls.server_client,
                                                 cls.autoscale_client,

--- a/autoscale_cloudroast/test_repo/autoscale/system/integration/test_system_integration_rcv3.py
+++ b/autoscale_cloudroast/test_repo/autoscale/system/integration/test_system_integration_rcv3.py
@@ -3,7 +3,6 @@ System Integration tests for autoscaling with RackConnect V3 load balancers
 """
 from __future__ import print_function
 
-import inspect
 import random
 import time
 import unittest
@@ -16,7 +15,8 @@ import common
 
 from autoscale.behaviors import safe_hasattr
 
-from test_repo.autoscale.fixtures import AutoscaleFixture, autoscale_config
+from test_repo.autoscale.fixtures import (
+    AutoscaleFixture, autoscale_config, rcv3_client)
 
 
 class DummyAsserter(object):
@@ -35,6 +35,7 @@ class DummyAsserter(object):
         self.err = msg
 
 
+@unittest.skipUnless(rcv3_client, "RCv3 is not supported by this account.")
 class AutoscaleRackConnectFixture(AutoscaleFixture):
     """
     System tests to verify lbaas integration with autoscale
@@ -56,17 +57,6 @@ class AutoscaleRackConnectFixture(AutoscaleFixture):
         across all tests which can benefit from it.
         """
         super(AutoscaleRackConnectFixture, cls).setUpClass()
-
-        if cls.rcv3_client is None:
-            # don't bother with the rest of the set-up; skip all tests
-            skip = unittest.skip("This account does not support RCv3.")
-
-            for test in inspect.getmembers(cls, predicate=inspect.ismethod):
-                # test is a tuple of name, object
-                if test[0].startswith("test_"):
-                    setattr(cls, test[0], skip(test[1]))
-            return
-
         cls.common = common.CommonTestUtilities(cls.server_client,
                                                 cls.autoscale_client,
                                                 cls.lbaas_client)

--- a/autoscale_cloudroast/test_repo/autoscale/system/integration/test_system_integration_rcv3.py
+++ b/autoscale_cloudroast/test_repo/autoscale/system/integration/test_system_integration_rcv3.py
@@ -11,12 +11,11 @@ from cafe.drivers.unittest.decorators import tags
 
 from cloudcafe.common.tools.datagen import rand_name
 
-import common
-
 from autoscale.behaviors import safe_hasattr
 
 from test_repo.autoscale.fixtures import (
     AutoscaleFixture, autoscale_config, rcv3_client)
+from test_repo.autoscale.system.integration import common
 
 
 class DummyAsserter(object):


### PR DESCRIPTION
Which happens when there is not enough configuration information for rcv3 in the cloudcafe config.

Just makes this nicer if the rcv3 tests ever get run by accident on an account without rcv3.  Also makes it so that test-running commands can be the same whether or not rcv3 is supported.

I couldn't figure out how to skip the class when already in the `setUpClass` function - raising `unittest.SkipTest` just failed the whole thing, and `unittest.skipTest()` didn't work.

Addresses part of #1028 

### Update:
I  moved a bunch of stuff from `setUpClass` to the global module state in `fixtures`, and just used `@unittest.skipUnless` to check for that module state instead.

While this still skips all the tests individually when the tests are run, it seems neater, and also reduces the amount of stuff in `setUpClass`.

Would probably be better if the rcv3 client is just made in the rcv3 system tests instead of in fixtures directly, but then the rcv3 system tests may need to create a new behaviors instance then - would prefer to neaten that up in a different refactor in the future, if necessary.