### PR TITLE
webhook info by hash using consistency one

### DIFF
--- a/otter/models/cass.py
+++ b/otter/models/cass.py
@@ -1457,7 +1457,7 @@ class CassScalingGroupCollection:
         """
         d = self.connection.execute(
             _cql_find_webhook_token.format(cf=self.webhook_keys_table),
-            {"webhookKey": capability_hash}, DEFAULT_CONSISTENCY)
+            {"webhookKey": capability_hash}, ConsistencyLevel.ONE)
 
         def extract_info(rows):
             if len(rows) == 0:
@@ -1482,7 +1482,7 @@ class CassScalingGroupCollection:
         query = _cql_find_webhook_token.format(cf=self.webhooks_table)
         d = self.connection.execute(query,
                                     {"webhookKey": capability_hash},
-                                    DEFAULT_CONSISTENCY)
+                                    ConsistencyLevel.ONE)
         d.addCallback(_do_webhook_lookup)
         return d
 

--- a/otter/test/models/test_cass_models.py
+++ b/otter/test/models/test_cass_models.py
@@ -3268,7 +3268,7 @@ class CassScalingGroupsCollectionTestCase(IScalingGroupCollectionProviderMixin,
         r = self.successResultOf(d)
         self.assertEqual(r, ('123', 'group1', 'pol1'))
         self.connection.execute.assert_called_once_with(
-            expectedCql, expectedData, ConsistencyLevel.QUORUM)
+            expectedCql, expectedData, ConsistencyLevel.ONE)
 
     def test_webhook_hash_table(self):
         """
@@ -3286,7 +3286,7 @@ class CassScalingGroupsCollectionTestCase(IScalingGroupCollectionProviderMixin,
         r = self.successResultOf(d)
         self.assertEqual(r, ('123', 'group1', 'pol1'))
         self.connection.execute.assert_called_once_with(
-            expectedCql, expectedData, ConsistencyLevel.QUORUM)
+            expectedCql, expectedData, ConsistencyLevel.ONE)
 
     def test_webhook_bad(self):
         """
@@ -3303,8 +3303,8 @@ class CassScalingGroupsCollectionTestCase(IScalingGroupCollectionProviderMixin,
         d = self.collection.webhook_info_by_hash(self.mock_log, 'x')
         self.failureResultOf(d, UnrecognizedCapabilityError)
         self.connection.execute.assert_has_calls(
-            [mock.call(expectedCql[0], expectedData, ConsistencyLevel.QUORUM),
-             mock.call(expectedCql[1], expectedData, ConsistencyLevel.QUORUM)])
+            [mock.call(expectedCql[0], expectedData, ConsistencyLevel.ONE),
+             mock.call(expectedCql[1], expectedData, ConsistencyLevel.ONE)])
 
     def test_get_counts(self):
         """


### PR DESCRIPTION
This should hopefully reduce some TimedOutException coming from Cassandra. Meanwhile, I'll work on completely transitioning to webhook table that should eliminate this error altogether.