### PR TITLE
CreateServer success semantics

### DIFF
--- a/otter/convergence/steps.py
+++ b/otter/convergence/steps.py
@@ -16,6 +16,7 @@ from toolz.itertoolz import concat
 from zope.interface import Interface, implementer
 
 from otter.constants import ServiceType
+from otter.convergence.model import StepResult
 from otter.http import has_code, service_request
 from otter.util.fp import predicate_any
 from otter.util.hashkey import generate_server_name
@@ -70,7 +71,15 @@ class CreateServer(object):
                 'servers',
                 data=thaw(server_config),
                 success_pred=has_code(202))
-        return eff.on(got_name)
+
+        def report_success(result):
+            return StepResult.SUCCESS, []
+
+        def report_failure(result):
+            return StepResult.RETRY, []
+
+        return eff.on(got_name).on(success=report_success,
+                                   error=report_failure)
 
 
 @implementer(IStep)

--- a/otter/test/convergence/test_steps.py
+++ b/otter/test/convergence/test_steps.py
@@ -9,7 +9,7 @@ from pyrsistent import freeze, pset
 from twisted.trial.unittest import SynchronousTestCase
 
 from otter.constants import ServiceType
-from otter.convergence.model import CLBDescription
+from otter.convergence.model import CLBDescription, StepResult
 from otter.convergence.steps import (
     AddNodesToCLB,
     BulkAddToRCv3,
@@ -25,6 +25,7 @@ from otter.convergence.steps import (
 from otter.http import has_code, service_request
 from otter.test.utils import StubResponse, resolve_effect
 from otter.util.hashkey import generate_server_name
+from otter.util.http import APIError
 
 
 class StepAsEffectTests(SynchronousTestCase):
@@ -43,19 +44,32 @@ class StepAsEffectTests(SynchronousTestCase):
         self.assertEqual(eff.intent, Func(generate_server_name))
         eff = resolve_effect(eff, 'random-name')
         self.assertEqual(
-            eff,
+            eff.intent,
             service_request(
                 ServiceType.CLOUD_SERVERS,
                 'POST',
                 'servers',
                 data={'server': {'name': 'myserver-random-name',
                                  'flavorRef': '1'}},
-                success_pred=has_code(202)))
+                success_pred=has_code(202)).intent)
+
+        self.assertEqual(
+            resolve_effect(eff, (None, {})),
+            (StepResult.SUCCESS, []))
+
+        self.assertEqual(
+            resolve_effect(eff,
+                           (APIError, APIError(500, None, None), None),
+                           is_error=True),
+            (StepResult.RETRY, []))
 
     def test_create_server_noname(self):
         """
         :obj:`CreateServer.as_effect`, when no name is provided in the launch
         config, will generate the name will from scratch.
+
+        This only verifies intent; result reporting is tested in
+        :meth:`test_create_server`.
         """
         create = CreateServer(
             server_config=freeze({'server': {'flavorRef': '1'}}))
@@ -63,13 +77,13 @@ class StepAsEffectTests(SynchronousTestCase):
         self.assertEqual(eff.intent, Func(generate_server_name))
         eff = resolve_effect(eff, 'random-name')
         self.assertEqual(
-            eff,
+            eff.intent,
             service_request(
                 ServiceType.CLOUD_SERVERS,
                 'POST',
                 'servers',
                 data={'server': {'name': 'random-name', 'flavorRef': '1'}},
-                success_pred=has_code(202)))
+                success_pred=has_code(202)).intent)
 
     def test_delete_server(self):
         """


### PR DESCRIPTION
This is a very simple PR, just to test the waters. Quite simply, if the service request results in any exception, `RETRY`, else `SUCCESS`, and no reasons either way. We can add smarter behavior (e.g. fail fast, or more reasons) in other PRs.

Refs #956.