### PR TITLE
Fix some of the remove/draining CLB tests

### DIFF
--- a/otter/test/convergence/test_planning.py
+++ b/otter/test/convergence/test_planning.py
@@ -51,14 +51,16 @@ class RemoveFromLBWithDrainingTests(SynchronousTestCase):
         """
         If the timeout is zero, all nodes are just removed.
         """
+        desc = CLBDescription(lb_id='5', port=80)
         self.assertEqual(
             self._filter_only_lb_steps(converge(
                 DesiredGroupState(server_config={}, capacity=0,
                                   draining_timeout=0.0),
                 set([server('abc', ServerState.ACTIVE,
-                            servicenet_address='1.1.1.1')]),
+                            servicenet_address='1.1.1.1',
+                            desired_lbs=freeze({'5': desc}))]),
                 set([CLBNode(node_id='123', address='1.1.1.1',
-                     description=CLBDescription(lb_id='5', port=80))]),
+                     description=desc)]),
                 now=0)),
             pbag([RemoveNodesFromCLB(lb_id='5', node_ids=('123',))]))
 
@@ -67,6 +69,7 @@ class RemoveFromLBWithDrainingTests(SynchronousTestCase):
         Nodes in disabled state are just removed from the load balancer even
         if the timeout is positive.
         """
+        desired = freeze({'5': CLBDescription(lb_id='5', port=80)})
         current = [CLBNode(node_id='123', address='1.1.1.1',
                            description=CLBDescription(
                                lb_id='5', port=80,
@@ -76,7 +79,8 @@ class RemoveFromLBWithDrainingTests(SynchronousTestCase):
                 DesiredGroupState(server_config={}, capacity=0,
                                   draining_timeout=10.0),
                 set([server('abc', ServerState.ACTIVE,
-                            servicenet_address='1.1.1.1')]),
+                            servicenet_address='1.1.1.1',
+                            desired_lbs=desired)]),
                 set(current),
                 now=0)),
             pbag([RemoveNodesFromCLB(lb_id='5', node_ids=('123',))]))
@@ -85,14 +89,15 @@ class RemoveFromLBWithDrainingTests(SynchronousTestCase):
         """
         Nodes in enabled state are put into draining.
         """
-        current = [CLBNode(node_id='123', address='1.1.1.1',
-                           description=CLBDescription(lb_id='5', port=80))]
+        desc = CLBDescription(lb_id='5', port=80)
+        current = [CLBNode(node_id='123', address='1.1.1.1', description=desc)]
         self.assertEqual(
             self._filter_only_lb_steps(converge(
                 DesiredGroupState(server_config={}, capacity=0,
                                   draining_timeout=10.0),
                 set([server('abc', ServerState.ACTIVE,
-                            servicenet_address='1.1.1.1')]),
+                            servicenet_address='1.1.1.1',
+                            desired_lbs=freeze({'5': desc}))]),
                 set(current),
                 now=0)),
             pbag([ChangeCLBNode(lb_id='5', node_id='123', weight=1,
@@ -104,6 +109,7 @@ class RemoveFromLBWithDrainingTests(SynchronousTestCase):
         Nodes in draining state will be ignored if they still have connections
         and the timeout is not yet expired.
         """
+        desired = freeze({'5': CLBDescription(lb_id='5', port=80)})
         current = [CLBNode(node_id='123', address='1.1.1.1',
                            description=CLBDescription(
                                lb_id='5', port=80,
@@ -114,7 +120,8 @@ class RemoveFromLBWithDrainingTests(SynchronousTestCase):
                 DesiredGroupState(server_config={}, capacity=0,
                                   draining_timeout=10.0),
                 set([server('abc', ServerState.ACTIVE,
-                            servicenet_address='1.1.1.1')]),
+                            servicenet_address='1.1.1.1',
+                            desired_lbs=desired)]),
                 set(current),
                 now=5)),
             pbag([]))
@@ -124,6 +131,7 @@ class RemoveFromLBWithDrainingTests(SynchronousTestCase):
         Nodes in draining state will be removed if they have no more
         connections, even if the timeout is not yet expired
         """
+        desired = freeze({'5': CLBDescription(lb_id='5', port=80)})
         current = [CLBNode(node_id='123', address='1.1.1.1',
                            description=CLBDescription(
                                lb_id='5', port=80,
@@ -134,7 +142,8 @@ class RemoveFromLBWithDrainingTests(SynchronousTestCase):
                 DesiredGroupState(server_config={}, capacity=0,
                                   draining_timeout=10.0),
                 set([server('abc', ServerState.ACTIVE,
-                            servicenet_address='1.1.1.1')]),
+                            servicenet_address='1.1.1.1',
+                            desired_lbs=desired)]),
                 set(current),
                 now=5)),
             pbag([RemoveNodesFromCLB(lb_id='5', node_ids=('123',))]))
@@ -144,6 +153,7 @@ class RemoveFromLBWithDrainingTests(SynchronousTestCase):
         Nodes in draining state will be ignored if timeout has not yet expired
         and the number of active connections are not provided
         """
+        desired = freeze({'5': CLBDescription(lb_id='5', port=80)})
         current = [CLBNode(node_id='123', address='1.1.1.1',
                            description=CLBDescription(
                                lb_id='5', port=80,
@@ -154,7 +164,8 @@ class RemoveFromLBWithDrainingTests(SynchronousTestCase):
                 DesiredGroupState(server_config={}, capacity=0,
                                   draining_timeout=10.0),
                 set([server('abc', ServerState.ACTIVE,
-                            servicenet_address='1.1.1.1')]),
+                            servicenet_address='1.1.1.1',
+                            desired_lbs=desired)]),
                 set(current),
                 now=5)),
             pbag([]))
@@ -164,6 +175,7 @@ class RemoveFromLBWithDrainingTests(SynchronousTestCase):
         Nodes in draining state will be removed when the timeout expires if
         the number of active connections are not provided
         """
+        desired = freeze({'5': CLBDescription(lb_id='5', port=80)})
         current = [CLBNode(node_id='123', address='1.1.1.1',
                            description=CLBDescription(
                                lb_id='5', port=80,
@@ -174,7 +186,8 @@ class RemoveFromLBWithDrainingTests(SynchronousTestCase):
                 DesiredGroupState(server_config={}, capacity=0,
                                   draining_timeout=10.0),
                 set([server('abc', ServerState.ACTIVE,
-                            servicenet_address='1.1.1.1')]),
+                            servicenet_address='1.1.1.1',
+                            desired_lbs=desired)]),
                 set(current),
                 now=15)),
             pbag([RemoveNodesFromCLB(lb_id='5', node_ids=('123',))]))
@@ -184,6 +197,7 @@ class RemoveFromLBWithDrainingTests(SynchronousTestCase):
         Nodes in draining state will be removed when the timeout expires even
         if they still have active connections
         """
+        desired = freeze({'5': CLBDescription(lb_id='5', port=80)})
         current = [CLBNode(node_id='123', address='1.1.1.1',
                            description=CLBDescription(
                                lb_id='5', port=80,
@@ -194,16 +208,23 @@ class RemoveFromLBWithDrainingTests(SynchronousTestCase):
                 DesiredGroupState(server_config={}, capacity=0,
                                   draining_timeout=10.0),
                 set([server('abc', ServerState.ACTIVE,
-                            servicenet_address='1.1.1.1')]),
+                            servicenet_address='1.1.1.1',
+                            desired_lbs=desired)]),
                 set(current),
                 now=15)),
             pbag([RemoveNodesFromCLB(lb_id='5', node_ids=('123',))]))
 
-    def test_all_changes_together(self):
+    def test_all_clb_changes_together(self):
         """
-        Given all possible combination of load balancer states and timeouts,
-        ensure function produces the right set of step for all of them.
+        Given all possible combination of clb load balancer states and
+        timeouts, ensure function produces the right set of step for all of
+        them.
         """
+        desired = freeze({'1': CLBDescription(lb_id='1', port=80),
+                          '2': CLBDescription(lb_id='2', port=80),
+                          '3': CLBDescription(lb_id='3', port=80),
+                          '4': CLBDescription(lb_id='4', port=80),
+                          '5': CLBDescription(lb_id='5', port=80)})
         current = [
             # enabled, should be drained
             CLBNode(node_id='1', address='1.1.1.1',
@@ -237,7 +258,8 @@ class RemoveFromLBWithDrainingTests(SynchronousTestCase):
                 DesiredGroupState(server_config={}, capacity=0,
                                   draining_timeout=10.0),
                 set([server('abc', ServerState.ACTIVE,
-                            servicenet_address='1.1.1.1')]),
+                            servicenet_address='1.1.1.1',
+                            desired_lbs=desired)]),
                 set(current),
                 now=10)),
             pbag([

--- a/otter/test/convergence/test_planning.py
+++ b/otter/test/convergence/test_planning.py
@@ -434,13 +434,16 @@ class DrainAndDeleteServerTests(SynchronousTestCase):
     def test_active_server_without_load_balancers_can_be_deleted(self):
         """
         If an active server to be scaled down is not attached to any load
-        balancers, it can be deleted. It is not first put into draining state.
+        balancers, even if it should be, it can be deleted.
+        It is not first put into draining state.
         """
+        desired = freeze({'1': CLBDescription(lb_id='1', port=80)})
         self.assertEqual(
             converge(
                 DesiredGroupState(server_config={}, capacity=0,
                                   draining_timeout=10.0),
-                set([server('abc', state=ServerState.ACTIVE)]),
+                set([server('abc', state=ServerState.ACTIVE,
+                            desired_lbs=desired)]),
                 set(),
                 0),
             pbag([DeleteServer(server_id='abc')]))
@@ -451,13 +454,16 @@ class DrainAndDeleteServerTests(SynchronousTestCase):
         balancers, the server can be deleted.  It is not first put into
         draining state.
         """
+        desc = CLBDescription(lb_id='1', port=80)
+        desired = freeze({'1': desc})
         self.assertEqual(
             converge(
                 DesiredGroupState(server_config={}, capacity=0),
                 set([server('abc', state=ServerState.ACTIVE,
-                            servicenet_address='1.1.1.1')]),
+                            servicenet_address='1.1.1.1',
+                            desired_lbs=desired)]),
                 set([CLBNode(node_id='1', address='1.1.1.1',
-                             description=CLBDescription(lb_id='1', port=80))]),
+                             description=desc)]),
                 0),
             pbag([
                 DeleteServer(server_id='abc'),
@@ -469,11 +475,13 @@ class DrainAndDeleteServerTests(SynchronousTestCase):
         If draining server can be removed from all the load balancers, the
         server can be deleted.
         """
+        desired = freeze({'1': CLBDescription(lb_id='1', port=80)})
         self.assertEqual(
             converge(
                 DesiredGroupState(server_config={}, capacity=0),
                 set([server('abc', state=ServerState.DRAINING,
-                            servicenet_address='1.1.1.1')]),
+                            servicenet_address='1.1.1.1',
+                            desired_lbs=desired)]),
                 set([CLBNode(node_id='1', address='1.1.1.1',
                              description=CLBDescription(
                                  lb_id='1', port=80,
@@ -489,12 +497,14 @@ class DrainAndDeleteServerTests(SynchronousTestCase):
         If the server already in draining state is waiting for the draining
         timeout on some load balancers, nothing is done to it.
         """
+        desired = freeze({'1': CLBDescription(lb_id='1', port=80)})
         self.assertEqual(
             converge(
                 DesiredGroupState(server_config={}, capacity=0,
                                   draining_timeout=10.0),
                 set([server('abc', state=ServerState.DRAINING,
-                            servicenet_address='1.1.1.1')]),
+                            servicenet_address='1.1.1.1',
+                            desired_lbs=desired)]),
                 set([CLBNode(node_id='1', address='1.1.1.1',
                              description=CLBDescription(
                                  lb_id='1', port=80,
@@ -509,12 +519,14 @@ class DrainAndDeleteServerTests(SynchronousTestCase):
         balancers, it is set to draining state and all the nodes are set to
         draining condition.
         """
+        desired = freeze({'1': CLBDescription(lb_id='1', port=80)})
         self.assertEqual(
             converge(
                 DesiredGroupState(server_config={}, capacity=0,
                                   draining_timeout=10.0),
                 set([server('abc', state=ServerState.ACTIVE,
-                            servicenet_address='1.1.1.1')]),
+                            servicenet_address='1.1.1.1',
+                            desired_lbs=desired)]),
                 set([CLBNode(node_id='1', address='1.1.1.1',
                              description=CLBDescription(lb_id='1', port=80))]),
                 0),
@@ -537,12 +549,14 @@ class DrainAndDeleteServerTests(SynchronousTestCase):
         in a previous convergence run, and the load balancers were set to
         draining but setting the server metadata failed.
         """
+        desired = freeze({'1': CLBDescription(lb_id='1', port=80)})
         self.assertEqual(
             converge(
                 DesiredGroupState(server_config={}, capacity=0,
                                   draining_timeout=10.0),
                 set([server('abc', state=ServerState.ACTIVE,
-                            servicenet_address='1.1.1.1')]),
+                            servicenet_address='1.1.1.1',
+                            desired_lbs=desired)]),
                 set([CLBNode(node_id='1', address='1.1.1.1',
                              description=CLBDescription(
                                  lb_id='1', port=80,
@@ -565,12 +579,14 @@ class DrainAndDeleteServerTests(SynchronousTestCase):
         in a previous convergence run, and the server metadata was set but
         the load balancers update failed.
         """
+        desired = freeze({'1': CLBDescription(lb_id='1', port=80)})
         self.assertEqual(
             converge(
                 DesiredGroupState(server_config={}, capacity=0,
                                   draining_timeout=10.0),
                 set([server('abc', state=ServerState.DRAINING,
-                            servicenet_address='1.1.1.1')]),
+                            servicenet_address='1.1.1.1',
+                            desired_lbs=desired)]),
                 set([CLBNode(node_id='1', address='1.1.1.1',
                              description=CLBDescription(lb_id='1', port=80))]),
                 1),


### PR DESCRIPTION
To ensure that the tests weren't just passing because no desired load balancers on the server were passed.