### PR TITLE
ChangeCLBNode is successful on 202, not 200

### DIFF
--- a/otter/convergence/steps.py
+++ b/otter/convergence/steps.py
@@ -281,7 +281,8 @@ class ChangeCLBNode(object):
             append_segments('loadbalancers', self.lb_id,
                             'nodes', self.node_id),
             data={'condition': self.condition,
-                  'weight': self.weight})
+                  'weight': self.weight},
+            success_pred=has_code(202))
 
 
 def _rackconnect_bulk_request(lb_node_pairs, method, success_pred):

--- a/otter/test/convergence/test_steps.py
+++ b/otter/test/convergence/test_steps.py
@@ -131,7 +131,8 @@ class StepAsEffectTests(SynchronousTestCase):
                 'PUT',
                 'loadbalancers/abc123/nodes/node1',
                 data={'condition': 'DRAINING',
-                      'weight': 50}))
+                      'weight': 50},
+                success_pred=has_code(202)))
 
     def test_add_nodes_to_clb(self):
         """


### PR DESCRIPTION
This doesn't cover all the codes; that's #1054. This is just for ensuring super-basic correctness.