### PR TITLE
RCv3 delete success semantics

### DIFF
--- a/otter/convergence/steps.py
+++ b/otter/convergence/steps.py
@@ -392,7 +392,7 @@ def _rcv3_check_bulk_delete(attempted_pairs, result):
     response, body = result
 
     if response.code == 204:  # All done!
-        return
+        return StepResult.SUCCESS, []
 
     to_retry = pset(attempted_pairs)
     for error in body["errors"]:

--- a/otter/test/convergence/test_steps.py
+++ b/otter/test/convergence/test_steps.py
@@ -485,7 +485,7 @@ class RCv3CheckBulkDeleteTests(SynchronousTestCase):
                  "load_balancer_pool": {"id": lb_id}}
                 for (lb_id, node_id) in pairs]
         res = _rcv3_check_bulk_delete(pairs, (resp, body))
-        self.assertIdentical(res, None)
+        self.assertEqual(res, (StepResult.SUCCESS, []))
 
     def test_try_again(self):
         """


### PR DESCRIPTION
This highlighted another potential issue re: termination, https://github.com/rackerlabs/otter/issues/1056. Doesn't affect worker because that already has a manual hack, but we can run the integration tests anyway.