### PR TITLE
moving `next_cron_occurrence` to models.interface

### DIFF
--- a/otter/models/cass.py
+++ b/otter/models/cass.py
@@ -35,8 +35,8 @@ from otter.models.interface import (
     PoliciesOverLimitError,
     ScalingGroupOverLimitError,
     UnrecognizedCapabilityError,
-    WebhooksOverLimitError)
-from otter.scheduler import next_cron_occurrence
+    WebhooksOverLimitError,
+    next_cron_occurrence)
 from otter.util import timestamp
 from otter.util.config import config_value
 from otter.util.cqlbatch import Batch, batch

--- a/otter/models/interface.py
+++ b/otter/models/interface.py
@@ -1,8 +1,13 @@
 """
 Interface to be used by the scaling groups engine
 """
-from zope.interface import Interface, Attribute
-from twisted.python.constants import Names, NamedConstant
+from datetime import datetime
+
+from croniter import croniter
+
+from twisted.python.constants import NamedConstant, Names
+
+from zope.interface import Attribute, Interface
 
 from otter.util import timestamp
 
@@ -708,6 +713,14 @@ class IScalingScheduleCollection(Interface):
         :return: Deferred that fires with dict of oldest event
         :rtype: :class:`dict`
         """
+
+
+def next_cron_occurrence(cron):
+    """
+    Return next occurence of given cron entry
+    """
+    return croniter(
+        cron, start_time=datetime.utcnow()).get_next(ret_type=datetime)
 
 
 class IScalingGroupCollection(Interface):


### PR DESCRIPTION
This is because cass importing scheduler causes cyclic import issues when having CQL intent in cass.py (that will be done in next PR). 

FYI: Cron scheduler tests pass against mimic.