### PR TITLE
fixes for some bugs in to_nova_server

### DIFF
--- a/otter/convergence/gathering.py
+++ b/otter/convergence/gathering.py
@@ -231,7 +231,7 @@ def to_nova_server(server_json):
     Convert from JSON format to :obj:`NovaServer` instance.
     """
     return NovaServer(id=server_json['id'],
-                      state=ServerState.lookupByName(server_json['state']),
+                      state=ServerState.lookupByName(server_json['status']),
                       created=timestamp_to_epoch(server_json['created']),
                       image_id=server_json.get('image', {}).get('id'),
                       flavor_id=server_json['flavor']['id'],

--- a/otter/convergence/model.py
+++ b/otter/convergence/model.py
@@ -102,7 +102,7 @@ class StepResult(Names):
              Attribute('desired_lbs', default_factory=pmap, instance_of=PMap),
              Attribute('servicenet_address',
                        default_value='',
-                       instance_of=str)])
+                       instance_of=basestring)])
 class NovaServer(object):
     """
     Information about a server that was retrieved from Nova.

--- a/otter/test/convergence/test_gathering.py
+++ b/otter/test/convergence/test_gathering.py
@@ -366,16 +366,16 @@ class ToNovaServerTests(SynchronousTestCase):
         self.createds = [('2020-10-10T10:00:00Z', 1602324000),
                          ('2020-10-20T11:30:00Z', 1603193400)]
         self.servers = [{'id': 'a',
-                         'state': 'ACTIVE',
+                         'status': 'ACTIVE',
                          'created': self.createds[0][0],
                          'image': {'id': 'valid_image'},
                          'flavor': {'id': 'valid_flavor'}},
                         {'id': 'b',
-                         'state': 'BUILD',
+                         'status': 'BUILD',
                          'image': {'id': 'valid_image'},
                          'flavor': {'id': 'valid_flavor'},
                          'created': self.createds[1][0],
-                         'addresses': {'private': [{'addr': '10.0.0.1',
+                         'addresses': {'private': [{'addr': u'10.0.0.1',
                                                     'version': 4}]}}]
 
     def test_without_address(self):
@@ -538,18 +538,18 @@ class GetAllConvergenceDataTests(SynchronousTestCase):
         """Save some stuff."""
         self.servers = [
             {'id': 'a',
-             'state': 'ACTIVE',
+             'status': 'ACTIVE',
              'image': {'id': 'image'},
              'flavor': {'id': 'flavor'},
              'created': '1970-01-01T00:00:00Z',
-             'addresses': {'private': [{'addr': '10.0.0.1',
+             'addresses': {'private': [{'addr': u'10.0.0.1',
                                         'version': 4}]}},
             {'id': 'b',
-             'state': 'ACTIVE',
+             'status': 'ACTIVE',
              'image': {'id': 'image'},
              'flavor': {'id': 'flavor'},
              'created': '1970-01-01T00:00:01Z',
-             'addresses': {'private': [{'addr': '10.0.0.2',
+             'addresses': {'private': [{'addr': u'10.0.0.2',
                                         'version': 4}]}}
         ]
 


### PR DESCRIPTION
- server status is in the "status" key, not "state"
- parsed json data gives us unicode, not str, so loosen the type check in NovaServer.servicenet_address.