### PR TITLE
Bare RCv3 request API

### DIFF
--- a/otter/convergence/steps.py
+++ b/otter/convergence/steps.py
@@ -352,7 +352,8 @@ class BulkRemoveFromRCv3(object):
     Some connections must be removed between some combination of nodes
     and RackConnect v3.0 load balancers.
 
-    See http://docs.rcv3.apiary.io/#delete-%2Fv3%2F{tenant_id}%2Fload_balancer_pools%2Fnodes.
+    See http://docs.rcv3.apiary.io/#delete-%2Fv3%2F{tenant_id}
+    %2Fload_balancer_pools%2Fnodes.
 
     :param list lb_node_pairs: A list of ``lb_id, node_id`` tuples of
         connections to be removed.

--- a/otter/convergence/steps.py
+++ b/otter/convergence/steps.py
@@ -343,7 +343,9 @@ class BulkAddToRCv3(object):
 
     _bare_effect = as_effect
 
+
 # TODO: add ticket for removing _bare_effect hacks
+
 
 @implementer(IStep)
 @attributes(['lb_node_pairs'])

--- a/otter/convergence/steps.py
+++ b/otter/convergence/steps.py
@@ -357,16 +357,21 @@ class BulkRemoveFromRCv3(object):
     :param list lb_node_pairs: A list of ``lb_id, node_id`` tuples of
         connections to be removed.
     """
+    def _bare_effect(self):
+        """
+        Just the RCv3 bulk request effect, with no callbacks.
+        """
+        # While 409 isn't success, that has to be introspected by
+        # _rcv3_check_bulk_delete in order to recover from it.
+        return _rackconnect_bulk_request(self.lb_node_pairs, "DELETE",
+                                         success_pred=has_code(204, 409))
 
     def as_effect(self):
         """
         Produce a :obj:`Effect` to remove some nodes from some RCv3 load
         balancers.
         """
-        eff = _rackconnect_bulk_request(self.lb_node_pairs, "DELETE",
-                                        success_pred=has_code(204, 409))
-        # While 409 isn't success, that has to be introspected by
-        # _rcv3_check_bulk_delete in order to recover from it.
+        eff = self._bare_effect()
         return eff.on(partial(_rcv3_check_bulk_delete, self.lb_node_pairs))
 
 

--- a/otter/convergence/steps.py
+++ b/otter/convergence/steps.py
@@ -341,6 +341,7 @@ class BulkAddToRCv3(object):
             self.lb_node_pairs, "POST",
             success_pred=has_code(201))
 
+    _bare_effect = as_effect
 
 # TODO: add ticket for removing _bare_effect hacks
 

--- a/otter/convergence/steps.py
+++ b/otter/convergence/steps.py
@@ -342,6 +342,8 @@ class BulkAddToRCv3(object):
             success_pred=has_code(201))
 
 
+# TODO: add ticket for removing _bare_effect hacks
+
 @implementer(IStep)
 @attributes(['lb_node_pairs'])
 class BulkRemoveFromRCv3(object):

--- a/otter/convergence/steps.py
+++ b/otter/convergence/steps.py
@@ -345,9 +345,6 @@ class BulkAddToRCv3(object):
     _bare_effect = as_effect
 
 
-# TODO: add ticket for removing _bare_effect hacks
-
-
 @implementer(IStep)
 @attributes(['lb_node_pairs'])
 class BulkRemoveFromRCv3(object):

--- a/otter/convergence/steps.py
+++ b/otter/convergence/steps.py
@@ -326,7 +326,8 @@ class BulkAddToRCv3(object):
 
     Each connection is independently specified.
 
-    See http://docs.rcv3.apiary.io/#post-%2Fv3%2F{tenant_id}%2Fload_balancer_pools%2Fnodes.
+    See http://docs.rcv3.apiary.io/#post-%2Fv3%2F{tenant_id}
+    %2Fload_balancer_pools%2Fnodes.
 
     :param list lb_node_pairs: A list of ``lb_id, node_id`` tuples of
         connections to be made.

--- a/otter/test/worker/test_rcv3.py
+++ b/otter/test/worker/test_rcv3.py
@@ -80,17 +80,16 @@ class RCv3Tests(SynchronousTestCase):
         # The method is either POST (add) or DELETE (remove).
         self.assertIn(req.method, ["POST", "DELETE"])
 
-        fake_response_object = object()
         if req.method == "POST":
             self.assertEqual(req.success_pred, has_code(201))
             # http://docs.rcv3.apiary.io/#post-%2Fv3%2F{tenant_id}
             # %2Fload_balancer_pools%2Fnodes
-            return succeed((fake_response_object, self.post_response))
+            return succeed(self.post_response)
         elif req.method == "DELETE":
             self.assertEqual(req.success_pred, has_code(204, 409))
             # http://docs.rcv3.apiary.io/#delete-%2Fv3%2F{tenant_id}
             # %2Fload_balancer_pools%2Fnode
-            return succeed((fake_response_object, self.del_response))
+            return succeed(self.del_response)
 
     def test_add_to_rcv3(self):
         """

--- a/otter/test/worker/test_rcv3.py
+++ b/otter/test/worker/test_rcv3.py
@@ -82,16 +82,17 @@ class RCv3Tests(SynchronousTestCase):
         # The method is either POST (add) or DELETE (remove).
         self.assertIn(req.method, ["POST", "DELETE"])
 
+        fake_response_object = object()
         if req.method == "POST":
             self.assertEqual(req.success_pred, has_code(201))
             # http://docs.rcv3.apiary.io/#post-%2Fv3%2F{tenant_id}
             # %2Fload_balancer_pools%2Fnodes
-            return succeed((None, self.post_response))
+            return succeed((fake_response_object, self.post_response))
         elif req.method == "DELETE":
             self.assertEqual(req.success_pred, has_code(204, 409))
             # http://docs.rcv3.apiary.io/#delete-%2Fv3%2F{tenant_id}
             # %2Fload_balancer_pools%2Fnode
-            return succeed((None, self.del_response))
+            return succeed((fake_response_object, self.del_response))
 
     def test_add_to_rcv3(self):
         """

--- a/otter/test/worker/test_rcv3.py
+++ b/otter/test/worker/test_rcv3.py
@@ -69,10 +69,8 @@ class RCv3Tests(SynchronousTestCase):
         self.assertIs(type(effect), Effect)
         tenant_scope = effect.intent
         self.assertEqual(tenant_scope.tenant_id, 'thetenantid')
-        parallel = effect.intent.effect.intent
-        (sub_effect,) = parallel.effects
-        req = sub_effect.intent
 
+        req = tenant_scope.effect.intent
         self.assertEqual(req.service_type, ServiceType.RACKCONNECT_V3)
         self.assertEqual(req.data,
                          [{'load_balancer_pool': {'id': 'lb_id'},

--- a/otter/test/worker/test_rcv3.py
+++ b/otter/test/worker/test_rcv3.py
@@ -54,7 +54,7 @@ class RCv3Tests(SynchronousTestCase):
         self.request_bag = _RequestBag(dispatcher=self.dispatcher,
                                        tenant_id='thetenantid')
         self.post_result = (StubResponse(201, {}),
-                              _rcv3_add_response_body("lb_id", "server_id"))
+                            _rcv3_add_response_body("lb_id", "server_id"))
         self.del_result = (StubResponse(204, {}), None)
 
     def _fake_perform(self, dispatcher, effect):

--- a/otter/test/worker/test_rcv3.py
+++ b/otter/test/worker/test_rcv3.py
@@ -100,14 +100,6 @@ class RCv3Tests(SynchronousTestCase):
         self.assertEqual(add_result["cloud_server"], {"id": "server_id"})
         self.assertEqual(add_result["load_balancer_pool"], {"id": "lb_id"})
 
-    def test_add_to_rcv3_fail_when_body_none(self):
-        """
-        :func:`_rcv3.add_to_rcv3` attempts to perform the correct effect.
-        """
-        self.post_result = None
-        d = _rcv3.add_to_rcv3(self.request_bag, "lb_id", "server_id")
-        self.failureResultOf(d)
-
     def test_remove_from_rcv3(self):
         """
         :func:`_rcv3.add_to_rcv3` attempts to perform the correct effect.

--- a/otter/test/worker/test_rcv3.py
+++ b/otter/test/worker/test_rcv3.py
@@ -85,7 +85,7 @@ class RCv3Tests(SynchronousTestCase):
         if req.method == "POST":
             self.assertEqual(req.success_pred, has_code(201))
             # http://docs.rcv3.apiary.io/#post-%2Fv3%2F{tenant_id}%2Fload_balancer_pools%2Fnodes
-            return succeed([self.post_response])
+            return succeed((None, self. post_response))
         elif req.method == "DELETE":
             self.assertEqual(req.success_pred, has_code(204, 409))
             # http://docs.rcv3.apiary.io/#delete-%2Fv3%2F{tenant_id}%2Fload_balancer_pools%2Fnode

--- a/otter/test/worker/test_rcv3.py
+++ b/otter/test/worker/test_rcv3.py
@@ -85,7 +85,7 @@ class RCv3Tests(SynchronousTestCase):
         if req.method == "POST":
             self.assertEqual(req.success_pred, has_code(201))
             # http://docs.rcv3.apiary.io/#post-%2Fv3%2F{tenant_id}%2Fload_balancer_pools%2Fnodes
-            return succeed((None, self. post_response))
+            return succeed((None, self.post_response))
         elif req.method == "DELETE":
             self.assertEqual(req.success_pred, has_code(204, 409))
             # http://docs.rcv3.apiary.io/#delete-%2Fv3%2F{tenant_id}%2Fload_balancer_pools%2Fnode

--- a/otter/test/worker/test_rcv3.py
+++ b/otter/test/worker/test_rcv3.py
@@ -84,7 +84,8 @@ class RCv3Tests(SynchronousTestCase):
 
         if req.method == "POST":
             self.assertEqual(req.success_pred, has_code(201))
-            # http://docs.rcv3.apiary.io/#post-%2Fv3%2F{tenant_id}%2Fload_balancer_pools%2Fnodes
+            # http://docs.rcv3.apiary.io/#post-%2Fv3%2F{tenant_id}
+            # %2Fload_balancer_pools%2Fnodes
             return succeed((None, self.post_response))
         elif req.method == "DELETE":
             self.assertEqual(req.success_pred, has_code(204, 409))

--- a/otter/test/worker/test_rcv3.py
+++ b/otter/test/worker/test_rcv3.py
@@ -55,7 +55,7 @@ class RCv3Tests(SynchronousTestCase):
                                        tenant_id='thetenantid')
         self.post_result = (StubResponse(201, {}),
                             _rcv3_add_response_body("lb_id", "server_id"))
-        self.del_result = (StubResponse(204, {}), None)
+        self.del_result = StubResponse(204, {}), None
 
     def _fake_perform(self, dispatcher, effect):
         """

--- a/otter/test/worker/test_rcv3.py
+++ b/otter/test/worker/test_rcv3.py
@@ -55,7 +55,7 @@ class RCv3Tests(SynchronousTestCase):
                                        tenant_id='thetenantid')
         self.post_result = (StubResponse(201, {}),
                               _rcv3_add_response_body("lb_id", "server_id"))
-        self.del_result = None
+        self.del_result = (StubResponse(204, {}), None)
 
     def _fake_perform(self, dispatcher, effect):
         """

--- a/otter/test/worker/test_rcv3.py
+++ b/otter/test/worker/test_rcv3.py
@@ -89,7 +89,8 @@ class RCv3Tests(SynchronousTestCase):
             return succeed((None, self.post_response))
         elif req.method == "DELETE":
             self.assertEqual(req.success_pred, has_code(204, 409))
-            # http://docs.rcv3.apiary.io/#delete-%2Fv3%2F{tenant_id}%2Fload_balancer_pools%2Fnode
+            # http://docs.rcv3.apiary.io/#delete-%2Fv3%2F{tenant_id}
+            # %2Fload_balancer_pools%2Fnode
             return succeed([self.del_response])
 
     def test_add_to_rcv3(self):

--- a/otter/test/worker/test_rcv3.py
+++ b/otter/test/worker/test_rcv3.py
@@ -91,7 +91,7 @@ class RCv3Tests(SynchronousTestCase):
             self.assertEqual(req.success_pred, has_code(204, 409))
             # http://docs.rcv3.apiary.io/#delete-%2Fv3%2F{tenant_id}
             # %2Fload_balancer_pools%2Fnode
-            return succeed([self.del_response])
+            return succeed((None, self.del_response))
 
     def test_add_to_rcv3(self):
         """

--- a/otter/test/worker/test_rcv3.py
+++ b/otter/test/worker/test_rcv3.py
@@ -53,9 +53,9 @@ class RCv3Tests(SynchronousTestCase):
         self.dispatcher = object()
         self.request_bag = _RequestBag(dispatcher=self.dispatcher,
                                        tenant_id='thetenantid')
-        self.post_response = (StubResponse(201, {}),
+        self.post_result = (StubResponse(201, {}),
                               _rcv3_add_response_body("lb_id", "server_id"))
-        self.del_response = None
+        self.del_result = None
 
     def _fake_perform(self, dispatcher, effect):
         """
@@ -84,12 +84,12 @@ class RCv3Tests(SynchronousTestCase):
             self.assertEqual(req.success_pred, has_code(201))
             # http://docs.rcv3.apiary.io/#post-%2Fv3%2F{tenant_id}
             # %2Fload_balancer_pools%2Fnodes
-            return succeed(self.post_response)
+            return succeed(self.post_result)
         elif req.method == "DELETE":
             self.assertEqual(req.success_pred, has_code(204, 409))
             # http://docs.rcv3.apiary.io/#delete-%2Fv3%2F{tenant_id}
             # %2Fload_balancer_pools%2Fnode
-            return succeed(self.del_response)
+            return succeed(self.del_result)
 
     def test_add_to_rcv3(self):
         """
@@ -104,7 +104,7 @@ class RCv3Tests(SynchronousTestCase):
         """
         :func:`_rcv3.add_to_rcv3` attempts to perform the correct effect.
         """
-        self.post_response = None
+        self.post_result = None
         d = _rcv3.add_to_rcv3(self.request_bag, "lb_id", "server_id")
         self.failureResultOf(d)
 

--- a/otter/worker/_rcv3.py
+++ b/otter/worker/_rcv3.py
@@ -9,7 +9,6 @@ from operator import itemgetter
 from effect import Effect
 from effect.twisted import perform
 
-from otter.convergence.effecting import steps_to_effect
 from otter.convergence.steps import BulkAddToRCv3, BulkRemoveFromRCv3
 from otter.http import TenantScope
 


### PR DESCRIPTION
In worker, RCv3 steps want to see the parsed request body. In convergence, it should return `Status, [reasons]` as per #956. Previously, there were some hacks in the RCv3 worker code to work around this, but that would stop working as soon as we try to make the return type of the RCv3 bulk add step also be `Effect (Status [reasons])`. This removes that hack by introducing a new private API, returning the bare request effect (of type `Effect (Response, ParsedResponseBody)`) without the callbacks attached.

This should be merged after #1064.