### PR TITLE
Webhook migrate script

### DIFF
--- a/otter/effect_dispatcher.py
+++ b/otter/effect_dispatcher.py
@@ -2,15 +2,10 @@
 
 from functools import partial
 
-from cql.connection import connect
-
 from effect import (
     ComposedDispatcher,
-    ParallelEffects,
     TypeDispatcher,
-    base_dispatcher,
-    sync_perform,
-    sync_performer)
+    base_dispatcher)
 from effect.twisted import make_twisted_dispatcher
 
 from .auth import (

--- a/otter/effect_dispatcher.py
+++ b/otter/effect_dispatcher.py
@@ -14,7 +14,7 @@ from .auth import (
     perform_invalidate_token,
 )
 from .http import TenantScope, perform_tenant_scope
-from .models.cass import CQLQueryExecute
+from .models.cass import CQLQueryExecute, perform_query_sync
 from .util.pure_http import Request, perform_request
 from .util.retry import Retry, perform_retry
 
@@ -66,6 +66,7 @@ def get_sync_cql_dispatcher(cursor):
             ParallelEffects: perform_serial
         })
     ])
+
 
 @sync_performer
 def perform_serial(disp, intent):

--- a/otter/effect_dispatcher.py
+++ b/otter/effect_dispatcher.py
@@ -73,13 +73,3 @@ def perform_serial(disp, intent):
     Performs parallel effects serially. Useful when testing or simple cases
     """
     return map(partial(perform, disp), intent.effects)
-
-
-@sync_performer
-def perform_query_sync(cursor, disp, intent):
-    """
-    Perform CQLQueryExecute synchronously using cursor
-    """
-    return cursor.execute(
-        intent.query, intent.params,
-        consistency_level=intent.consistency_level)

--- a/otter/effect_dispatcher.py
+++ b/otter/effect_dispatcher.py
@@ -36,7 +36,7 @@ def get_simple_dispatcher(reactor):
             Authenticate: perform_authenticate,
             InvalidateToken: perform_invalidate_token,
             Request: perform_request,
-            Retry: perform_retry
+            Retry: perform_retry,
         }),
         make_twisted_dispatcher(reactor),
     ])

--- a/otter/models/cass.py
+++ b/otter/models/cass.py
@@ -1166,43 +1166,6 @@ class CassScalingGroup(object):
 
         return self.get_webhook(policy_id, webhook_id).addCallback(_do_delete)
 
-    def get_webhook_index_only(self):
-        """
-        Get webhook info that is there in webhook index but is not there in
-        webhook_keys table
-
-        :return: Effect of CQLQueryExecute
-        """
-        query = ('SELECT "tenantId", "groupId", "policyId", "webhookKey" '
-                 'FROM {cf}')
-        eff = parallel(
-            [CQLQueryExecute(query=query.format(cf=self.webhooks_table),
-                             params={},
-                             consistency_level=ConsistencyLevel.ONE),
-             CQLQueryExecute(query=query.format(cf=self.webhooks_keys_table),
-                             params={},
-                             consistency_level=ConsistencyLevel.ONE)])
-        return eff.on(
-            lambda (whooks, wkeys): set(freeze(whooks)) - set(freeze(wkeys)))
-
-    def add_webhook_keys(self, webhook_keys):
-        """
-        Add webhook keys to webhook_keys table
-
-        :return: Effect of CQLQueryExecute
-        """
-        query = (
-            'INSERT INTO {cf} "tenantId", "groupId", "policyId", "webhookKey"'
-            'VALUES (:tenantId{i}, :groupId{i}, :policyId{i}, :webhookKey{i})')
-        stmts = []
-        data = {}
-        for i, wkey in enumerate(webhook_keys):
-            data.update(keymap(lambda k: k + str(i), wkey))
-            stmts.append(query.format(cf=self.webhooks_keys_table, i=i))
-        return Effect(
-            CQLQueryExecute(query=batch(stmts), params=data,
-                            consistency_level=ConsistencyLevel.ONE))
-
     def delete_group(self):
         """
         see :meth:`otter.models.interface.IScalingGroup.delete_group`
@@ -1546,6 +1509,43 @@ class CassScalingGroupCollection:
                                     ConsistencyLevel.ONE)
         d.addCallback(_do_webhook_lookup)
         return d
+
+    def get_webhook_index_only(self):
+        """
+        Get webhook info that is there in webhook index but is not there in
+        webhook_keys table
+
+        :return: Effect of CQLQueryExecute
+        """
+        query = ('SELECT "tenantId", "groupId", "policyId", "webhookKey" '
+                 'FROM {cf}')
+        eff = parallel(
+            [CQLQueryExecute(query=query.format(cf=self.webhooks_table),
+                             params={},
+                             consistency_level=ConsistencyLevel.ONE),
+             CQLQueryExecute(query=query.format(cf=self.webhook_keys_table),
+                             params={},
+                             consistency_level=ConsistencyLevel.ONE)])
+        return eff.on(
+            lambda (whooks, wkeys): set(freeze(whooks)) - set(freeze(wkeys)))
+
+    def add_webhook_keys(self, webhook_keys):
+        """
+        Add webhook keys to webhook_keys table
+
+        :return: Effect of CQLQueryExecute
+        """
+        query = (
+            'INSERT INTO {cf} "tenantId", "groupId", "policyId", "webhookKey"'
+            'VALUES (:tenantId{i}, :groupId{i}, :policyId{i}, :webhookKey{i})')
+        stmts = []
+        data = {}
+        for i, wkey in enumerate(webhook_keys):
+            data.update(keymap(lambda k: k + str(i), wkey))
+            stmts.append(query.format(cf=self.webhook_keys_table, i=i))
+        return Effect(
+            CQLQueryExecute(query=batch(stmts), params=data,
+                            consistency_level=ConsistencyLevel.ONE))
 
     def get_counts(self, log, tenant_id):
         """

--- a/otter/models/cass.py
+++ b/otter/models/cass.py
@@ -12,7 +12,8 @@ from datetime import datetime
 
 from characteristic import attributes
 
-from effect import Effect, parallel, sync_performer
+from effect import Effect, parallel
+from effect.twisted import deferred_performer
 
 from jsonschema import ValidationError
 
@@ -61,15 +62,13 @@ class CQLQueryExecute(object):
     """
 
 
-@sync_performer
-def perform_query_sync(cursor, disp, intent):
+@deferred_performer
+def perform_cql_query(conn, disp, intent):
     """
-    Perform CQLQueryExecute synchronously using cursor
+    Perform CQLQueryExecute intent using given silverberg connection
     """
-    cursor.execute(
-        intent.query, intent.params)
-        #consistency_level=intent.consistency_level)
-    return cursor.fetchall()
+    return conn.execute(
+        intent.query, intent.params, intent.consistency_level)
 
 
 def serialize_json_data(data, ver):

--- a/otter/models/cass.py
+++ b/otter/models/cass.py
@@ -8,8 +8,9 @@ import json
 import time
 import uuid
 import weakref
-
 from datetime import datetime
+
+from characteristic import attributes
 
 from jsonschema import ValidationError
 
@@ -45,6 +46,13 @@ from otter.util.hashkey import generate_capability, generate_key_str
 
 
 LOCK_PATH = '/locks'
+
+
+@attributes(['query', 'params', 'consistency_level'])
+class CQLQueryExecute(object):
+    """
+    An intent to execute CQL query
+    """
 
 
 def serialize_json_data(data, ver):

--- a/otter/models/cass.py
+++ b/otter/models/cass.py
@@ -1520,12 +1520,14 @@ class CassScalingGroupCollection:
         query = ('SELECT "tenantId", "groupId", "policyId", "webhookKey" '
                  'FROM {cf}')
         eff = parallel(
-            [CQLQueryExecute(query=query.format(cf=self.webhooks_table),
-                             params={},
-                             consistency_level=ConsistencyLevel.ONE),
-             CQLQueryExecute(query=query.format(cf=self.webhook_keys_table),
-                             params={},
-                             consistency_level=ConsistencyLevel.ONE)])
+            [Effect(
+                CQLQueryExecute(query=query.format(cf=self.webhooks_table),
+                                params={},
+                                consistency_level=ConsistencyLevel.ONE)),
+             Effect(
+                CQLQueryExecute(query=query.format(cf=self.webhook_keys_table),
+                                params={},
+                                consistency_level=ConsistencyLevel.ONE))])
         return eff.on(
             lambda (whooks, wkeys): set(freeze(whooks)) - set(freeze(wkeys)))
 

--- a/otter/models/cass.py
+++ b/otter/models/cass.py
@@ -1515,7 +1515,8 @@ class CassScalingGroupCollection:
         Get webhook info that is there in webhook index but is not there in
         webhook_keys table
 
-        :return: Effect of list of dict
+        :return: Effect of list of pmap. The pmap contains tenantId, groupId,
+            policyId and webhookKey
         """
         query = ('SELECT "tenantId", "groupId", "policyId", "webhookKey" '
                  'FROM {cf}')
@@ -1533,7 +1534,10 @@ class CassScalingGroupCollection:
 
     def add_webhook_keys(self, webhook_keys):
         """
-        Add webhook keys to webhook_keys table
+        Add webhook keys to webhook_keys table.
+
+        :param dict webhook_keys: It must have tenantId, groupId, policyId
+            and webhookKey
 
         :return: Effect of None
         """

--- a/otter/models/cass.py
+++ b/otter/models/cass.py
@@ -12,7 +12,7 @@ from datetime import datetime
 
 from characteristic import attributes
 
-from effect import Effect, parallel
+from effect import Effect, parallel, sync_performer
 
 from jsonschema import ValidationError
 
@@ -59,6 +59,16 @@ class CQLQueryExecute(object):
     """
     An intent to execute CQL query
     """
+
+
+@sync_performer
+def perform_query_sync(cursor, disp, intent):
+    """
+    Perform CQLQueryExecute synchronously using cursor
+    """
+    return cursor.execute(
+        intent.query, intent.params,
+        consistency_level=intent.consistency_level)
 
 
 def serialize_json_data(data, ver):

--- a/otter/models/cass.py
+++ b/otter/models/cass.py
@@ -1515,7 +1515,7 @@ class CassScalingGroupCollection:
         Get webhook info that is there in webhook index but is not there in
         webhook_keys table
 
-        :return: Effect of CQLQueryExecute
+        :return: Effect of list of dict
         """
         query = ('SELECT "tenantId", "groupId", "policyId", "webhookKey" '
                  'FROM {cf}')
@@ -1535,7 +1535,7 @@ class CassScalingGroupCollection:
         """
         Add webhook keys to webhook_keys table
 
-        :return: Effect of CQLQueryExecute
+        :return: Effect of None
         """
         query = (
             'INSERT INTO {cf} ("tenantId", "groupId", "policyId", '

--- a/otter/models/cass.py
+++ b/otter/models/cass.py
@@ -66,9 +66,10 @@ def perform_query_sync(cursor, disp, intent):
     """
     Perform CQLQueryExecute synchronously using cursor
     """
-    return cursor.execute(
-        intent.query, intent.params,
-        consistency_level=intent.consistency_level)
+    cursor.execute(
+        intent.query, intent.params)
+        #consistency_level=intent.consistency_level)
+    return cursor.fetchall()
 
 
 def serialize_json_data(data, ver):
@@ -1538,7 +1539,8 @@ class CassScalingGroupCollection:
         :return: Effect of CQLQueryExecute
         """
         query = (
-            'INSERT INTO {cf} "tenantId", "groupId", "policyId", "webhookKey"'
+            'INSERT INTO {cf} ("tenantId", "groupId", "policyId", '
+            '"webhookKey")'
             'VALUES (:tenantId{i}, :groupId{i}, :policyId{i}, :webhookKey{i})')
         stmts = []
         data = {}

--- a/otter/test/models/test_cass_models.py
+++ b/otter/test/models/test_cass_models.py
@@ -2570,7 +2570,9 @@ class ScalingGroupWebhookMigrateTests(SynchronousTestCase):
 
     def test_webhook_index_only(self):
         """
-        Test `get_webhook_index_only`
+        `get_webhook_index_only` gets webhook info from policy_webhooks table
+        and webhook_keys in parallel and returns those webhook info that is
+        there in policy_webhooks table but NOT in webhook_keys table
         """
         eff = self.store.get_webhook_index_only()
         self.assertEqual(

--- a/otter/test/models/test_cass_models.py
+++ b/otter/test/models/test_cass_models.py
@@ -2579,12 +2579,12 @@ class ScalingGroupWebhookMigrateTests(SynchronousTestCase):
                 Effect(
                     CQLQueryExecute(
                         query=('SELECT "tenantId", "groupId", "policyId", '
-                            '"webhookKey" FROM policy_webhooks'),
+                               '"webhookKey" FROM policy_webhooks'),
                         params={}, consistency_level=ConsistencyLevel.ONE)),
                  Effect(
                     CQLQueryExecute(
                         query=('SELECT "tenantId", "groupId", "policyId", '
-                            '"webhookKey" FROM webhook_keys'),
+                               '"webhookKey" FROM webhook_keys'),
                         params={}, consistency_level=ConsistencyLevel.ONE))]))
         r = resolve_effect(
             eff, [[{'w1': '1'}, {'w2': '2'}], [{'w1': '1'}]])

--- a/otter/test/models/test_cass_models.py
+++ b/otter/test/models/test_cass_models.py
@@ -2581,7 +2581,7 @@ class ScalingGroupWebhookMigrateTests(SynchronousTestCase):
                         query=('SELECT "tenantId", "groupId", "policyId", '
                                '"webhookKey" FROM policy_webhooks'),
                         params={}, consistency_level=ConsistencyLevel.ONE)),
-                 Effect(
+                Effect(
                     CQLQueryExecute(
                         query=('SELECT "tenantId", "groupId", "policyId", '
                                '"webhookKey" FROM webhook_keys'),

--- a/otter/test/models/test_cass_models.py
+++ b/otter/test/models/test_cass_models.py
@@ -2602,11 +2602,11 @@ class ScalingGroupWebhookMigrateTests(SynchronousTestCase):
 
         query = (
             'BEGIN BATCH '
-            'INSERT INTO webhook_keys "tenantId", "groupId", "policyId", '
-            '"webhookKey"'
+            'INSERT INTO webhook_keys ("tenantId", "groupId", "policyId", '
+            '"webhookKey")'
             'VALUES (:tenantId0, :groupId0, :policyId0, :webhookKey0) '
-            'INSERT INTO webhook_keys "tenantId", "groupId", "policyId", '
-            '"webhookKey"'
+            'INSERT INTO webhook_keys ("tenantId", "groupId", "policyId", '
+            '"webhookKey")'
             'VALUES (:tenantId1, :groupId1, :policyId1, :webhookKey1) '
             'APPLY BATCH;')
         params = {

--- a/otter/test/models/test_cass_models.py
+++ b/otter/test/models/test_cass_models.py
@@ -119,12 +119,12 @@ class PerformTests(SynchronousTestCase):
     Tests for :func:`perform_cql_query` function
     """
 
-    def test_perform_query_sync(self):
+    def test_perform_cql_query(self):
         """
         Calls given connection's execute
         """
         conn = mock.Mock(spec=CQLClient)
-        conn.execute.return_value = 'ret'
+        conn.execute.return_value = defer.succeed('ret')
         intent = CQLQueryExecute(query='query', params={'w': 2},
                                  consistency_level=ConsistencyLevel.ONE)
         r = sync_perform(

--- a/otter/test/models/test_cass_models.py
+++ b/otter/test/models/test_cass_models.py
@@ -2566,9 +2566,7 @@ class ScalingGroupWebhookMigrateTests(SynchronousTestCase):
         """
         Sample CassScalingGroup object
         """
-        self.store = CassScalingGroup(
-            mock_log(), 'tid', 'gid', object(), [], object(), object(),
-            object())
+        self.store = CassScalingGroupCollection(None, None)
 
     def test_webhook_index_only(self):
         """

--- a/otter/test/models/test_cass_models.py
+++ b/otter/test/models/test_cass_models.py
@@ -36,7 +36,7 @@ from otter.models.cass import (
     WeakLocks,
     _assemble_webhook_from_row,
     assemble_webhooks_in_policies,
-    perform_query_sync,
+    perform_cql_query,
     serialize_json_data,
     verified_view
 )
@@ -116,24 +116,24 @@ def _cassandrify_data(list_of_dicts):
 
 class PerformTests(SynchronousTestCase):
     """
-    Tests for :func:`perform_query_sync` function
+    Tests for :func:`perform_cql_query` function
     """
 
     def test_perform_query_sync(self):
         """
-        Test for :func:`perform_query_sync`
+        Calls given connection's execute
         """
-        cursor = mock.Mock(spec=['execute'])
-        cursor.execute.return_value = 'ret'
+        conn = mock.Mock(spec=CQLClient)
+        conn.execute.return_value = 'ret'
         intent = CQLQueryExecute(query='query', params={'w': 2},
                                  consistency_level=ConsistencyLevel.ONE)
         r = sync_perform(
-            TypeDispatcher({CQLQueryExecute: partial(perform_query_sync,
-                                                     cursor)}),
+            TypeDispatcher({CQLQueryExecute: partial(perform_cql_query,
+                                                     conn)}),
             Effect(intent))
         self.assertEqual(r, 'ret')
-        cursor.execute.assert_called_once_with(
-            'query', {'w': 2}, consistency_level=ConsistencyLevel.ONE)
+        conn.execute.assert_called_once_with(
+            'query', {'w': 2}, ConsistencyLevel.ONE)
 
 
 class SerialJsonDataTestCase(SynchronousTestCase):

--- a/otter/test/models/test_cass_models.py
+++ b/otter/test/models/test_cass_models.py
@@ -2575,15 +2575,17 @@ class ScalingGroupWebhookMigrateTests(SynchronousTestCase):
         eff = self.store.get_webhook_index_only()
         self.assertEqual(
             eff.intent,
-            ParallelEffects(
-                [CQLQueryExecute(
-                    query=('SELECT "tenantId", "groupId", "policyId", '
-                           '"webhookKey" FROM policy_webhooks'),
-                    params={}, consistency_level=ConsistencyLevel.ONE),
-                 CQLQueryExecute(
-                    query=('SELECT "tenantId", "groupId", "policyId", '
-                           '"webhookKey" FROM webhook_keys'),
-                    params={}, consistency_level=ConsistencyLevel.ONE)]))
+            ParallelEffects([
+                Effect(
+                    CQLQueryExecute(
+                        query=('SELECT "tenantId", "groupId", "policyId", '
+                            '"webhookKey" FROM policy_webhooks'),
+                        params={}, consistency_level=ConsistencyLevel.ONE)),
+                 Effect(
+                    CQLQueryExecute(
+                        query=('SELECT "tenantId", "groupId", "policyId", '
+                            '"webhookKey" FROM webhook_keys'),
+                        params={}, consistency_level=ConsistencyLevel.ONE))]))
         r = resolve_effect(
             eff, [[{'w1': '1'}, {'w2': '2'}], [{'w1': '1'}]])
         self.assertEqual(r, set(freeze([{'w2': '2'}])))

--- a/otter/test/test_effect_dispatcher.py
+++ b/otter/test/test_effect_dispatcher.py
@@ -56,4 +56,3 @@ class FullDispatcherTests(SynchronousTestCase):
         scope = TenantScope(Effect(Constant('foo')), 1)
         eff = Effect(scope)
         self.assertEqual(sync_perform(dispatcher, eff), 'foo')
-

--- a/otter/test/test_effect_dispatcher.py
+++ b/otter/test/test_effect_dispatcher.py
@@ -57,25 +57,3 @@ class FullDispatcherTests(SynchronousTestCase):
         eff = Effect(scope)
         self.assertEqual(sync_perform(dispatcher, eff), 'foo')
 
-
-class PerformTests(SynchronousTestCase):
-    """
-    Tests for perform_* functions
-    """
-
-    def test_perform_query_sync(self):
-        """
-        Test for :func:`perform_query_sync`
-        """
-        cursor = mock.Mock(spec=['execute'])
-        cursor.execute.return_value = 'ret'
-        intent = CQLQueryExecute(query='query', params={'w': 2},
-                                 consistency_level=ConsistencyLevel.ONE)
-        r = sync_perform(
-            TypeDispatcher({CQLQueryExecute: partial(perform_query_sync,
-                                                     conn)}),
-            Effect(intent))
-        self.assertEqual(r, 'ret')
-        cursor.execute.assert_called_once_with(
-            'query', {'w': 2}, consistency_level=ConsistencyLevel.ONE)
-

--- a/otter/test/test_effect_dispatcher.py
+++ b/otter/test/test_effect_dispatcher.py
@@ -1,12 +1,18 @@
 """Tests for :module:`otter.effect_dispatcher`."""
 
 from effect import Constant, Delay, Effect, sync_perform
+from effect.twisted import deferred_performer
 
+import mock
+
+from twisted.internet.defer import succeed
 from twisted.trial.unittest import SynchronousTestCase
 
 from otter.auth import Authenticate, InvalidateToken
-from otter.effect_dispatcher import get_full_dispatcher, get_simple_dispatcher
+from otter.effect_dispatcher import (
+    get_cql_dispatcher, get_full_dispatcher, get_simple_dispatcher)
 from otter.http import TenantScope
+from otter.models.cass import CQLQueryExecute
 from otter.util.pure_http import Request
 from otter.util.retry import Retry
 
@@ -56,3 +62,28 @@ class FullDispatcherTests(SynchronousTestCase):
         scope = TenantScope(Effect(Constant('foo')), 1)
         eff = Effect(scope)
         self.assertEqual(sync_perform(dispatcher, eff), 'foo')
+
+
+class CQLDispatcherTests(SynchronousTestCase):
+    """Tests for :func:`get_cql_dispatcher`."""
+
+    def test_intent_support(self):
+        """Basic intents are supported by the dispatcher."""
+        dispatcher = get_simple_dispatcher(None)
+        for intent in simple_intents():
+            self.assertIsNot(dispatcher(intent), None)
+
+    @mock.patch('otter.effect_dispatcher.perform_cql_query')
+    def test_cql_disp(self, mock_pcq):
+        """The :obj:`CQLQueryExecute` performer is called."""
+
+        @deferred_performer
+        def performer(c, d, i):
+            return succeed('p' + c)
+
+        mock_pcq.side_effect = performer
+
+        dispatcher = get_cql_dispatcher(object(), 'conn')
+        intent = CQLQueryExecute(query='q', params='p', consistency_level=1)
+        eff = Effect(intent)
+        self.assertEqual(sync_perform(dispatcher, eff), 'pconn')

--- a/otter/test/test_effect_dispatcher.py
+++ b/otter/test/test_effect_dispatcher.py
@@ -56,3 +56,26 @@ class FullDispatcherTests(SynchronousTestCase):
         scope = TenantScope(Effect(Constant('foo')), 1)
         eff = Effect(scope)
         self.assertEqual(sync_perform(dispatcher, eff), 'foo')
+
+
+class PerformTests(SynchronousTestCase):
+    """
+    Tests for perform_* functions
+    """
+
+    def test_perform_query_sync(self):
+        """
+        Test for :func:`perform_query_sync`
+        """
+        cursor = mock.Mock(spec=['execute'])
+        cursor.execute.return_value = 'ret'
+        intent = CQLQueryExecute(query='query', params={'w': 2},
+                                 consistency_level=ConsistencyLevel.ONE)
+        r = sync_perform(
+            TypeDispatcher({CQLQueryExecute: partial(perform_query_sync,
+                                                     conn)}),
+            Effect(intent))
+        self.assertEqual(r, 'ret')
+        cursor.execute.assert_called_once_with(
+            'query', {'w': 2}, consistency_level=ConsistencyLevel.ONE)
+

--- a/scripts/load_cql.py
+++ b/scripts/load_cql.py
@@ -5,7 +5,6 @@ Loads cql into Cassandra
 """
 
 import argparse
-from functools import partial
 import sys
 import re
 
@@ -28,7 +27,7 @@ the_parser = argparse.ArgumentParser(description="Load data into Cassandra.")
 
 
 the_parser.add_argument(
-    'cql_dir', type=str, metavar='cql_dir', nargs='?',
+    'cql_dir', type=str, metavar='cql_dir',
     help='Directory containing *.cql files to merge and replace.')
 
 the_parser.add_argument(

--- a/scripts/load_cql.py
+++ b/scripts/load_cql.py
@@ -5,13 +5,35 @@ Loads cql into Cassandra
 """
 
 import argparse
+from functools import partial
 import sys
 import re
 
 from cql.apivalues import ProgrammingError
 from cql.connection import connect
 
+# from cassandra.cluster import Cluster
+
+from effect import (
+    ComposedDispatcher,
+    Effect,
+    ParallelEffects,
+    TypeDispatcher,
+    base_dispatcher,
+    parallel,
+    perform,
+    sync_performer
+)
+
+from pyrsistent import freeze
+
+from silverberg.client import ConsistencyLevel
+
+from toolz.dicttoolz import keymap
+
+from otter.models.cass import CQLQueryExecute
 from otter.test.resources import CQLGenerator
+from otter.util.cqlbatch import batch
 
 
 the_parser = argparse.ArgumentParser(description="Load data into Cassandra.")
@@ -20,6 +42,10 @@ the_parser = argparse.ArgumentParser(description="Load data into Cassandra.")
 the_parser.add_argument(
     'cql_dir', type=str, metavar='cql_dir',
     help='Directory containing *.cql files to merge and replace.')
+
+the_parser.add_argument(
+    '--webhook-migrate', action='store_false',
+    help='Migrate webhook indexes to table')
 
 the_parser.add_argument(
     '--keyspace', type=str, default='otter',
@@ -55,7 +81,7 @@ the_parser.add_argument(
     '--verbose', '-v', action='count', default=0, help="How verbose to be")
 
 
-def run(args):
+def generate(args):
     """
     Generate CQL and/or load it into a cassandra instance/cluster.
     """
@@ -127,6 +153,84 @@ def run(args):
     cursor.close()
     connection.close()
 
+
+@sync_performer
+def perform_query_sync(session, dispatcher, intent):
+    query = re.sub(r':(\w+)', r'%(\1)s', intent.query)
+    if intent.consistency_level == ConsistencyLevel.ONE:
+        return session.execute(query, intent.params)
+    else:
+        return session.execute(
+            SimpleStatement(query, consistency_level=intent.consistency_level),
+            intent.params)
+
+
+@sync_performer
+def perform_serial(disp, intent):
+    return map(partial(perform, disp), intent.effects)
+
+
+def get_dispatcher(session):
+    return ComposedDispatcher([
+        base_dispatcher,
+        TypeDispatcher({
+            CQLQueryExecute: partial(perform_query_sync, session),
+            ParallelEffects: perform_serial
+        })
+    ])
+
+
+def get_webhook_index_only():
+    """
+    Get webhook info that is there in webhook index but is not there in
+    webhook_keys table
+    """
+    query = 'SELECT "tenantId", "groupId", "policyId", "webhookKey" FROM {cf}'
+    eff = parallel(
+        [CQLQueryExecute(query=query.format(cf='policy_webhooks'), params={},
+                         consistency_level=ConsistencyLevel.ONE),
+         CQLQueryExecute(query=query.format(cf='webhook_keys'), params={},
+                         consistency_level=ConsistencyLevel.ONE)])
+    return eff.on(
+        lambda (webhooks, wkeys): set(freeze(webhooks)) - set(freeze(wkeys)))
+
+
+def add_webhook_keys(webhook_keys):
+    """
+    Add webhook keys to webhook_keys table
+    """
+    query = (
+        'INSERT INTO {cf} "tenantId", "groupId", "policyId", "webhookKey"'
+        'VALUES (:tenantId{i}, :groupId{i}, :policyId{i}, :webhookKey{i})')
+    stmts = []
+    data = {}
+    for i, wkey in enumerate(webhook_keys):
+        data.update(keymap(lambda k: k + str(i), wkey))
+        stmts.append(query.format(cf='webhook_keys', i=i))
+    return Effect(
+        CQLQueryExecute(query=batch(stmts), params=data,
+                        consistency_level=ConsistencyLevel.ONE))
+
+
+def webhook_migrate():
+    """
+    Migrate webhook indexes to table
+    """
+    return get_webhook_index_only().on(add_webhook_keys)
+
+
+def setup_session(args):
+#     cluster = Cluster([args.host], port=args.port)
+#     return cluster.connect(args.keyspace)
+    pass
+
+
+def run(args):
+    if args.webhook_migrate:
+        eff = webhook_migrate()
+        perform(get_dispatcher(setup_session(args)), eff)
+    else:
+        generate(args)
 
 args = the_parser.parse_args()
 run(args)


### PR DESCRIPTION
First task of #1039. This creates `CQLQueryExecute` intent along with its performer and dispatcher to migrate the webhooks. Would like to know if having separate `otter.effect_dispatcher.get_cql_dispatcher` is a good idea @radix ?

I've tested this from dev vm by copying data from SYD prod. 