### PR TITLE
coveralls support added

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,13 @@ python:
 install:
     - pip install -r dev_requirements.txt
     - pip install -r requirements.txt
+    - pip install coveralls
 
 script:
     - make lint
     - make docbook
     - make unit
+    - make coverage
+
+after_success:
+    - coveralls

--- a/Makefile
+++ b/Makefile
@@ -63,13 +63,15 @@ flake8diff:
 flake8full:
 	flake8 ${PYDIRS}
 
+TRIAL_OPTIONS=--jobs=4 --random 0
+
 unit:
 ifneq ($(JENKINS_URL), )
-	trial --jobs=4 --random 0 --reporter=subunit ${UNITTESTS} \
+	trial ${TRIAL_OPTIONS} --reporter=subunit ${UNITTESTS} \
 		| tee subunit-output.txt
 	tail -n +4 subunit-output.txt | subunit2junitxml > test-report.xml
 else
-	trial --jobs=4 --random 0 ${UNITTESTS}
+	trial ${TRIAL_OPTIONS} ${UNITTESTS}
 endif
 
 integration:
@@ -87,7 +89,9 @@ else
 endif
 
 coverage:
-	coverage run --source=${CODEDIR} --branch `which trial` ${UNITTESTS}
+	coverage run --source=${CODEDIR} --branch `which trial` ${TRIAL_OPTIONS} ${UNITTESTS}
+
+coverage-html: coverage
 	coverage html -d _trial_coverage --omit="*/test/*"
 
 cleandocs:


### PR DESCRIPTION
One issue is that unit tests will be run twice; once with `make unit` and another one with `make coverage`.