### PR TITLE
RCv3 bulk add success semantics

### DIFF
--- a/otter/convergence/steps.py
+++ b/otter/convergence/steps.py
@@ -357,7 +357,7 @@ class BulkAddToRCv3(object):
         Just the RCv3 bulk request effect, with no callbacks.
         """
         return _rackconnect_bulk_request(self.lb_node_pairs, "POST",
-                                         success_pred=has_code(201))
+                                         success_pred=has_code(201, 409))
 
     def as_effect(self):
         """

--- a/otter/convergence/steps.py
+++ b/otter/convergence/steps.py
@@ -364,7 +364,8 @@ class BulkAddToRCv3(object):
         Produce a :obj:`Effect` to add some nodes to some RCv3 load
         balancers.
         """
-        return self._bare_effect()
+        eff = self._bare_effect()
+        return eff.on(partial(_rcv3_check_bulk_add, self.lb_node_pairs))
 
 
 def _rcv3_check_bulk_add(attempted_pairs, result):

--- a/otter/convergence/steps.py
+++ b/otter/convergence/steps.py
@@ -328,6 +328,9 @@ def _rcv3_re(pattern):
 _RCV3_NODE_NOT_A_MEMBER_PATTERN = _rcv3_re(
     "Node (?P<node_id>{uuid}) is not a member of Load Balancer Pool "
     "(?P<lb_id>{uuid})")
+_RCV3_NODE_ALREADY_A_MEMBER_PATTERN = _rcv3_re(
+    "Cloud Server (?P<node_id>{uuid}) is already a member of Load Balancer "
+    "Pool (?P<lb_id>{uuid})")
 _RCV3_LB_INACTIVE_PATTERN = _rcv3_re(
     "Load Balancer Pool (?P<lb_id>{uuid}) is not in an ACTIVE state")
 _RCV3_LB_DOESNT_EXIST_PATTERN = _rcv3_re(

--- a/otter/convergence/steps.py
+++ b/otter/convergence/steps.py
@@ -372,7 +372,10 @@ def _rcv3_check_bulk_add(attempted_pairs, result):
     """
     Checks if the RCv3 bulk add command was successful.
     """
-    return StepResult.SUCCESS, []
+    response, body = result
+
+    if response.code == 201:  # All done!
+        return StepResult.SUCCESS, []
 
 
 @implementer(IStep)

--- a/otter/convergence/steps.py
+++ b/otter/convergence/steps.py
@@ -364,6 +364,13 @@ class BulkAddToRCv3(object):
         return self._bare_effect()
 
 
+def _rcv3_check_bulk_add(attempted_pairs, result):
+    """
+    Checks if the RCv3 bulk add command was successful.
+    """
+    return StepResult.SUCCESS, []
+
+
 @implementer(IStep)
 @attributes(['lb_node_pairs'])
 class BulkRemoveFromRCv3(object):

--- a/otter/test/convergence/test_steps.py
+++ b/otter/test/convergence/test_steps.py
@@ -701,8 +701,8 @@ class RCv3CheckBulkDeleteTests(SynchronousTestCase):
 
     def test_node_not_a_member(self):
         """
-        If the node is not a member of the load balancer pool it's being
-        removed from, the response was successful.
+        If the nodes are already not member of the load balancer pools
+        they're being removed from, the response was successful.
         """
         node_id = '825b8c72-9951-4aff-9cd8-fa3ca5551c90'
         lb_id = '2b0e17b6-0429-4056-b86c-e670ad5de853'

--- a/otter/test/convergence/test_steps.py
+++ b/otter/test/convergence/test_steps.py
@@ -373,7 +373,7 @@ class StepAsEffectTests(SynchronousTestCase):
 
         success_pred = request.intent.success_pred
         if request.intent.method == "POST":
-            self.assertEqual(success_pred, has_code(201))
+            self.assertEqual(success_pred, has_code(201, 409))
         else:
             self.assertEqual(success_pred, has_code(204, 409))
 

--- a/otter/test/convergence/test_steps.py
+++ b/otter/test/convergence/test_steps.py
@@ -472,7 +472,7 @@ class RCv3RegexTests(SynchronousTestCase):
                     self.assertNotIdentical(res, None)
                     self.assertEqual(res.groupdict(), expected_group_dict)
 
-    def test_node_not_a_member_error_message_regex(self):
+    def test_node_not_a_member_regex(self):
         """
         The regex for parsing messages saying the node isn't part of the
         load balancer parses those messages. It rejects other

--- a/otter/test/convergence/test_steps.py
+++ b/otter/test/convergence/test_steps.py
@@ -494,6 +494,30 @@ class RCv3RegexTests(SynchronousTestCase):
         self._regex_test(_RCV3_LB_DOESNT_EXIST_PATTERN)
 
 
+class RCv3CheckBulkAddTests(SynchronousTestCase):
+    """
+    Tests for :func:`_rcv3_check_bulk_add`.
+    """
+    def test_good_response(self):
+        """
+        If the response code indicates success, the response was successful.
+        """
+        node_a_id = '825b8c72-9951-4aff-9cd8-fa3ca5551c90'
+        lb_a_id = '2b0e17b6-0429-4056-b86c-e670ad5de853'
+
+        node_b_id = "d6d3aa7c-dfa5-4e61-96ee-1d54ac1075d2"
+        lb_b_id = 'd95ae0c4-6ab8-4873-b82f-f8433840cff2'
+
+        pairs = [(lb_a_id, node_a_id), (lb_b_id, node_b_id)]
+
+        resp = StubResponse(201, {})
+        body = [{"cloud_server": {"id": node_id},
+                 "load_balancer_pool": {"id": lb_id}}
+                for (lb_id, node_id) in pairs]
+        res = _rcv3_check_bulk_add(pairs, (resp, body))
+        self.assertEqual(res, (StepResult.SUCCESS, []))
+
+
 class RCv3CheckBulkDeleteTests(SynchronousTestCase):
     """
     Tests for :func:`_rcv3_check_bulk_delete`.

--- a/otter/test/convergence/test_steps.py
+++ b/otter/test/convergence/test_steps.py
@@ -545,8 +545,9 @@ class RCv3CheckBulkDeleteTests(SynchronousTestCase):
     def test_try_again(self):
         """
         If a node was already removed (or maybe was never part of the load
-        balancer pool to begin with), returns an effect that removes
-        the remaining load balancer pairs.
+        balancer pool to begin with), or some load balancer was
+        inactive, or one of the load balancers doesn't exist, returns
+        an effect that removes the remaining load balancer pairs.
         """
         # This little piggy isn't even on this load balancer.
         node_a_id = '825b8c72-9951-4aff-9cd8-fa3ca5551c90'

--- a/otter/test/convergence/test_steps.py
+++ b/otter/test/convergence/test_steps.py
@@ -22,6 +22,7 @@ from otter.convergence.steps import (
     _RCV3_LB_DOESNT_EXIST_PATTERN,
     _RCV3_LB_INACTIVE_PATTERN,
     _RCV3_NODE_NOT_A_MEMBER_PATTERN,
+    _rcv3_check_bulk_add,
     _rcv3_check_bulk_delete)
 from otter.http import has_code, service_request
 from otter.test.utils import StubResponse, resolve_effect

--- a/otter/test/convergence/test_steps.py
+++ b/otter/test/convergence/test_steps.py
@@ -556,6 +556,22 @@ class RCv3CheckBulkAddTests(SynchronousTestCase):
         self.assertEqual(partial_check_bulk_add.args, (expected_pairs,))
         self.assertEqual(partial_check_bulk_add.keywords, None)
 
+    def test_node_already_a_member(self):
+        """
+        If the node was already a member, the request is successful.
+        """
+        node_id = "d6d3aa7c-dfa5-4e61-96ee-1d54ac1075d2"
+        lb_id = 'd95ae0c4-6ab8-4873-b82f-f8433840cff2'
+        pairs = [(node_id, lb_id)]
+
+        resp = StubResponse(409, {})
+        body = {"errors": [
+            "Cloud Server {node_id} is already a member of Load "
+            "Balancer Pool {lb_id}".format(node_id=node_id, lb_id=lb_id)]}
+        result = _rcv3_check_bulk_add(pairs, (resp, body))
+        self.assertEqual(result, (StepResult.SUCCESS, []))
+
+
 class RCv3CheckBulkDeleteTests(SynchronousTestCase):
     """
     Tests for :func:`_rcv3_check_bulk_delete`.

--- a/otter/test/convergence/test_steps.py
+++ b/otter/test/convergence/test_steps.py
@@ -21,6 +21,7 @@ from otter.convergence.steps import (
     SetMetadataItemOnServer,
     _RCV3_LB_DOESNT_EXIST_PATTERN,
     _RCV3_LB_INACTIVE_PATTERN,
+    _RCV3_NODE_ALREADY_A_MEMBER_PATTERN,
     _RCV3_NODE_NOT_A_MEMBER_PATTERN,
     _rcv3_check_bulk_add,
     _rcv3_check_bulk_delete)
@@ -431,6 +432,18 @@ _RCV3_TEST_DATA = {
          {'lb_id': 'D95AE0C4-6AB8-4873-B82F-F8433840CFF2',
           'node_id': 'D6D3AA7C-DFA5-4E61-96EE-1D54AC1075D2'})
     ],
+    _RCV3_NODE_ALREADY_A_MEMBER_PATTERN: [
+        ('Cloud Server d6d3aa7c-dfa5-4e61-96ee-1d54ac1075d2 is already '
+         'a member of Load Balancer Pool '
+         'd95ae0c4-6ab8-4873-b82f-f8433840cff2',
+         {'lb_id': 'd95ae0c4-6ab8-4873-b82f-f8433840cff2',
+          'node_id': 'd6d3aa7c-dfa5-4e61-96ee-1d54ac1075d2'}),
+        ('Cloud Server D6D3AA7C-DFA5-4E61-96EE-1D54AC1075D2 is already '
+         'a member of Load Balancer Pool '
+         'D95AE0C4-6AB8-4873-B82F-F8433840CFF2',
+         {'lb_id': 'D95AE0C4-6AB8-4873-B82F-F8433840CFF2',
+          'node_id': 'D6D3AA7C-DFA5-4E61-96EE-1D54AC1075D2'})
+    ],
     _RCV3_LB_INACTIVE_PATTERN: [
         ('Load Balancer Pool d95ae0c4-6ab8-4873-b82f-f8433840cff2 is '
          'not in an ACTIVE state',
@@ -479,6 +492,14 @@ class RCv3RegexTests(SynchronousTestCase):
         messages.
         """
         self._regex_test(_RCV3_NODE_NOT_A_MEMBER_PATTERN)
+
+    def test_node_already_a_member_regex(self):
+        """
+        The regex for parsing messages saying the node is already part of
+        the load balancer parses those messages. It rejects other
+        messages.
+        """
+        self._regex_test(_RCV3_NODE_ALREADY_A_MEMBER_PATTERN)
 
     def test_lb_inactive_regex(self):
         """

--- a/otter/test/convergence/test_steps.py
+++ b/otter/test/convergence/test_steps.py
@@ -583,7 +583,7 @@ class RCv3CheckBulkAddTests(SynchronousTestCase):
         """
         node_id = "d6d3aa7c-dfa5-4e61-96ee-1d54ac1075d2"
         lb_id = 'd95ae0c4-6ab8-4873-b82f-f8433840cff2'
-        pairs = [(node_id, lb_id)]
+        pairs = [(lb_id, node_id)]
 
         resp = StubResponse(409, {})
         body = {"errors": [

--- a/otter/test/convergence/test_steps.py
+++ b/otter/test/convergence/test_steps.py
@@ -572,7 +572,7 @@ class RCv3CheckBulkAddTests(SynchronousTestCase):
         self.assertEqual(eff.intent, expected_intent)
         (partial_check_bulk_add, _), = eff.callbacks
         self.assertEqual(partial_check_bulk_add.func,
-                         _rcv3_check_bulk_delete)
+                         _rcv3_check_bulk_add)
         expected_pairs = pset([(lb_b_id, node_b_id)])
         self.assertEqual(partial_check_bulk_add.args, (expected_pairs,))
         self.assertEqual(partial_check_bulk_add.keywords, None)

--- a/otter/test/convergence/test_steps.py
+++ b/otter/test/convergence/test_steps.py
@@ -579,7 +579,8 @@ class RCv3CheckBulkAddTests(SynchronousTestCase):
 
     def test_node_already_a_member(self):
         """
-        If the node was already a member, the request is successful.
+        If all nodes were already member of the load balancers we were
+        trying to add them to, the request is successful.
         """
         node_id = "d6d3aa7c-dfa5-4e61-96ee-1d54ac1075d2"
         lb_id = 'd95ae0c4-6ab8-4873-b82f-f8433840cff2'


### PR DESCRIPTION
This covers the case where a machine has already been added. This should probably also only happen after I resolve #1082 with #1088, otherwise we might break RCv3.