### PR TITLE
Refactor integration tests away from unit tests.

### DIFF
--- a/otter/integration/__init__.py
+++ b/otter/integration/__init__.py
@@ -1,0 +1,3 @@
+"""
+Black-box, end-to-end tests for Otter API.
+"""

--- a/otter/integration/config.sh-template
+++ b/otter/integration/config.sh-template
@@ -1,0 +1,22 @@
+#!/bin/sh
+#
+# To run the integration tests, you'll need to have various environment
+# settings established.
+
+# This is the username used to authenticate against Identity.
+export AS_USERNAME=joe_user
+
+# This is the password used to authenticate against Identity.
+export AS_PASSWORD=joes_password
+
+# This is the Identity V2 API endpoint.
+export AS_IDENTITY=https://identity.api.rackspacecloud.com/v2.0
+
+# When creating servers, use this flavor.
+export AS_FLAVOR_REF=2
+
+# When creating servers, use this image.
+export AS_IMAGE_REF=cca73d10-8953-4949-a2f2-1e5444a4130d
+
+# When creating servers, use this region.
+export AS_REGION=iad

--- a/otter/integration/config.sh-template
+++ b/otter/integration/config.sh-template
@@ -18,5 +18,5 @@ export AS_FLAVOR_REF=2
 # When creating servers, use this image.
 export AS_IMAGE_REF=cca73d10-8953-4949-a2f2-1e5444a4130d
 
-# When creating servers, use this region.
-export AS_REGION=iad
+# When creating servers, use this region.  Beware; this is case sensitive.
+export AS_REGION=IAD

--- a/otter/integration/lib/__init__.py
+++ b/otter/integration/lib/__init__.py
@@ -1,0 +1,5 @@
+"""
+The lib package, and its constituent modules, are not tests.  Rather, they
+implement a useful set of utilities that the tests may use which are not
+otherwise already available (or as easy to use) from the mainline Otter code.
+"""

--- a/otter/integration/lib/autoscale.py
+++ b/otter/integration/lib/autoscale.py
@@ -1,0 +1,222 @@
+"""Contains reusable classes relating to autoscale."""
+
+import json
+
+from characteristic import Attribute, attributes
+
+import treq
+
+from otter.util.http import check_success, headers
+
+
+@attributes([
+    Attribute('group_config', instance_of=dict),
+    Attribute('pool', default_value=None),
+])
+class ScalingGroup(object):
+    """This class encapsulates a scaling group resource.  It provides a means
+    which lets you create new scaling groups and, later, automatically
+    dispose of them upon integration test completion.
+    """
+
+    def stop(self, rcs):
+        """Clean up a scaling group.  Although safe to call yourself, you
+        should think twice about it.  Let :method:`start` handle registering
+        this function for you.
+
+        At the present time, this function DOES NOT stop to verify
+        servers are removed.  (This is because I haven't created
+        any tests which create them yet.)
+        """
+
+        return self.delete_scaling_group(rcs)
+
+    def delete_scaling_group(self, rcs):
+        """Unconditionally delete the scaling group.  You may call this only
+        once.
+
+        :return: A :class:`Deferred` which, upon firing, disposes of the
+            scaling group.
+        """
+
+        return (treq.delete(
+            "%s/groups/%s?force=true" % (
+                str(rcs.endpoints["otter"]), self.group_id
+            ),
+            headers=headers(str(rcs.token)),
+            pool=self.pool
+        ).addCallback(check_success, [204, 404]))
+
+    def get_scaling_group_state(self, rcs):
+        """Retrieve the state of the scaling group.
+
+        :return: A :class:`Deferred` which, upon firing, returns the result
+            code and, optionally, scaling group state as a 2-tuple, in that
+            order.  If not found, the result code will be 404, and the state
+            will be None.
+        """
+
+        def decide(resp):
+            if resp.code == 200:
+                return treq.json_content(resp).addCallback(lambda x: (200, x))
+            return (404, None)
+
+        return (
+            treq.get(
+                "%s/groups/%s/state" % (
+                    str(rcs.endpoints["otter"]), self.group_id
+                ),
+                headers=headers(str(rcs.token)),
+                pool=self.pool
+            ).addCallback(check_success, [200, 404])
+            .addCallback(decide)
+        )
+
+    def start(self, rcs, test):
+        """Create a scaling group.
+
+        :param TestResources rcs: A set of OpenStack resources encapsulated
+            in a TestResources instance.
+
+        :return: The same instance of TestResources.
+        """
+
+        test.addCleanup(self.stop, rcs)
+
+        def record_results(resp):
+            rcs.groups.append(resp)
+            self.group_id = str(resp["group"]["id"])
+            return rcs
+
+        return (
+            treq.post(
+                "%s/groups" % str(rcs.endpoints["otter"]),
+                json.dumps(self.group_config),
+                headers=headers(str(rcs.token)),
+                pool=self.pool
+            )
+            .addCallback(check_success, [201])
+            .addCallback(treq.json_content)
+            .addCallback(record_results)
+        )
+
+
+@attributes([
+    Attribute('scale_by', instance_of=int),
+    Attribute('scaling_group', instance_of=ScalingGroup),
+])
+class ScalingPolicy(object):
+    """ScalingPolicy class instances represent individual policies which your
+    integration tests can execute at their convenience.
+
+    :param int scale_by: The number of servers to scale up (positive) or down
+        (negative) by.  Cannot be zero, lest an API-generated error occur.
+    :param ScalingGroup scaling_group: The scaling group to which this policy
+        applies.
+    """
+
+    def __init__(self):
+        self.policy = [{
+            "name": "integration-test-policy",
+            "cooldown": 0,
+            "type": "webhook",
+            "change": self.scale_by
+        }]
+
+    def stop(self, rcs):
+        """Disposes of the policy.
+
+        :param TestResources rcs: The integration test resources instance.
+            This provides useful information to complete the request, like
+            which endpoint to use to make the API request.
+
+        :return: A :class:`Deferred` which, when triggered, removes the scaling
+            policy.  It returns the test resources supplied, easing continuity
+            of integration test code.
+        """
+        return self.delete(rcs)
+
+    def start(self, rcs, test):
+        """Creates and registers, but does not execute, the policy.
+
+        :param TestResources rcs: The integration test resources instance.
+            This provides useful information to complete the request, like
+            which endpoint to use to make the API request.
+
+        :param twisted.trial.unittest.TestCase test: The test case running the
+            integration test.
+
+        :return: A :class:`Deferred` which, when triggered, creates the scaling
+            policy and registers it with AutoScale API.  It does not execute
+            the policy, however.  The policy, when created, will also appear in
+            the test resources `groups` list.  The full JSON will be available
+            for inspection.  In addition, this object's :attribute:`policy_id`
+            member will contain the ID of the policy.
+
+            The deferred will itself return the TestResources instance
+            provided.
+        """
+        test.addCleanup(self.stop, rcs)
+
+        def record_results(resp):
+            self.policy_id = resp["policies"][0]["id"]
+            self.link = str(resp["policies"][0]["links"][0]["href"])
+            return rcs
+
+        return (
+            treq.post(
+                "%s/groups/%s/policies" % (
+                    str(rcs.endpoints["otter"]), self.scaling_group.group_id
+                ),
+                json.dumps(self.policy),
+                headers=headers(str(rcs.token)),
+                pool=self.scaling_group.pool,
+            )
+            .addCallback(check_success, [201])
+            .addCallback(treq.json_content)
+            .addCallback(record_results)
+        )
+
+    def delete(self, rcs):
+        """Removes the scaling policy.
+
+        :param TestResources rcs: The integration test resources instance.
+            This provides useful information to complete the request, like
+            which endpoint to use to make the API request.
+
+        :return: A :class:`Deferred` which, when triggered, removes the scaling
+            policy.  It returns the test resources supplied, easing continuity
+            of integration test code.
+        """
+        return (
+            treq.delete(
+                "%s?force=true" % self.link,
+                headers=headers(str(rcs.token)),
+                pool=self.scaling_group.pool,
+            )
+            .addCallback(check_success, [204, 404])
+        ).addCallback(lambda _: rcs)
+
+    def execute(self, rcs):
+        """Executes the scaling policy.
+
+        :param TestResources rcs: The integration test resources instance.
+            This provides useful information to complete the request, like
+            which endpoint to use to make the API request.
+
+        :return: A :class:`Deferred` which, when triggered, removes the scaling
+            policy.  It returns the test resources supplied, easing continuity
+            of integration test code.
+        """
+        return (
+            treq.post(
+                "%sexecute" % self.link,
+                headers=headers(str(rcs.token)),
+                pool=self.scaling_group.pool,
+            ).addCallback(check_success, [202])
+            # Policy execution does not return anything meaningful,
+            # per http://tinyurl.com/ndds6ap (link to docs.rackspace).
+            # So, we forcefully return our resources here.
+            .addCallback(lambda _, x: x, rcs)
+        )
+        return rcs

--- a/otter/integration/lib/identity.py
+++ b/otter/integration/lib/identity.py
@@ -1,0 +1,80 @@
+"""This module contains reusable Identity components."""
+
+from characteristic import Attribute, attributes
+
+from pyrsistent import freeze
+
+
+@attributes([
+    Attribute('auth'),
+    Attribute('username', instance_of=str),
+    Attribute('password', instance_of=str),
+    Attribute('endpoint', instance_of=str),
+    Attribute('pool', default_value=None),
+])
+class IdentityV2(object):
+    """This class provides a way to configure commonly used parameters
+    exactly once for any number of Identity-related API calls.
+
+    :param module auth: Either the ``otter.auth`` module, or a compatible
+        interface for testing purposes.
+    :param str username: The username you wish to authenticate against
+        Identity with.
+    :param str password: The password you wish to authenticate against
+        Identity with.
+    :param str endpoint: The Identity V2 API base endpoint address.
+    :param twisted.web.client.HTTPConnectionPool pool: If left
+        unspecified, Twisted will use its own connection pool for making
+        HTTP requests.  When running tests via Trial, this may cause
+        some race conditions inside the treq module.  Providing your
+        own connection pool for manual management inside of a test class'
+        setUp and tearDown methods will work around this problem.
+        See https://github.com/dreid/treq/blob/master/treq/
+        test/test_treq_integration.py#L60-L74 for more information.
+    """
+
+    def __init__(self):
+        self.access = None
+
+    def authenticate_user(self, rcs):
+        """Authenticates against the Identity API.  Prior to success, the
+        :attr:`access` member will be set to `None`.  After authentication
+        completes, :attr:`access` will hold the raw Identity V2 API results as
+        a Python dictionary, including service catalog and API authentication
+        token.
+
+        :param TestResources rcs: A :class:`TestResources` instance used to
+            record the identity results.
+
+        :return: A Deferred which, when fired, returns a copy of the resources
+            given.  The :attr:`access` field will be set to the Python
+            dictionary representation of the Identity authentication results.
+        """
+
+        def record_result(r):
+            rcs.access = freeze(r)
+            return rcs
+
+        return self.auth.authenticate_user(
+            self.endpoint, self.username, self.password, pool=self.pool
+        ).addCallback(record_result)
+
+
+def find_endpoint(catalog, service_type, region):
+    """Locate an endpoint in a service catalog, as returned by IdentityV2.
+    Please note that both :param:`service_type` and :param:`region` are
+    case sensitive.
+
+    :param dict catalog: The Identity service catalog.
+    :param str service_type: The type of service to look for.
+    :param str region: The service region the desired endpoint must service.
+    :return: The endpoint offering the desired type of service for the
+        desired region, if available.  None otherwise.
+    """
+    for entry in catalog["access"]["serviceCatalog"]:
+        if entry["type"] != service_type:
+            continue
+        for endpoint in entry["endpoints"]:
+            if endpoint["region"] == region:
+                return endpoint["publicURL"]
+    return None

--- a/otter/integration/lib/resources.py
+++ b/otter/integration/lib/resources.py
@@ -2,7 +2,7 @@
 integration tests.
 """
 
-from characteristic import attributes, Attribute
+from characteristic import Attribute, attributes
 
 
 @attributes([

--- a/otter/integration/lib/resources.py
+++ b/otter/integration/lib/resources.py
@@ -1,0 +1,23 @@
+"""This module contains entities useful for representing shared state in
+integration tests.
+"""
+
+from characteristic import attributes, Attribute
+
+
+@attributes([
+    Attribute('access', default_value=None),
+    Attribute('endpoints', default_value={}),
+    Attribute('groups', default_value=[]),
+])
+class TestResources(object):
+    """This class records the various resources used by a test.
+    It is NOT intended to be used for clean-up purposes (use
+    :func:`unittest.addCleanup` for this purpose).  Instead, it's just a
+    useful scratchpad for passing test resource availability amongst Twisted
+    callbacks.
+
+    If you have custom state you'd like to pass around, use the :attr:`other`
+    attribute for this purpose.  The library will not interpret this attribute,
+    nor will it change it (bugs notwithstanding).
+    """

--- a/otter/integration/lib/test_identity.py
+++ b/otter/integration/lib/test_identity.py
@@ -1,0 +1,138 @@
+"""
+Tests for the lib functions for convergence black-box testing.
+"""
+
+from twisted.internet import defer
+from twisted.trial.unittest import SynchronousTestCase
+
+from otter.integration.lib.identity import IdentityV2, find_endpoint
+from otter.integration.lib.resources import TestResources
+
+
+class IdentityV2Tests(SynchronousTestCase):
+    """Tests for the :class:`IdentityV2` class."""
+
+    def test_missing_params(self):
+        """Missing parameters to the IdentityV2 constructor should raise
+        a ValueError exception.
+        """
+        def x(u, p, e):
+            self.assertRaises(ValueError, IdentityV2, None, u, p, e)
+        x("", "pw", "ep")
+        x("un", "", "ep")
+        x("un", "pw", "")
+        x(None, "pw", "ep")
+        x("un", None, "ep")
+        x("un", "pw", None)
+
+    def test_pool_kwarg(self):
+        """The pool keyword argument should be passed through to the
+        authenticate_user Otter function.
+        """
+        rcs = TestResources()
+
+        class Stub(object):
+            def __init__(self):
+                self.pool = None
+
+            def authenticate_user(self, endpt, user, passwd, pool=None):
+                self.pool = pool
+                return defer.succeed({})
+
+        stub = Stub()
+        IdentityV2(
+            auth=stub, username="username",
+            password="password", endpoint="endpoint"
+        ).authenticate_user(rcs)
+        self.assertFalse(stub.pool)
+
+        IdentityV2(
+            auth=stub, username="username",
+            password="password", endpoint="endpoint", pool=42
+        ).authenticate_user(rcs)
+        self.assertEquals(stub.pool, 42)
+
+    def test_records_results(self):
+        """The IdentityV2 instance you create should cache its
+        results when it receives them.
+        """
+        class Stub(object):
+            def authenticate_user(self, *unused_args, **unused_kwargs):
+                return defer.succeed("cached")
+
+        rcs = TestResources()
+        stub = Stub()
+        i = IdentityV2(
+            auth=stub, username="username",
+            password="password", endpoint="endpoint"
+        )
+        i.authenticate_user(rcs)
+        self.assertEqual(rcs.access, "cached")
+
+
+_test_catalog = {
+    "access": {
+        "serviceCatalog": [
+            {
+                "endpoints": [
+                    {
+                        "publicURL": "https://syd.localhost/v1/775360",
+                        "region": "SYD",
+                        "tenantId": "123456"
+                    },
+                    {
+                        "publicURL": "https://dfw.localhost/v1/123456",
+                        "region": "DFW",
+                        "tenantId": "123456"
+                    },
+                ],
+                "name": "cloudBlockStorage",
+                "type": "volume"
+            },
+            {
+                "endpoints": [
+                    {
+                        "publicURL": "https://iad.localhost/v2",
+                        "region": "IAD",
+                        "tenantId": "123456"
+                    },
+                    {
+                        "publicURL": "https://ord.localhost/v2",
+                        "region": "ORD",
+                        "tenantId": "123456"
+                    },
+                ],
+                "name": "cloudImages",
+                "type": "image"
+            }
+        ],
+        "token": {
+            "RAX-AUTH:authenticatedBy": [
+                "PASSWORD"
+            ],
+            "expires": "2015-02-01T00:56:59.631Z",
+            "id": "18363c2fe021475789be10d361753481",
+            "tenant": {
+                "id": "123456",
+                "name": "123456"
+            }
+        }
+    }
+}
+
+
+class FindEndpointTests(SynchronousTestCase):
+    """These tests exercise the :func:`find_endpoint` library function."""
+
+    def test_happy_path(self):
+        """If the region and the service type exists, then we should receive
+        an endpoint.
+        """
+        self.assertEqual(
+            find_endpoint(_test_catalog, "volume", "DFW"),
+            "https://dfw.localhost/v1/123456"
+        )
+        self.assertEqual(
+            find_endpoint(_test_catalog, "image", "IAD"),
+            "https://iad.localhost/v2"
+        )

--- a/otter/integration/lib/test_utils.py
+++ b/otter/integration/lib/test_utils.py
@@ -1,0 +1,204 @@
+"""
+Tests for the utility functions for convergence black-box testing.
+"""
+from pyrsistent import pmap, pset
+
+from twisted.trial.unittest import SynchronousTestCase
+
+from otter.convergence.model import (
+    DesiredGroupState,
+    NovaServer,
+    ServerState
+)
+from utils import (
+    GroupState,
+    OvershootError,
+    UndershootError,
+    measure_progress
+)
+
+
+class MeasureProgressTests(SynchronousTestCase):
+    """
+    Tests for :func:`measure_progress`.
+    """
+    def _create_servers(self, n, state=ServerState.ACTIVE):
+        """
+        Create some dummy test servers.
+        """
+        return pset([
+            NovaServer(id=str(i), state=state, created=123456789.,
+                       image_id='image', flavor_id='flavor')
+            for i in xrange(n)
+        ])
+
+    def test_capacity_closer_to_desired_when_scaling_up(self):
+        """
+        If the capacity moves closer to the desired, progress has been
+        made.
+        """
+        previous_state = GroupState(
+            servers=self._create_servers(2),
+            lb_connections=pset([])
+        )
+        current_state = GroupState(
+            servers=self._create_servers(4),
+            lb_connections=pset([])
+        )
+        desired_state = DesiredGroupState(
+            server_config=pmap(),
+            capacity=5,
+        )
+        progress = measure_progress(
+            previous_state, current_state, desired_state)
+        self.assertEqual(progress, 2)
+
+    def test_capacity_closer_to_desired_when_scaling_down(self):
+        """
+        If the capacity moves closer to the desired, progress has been
+        made.
+        """
+        previous_state = GroupState(
+            servers=self._create_servers(4),
+            lb_connections=pset([])
+        )
+        current_state = GroupState(
+            servers=self._create_servers(2),
+            lb_connections=pset([])
+        )
+        desired_state = DesiredGroupState(
+            server_config=pmap(),
+            capacity=1,
+        )
+        progress = measure_progress(
+            previous_state, current_state, desired_state)
+        self.assertEqual(progress, 2)
+
+    def test_overshoot(self):
+        """
+        When overshooting the desired capacity (group was below desired,
+        and is now above desired), no progress was made.
+        """
+        previous_state = GroupState(
+            servers=self._create_servers(4),
+            lb_connections=pset([])
+        )
+        current_state = GroupState(
+            servers=self._create_servers(6),
+            lb_connections=pset([])
+        )
+        desired_state = DesiredGroupState(
+            server_config=pmap(),
+            capacity=5,
+        )
+        self.assertRaises(
+            OvershootError,
+            measure_progress, previous_state, current_state, desired_state)
+
+    def test_undershoot(self):
+        """
+        When undershooting the desired capacity (group was above desired,
+        and is now below desired), no progress was made.
+        """
+        previous_state = GroupState(
+            servers=self._create_servers(6),
+            lb_connections=pset([])
+        )
+        current_state = GroupState(
+            servers=self._create_servers(4),
+            lb_connections=pset([])
+        )
+        desired_state = DesiredGroupState(
+            server_config=pmap(),
+            capacity=5,
+        )
+        self.assertRaises(
+            UndershootError,
+            measure_progress, previous_state, current_state, desired_state)
+
+    def test_building_servers_towards_desired_capacity(self):
+        """
+        When some servers are being built, which would put us closer to
+        the desired capacity, progress is being made.
+        """
+        previous_state = GroupState(
+            servers=self._create_servers(2),
+            lb_connections=pset([])
+        )
+        current_state = GroupState(
+            servers=(self._create_servers(2, state=ServerState.ACTIVE)
+                     | self._create_servers(2, state=ServerState.BUILD)),
+            lb_connections=pset([])
+        )
+        desired_state = DesiredGroupState(
+            server_config=pmap(),
+            capacity=5,
+        )
+        progress = measure_progress(
+            previous_state, current_state, desired_state)
+        self.assertEqual(progress, 2)
+
+    def test_servers_going_from_build_to_error(self):
+        """
+        When some servers go from build to error, no progress was made.
+        """
+        previous_state = GroupState(
+            servers=self._create_servers(3, state=ServerState.BUILD),
+            lb_connections=pset([])
+        )
+        current_state = GroupState(
+            servers=(self._create_servers(1, state=ServerState.ACTIVE)
+                     | self._create_servers(2, state=ServerState.ERROR)),
+            lb_connections=pset([])
+        )
+        desired_state = DesiredGroupState(
+            server_config=pmap(),
+            capacity=5,
+        )
+        progress = measure_progress(
+            previous_state, current_state, desired_state)
+        self.assertEqual(progress, 0)
+
+    def test_servers_going_from_build_to_error_with_reaping(self):
+        """
+        When some servers go from build to error, no progress was
+        made. That works correctly even if some of the errored
+        machines get reaped in the mean while.
+        """
+        previous_state = GroupState(
+            servers=self._create_servers(3, state=ServerState.BUILD),
+            lb_connections=pset([])
+        )
+        current_state = GroupState(
+            servers=(self._create_servers(1, state=ServerState.ACTIVE)
+                     | self._create_servers(1, state=ServerState.ERROR)),
+            lb_connections=pset([])
+        )
+        desired_state = DesiredGroupState(
+            server_config=pmap(),
+            capacity=5,
+        )
+        progress = measure_progress(
+            previous_state, current_state, desired_state)
+        self.assertEqual(progress, 0)
+
+    def test_reaping_errored_servers(self):
+        """
+        Errored servers are removed; no progress is made.
+        """
+        previous_state = GroupState(
+            servers=(self._create_servers(1, state=ServerState.ACTIVE)
+                     | self._create_servers(2, state=ServerState.ERROR)),
+            lb_connections=pset([])
+        )
+        current_state = GroupState(
+            servers=(self._create_servers(1, state=ServerState.ACTIVE)),
+            lb_connections=pset([])
+        )
+        desired_state = DesiredGroupState(
+            server_config=pmap(),
+            capacity=5,
+        )
+        progress = measure_progress(
+            previous_state, current_state, desired_state)
+        self.assertEqual(progress, 0)

--- a/otter/integration/lib/test_utils.py
+++ b/otter/integration/lib/test_utils.py
@@ -5,16 +5,17 @@ from pyrsistent import pmap, pset
 
 from twisted.trial.unittest import SynchronousTestCase
 
-from otter.convergence.model import (
-    DesiredGroupState,
-    NovaServer,
-    ServerState
-)
 from utils import (
     GroupState,
     OvershootError,
     UndershootError,
     measure_progress
+)
+
+from otter.convergence.model import (
+    DesiredGroupState,
+    NovaServer,
+    ServerState
 )
 
 

--- a/otter/integration/lib/utils.py
+++ b/otter/integration/lib/utils.py
@@ -1,0 +1,91 @@
+from characteristic import Attribute, attributes
+
+from pyrsistent import PSet
+
+from otter.convergence.model import ServerState
+
+
+class OvershootError(AssertionError):
+    """
+    Raised when Otter creates more servers than a launch configuration
+    specifies.
+    """
+    pass
+
+
+class UndershootError(AssertionError):
+    """
+    Raised when Otter removes more servers than a launch configuration
+    specifies.
+    """
+    pass
+
+
+@attributes([Attribute("servers", instance_of=PSet),
+             Attribute("lb_connections", instance_of=PSet)],
+            apply_immutable=True)
+class GroupState(object):
+    """
+    The externally visible state of a group at a point in time.
+
+    :attr pset servers: Set of the servers in the group.
+    :attr pset lb_nodes: Set of the load balancer nodes in the group.
+    """
+
+
+def measure_progress(prev_state, curr_state, desired_state):
+    """
+    How many steps have been made towards the desired state between
+    the previous and current states?
+
+    XXX: The NovaServer instances we get from GroupState don't
+    describe their own flavor/image, making it impossible to see if
+    the new servers are of the correct type.
+
+    :param GroupState prev_state: The previous state of a scaling group.
+    :param GroupState curr_state: The current state of a scaling group.
+    :param DesiredState desired_state: The desired state of a scaling group.
+    :return: The number of steps made towards the desired.
+    :rtype: int
+    :raises UndershootError: If Autoscale removes more servers than a launch
+     configuration specifies.
+    :raises OvershootError: If Autoscale creates more servers than a launch
+     configuration specifies.
+    """
+    prev_capacity = _count_live_servers(prev_state.servers)
+    curr_capacity = _count_live_servers(curr_state.servers)
+    capacity_delta = curr_capacity - prev_capacity
+    desired = desired_state.capacity
+
+    if prev_capacity > desired and curr_capacity < desired:
+        msg = "Undershoot: prev capacity = %d, desired = %d, current = %d"
+        raise UndershootError(msg.format(
+            prev_capacity, desired, curr_capacity
+        ))
+    elif prev_capacity < desired and curr_capacity > desired:
+        msg = "Overshoot: prev capacity = %d, desired = %d, current = %d"
+        raise OvershootError(msg.format(
+            prev_capacity, desired, curr_capacity
+        ))
+
+    if capacity_delta < 0 and curr_capacity < desired:
+        return 0
+    elif capacity_delta > 0 and curr_capacity > desired:
+        return 0
+    else:
+        return abs(capacity_delta)
+
+
+def _count_live_servers(servers):
+    """
+    Count servers that are active or building.
+    """
+    live_states = [ServerState.BUILD, ServerState.ACTIVE]
+    return len([s for s in servers if s.state in live_states])
+
+
+def _count_dead_servers(servers):
+    """
+    Count servers that are in error state.
+    """
+    return len([s for s in servers if s.state is ServerState.ERROR])

--- a/otter/integration/tests/test_scaling.py
+++ b/otter/integration/tests/test_scaling.py
@@ -46,7 +46,7 @@ def dump_groups(rcs):
 def find_end_point(rcs):
     rcs.token = rcs.access["access"]["token"]["id"]
     sc = rcs.access["access"]["serviceCatalog"]
-    rcs.endpoints["otter"] = auth.public_endpoint_url(sc, "autoscale", "IAD")
+    rcs.endpoints["otter"] = auth.public_endpoint_url(sc, "autoscale", region)
     return rcs
 
 

--- a/otter/integration/tests/test_scaling.py
+++ b/otter/integration/tests/test_scaling.py
@@ -1,0 +1,114 @@
+"""A quick trial-based test to exercise scale-up and scale-down functionality.
+"""
+
+# TODO(sfalvo): Scale-up functionality isn't finished yet.  I'll finish this
+# after refactoring is done.
+#
+# TODO(sfalvo): Scale-down functionality isn't implemented yet.  I'll finish
+# this after refactoring is done.
+
+
+import json
+import os
+
+from twisted.internet import reactor
+from twisted.internet.task import deferLater
+from twisted.internet.tcp import Client
+from twisted.trial import unittest
+from twisted.web.client import HTTPConnectionPool
+
+from otter import auth
+from otter.integration.lib.identity import IdentityV2
+from otter.integration.lib import autoscale
+from otter.integration.lib.resources import TestResources
+
+
+username = os.environ['AS_USERNAME']
+password = os.environ['AS_PASSWORD']
+endpoint = os.environ['AS_IDENTITY']
+flavor_ref = os.environ['AS_FLAVOR_REF']
+image_ref = os.environ['AS_IMAGE_REF']
+region = os.environ['AS_REGION']
+
+
+def dump_js(js):
+    print json.dumps(js, indent=4)
+
+
+def dump_groups(rcs):
+    for g in rcs.groups:
+        dump_js(g)
+    return rcs
+
+
+def find_end_point(rcs):
+    rcs.token = rcs.access["access"]["token"]["id"]
+    sc = rcs.access["access"]["serviceCatalog"]
+    rcs.endpoints["otter"] = auth.public_endpoint_url(sc, "autoscale", "IAD")
+    return rcs
+
+
+def print_token_and_ep(rcs):
+    print "TOKEN(%s) EP(%s)" % (rcs.token, rcs.endpoints["otter"])
+    return rcs
+
+
+class TestScaling(unittest.TestCase):
+    def setUp(self):
+        self.pool = HTTPConnectionPool(reactor, False)
+        self.identity = IdentityV2(
+            auth=auth, username=username, password=password,
+            endpoint=endpoint, pool=self.pool
+        )
+
+    def tearDown(self):
+        def _check_fds(_):
+            fds = set(reactor.getReaders() + reactor.getReaders())
+            if not [fd for fd in fds if isinstance(fd, Client)]:
+                return
+            return deferLater(reactor, 0, _check_fds, None)
+        return self.pool.closeCachedConnections().addBoth(_check_fds)
+
+    def test_scaling_up(self):
+        group_configuration = {
+            "name": "my-group-configuration",
+            "cooldown": 0,
+            "minEntities": 0,
+        }
+        launch_configuration = {
+            "type": "launch_server",
+            "args": {
+                "server": {
+                    "flavorRef": flavor_ref,
+                    "imageRef": image_ref,
+                }
+            }
+        }
+        scaling_group_body = {
+            "launchConfiguration": launch_configuration,
+            "groupConfiguration": group_configuration,
+            "scalingPolicies": [],
+        }
+
+        self.scaling_group = autoscale.ScalingGroup(
+            group_config=scaling_group_body,
+            pool=self.pool
+        )
+
+        self.scaling_policy = autoscale.ScalingPolicy(
+            scale_by=2,
+            scaling_group=self.scaling_group
+        )
+
+        rcs = TestResources()
+        d = (
+            self.identity.authenticate_user(rcs)
+            .addCallback(find_end_point)
+            .addCallback(print_token_and_ep)
+            .addCallback(self.scaling_group.start, self)
+            .addCallback(dump_groups)
+            .addCallback(self.scaling_policy.start, self)
+            .addCallback(self.scaling_policy.execute)
+            .addCallback(dump_groups)
+        )
+        return d

--- a/otter/integration/tests/test_scaling.py
+++ b/otter/integration/tests/test_scaling.py
@@ -8,6 +8,8 @@
 # this after refactoring is done.
 
 
+from __future__ import print_function
+
 import json
 import os
 
@@ -18,8 +20,8 @@ from twisted.trial import unittest
 from twisted.web.client import HTTPConnectionPool
 
 from otter import auth
-from otter.integration.lib.identity import IdentityV2
 from otter.integration.lib import autoscale
+from otter.integration.lib.identity import IdentityV2
 from otter.integration.lib.resources import TestResources
 
 
@@ -32,7 +34,7 @@ region = os.environ['AS_REGION']
 
 
 def dump_js(js):
-    print json.dumps(js, indent=4)
+    print(json.dumps(js, indent=4))
 
 
 def dump_groups(rcs):
@@ -49,7 +51,7 @@ def find_end_point(rcs):
 
 
 def print_token_and_ep(rcs):
-    print "TOKEN(%s) EP(%s)" % (rcs.token, rcs.endpoints["otter"])
+    print("TOKEN(%s) EP(%s)" % (rcs.token, rcs.endpoints["otter"]))
     return rcs
 
 


### PR DESCRIPTION
This is a moderate-sized PR, but I couldn't really break it up into
smaller pieces without it making sense.  It refactors the work invested
in otter/test/integration/lib.py into component modules which can me
"from otter.integrat.lib import"-ed, making it easier to manage in the
future as the feature set grows.  Work on lib.py has already been
reviewed previously, so despite the apparent size of the PR, relatively
little needs to be reviewed.  In particular, the reviewer should focus
on the refactoring action, and not so much on the code.

The actual "new code" in this PR sits in the new tests/ subdirectory --
the test_scaling.py module.  This module isn't finished yet; however,
refactoring was a good idea before continuing for two reasons:

1) Refactoring removes lib.py and test_lib.py from the "make unit"
execution path.

2) Refactoring allows me to commit my integration test work to the
repository in conjunction with its co-developed support library.
Previously, this work contained credentials hard-wired into the code.

NOTE: This is the first of two PRs related to this refactor.  The second
will actually remove the old files from otter/test/integration.

Fixes #1074 