### PR TITLE
Lk add rcv3 bulk delete

### DIFF
--- a/autoscale_cloudcafe/autoscale/client.py
+++ b/autoscale_cloudcafe/autoscale/client.py
@@ -3,6 +3,7 @@ Client objects for all the autoscale api calls
 """
 from __future__ import print_function
 
+import json
 
 from urlparse import urlparse
 
@@ -23,6 +24,7 @@ from autoscale.models.response.autoscale_response import (
 )
 
 from autoscale.models.response.limits_response import Limits
+
 
 
 class AutoscalingAPIClient(AutoMarshallingRestClient):
@@ -940,18 +942,18 @@ class RackConnectV3APIClient(AutoMarshallingRestClient):
         return self.request('GET', url,
                             response_entity_type=RackConnectLBNodeDetail)
 
-    def remove_node_from_pool(self, pool_id, server_id,
-                              requestslib_kwargs=None):
+    def remove_server_from_pool(self, pool_id, server_id,
+                                requestslib_kwargs=None):
         """
         :summary: Remove a node from a lb pool using the bulk delete API
         """
         url = self.url + '/load_balancer_pools/nodes'
         print("... RCV3 request ... ", url)
-        requestslib_kwargs = [
+        data = [
             {
                 "cloud_server": {"id": server_id},
                 "load_balancer_pool": {"id": pool_id}
             }]
-        return self.request('DELETE', url,
+        return self.request('DELETE', url, data=json.dumps(data),
                             requestslib_kwargs=requestslib_kwargs)
 

--- a/autoscale_cloudcafe/autoscale/client.py
+++ b/autoscale_cloudcafe/autoscale/client.py
@@ -940,12 +940,18 @@ class RackConnectV3APIClient(AutoMarshallingRestClient):
         return self.request('GET', url,
                             response_entity_type=RackConnectLBNodeDetail)
 
-    def remove_node_from_pool(self, pool_id, node_id, requestslib_kwargs=None):
+    def remove_node_from_pool(self, pool_id, server_id,
+                              requestslib_kwargs=None):
         """
-        :summary: Remove a node from a lb pool
+        :summary: Remove a node from a lb pool using the bulk delete API
         """
-        url = self.url + '/load_balancer_pools/{0}/nodes/{1}'.format(pool_id,
-                                                                     node_id)
+        url = self.url + '/load_balancer_pools/nodes'
         print("... RCV3 request ... ", url)
+        requestslib_kwargs = [
+            {
+                "cloud_server": {"id": server_id},
+                "load_balancer_pool": {"id": pool_id}
+            }]
         return self.request('DELETE', url,
                             requestslib_kwargs=requestslib_kwargs)
+

--- a/autoscale_cloudcafe/autoscale/client.py
+++ b/autoscale_cloudcafe/autoscale/client.py
@@ -26,7 +26,6 @@ from autoscale.models.response.autoscale_response import (
 from autoscale.models.response.limits_response import Limits
 
 
-
 class AutoscalingAPIClient(AutoMarshallingRestClient):
 
     """

--- a/autoscale_cloudcafe/autoscale/client.py
+++ b/autoscale_cloudcafe/autoscale/client.py
@@ -945,7 +945,7 @@ class RackConnectV3APIClient(AutoMarshallingRestClient):
     def remove_server_from_pool(self, pool_id, server_id,
                                 requestslib_kwargs=None):
         """
-        :summary: Remove a node from a lb pool using the bulk delete API
+        :summary: Remove a server from a lb pool using the bulk delete API
         """
         url = self.url + '/load_balancer_pools/nodes'
         print("... RCV3 request ... ", url)
@@ -956,4 +956,3 @@ class RackConnectV3APIClient(AutoMarshallingRestClient):
             }]
         return self.request('DELETE', url, data=json.dumps(data),
                             requestslib_kwargs=requestslib_kwargs)
-


### PR DESCRIPTION
Fixes #1058
I changed the rcv3 client to use the bulk delete functionality to match otter operation.