### PR TITLE
RCv3 worker error handling

### DIFF
--- a/otter/test/worker/test_rcv3.py
+++ b/otter/test/worker/test_rcv3.py
@@ -86,7 +86,7 @@ class RCv3Tests(SynchronousTestCase):
             # %2Fload_balancer_pools%2Fnodes
             return succeed(self.post_result)
         elif req.method == "DELETE":
-            self.assertEqual(req.success_pred, has_code(204, 409))
+            self.assertEqual(req.success_pred, has_code(204))
             # http://docs.rcv3.apiary.io/#delete-%2Fv3%2F{tenant_id}
             # %2Fload_balancer_pools%2Fnode
             return succeed(self.del_result)

--- a/otter/test/worker/test_rcv3.py
+++ b/otter/test/worker/test_rcv3.py
@@ -86,7 +86,7 @@ class RCv3Tests(SynchronousTestCase):
             # %2Fload_balancer_pools%2Fnodes
             return succeed(self.post_result)
         elif req.method == "DELETE":
-            self.assertEqual(req.success_pred, has_code(204))
+            self.assertEqual(req.success_pred, has_code(204, 409))
             # http://docs.rcv3.apiary.io/#delete-%2Fv3%2F{tenant_id}
             # %2Fload_balancer_pools%2Fnode
             return succeed(self.del_result)

--- a/otter/worker/_rcv3.py
+++ b/otter/worker/_rcv3.py
@@ -11,6 +11,7 @@ from effect.twisted import perform
 
 from otter.convergence.steps import BulkAddToRCv3, BulkRemoveFromRCv3
 from otter.http import TenantScope
+from otter.util.pure_http import has_code
 
 
 def _generic_rcv3_request(step_class, request_bag, lb_id, server_id):
@@ -27,6 +28,11 @@ def _generic_rcv3_request(step_class, request_bag, lb_id, server_id):
         request has no body.
     """
     effect = step_class(lb_node_pairs=[(lb_id, server_id)])._bare_effect()
+
+    svc_req = effect.intent
+    codes = set(svc_req.success_pred.codes) - set([409])
+    svc_req.succes_pred = has_code(*codes)
+
     # Unfortunate that we have to TenantScope here, but here's where we're
     # performing.
     scoped = Effect(TenantScope(effect, request_bag.tenant_id))

--- a/otter/worker/_rcv3.py
+++ b/otter/worker/_rcv3.py
@@ -29,9 +29,10 @@ def _generic_rcv3_request(step_class, request_bag, lb_id, server_id):
     """
     effect = step_class(lb_node_pairs=[(lb_id, server_id)])._bare_effect()
 
-    svc_req = effect.intent
-    codes = set(svc_req.success_pred.codes) - set([409])
-    svc_req.success_pred = has_code(*codes)
+    if step_class is BulkAddToRCv3:
+        svc_req = effect.intent
+        codes = set(svc_req.success_pred.codes) - set([409])
+        svc_req.success_pred = has_code(*codes)
 
     # Unfortunate that we have to TenantScope here, but here's where we're
     # performing.

--- a/otter/worker/_rcv3.py
+++ b/otter/worker/_rcv3.py
@@ -31,7 +31,7 @@ def _generic_rcv3_request(step_class, request_bag, lb_id, server_id):
 
     svc_req = effect.intent
     codes = set(svc_req.success_pred.codes) - set([409])
-    svc_req.succes_pred = has_code(*codes)
+    svc_req.success_pred = has_code(*codes)
 
     # Unfortunate that we have to TenantScope here, but here's where we're
     # performing.


### PR DESCRIPTION
This closes #1082.

This takes the bare effect and strips off the 409 success_pred.

I figured you don't actually want to use the 409-recovery callback, because that way you lose the original body, which is important for worker.

This is kind of a hack, but fortunately it's in code that's going away soon. I kinda want to put the ugly in `otter.convergence.steps` since that already has `bare_request` anyway, but I figure it doesn't matter too much.

This requires ~~#1085~~ first.