### PR TITLE
policy info from webhook hash using the webhook_keys table only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ install:
     - pip install -r dev_requirements.txt
     - pip install -r requirements.txt
     - pip install coveralls
+    - pip freeze
 
 script:
     - make lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ install:
     - pip install -r dev_requirements.txt
     - pip install -r requirements.txt
     - pip install coveralls
-    - pip freeze
 
 script:
     - make lint

--- a/otter/test/models/test_cass_models.py
+++ b/otter/test/models/test_cass_models.py
@@ -3198,81 +3198,9 @@ class CassScalingGroupsCollectionTestCase(IScalingGroupCollectionProviderMixin,
         self.assertEqual(g.tenant_id, '123')
         self.assertIs(g.local_locks, self.collection.local_locks)
 
-    def test_webhook_hash_from_table(self):
+    def test_webhook_info_by_hash(self):
         """
-        `webhook_info_by_hash` returns info from _webhook_info_from_table
-        if available.
-        """
-        self.collection._webhook_info_from_table = mock.Mock(
-            return_value=defer.succeed('g'))
-        self.collection._webhook_info_by_index = mock.Mock()
-
-        d = self.collection.webhook_info_by_hash(self.mock_log, 'hash')
-
-        self.assertEqual(self.successResultOf(d), 'g')
-        self.collection._webhook_info_from_table.assert_called_once_with(
-            self.mock_log, 'hash')
-        self.assertFalse(self.collection._webhook_info_by_index.called)
-
-    def test_webhook_hash_from_index(self):
-        """
-        `webhook_info_by_hash` returns info from _webhook_info_by_index if
-        _webhook_info_from_table returns nothing.
-        """
-        self.collection._webhook_info_from_table = mock.Mock(
-            return_value=defer.fail(UnrecognizedCapabilityError('hash', 1)))
-        self.collection._webhook_info_by_index = mock.Mock(
-            return_value=defer.succeed('g'))
-
-        d = self.collection.webhook_info_by_hash(self.mock_log, 'hash')
-
-        self.assertEqual(self.successResultOf(d), 'g')
-        self.collection._webhook_info_from_table.assert_called_once_with(
-            self.mock_log, 'hash')
-        self.collection._webhook_info_by_index.assert_called_once_with(
-            self.mock_log, 'hash')
-
-    def test_webhook_hash_from_index_logs_unknown_err(self):
-        """
-        `webhook_info_by_hash` returns info from _webhook_info_by_index if
-        _webhook_info_from_table fails with unknown error.
-        """
-        self.collection._webhook_info_from_table = mock.Mock(
-            return_value=defer.fail(ValueError(1)))
-        self.collection._webhook_info_by_index = mock.Mock(
-            return_value=defer.succeed('g'))
-
-        d = self.collection.webhook_info_by_hash(self.mock_log, 'hash')
-
-        self.assertEqual(self.successResultOf(d), 'g')
-        self.collection._webhook_info_from_table.assert_called_once_with(
-            self.mock_log, 'hash')
-        self.collection._webhook_info_by_index.assert_called_once_with(
-            self.mock_log, 'hash')
-        self.mock_log.err.assert_called_once_with(
-            CheckFailure(ValueError), 'Error getting webhook info from table')
-
-    def test_webhook_hash_index(self):
-        """
-        `_webhook_info_by_index` uses webhooks_by_token INDEX
-        """
-        self.returns = [_cassandrify_data([
-            {'tenantId': '123', 'groupId': 'group1', 'policyId': 'pol1'}]),
-            _cassandrify_data([{'data': '{}'}])
-        ]
-        expectedData = {'webhookKey': 'x'}
-        expectedCql = ('SELECT "tenantId", "groupId", "policyId" '
-                       'FROM policy_webhooks '
-                       'WHERE "webhookKey" = :webhookKey;')
-        d = self.collection._webhook_info_by_index(self.mock_log, 'x')
-        r = self.successResultOf(d)
-        self.assertEqual(r, ('123', 'group1', 'pol1'))
-        self.connection.execute.assert_called_once_with(
-            expectedCql, expectedData, ConsistencyLevel.ONE)
-
-    def test_webhook_hash_table(self):
-        """
-        `_webhook_info_from_table` uses webhook_keys table
+        `webhook_info_by_hash` gets the info from webhook_keys table
         """
         self.returns = [_cassandrify_data([
             {'tenantId': '123', 'groupId': 'group1', 'policyId': 'pol1'}]),
@@ -3282,7 +3210,7 @@ class CassScalingGroupsCollectionTestCase(IScalingGroupCollectionProviderMixin,
         expectedCql = ('SELECT "tenantId", "groupId", "policyId" '
                        'FROM webhook_keys '
                        'WHERE "webhookKey" = :webhookKey;')
-        d = self.collection._webhook_info_from_table(self.mock_log, 'x')
+        d = self.collection.webhook_info_by_hash(self.mock_log, 'x')
         r = self.successResultOf(d)
         self.assertEqual(r, ('123', 'group1', 'pol1'))
         self.connection.execute.assert_called_once_with(
@@ -3290,21 +3218,17 @@ class CassScalingGroupsCollectionTestCase(IScalingGroupCollectionProviderMixin,
 
     def test_webhook_bad(self):
         """
-        Test that a bad webhook will fail predictably
+        Test that a bad webhook will fail with UnrecognizedCapabilityError
         """
-        self.returns = [[], []]
+        self.returns = [[]]
         expectedData = {'webhookKey': 'x'}
-        expectedCql = [('SELECT "tenantId", "groupId", "policyId" '
-                        'FROM webhook_keys '
-                        'WHERE "webhookKey" = :webhookKey;'),
-                       ('SELECT "tenantId", "groupId", "policyId" '
-                        'FROM policy_webhooks '
-                        'WHERE "webhookKey" = :webhookKey;')]
+        expectedCql = ('SELECT "tenantId", "groupId", "policyId" '
+                       'FROM webhook_keys '
+                       'WHERE "webhookKey" = :webhookKey;')
         d = self.collection.webhook_info_by_hash(self.mock_log, 'x')
         self.failureResultOf(d, UnrecognizedCapabilityError)
-        self.connection.execute.assert_has_calls(
-            [mock.call(expectedCql[0], expectedData, ConsistencyLevel.ONE),
-             mock.call(expectedCql[1], expectedData, ConsistencyLevel.ONE)])
+        self.connection.execute.assert_called_once_with(
+            expectedCql, expectedData, ConsistencyLevel.ONE)
 
     def test_get_counts(self):
         """

--- a/otter/test/models/test_cass_models.py
+++ b/otter/test/models/test_cass_models.py
@@ -29,10 +29,10 @@ from twisted.trial.unittest import SynchronousTestCase
 
 from otter.json_schema import group_examples
 from otter.models.cass import (
+    CQLQueryExecute,
     CassAdmin,
     CassScalingGroup,
     CassScalingGroupCollection,
-    CQLQueryExecute,
     WeakLocks,
     _assemble_webhook_from_row,
     assemble_webhooks_in_policies,
@@ -58,7 +58,6 @@ from otter.test.models.test_interface import (
     IScalingScheduleCollectionProviderMixin
 )
 from otter.test.utils import (
-    CheckFailure,
     DummyException,
     LockMixin,
     matches,


### PR DESCRIPTION
This needs to be merged after all the webhooks have been migrated. I've merged the script to do that in #1069 but it is yet to be run on all the regions. I've put this up for any early reviews.