### PR TITLE
RCv3 bulk add success semantics

### DIFF
--- a/otter/convergence/steps.py
+++ b/otter/convergence/steps.py
@@ -377,13 +377,20 @@ def _rcv3_check_bulk_add(attempted_pairs, result):
     if response.code == 201:  # All done!
         return StepResult.SUCCESS, []
 
+    failure_reasons = []
     to_retry = pset(attempted_pairs)
     for error in body["errors"]:
         match = _RCV3_NODE_ALREADY_A_MEMBER_PATTERN.match(error)
         if match is not None:
             to_retry -= pset([match.groups()[::-1]])
 
-    if to_retry:
+        match = _RCV3_LB_INACTIVE_PATTERN.match(error)
+        if match is not None:
+            failure_reasons.append(
+                "RCv3 LB {lb_id} was inactive".format(**match.groupdict()))
+    if failure_reasons:
+        return StepResult.FAILURE, failure_reasons
+    elif to_retry:
         next_step = BulkAddToRCv3(lb_node_pairs=to_retry)
         return next_step.as_effect()
     else:

--- a/otter/convergence/steps.py
+++ b/otter/convergence/steps.py
@@ -388,6 +388,12 @@ def _rcv3_check_bulk_add(attempted_pairs, result):
         if match is not None:
             failure_reasons.append(
                 "RCv3 LB {lb_id} was inactive".format(**match.groupdict()))
+
+        match = _RCV3_LB_DOESNT_EXIST_PATTERN.match(error)
+        if match is not None:
+            failure_reasons.append(
+                "RCv3 LB {lb_id} does not exist".format(**match.groupdict()))
+
     if failure_reasons:
         return StepResult.FAILURE, failure_reasons
     elif to_retry:

--- a/otter/test/convergence/test_steps.py
+++ b/otter/test/convergence/test_steps.py
@@ -610,6 +610,7 @@ class RCv3CheckBulkAddTests(SynchronousTestCase):
         self.assertEqual(
             result,
             (StepResult.FAILURE,
+             ["RCv3 LB {lb_id} was inactive".format(lb_id=lb_id)])
              "RCv3 LB {lb_id} was inactive".format(lb_id=lb_id))
 
 class RCv3CheckBulkDeleteTests(SynchronousTestCase):

--- a/otter/test/convergence/test_steps.py
+++ b/otter/test/convergence/test_steps.py
@@ -612,6 +612,31 @@ class RCv3CheckBulkAddTests(SynchronousTestCase):
             (StepResult.FAILURE,
              ["RCv3 LB {lb_id} was inactive".format(lb_id=lb_id)]))
 
+    def test_multiple_lbs_inactive(self):
+        """
+        If multiple LBs we tried to attach one or more nodes to is
+        inactive, the request fails, and all of the inactive LBs are
+        reported.
+
+        By logging as much of the failure as we can see, we will
+        hopefully produce better audit logs.
+        """
+        node_id = "d6d3aa7c-dfa5-4e61-96ee-1d54ac1075d2"
+        lb_1_id = 'd95ae0c4-6ab8-4873-b82f-f8433840cff2'
+        lb_2_id = 'fb32470f-6ebe-44a9-9360-3f48c9ac768c'
+        pairs = [(lb_1_id, node_id), (lb_2_id, node_id)]
+
+        resp = StubResponse(409, {})
+        body = {"errors": [
+            "Load Balancer Pool {lb_id} is not in an ACTIVE state"
+            .format(lb_id=lb_id) for lb_id in [lb_1_id, lb_2_id]]}
+        result = _rcv3_check_bulk_add(pairs, (resp, body))
+        self.assertEqual(
+            result,
+            (StepResult.FAILURE,
+             ["RCv3 LB {lb_id} was inactive".format(lb_id=lb_id)
+              for lb_id in [lb_1_id, lb_2_id]]))
+
 class RCv3CheckBulkDeleteTests(SynchronousTestCase):
     """
     Tests for :func:`_rcv3_check_bulk_delete`.

--- a/otter/test/convergence/test_steps.py
+++ b/otter/test/convergence/test_steps.py
@@ -593,6 +593,24 @@ class RCv3CheckBulkAddTests(SynchronousTestCase):
         result = _rcv3_check_bulk_add(pairs, (resp, body))
         self.assertEqual(result, (StepResult.SUCCESS, []))
 
+    def test_lb_inactive(self):
+        """
+        If one of the LBs we tried to attach one or more nodes to is
+        inactive, the request fails.
+        """
+        node_id = "d6d3aa7c-dfa5-4e61-96ee-1d54ac1075d2"
+        lb_id = 'd95ae0c4-6ab8-4873-b82f-f8433840cff2'
+        pairs = [(lb_id, node_id)]
+
+        resp = StubResponse(409, {})
+        body = {"errors": [
+            "Load Balancer Pool {lb_id} is not in an ACTIVE state"
+            .format(lb_id=lb_id)]}
+        result = _rcv3_check_bulk_add(pairs, (resp, body))
+        self.assertEqual(
+            result,
+            (StepResult.FAILURE,
+             "RCv3 LB {lb_id} was inactive".format(lb_id=lb_id))
 
 class RCv3CheckBulkDeleteTests(SynchronousTestCase):
     """

--- a/otter/test/convergence/test_steps.py
+++ b/otter/test/convergence/test_steps.py
@@ -610,8 +610,7 @@ class RCv3CheckBulkAddTests(SynchronousTestCase):
         self.assertEqual(
             result,
             (StepResult.FAILURE,
-             ["RCv3 LB {lb_id} was inactive".format(lb_id=lb_id)])
-             "RCv3 LB {lb_id} was inactive".format(lb_id=lb_id))
+             ["RCv3 LB {lb_id} was inactive".format(lb_id=lb_id)]))
 
 class RCv3CheckBulkDeleteTests(SynchronousTestCase):
     """

--- a/otter/test/convergence/test_steps.py
+++ b/otter/test/convergence/test_steps.py
@@ -656,6 +656,31 @@ class RCv3CheckBulkAddTests(SynchronousTestCase):
             (StepResult.FAILURE,
              ["RCv3 LB {lb_id} does not exist".format(lb_id=lb_id)]))
 
+    def test_multiple_lbs_do_not_exist(self):
+        """
+        If multiple LBs we tried to attach one or more nodes to do not
+        exist, the request fails, and all of the nonexistent LBs are
+        reported.
+
+        By logging as much of the failure as we can see, we will
+        hopefully produce better audit logs.
+        """
+        node_id = "d6d3aa7c-dfa5-4e61-96ee-1d54ac1075d2"
+        lb_1_id = 'd95ae0c4-6ab8-4873-b82f-f8433840cff2'
+        lb_2_id = 'fb32470f-6ebe-44a9-9360-3f48c9ac768c'
+        pairs = [(lb_1_id, node_id), (lb_2_id, node_id)]
+
+        resp = StubResponse(409, {})
+        body = {"errors": [
+            "Load Balancer Pool {lb_id} does not exist"
+            .format(lb_id=lb_id) for lb_id in [lb_1_id, lb_2_id]]}
+        result = _rcv3_check_bulk_add(pairs, (resp, body))
+        self.assertEqual(
+            result,
+            (StepResult.FAILURE,
+             ["RCv3 LB {lb_id} does not exist".format(lb_id=lb_id)
+              for lb_id in [lb_1_id, lb_2_id]]))
+
 
 class RCv3CheckBulkDeleteTests(SynchronousTestCase):
     """

--- a/otter/test/convergence/test_steps.py
+++ b/otter/test/convergence/test_steps.py
@@ -637,6 +637,26 @@ class RCv3CheckBulkAddTests(SynchronousTestCase):
              ["RCv3 LB {lb_id} was inactive".format(lb_id=lb_id)
               for lb_id in [lb_1_id, lb_2_id]]))
 
+    def test_lb_does_not_exist(self):
+        """
+        If one of the LBs we tried to attach one or more nodes to does not
+        exist, the request fails.
+        """
+        node_id = "d6d3aa7c-dfa5-4e61-96ee-1d54ac1075d2"
+        lb_id = 'd95ae0c4-6ab8-4873-b82f-f8433840cff2'
+        pairs = [(lb_id, node_id)]
+
+        resp = StubResponse(409, {})
+        body = {"errors": [
+            "Load Balancer Pool {lb_id} does not exist"
+            .format(lb_id=lb_id)]}
+        result = _rcv3_check_bulk_add(pairs, (resp, body))
+        self.assertEqual(
+            result,
+            (StepResult.FAILURE,
+             ["RCv3 LB {lb_id} does not exist".format(lb_id=lb_id)]))
+
+
 class RCv3CheckBulkDeleteTests(SynchronousTestCase):
     """
     Tests for :func:`_rcv3_check_bulk_delete`.


### PR DESCRIPTION
This adds support for inactive LBs and nonexistent LBs. In both cases, the request is set to failure. (It's possible that we get to retry these failed groups later, but for now I think failure is the most correct thing that describes what happened).

This refs #955, but doesn't resolve it yet. There's still the matter of invalid cloud servers and "unprocessable" cloud servers.