### PR TITLE
Nova metadata consistency

### DIFF
--- a/otter/convergence/composition.py
+++ b/otter/convergence/composition.py
@@ -1,16 +1,17 @@
 """
 Code for composing all of the convergence functionality together.
 """
-import json
-
 from collections import defaultdict
 
 from pyrsistent import freeze
 
-from toolz.dicttoolz import keyfilter
-from toolz.itertoolz import groupby
+from toolz.dicttoolz import get_in, merge
+from toolz.itertoolz import concat
 
-from otter.convergence.model import CLBDescription, DesiredGroupState
+from otter.convergence.model import (
+    CLBDescription,
+    DesiredGroupState,
+    NovaServer)
 
 
 def tenant_is_enabled(tenant_id, get_config_value):
@@ -58,60 +59,31 @@ def get_desired_group_state(group_id, launch_config, desired):
     not been added to any schema yet.
     """
     lbs = freeze(launch_config['args'].get('loadBalancers', []))
+    lbs = json_to_LBConfigs(lbs)
     server_lc = prepare_server_launch_config(
         group_id,
         freeze({'server': launch_config['args']['server']}),
         lbs)
-    lbs = json_to_LBConfigs(lbs)
     desired_state = DesiredGroupState(
         server_config=server_lc,
         capacity=desired, desired_lbs=lbs)
     return desired_state
 
 
-def _sanitize_lb_metadata(lb_config_json):
+def prepare_server_launch_config(group_id, server_config, lb_descriptions):
     """
-    Takes load balancer config json, as from :obj:`otter.json_schema._clb_lb`
-    and :obj:`otter.json_schema._rcv3_lb` and normalizes it.
-    """
-    sanitized = keyfilter(lambda k: k in ('type', 'port'), lb_config_json)
-    # provide a default type
-    sanitized.setdefault('type', 'CloudLoadBalancer')
-    return sanitized
-
-
-def prepare_server_launch_config(group_id, server_config, lb_args):
-    """
-    Prepares a server config (the server part of the Group's launch config)
+    Prepare a server config (the server part of the Group's launch config)
     with any necessary dynamic data.
 
     :param str group_id: The group ID
     :param PMap server_config: The server part of the Group's launch config,
         as per :obj:`otter.json_schema.group_schemas.server` except as the
         value of a one-element PMap with key "server".
-    :param PMap lb_args: The load balancer part of the Group's launch_config
-
-    This function assumes that `lb_args` is mostly well-formed data, and is
-    not missing any data, since it should have been sanitized before getting
-    to this point.
-
-    NOTE: Currently this ignores RCv3 settings and draining timeout settings,
-    since they haven't been implemented yet.
+    :param iterable lb_descriptions: iterable of
+        :class:`ILBDescription` providers
     """
-    server_config = server_config.set_in(
-        ('server', 'metadata', 'rax:auto_scaling_group_id'), group_id).set_in(
-        ('server', 'metadata', 'rax:autoscale:group:id'), group_id)
-
-    lbs = groupby(
-        lambda conf: (conf['loadBalancerId'],
-                      conf.get('type', 'CloudLoadBalancer')),
-        lb_args)
-
-    for (lb_id, lb_type), configs in lbs.iteritems():
-        configs = [_sanitize_lb_metadata(config) for config in configs]
-        server_config = server_config.set_in(
-            ('server', 'metadata', 'rax:autoscale:lb:{0}:{1}'.format(
-                lb_type, lb_id)),
-            json.dumps(configs))
-
-    return server_config
+    lbs = concat(lb_descriptions.values())
+    return server_config.set_in(
+        ('server', 'metadata'),
+        merge(get_in(('server', 'metadata'), server_config, {}),
+              NovaServer.generate_metadata(group_id, lbs)))

--- a/otter/convergence/gathering.py
+++ b/otter/convergence/gathering.py
@@ -1,12 +1,7 @@
 """Code related to gathering data to inform convergence."""
-import json
-import re
-from collections import defaultdict
 from urllib import urlencode
 
 from effect import parallel
-
-from pyrsistent import pmap
 
 from toolz.curried import filter, groupby, keyfilter, map
 from toolz.dicttoolz import get_in
@@ -20,7 +15,6 @@ from otter.convergence.model import (
     CLBNodeType,
     NovaServer,
     ServerState)
-from otter.convergence.steps import _UUID4_REGEX
 from otter.http import service_request
 from otter.indexer import atom
 from otter.util.http import append_segments

--- a/otter/convergence/gathering.py
+++ b/otter/convergence/gathering.py
@@ -8,7 +8,7 @@ from effect import parallel
 
 from pyrsistent import pmap
 
-from toolz.curried import filter, groupby, map
+from toolz.curried import filter, groupby, keyfilter, map
 from toolz.dicttoolz import get_in
 from toolz.functoolz import compose, identity
 
@@ -83,12 +83,13 @@ def get_scaling_group_servers(server_predicate=identity):
     """
 
     def has_group_id(s):
-        return 'metadata' in s and 'rax:auto_scaling_group_id' in s['metadata']
+        return 'metadata' in s and isinstance(s['metadata'], dict)
 
     def group_id(s):
-        return s['metadata']['rax:auto_scaling_group_id']
+        return NovaServer.group_id_from_metadata(s['metadata'])
 
-    servers_apply = compose(groupby(group_id),
+    servers_apply = compose(keyfilter(lambda k: k is not None),
+                            groupby(group_id),
                             filter(server_predicate),
                             filter(has_group_id))
 

--- a/otter/convergence/model.py
+++ b/otter/convergence/model.py
@@ -7,9 +7,9 @@ import re
 
 from characteristic import Attribute, attributes
 
-from toolz.itertoolz import groupby
-
 from pyrsistent import PMap, freeze, pmap
+
+from toolz.itertoolz import groupby
 
 from twisted.python.constants import NamedConstant, Names
 

--- a/otter/convergence/model.py
+++ b/otter/convergence/model.py
@@ -146,7 +146,7 @@ class NovaServer(object):
     :ivar str image_id: The ID of the image the server was launched with
     :ivar str flavor_id: The ID of the flavor the server was launched with
 
-    :ivar PSet desired_lbs: An immutable mapping of load balancer IDs to lists
+    :ivar PMap desired_lbs: An immutable mapping of load balancer IDs to lists
         of :class:`CLBDescription` instances.
     """
 

--- a/otter/convergence/model.py
+++ b/otter/convergence/model.py
@@ -112,12 +112,14 @@ def get_service_metadata(service_name, metadata):
     """
     as_metadata = pmap()
     if isinstance(metadata, dict):
-        key_pattern = re.compile("^rax:{service}((:[A-Za-z0-9\-_]+)+)$"
-                                 .format(service=service_name))
+        key_pattern = re.compile(
+            "^rax:{service}(?P<subkeys>(:[A-Za-z0-9\-_]+)+)$"
+            .format(service=service_name))
+
         for k, v in metadata.iteritems():
             m = key_pattern.match(k)
             if m:
-                subkeys = m.groups()[0]  # largest group
+                subkeys = m.groupdict()['subkeys']
                 as_metadata = as_metadata.set_in(
                     [sk for sk in subkeys.split(':') if sk],
                     v)

--- a/otter/convergence/model.py
+++ b/otter/convergence/model.py
@@ -2,6 +2,7 @@
 Data classes for representing bits of information that need to share a
 representation across the different phases of convergence.
 """
+import json
 import re
 
 from characteristic import Attribute, attributes
@@ -147,6 +148,19 @@ class NovaServer(object):
     def __init__(self):
         assert self.state in ServerState.iterconstants(), \
             "%r is not a ServerState" % (self.state,)
+
+    @classmethod
+    def group_id_from_metadata(cls, metadata):
+        """
+        Get the group ID of a server based on the metadata.
+
+        The old key was ``rax:auto_scaling_group_id``, but the new key is
+        ``rax:autoscale:group:id``.  Try pulling from the new key first, and
+        if it doesn't exist, pull from the old.
+        """
+        return metadata.get(
+            "rax:autoscale:group:id",
+            metadata.get("rax:auto_scaling_group_id", None))
 
 
 @attributes(['server_config', 'capacity',

--- a/otter/test/convergence/test_composition.py
+++ b/otter/test/convergence/test_composition.py
@@ -67,12 +67,8 @@ class GetDesiredGroupStateTests(SynchronousTestCase):
                     'rax:auto_scaling_group_id': 'uuid',
                     'rax:autoscale:group:id': 'uuid',
                     'rax:autoscale:lb:CloudLoadBalancer:23': json.dumps(
-                        [{"port": 80, "type": "CloudLoadBalancer"},
-                         {"port": 90, "type": "CloudLoadBalancer"}]),
-                    'rax:autoscale:lb:RackConnectV3:23': json.dumps(
-                        [{"type": "RackConnectV3"}]),
-                    'rax:autoscale:lb:RackConnectV3:12': json.dumps(
-                        [{"type": "RackConnectV3"}])
+                        [{"port": 80},
+                         {"port": 90}])
                 }
             }
         }

--- a/otter/test/convergence/test_composition.py
+++ b/otter/test/convergence/test_composition.py
@@ -52,9 +52,12 @@ class GetDesiredGroupStateTests(SynchronousTestCase):
         """
         server_config = {'name': 'test', 'flavorRef': 'f'}
         lc = {'args': {'server': server_config,
-                       'loadBalancers': [{'loadBalancerId': 23, 'port': 80,
-                                          'whatsit': 'invalid'},
-                                         {'loadBalancerId': 23, 'port': 90}]}}
+                       'loadBalancers': [
+                           {'loadBalancerId': 23, 'port': 80,
+                            'whatsit': 'invalid'},
+                           {'loadBalancerId': 23, 'port': 90},
+                           {'loadBalancerId': 23, 'type': 'RackConnectV3'},
+                           {'loadBalancerId': '12', 'type': 'RackConnectV3'}]}}
 
         expected_server_config = {
             'server': {
@@ -62,9 +65,14 @@ class GetDesiredGroupStateTests(SynchronousTestCase):
                 'flavorRef': 'f',
                 'metadata': {
                     'rax:auto_scaling_group_id': 'uuid',
-                    'rax:autoscale:lb:23': json.dumps(
+                    'rax:autoscale:group:id': 'uuid',
+                    'rax:autoscale:lb:CloudLoadBalancer:23': json.dumps(
                         [{"port": 80, "type": "CloudLoadBalancer"},
-                         {"port": 90, "type": "CloudLoadBalancer"}])
+                         {"port": 90, "type": "CloudLoadBalancer"}]),
+                    'rax:autoscale:lb:RackConnectV3:23': json.dumps(
+                        [{"type": "RackConnectV3"}]),
+                    'rax:autoscale:lb:RackConnectV3:12': json.dumps(
+                        [{"type": "RackConnectV3"}])
                 }
             }
         }
@@ -91,7 +99,8 @@ class GetDesiredGroupStateTests(SynchronousTestCase):
                 'name': 'test',
                 'flavorRef': 'f',
                 'metadata': {
-                    'rax:auto_scaling_group_id': 'uuid'}}}
+                    'rax:auto_scaling_group_id': 'uuid',
+                    'rax:autoscale:group:id': 'uuid'}}}
         state = get_desired_group_state('uuid', lc, 2)
         self.assertEqual(
             state,

--- a/otter/test/convergence/test_gathering.py
+++ b/otter/test/convergence/test_gathering.py
@@ -18,7 +18,6 @@ from otter.convergence.gathering import (
     get_clb_contents,
     get_scaling_group_servers,
     to_nova_server,
-    _LB_KEY_PATTERN,
     _private_ipv4_addresses,
     _servicenet_address)
 from otter.convergence.model import (
@@ -354,68 +353,6 @@ class GetLBContentsTests(SynchronousTestCase):
                      description=make_desc(lb_id='1')),
              CLBNode(node_id='21', address='a21',
                      description=make_desc(lb_id='2'))])
-
-
-class RegexTests(SynchronousTestCase):
-    """
-    Tests regexes that are used in `gathering`.
-    """
-    def test_invalid_prefix_doesnt_match(self):
-        """
-        Strings that do not start with `rax:autoscale:lb:CloudLoadbalancer:`
-        or `rax:autoscale:lb:RackConnectV3` do not match.
-        """
-        invalids = (
-            "rax:autoscale:CloudLoadBalancer:123",      # no :lb:
-            "rax:monitoring:lb:CloudLoadBalancer:123",  # no :autoscale:
-            "rax:autoscale:lb:Neutron:12",              # unsupported service
-        )
-        for invalid in invalids:
-            self.assertIsNone(_LB_KEY_PATTERN.match(invalid))
-
-    def test_CLB(self):
-        """
-        Strings that look like `rax:autoscale:lb:CloudLoadbalancer:00000`,
-        without case, match cloud load balancers.
-        """
-        valids = (
-            "rax:autoscale:lb:CloudLoadBalancer:135",
-            "rax:autoscale:lb:cloudloadbalancer:135",
-        )
-        for valid in valids:
-            self.assertIsNotNone(_LB_KEY_PATTERN.match(valid))
-
-        invalids = (
-            "rax:autoscale:lb:CloudLoadBalancer:abcd",
-            "rax:autoscale:lb:CloudLoadBalancer:",
-            "rax:autoscale:lb:CloudLoadBalancer1234",
-            "rax:autoscale:lb:CloudLoadbalancer:" +
-            "de305d54-75b4-431b-adb2-eb6b9e546013"
-        )
-        for invalid in invalids:
-            self.assertIsNone(_LB_KEY_PATTERN.match(invalid))
-
-    def test_RCV3(self):
-        """
-        Strings that look like `rax:autoscale:lb:CloudLoadbalancer:00000`,
-        without case, match cloud load balancers.
-        """
-        _uuid = "de305d54-75b4-431b-adb2-eb6b9e546013"
-        valids = (
-            "rax:autoscale:lb:RackConnectV3:" + _uuid,
-            "rax:autoscale:lb:rackconnectv3:" + _uuid
-        )
-        for valid in valids:
-            self.assertIsNotNone(_LB_KEY_PATTERN.match(valid))
-
-        invalids = (
-            "rax:autoscale:lb:RackConnectV3:abcd",
-            "rax:autoscale:lb:RackConnectV3:1234",
-            "rax:autoscale:lb:RackConnectV3:"
-            "rax:autoscale:lb:RackConnectV3" + _uuid
-        )
-        for invalid in invalids:
-            self.assertIsNone(_LB_KEY_PATTERN.match(invalid))
 
 
 class ToNovaServerTests(SynchronousTestCase):

--- a/otter/test/convergence/test_gathering.py
+++ b/otter/test/convergence/test_gathering.py
@@ -451,11 +451,12 @@ class ToNovaServerTests(SynchronousTestCase):
         """
         self.servers[0]['metadata'] = {
             # two correct lbconfigs and one incorrect one
-            'rax:autoscale:lb:12345': '[{"port":80},{"bad":"1"},{"port":90}]',
+            'rax:autoscale:lb:CloudLoadBalancer:12345':
+            '[{"port":80},{"bad":"1"},{"port":90}]',
             # a dictionary instead of a list
-            'rax:autoscale:lb:23456': '{"port": 80}',
+            'rax:autoscale:lb:CloudLoadBalancer:23456': '{"port": 80}',
             # not even valid json
-            'rax:autoscale:lb:34567': 'invalid json string'
+            'rax:autoscale:lb:CloudLoadBalancer:34567': 'invalid json string'
         }
         self.assertEqual(
             to_nova_server(self.servers[0]),

--- a/otter/test/convergence/test_model.py
+++ b/otter/test/convergence/test_model.py
@@ -270,3 +270,30 @@ class ServiceMetadataTests(SynchronousTestCase):
         }
         self.assertEqual(get_service_metadata('autoscale', metadata),
                          pmap(expected))
+
+
+class AutoscaleMetadataTests(SynchronousTestCase):
+    """
+    Tests for generating and parsing Nova server metadata.
+    """
+    def test_get_group_id_from_metadata(self):
+        """
+        Get the group ID from metadata no matter if it's old style or new
+        style.
+        """
+        for key in ("rax:autoscale:group:id", "rax:auto_scaling_group_id"):
+            self.assertEqual(
+                NovaServer.group_id_from_metadata({key: "group_id"}),
+                "group_id")
+
+    def test_invalid_group_id_key_returns_none(self):
+        """
+        If there is no group ID key, either old or new style, no group ID is
+        returned.
+        """
+        for key in (":rax:autoscale:group:id", "rax:autoscaling_group_id",
+                    "completely_wrong"):
+            self.assertIsNone(
+                NovaServer.group_id_from_metadata({key: "group_id"}))
+
+        self.assertIsNone(NovaServer.group_id_from_metadata({}))

--- a/otter/test/convergence/test_model.py
+++ b/otter/test/convergence/test_model.py
@@ -249,7 +249,8 @@ class ServiceMetadataTests(SynchronousTestCase):
             "rax:autoscale:lb otherstuff": "fails because space",
             "rax:monitoring:check": "fails because wrong service",
             ":rax:autoscale:lb": "fails because starts with colon",
-            "rax:autoscale:lb:": "fails because ends with colon"
+            "rax:autoscale:lb:": "fails because ends with colon",
+            "rax:rax:autoscale:lb:autoscale:lb": "fails because 2x'rax'"
         }
         self.assertEqual(get_service_metadata('autoscale', metadata), pmap())
 
@@ -265,7 +266,8 @@ class ServiceMetadataTests(SynchronousTestCase):
             "rax:autoscale:lb:RackConnectV3:123": "result3",
             "rax:autoscale:lb:RackConnectV3:234": "result4",
             "rax:autoscale:some:other:nested:key": "result5",
-            "rax:autoscale:topLevelKey_with_underlines-and-dashes": "result6"
+            "rax:autoscale:topLevelKey_with_underlines-and-dashes": "result6",
+            "rax:autoscale:autoscale:lb": "result7"
         }
         expected = {
             'group': {'id': 'group id'},
@@ -276,7 +278,8 @@ class ServiceMetadataTests(SynchronousTestCase):
                                   '234': 'result4'}
             },
             'some': {'other': {'nested': {'key': 'result5'}}},
-            "topLevelKey_with_underlines-and-dashes": "result6"
+            "topLevelKey_with_underlines-and-dashes": "result6",
+            'autoscale': {'lb': 'result7'}
         }
         self.assertEqual(get_service_metadata('autoscale', metadata),
                          pmap(expected))

--- a/otter/test/convergence/test_model.py
+++ b/otter/test/convergence/test_model.py
@@ -5,7 +5,7 @@ from uuid import uuid4
 
 from characteristic import attributes
 
-from pyrsistent import pmap, pset
+from pyrsistent import pmap
 
 from twisted.trial.unittest import SynchronousTestCase
 

--- a/otter/test/convergence/test_model.py
+++ b/otter/test/convergence/test_model.py
@@ -339,3 +339,24 @@ class AutoscaleMetadataTests(SynchronousTestCase):
             "rax:autoscale:lb:Neutron:456": None
         }
         self.assertEqual(NovaServer.lbs_from_metadata(metadata), pmap())
+
+    def test_generate_metadata(self):
+        """
+        :func:`NovaServer.lbs_from_metadata` produces a dictionary with
+        metadata for the group ID and any load balancers provided.
+        """
+        lbs = [
+            CLBDescription(port=80, lb_id='123'),
+            CLBDescription(port=8080, lb_id='123'),
+            CLBDescription(port=80, lb_id='234')
+        ]
+        expected = {
+            'rax:autoscale:group:id': 'group_id',
+            'rax:auto_scaling_group_id': 'group_id',
+            'rax:autoscale:lb:CloudLoadBalancer:123': (
+                '[{"port": 80}, {"port": 8080}]'),
+            'rax:autoscale:lb:CloudLoadBalancer:234': '[{"port": 80}]'
+        }
+
+        self.assertEqual(NovaServer.generate_metadata('group_id', lbs),
+                         expected)


### PR DESCRIPTION
This fixes #1048.

It also addresses part of #973.  (I hope)

So one thing that may not be cool is that the type is already in the metadata key.  Wondering if I should eliminate it from the value too, but then for stuff like RackConnect the value would be empty.