### PR TITLE
Factor out the partitioning logic from scheduler into its own service

### DIFF
--- a/otter/scheduler.py
+++ b/otter/scheduler.py
@@ -7,7 +7,7 @@ in the first place.
 from datetime import datetime
 from functools import partial
 
-from twisted.application.internet import TimerService
+from twisted.application.service import MultiService
 from twisted.internet import defer
 
 from otter.controller import (
@@ -19,81 +19,46 @@ from otter.util.deferredutils import ignore_and_log
 from otter.util.hashkey import generate_transaction_id
 
 
-class SchedulerService(TimerService):
+class SchedulerService(MultiService, object):
     """
     Service to trigger scheduled events
     """
 
-    def __init__(self, batchsize, interval, store, kz_client,
-                 zk_partition_path, time_boundary, buckets, clock=None, threshold=60):
+    def __init__(self, batchsize, store, partitioner_factory, threshold=60):
         """
         Initialize the scheduler service
 
         :param int batchsize: number of events to fetch on each iteration
-        :param int interval: time between each iteration
-        :param kz_client: `TxKazooClient` instance
-        :param buckets: an iterable containing the buckets which contains scheduled events
-        :param zk_partition_path: Partiton path used by kz_client to partition the buckets
-        :param time_boundary: Time to wait for partition to become stable
-        :param clock: An instance of IReactorTime provider that defaults to reactor if not provided
+        :param store: cassandra store
+        :param partitioner_factory: :obj:`Partitioner`
         """
-        TimerService.__init__(self, interval, self.check_events, batchsize)
+        super(SchedulerService, self).__init__()
         self.store = store
-        self.clock = clock
-        self.kz_client = kz_client
-        self.buckets = buckets
-        self.zk_partition_path = zk_partition_path
-        self.time_boundary = time_boundary
-        self.kz_partition = None
         self.threshold = threshold
         self.log = otter_log.bind(system='otter.scheduler')
-
-    def startService(self):
-        """
-        Start this service. This will start buckets partitioning
-        """
-        self.kz_partition = self.kz_client.SetPartitioner(
-            self.zk_partition_path, set=set(self.buckets),
-            time_boundary=self.time_boundary)
-        TimerService.startService(self)
-
-    def stopService(self):
-        """
-        Stop this service. This will release buckets partitions it holds
-        """
-        TimerService.stopService(self)
-        if self.kz_partition.acquired:
-            return self.kz_partition.finish()
+        self.partitioner = partitioner_factory(
+            self.log, partial(self._check_events, batchsize))
+        self.partitioner.setServiceParent(self)
 
     def reset(self, path):
         """
-        Reset the scheduler with new path
+        Reset the scheduler with a new path.
         """
-        if self.zk_partition_path != path:
-            self.zk_partition_path = path
-            self.kz_partition = self.kz_client.SetPartitioner(
-                self.zk_partition_path, set=set(self.buckets),
-                time_boundary=self.time_boundary)
-        else:
-            raise ValueError('same path')
+        return self.partitioner.reset_path(path)
 
     def health_check(self):
         """
-        Checks if scheduler service is healthy by comparing oldest event w.r.t current
-        time. If oldtest event is older than a threshold, then it is not healthy
+        Checks if scheduler service is healthy by comparing oldest event w.r.t
+        current time. If oldtest event is older than a threshold, then it is
+        not healthy
 
-        :return: Deferred that fires with tuple (Bool, `dict` of extra debug info)
+        :return: Deferred that fires with tuple (Bool, `dict` of extra debug
+        info)
         """
         if not self.running:
             return defer.succeed((False, {'reason': 'Not running'}))
 
-        if not self.kz_partition.acquired:
-            # TODO: Until there is check added for not being allocted for long time
-            # it is fine to assume service is not healthy when it is allocating since
-            # allocating should happen only on deploy or network issues
-            return defer.succeed((False, {'reason': 'Not acquired'}))
-
-        def check_older_events(events):
+        def check_older_events(events, info):
             now = datetime.utcnow()
             old_events = []
             for event in events:
@@ -101,50 +66,35 @@ class SchedulerService(TimerService):
                     event['version'] = str(event['version'])
                     event['trigger'] = str(event['trigger'])
                     old_events.append(event)
-            return (not bool(old_events), {'old_events': old_events,
-                                           'buckets': list(self.kz_partition)})
+            info['old_events'] = old_events
+            return (not bool(old_events), info)
 
-        d = defer.gatherResults(
-            [self.store.get_oldest_event(bucket) for bucket in self.kz_partition],
-            consumeErrors=True)
-        d.addCallback(check_older_events)
-        return d
+        def got_partitioner_health_check(result):
+            healthy, info = result
+            if healthy is False:
+                return result
+            buckets = info['buckets']
+            d = defer.gatherResults(
+                [self.store.get_oldest_event(bucket) for bucket in buckets],
+                consumeErrors=True)
+            d.addCallback(check_older_events, info)
+            return d
 
-    def check_events(self, batchsize):
+        d = self.partitioner.health_check()
+        return d.addCallback(got_partitioner_health_check)
+
+    def _check_events(self, batchsize, buckets):
         """
         Check for events occurring now and earlier
         """
-        if self.kz_partition.allocating:
-            self.log.msg('Partition allocating')
-            return
-        if self.kz_partition.release:
-            self.log.msg('Partition changed. Repartitioning')
-            return self.kz_partition.release_set()
-        if self.kz_partition.failed:
-            self.log.msg('Partition failed. Starting new')
-            self.kz_partition = self.kz_client.SetPartitioner(
-                self.zk_partition_path, set=set(self.buckets),
-                time_boundary=self.time_boundary)
-            return
-        if not self.kz_partition.acquired:
-            self.log.err('Unknown state {}. This cannot happen. Starting new'.format(
-                self.kz_partition.state))
-            self.kz_partition.finish()
-            self.kz_partition = self.kz_client.SetPartitioner(
-                self.zk_partition_path, set=set(self.buckets),
-                time_boundary=self.time_boundary)
-            return
-
-        buckets = list(self.kz_partition)
         utcnow = datetime.utcnow()
-        log = self.log.bind(scheduler_run_id=generate_transaction_id(), utcnow=utcnow)
-        # TODO: This log might feel like spam since it'll occur on every tick. But
-        # it'll be useful to debug partitioning problems (at least in initial deployment)
-        log.msg('Got buckets {buckets}', buckets=buckets, path=self.zk_partition_path)
+        log = self.log.bind(scheduler_run_id=generate_transaction_id(),
+                            utcnow=utcnow)
 
         return defer.gatherResults(
             [check_events_in_bucket(
-                log, self.store, bucket, utcnow, batchsize) for bucket in buckets])
+                log, self.store, bucket, utcnow, batchsize)
+             for bucket in buckets])
 
 
 def check_events_in_bucket(log, store, bucket, now, batchsize):

--- a/otter/scheduler.py
+++ b/otter/scheduler.py
@@ -19,7 +19,7 @@ from otter.util.deferredutils import ignore_and_log
 from otter.util.hashkey import generate_transaction_id
 
 
-class SchedulerService(MultiService, object):
+class SchedulerService(MultiService):
     """
     Service to trigger scheduled events
     """
@@ -33,7 +33,7 @@ class SchedulerService(MultiService, object):
         :param partitioner_factory: Callable of (log, callback) ->
             :obj:`Partitioner`
         """
-        super(SchedulerService, self).__init__()
+        MultiService.__init__(self)
         self.store = store
         self.threshold = threshold
         self.log = otter_log.bind(system='otter.scheduler')
@@ -49,9 +49,9 @@ class SchedulerService(MultiService, object):
 
     def health_check(self):
         """
-        Checks if scheduler service is healthy by comparing oldest event w.r.t
-        current time. If oldtest event is older than a threshold, then it is
-        not healthy
+        Check if scheduler service is healthy by comparing oldest event to
+        current time. If the oldest event is older than the threshold, then
+        we're considered unhealthy.
 
         :return: Deferred that fires with tuple (Bool, `dict` of extra debug
         info)

--- a/otter/scheduler.py
+++ b/otter/scheduler.py
@@ -30,7 +30,8 @@ class SchedulerService(MultiService, object):
 
         :param int batchsize: number of events to fetch on each iteration
         :param store: cassandra store
-        :param partitioner_factory: :obj:`Partitioner`
+        :param partitioner_factory: Callable of (log, callback) ->
+            :obj:`Partitioner`
         """
         super(SchedulerService, self).__init__()
         self.store = store

--- a/otter/tap/api.py
+++ b/otter/tap/api.py
@@ -37,6 +37,7 @@ from otter.supervisor import SupervisorService, set_supervisor
 from otter.util.config import config_value, set_config_data
 from otter.util.cqlbatch import TimingOutCQLClient
 from otter.util.deferredutils import timeout_deferred
+from otter.util.zkpartitioner import Partitioner
 
 
 class Options(usage.Options):
@@ -290,10 +291,12 @@ def setup_scheduler(parent, store, kz_client):
     partition_path = (config_value('scheduler.partition.path')
                       or '/scheduler_partition')
     time_boundary = config_value('scheduler.partition.time_boundary') or 15
+    partitioner_factory = partial(
+        Partitioner,
+        kz_client, int(config_value('scheduler.interval')), partition_path,
+        buckets, time_boundary)
     scheduler_service = SchedulerService(
         int(config_value('scheduler.batchsize')),
-        int(config_value('scheduler.interval')),
-        store, kz_client, partition_path, time_boundary,
-        buckets)
+        store, partitioner_factory)
     scheduler_service.setServiceParent(parent)
     return scheduler_service

--- a/otter/tap/api.py
+++ b/otter/tap/api.py
@@ -288,8 +288,8 @@ def setup_scheduler(parent, store, kz_client):
         return
     buckets = range(1, int(config_value('scheduler.buckets')) + 1)
     store.set_scheduler_buckets(buckets)
-    partition_path = (config_value('scheduler.partition.path')
-                      or '/scheduler_partition')
+    partition_path = (config_value('scheduler.partition.path') or
+                      '/scheduler_partition')
     time_boundary = config_value('scheduler.partition.time_boundary') or 15
     partitioner_factory = partial(
         Partitioner,

--- a/otter/test/tap/test_api.py
+++ b/otter/test/tap/test_api.py
@@ -610,7 +610,6 @@ class SchedulerSetupTests(SynchronousTestCase):
         """
         Mock args
         """
-        self.scheduler_service = patch(self, 'otter.tap.api.SchedulerService')
         self.config = {
             'scheduler': {
                 'buckets': 10,
@@ -620,7 +619,7 @@ class SchedulerSetupTests(SynchronousTestCase):
             }
         }
         set_config_data(self.config)
-        self.parent = mock.Mock()
+        self.parent = MultiService()
         self.store = mock.Mock()
         self.kz_client = mock.Mock()
 
@@ -635,13 +634,14 @@ class SchedulerSetupTests(SynchronousTestCase):
         `SchedulerService` is configured with config values and set as parent
         to passed `MultiService`
         """
-        setup_scheduler(self.parent, self.store, self.kz_client)
+        svc = setup_scheduler(self.parent, self.store, self.kz_client)
         buckets = range(1, 11)
         self.store.set_scheduler_buckets.assert_called_once_with(buckets)
-        self.scheduler_service.assert_called_once_with(
-            100, 10, self.store, self.kz_client, '/part_path', 15, buckets)
-        self.scheduler_service.return_value.setServiceParent\
-            .assert_called_once_with(self.parent)
+        self.assertEqual(self.parent.services, [svc])
+        self.assertEqual(svc.store, self.store)
+        self.assertEqual(svc.partitioner.buckets, buckets)
+        self.assertEqual(svc.partitioner.kz_client, self.kz_client)
+        self.assertEqual(svc.partitioner.partitioner_path, '/part_path')
 
     def test_mock_store_with_scheduler(self):
         """
@@ -649,8 +649,7 @@ class SchedulerSetupTests(SynchronousTestCase):
         """
         self.config['mock'] = True
         set_config_data(self.config)
-
-        setup_scheduler(self.parent, self.store, self.kz_client)
-
+        self.assertIs(
+            setup_scheduler(self.parent, self.store, self.kz_client),
+            None)
         self.assertFalse(self.store.set_scheduler_buckets.called)
-        self.assertFalse(self.scheduler_service.called)

--- a/otter/test/util/test_zkpartitioner.py
+++ b/otter/test/util/test_zkpartitioner.py
@@ -65,7 +65,7 @@ class PartitionerTests(SynchronousTestCase):
 
         self.log.msg.assert_called_with('Partition failed. Starting new',
                                         otter_msg_type='partition-failed')
-        # # Called once when starting and now again when partition failed
+        # Called once when starting and now again when partition failed
         self.assertEqual(self.kz_client.SetPartitioner.call_args_list,
                          [mock.call(self.path,
                                     set=self.buckets,

--- a/otter/test/util/test_zkpartitioner.py
+++ b/otter/test/util/test_zkpartitioner.py
@@ -113,6 +113,21 @@ class PartitionerTests(SynchronousTestCase):
             otter_msg_type='partition-acquired')
         self.assertEqual(self.buckets_received, [[2, 3]])
 
+    def test_repeat(self):
+        """
+        buckets are received every iteration that the partitioner is acquired.
+        """
+        self.kz_partitioner.acquired = True
+        self.kz_partitioner.__iter__.return_value = [2, 3]
+        self.partitioner.startService()
+        self.log.msg.assert_called_once_with(
+            'Got buckets {buckets}',
+            buckets=[2, 3], path=self.path,
+            otter_msg_type='partition-acquired')
+        self.clock.advance(10)
+        self.clock.advance(10)
+        self.assertEqual(self.buckets_received, [[2, 3], [2, 3], [2, 3]])
+
     def test_stop_service_not_acquired(self):
         """
         stopService() does not stop the allocation (i.e. call finish) if

--- a/otter/test/util/test_zkpartitioner.py
+++ b/otter/test/util/test_zkpartitioner.py
@@ -133,6 +133,21 @@ class PartitionerTests(SynchronousTestCase):
         d = self.partitioner.stopService()
         self.assertIs(self.kz_partitioner.finish.return_value, d)
 
+    def test_stop_service_stops_polling(self):
+        """
+        stopService causes the service to stop checking the partitioner every
+        interval.
+        """
+        self.kz_partitioner.allocating = True
+        self.partitioner.startService()
+        self.kz_partitioner.acquired = True
+        self.kz_partitioner.allocating = False
+        self.kz_partitioner.__iter__.return_value = iter([2, 3])
+        self.partitioner.stopService()
+        self.assertEqual(self.partitioner.running, False)
+        self.clock.advance(10)
+        self.assertEqual(self.buckets_received, [])
+
     def test_reset_path(self):
         """``reset_path`` creates a new partitioner at the given path."""
         self.partitioner.reset_path('/new_path')

--- a/otter/test/util/test_zkpartitioner.py
+++ b/otter/test/util/test_zkpartitioner.py
@@ -1,0 +1,146 @@
+"""Tests for otter.util.zkpartitioner"""
+
+import mock
+
+from twisted.internet.task import Clock
+from twisted.trial.unittest import SynchronousTestCase
+
+from otter.test.utils import mock_log
+from otter.util.zkpartitioner import Partitioner
+
+
+class PartitionerTests(SynchronousTestCase):
+    """Tests for :obj:`Partitioner`."""
+
+    def setUp(self):
+        self.clock = Clock()
+        self.kz_client = mock.Mock(spec=['SetPartitioner'])
+        self.kz_partitioner = mock.MagicMock(
+            allocating=False,
+            release=False,
+            failed=False,
+            acquired=False)
+        self.kz_client.SetPartitioner.return_value = self.kz_partitioner
+        self.path = '/the-part-path'
+        self.buckets = range(5)
+        self.log = mock_log()
+        self.time_boundary = 30
+        self.buckets_received = []
+        self.partitioner = Partitioner(
+            self.kz_client, 10, self.path, self.buckets, self.time_boundary,
+            self.log, self.buckets_received.append, clock=self.clock)
+
+    def test_allocating(self):
+        """When state is ``allocating``, nothing happens."""
+        self.kz_partitioner.allocating = True
+        self.partitioner.startService()
+        #self.partitioner.check_events(100)
+        self.log.msg.assert_called_with('Partition allocating',
+                                        otter_msg_type='partition-allocating')
+        self.assertEqual(self.buckets_received, [])
+
+    def test_release(self):
+        """
+        When state is ``release``, the :obj:`SetPartitioner`'s ``release_set``
+        method is called.
+        """
+        self.kz_partitioner.release = True
+        self.partitioner.startService()
+        self.log.msg.assert_called_with('Partition changed. Repartitioning',
+                                        otter_msg_type='partition-released')
+        self.kz_partitioner.release_set.assert_called_once_with()
+        self.assertEqual(self.buckets_received, [])
+
+    def test_failed(self):
+        """When state is ``failed``, a new partitioner is created."""
+        self.kz_partitioner.allocating = True
+        self.partitioner.startService()
+
+        self.kz_partitioner.allocating = False
+        self.kz_partitioner.failed = True
+        # expect a new SetPartitioner to be created
+        new_kz_partition = object()
+        self.kz_client.SetPartitioner.return_value = new_kz_partition
+
+        self.clock.advance(10)
+
+        self.log.msg.assert_called_with('Partition failed. Starting new',
+                                        otter_msg_type='partition-failed')
+        # # Called once when starting and now again when partition failed
+        self.assertEqual(self.kz_client.SetPartitioner.call_args_list,
+                         [mock.call(self.path,
+                                    set=set(self.buckets),
+                                    time_boundary=self.time_boundary)] * 2)
+        self.assertEqual(self.partitioner.partitioner, new_kz_partition)
+        self.assertEqual(self.buckets_received, [])
+
+    def test_invalid_state(self):
+        """
+        When none of the expected states are True, the ``finish`` method is
+        called on the partitioner and a new partitioner is created.
+        """
+        self.kz_partitioner.allocating = True
+        self.partitioner.startService()
+        self.kz_partitioner.allocating = False
+        self.kz_partitioner.state = 'bad'
+
+        # expect a new SetPartitioner to be created
+        new_kz_partition = object()
+        self.kz_client.SetPartitioner.return_value = new_kz_partition
+
+        self.clock.advance(10)
+
+        self.log.err.assert_called_with(
+            'Unknown state bad. This cannot happen. Starting new',
+            otter_msg_type='partition-invalid-state')
+        self.kz_partitioner.finish.assert_called_once_with()
+
+        # Called once when starting and now again when got bad state
+        self.assertEqual(self.kz_client.SetPartitioner.call_args_list,
+                         [mock.call(self.path,
+                                    set=set(self.buckets),
+                                    time_boundary=self.time_boundary)] * 2)
+        self.assertEqual(self.partitioner.partitioner, new_kz_partition)
+        self.assertEqual(self.buckets_received, [])
+
+    def test_acquired(self):
+        """When state is acquired, our callback is invoked with the buckets."""
+        self.kz_partitioner.acquired = True
+        self.kz_partitioner.__iter__.return_value = iter([2, 3])
+        self.partitioner.startService()
+        self.log.msg.assert_called_once_with(
+            'Got buckets {buckets}',
+            buckets=[2, 3], path=self.path,
+            otter_msg_type='partition-acquired')
+        self.assertEqual(self.buckets_received, [[2, 3]])
+
+    def test_stop_service_not_acquired(self):
+        """
+        stopService() does not stop the allocation (i.e. call finish) if
+        it is not acquired.
+        """
+        self.kz_partitioner.allocating = True
+        self.partitioner.startService()
+        d = self.partitioner.stopService()
+        self.assertFalse(self.kz_partitioner.finish.called)
+        self.assertIsNone(d)
+
+    def test_stop_service_acquired(self):
+        """
+        stopService() calls ``finish`` on the partitioner if it is acquired.
+        """
+        self.kz_partitioner.acquired = True
+        self.partitioner.startService()
+        d = self.partitioner.stopService()
+        self.assertIs(self.kz_partitioner.finish.return_value, d)
+
+    def test_reset_path(self):
+        """``reset_path`` creates a new partitioner at the given path."""
+        self.partitioner.reset_path('/new_path')
+        self.assertEqual(self.partitioner.partitioner_path, '/new_path')
+        self.kz_client.SetPartitioner.assert_called_once_with(
+            '/new_path',
+            set=set(self.buckets),
+            time_boundary=self.time_boundary)
+        self.assertEqual(self.partitioner.partitioner,
+                         self.kz_client.SetPartitioner.return_value)

--- a/otter/test/util/test_zkpartitioner.py
+++ b/otter/test/util/test_zkpartitioner.py
@@ -68,7 +68,7 @@ class PartitionerTests(SynchronousTestCase):
         # # Called once when starting and now again when partition failed
         self.assertEqual(self.kz_client.SetPartitioner.call_args_list,
                          [mock.call(self.path,
-                                    set=set(self.buckets),
+                                    set=self.buckets,
                                     time_boundary=self.time_boundary)] * 2)
         self.assertEqual(self.partitioner.partitioner, new_kz_partition)
         self.assertEqual(self.buckets_received, [])
@@ -97,7 +97,7 @@ class PartitionerTests(SynchronousTestCase):
         # Called once when starting and now again when got bad state
         self.assertEqual(self.kz_client.SetPartitioner.call_args_list,
                          [mock.call(self.path,
-                                    set=set(self.buckets),
+                                    set=self.buckets,
                                     time_boundary=self.time_boundary)] * 2)
         self.assertEqual(self.partitioner.partitioner, new_kz_partition)
         self.assertEqual(self.buckets_received, [])
@@ -139,7 +139,7 @@ class PartitionerTests(SynchronousTestCase):
         self.assertEqual(self.partitioner.partitioner_path, '/new_path')
         self.kz_client.SetPartitioner.assert_called_once_with(
             '/new_path',
-            set=set(self.buckets),
+            set=self.buckets,
             time_boundary=self.time_boundary)
         self.assertEqual(self.partitioner.partitioner,
                          self.kz_client.SetPartitioner.return_value)

--- a/otter/util/zkpartitioner.py
+++ b/otter/util/zkpartitioner.py
@@ -7,14 +7,14 @@ from twisted.application.service import MultiService
 from twisted.internet.defer import succeed
 
 
-class Partitioner(MultiService, object):
+class Partitioner(MultiService):
     """
     A Twisted service which uses a Kazoo :obj:`SetPartitioner` to allocate
     logical ``buckets`` between nodes.
 
     Multiple servers can instantiate these with the same ``partitioner_path``
-    and ``buckets``, and each server will get a disjoint subset of
-    ``range(buckets)`` allocated to them.
+    and ``buckets``, and each server will get a disjoint subset of ``buckets``
+    allocated to them.
 
     In order to be notified of which buckets are allocated to the current node,
     a ``got_buckets`` function must be passed in which will be called when the
@@ -35,7 +35,7 @@ class Partitioner(MultiService, object):
             buckets when buckets have been allocated to this node.
         :param clock: clock to use for checking the buckets on an interval.
         """
-        super(Partitioner, self).__init__()
+        MultiService.__init__(self)
         self.kz_client = kz_client
         self.partitioner_path = partitioner_path
         self.buckets = buckets
@@ -58,7 +58,7 @@ class Partitioner(MultiService, object):
         # TimerService may call `check_partition` before self.partitioner is
         # created.
         self.partitioner = self._new_partitioner()
-        super(Partitioner, self).startService()
+        MultiService.startService(self)
 
     def stopService(self):
         """Release the buckets."""

--- a/otter/util/zkpartitioner.py
+++ b/otter/util/zkpartitioner.py
@@ -120,10 +120,10 @@ class Partitioner(MultiService, object):
             return succeed((False, {'reason': 'Not running'}))
 
         if not self.partitioner.acquired:
-            # TODO: Until there is check added for not being allocated for long
-            # time it is fine to assume service is not healthy when it is
-            # allocating since allocating should happen only on deploy or
-            # network issues
+            # TODO: Until there is check added for not being allocated for too
+            # long, it is fine to indicate the service is not healthy when it
+            # is allocating, since allocating should happen only on start-up or
+            # during network issues.
             return succeed((False, {'reason': 'Not acquired'}))
 
         return succeed((True, {'buckets': self._get_current_buckets()}))

--- a/otter/util/zkpartitioner.py
+++ b/otter/util/zkpartitioner.py
@@ -62,6 +62,7 @@ class Partitioner(MultiService):
 
     def stopService(self):
         """Release the buckets."""
+        MultiService.stopService(self)
         if self.partitioner.acquired:
             return self.partitioner.finish()
 

--- a/otter/util/zkpartitioner.py
+++ b/otter/util/zkpartitioner.py
@@ -27,9 +27,9 @@ class Partitioner(MultiService):
         :param log: a bound log
         :param kz_client: txKazoo client
         :param partitioner_path: ZooKeeper path, used for partitioning
-        :param list buckets: buckets to distribute between nodes. Ideally
-            there should be at least as many elements as nodes taking part in
-            this partitioner. This should be a sequence of str.
+        :param buckets: iterable of buckets to distribute between
+            nodes. Ideally there should be at least as many elements as nodes
+            taking part in this partitioner. This should be a sequence of str.
         :param time_boundary: time to wait for partitioning to stabilize.
         :param got_buckets: Callable which will be called with a list of
             buckets when buckets have been allocated to this node.
@@ -49,7 +49,7 @@ class Partitioner(MultiService):
     def _new_partitioner(self):
         return self.kz_client.SetPartitioner(
             self.partitioner_path,
-            set=set(self.buckets),
+            set=self.buckets,
             time_boundary=self.time_boundary)
 
     def startService(self):

--- a/otter/util/zkpartitioner.py
+++ b/otter/util/zkpartitioner.py
@@ -1,0 +1,240 @@
+"""
+ZooKeeper set-partitioning stuff.
+"""
+
+from twisted.application.internet import TimerService
+from twisted.application.service import MultiService
+from twisted.internet.defer import succeed
+
+
+class Partitioner(MultiService, object):
+    """
+    A Twisted service which uses a Kazoo :obj:`SetPartitioner` to allocate
+    logical ``buckets`` between nodes.
+
+    Multiple servers can instantiate these with the same ``partitioner_path``
+    and ``buckets``, and each server will get a disjoint subset of
+    ``range(buckets)`` allocated to them.
+
+    In order to be notified of which buckets are allocated to the current node,
+    a ``got_buckets`` function must be passed in which will be called when the
+    local buckets have been determined.
+    """
+    def __init__(self, kz_client,
+                 interval,
+                 partitioner_path, buckets, time_boundary,
+                 log, got_buckets):
+        """
+        :param log: a bound log
+        :param kz_client: txKazoo client
+        :param partitioner_path: ZooKeeper path, used for partitioning
+        :param int buckets: buckets to distribute between nodes. Ideally there
+            should be at least as many elements as nodes taking part in this
+            partitioner.
+        :param time_boundary: time to wait for partitioning to stabilize.
+        :param got_buckets: Callable which will be called with a list of
+            buckets when buckets have been allocated to this node.
+        """
+        super(Partitioner, self).__init__()
+        self.kz_client = kz_client
+        self.partitioner_path = partitioner_path
+        self.buckets = buckets
+        self.log = log
+        self.got_buckets = got_buckets
+        ts = TimerService(interval, self.check_partition)
+        ts.setServiceParent(self)
+
+    def _new_partitioner(self):
+        return self.kz_client.SetPartitioner(
+            self.partitioner_path,
+            set=set(map(str, self.buckets)),
+            time_boundary=self.time_boundary)
+
+    def startService(self):
+        """Start partitioning."""
+        super(Partitioner, self).startService()
+        self.partitioner = self._new_partitioner()
+
+    def stopService(self):
+        """Release the buckets."""
+        if self.partitioner.acquired:
+            return self.partitioner.finish()
+
+    def reset_path(self, path):
+        """Re-initialize the partitioner to use a new path."""
+        if self.partitioner_path != path:
+            self.partitioner_path = path
+            self.partitioner = self._new_partitioner()
+        else:
+            raise ValueError('same path')
+
+    def check_partition(self):
+        """
+        Step through the SetPartitioner state machine, and once everything is
+        sorted out, call the ``got_buckets`` function with the buckets that
+        have been allocated to this node.
+        """
+        if self.partitioner.allocating:
+            self.log.msg('Partition allocating',
+                         otter_msg_type='partition-allocating')
+            return
+        if self.partitioner.release:
+            self.log.msg('Partition changed. Repartitioning',
+                         otter_msg_type='partition-released')
+            return self.partitioner.release_set()
+        if self.partitioner.failed:
+            self.log.msg('Partition failed. Starting new',
+                         otter_msg_type='partition-failed')
+            self.partitioner = self._new_partitioner()
+            return
+        if not self.partitioner.acquired:
+            self.log.err(
+                'Unknown state {}. This cannot happen. Starting new'.format(
+                    self.partitioner.state),
+                otter_msg_type='partition-invalid-state')
+            self.partitioner.finish()
+            self.partitioner = self._new_partitioner()
+            return
+
+        buckets = self._get_current_buckets()
+        # TODO: This log might feel like spam since it'll occur on every
+        # tick. But it'll be useful to debug partitioning problems (at least in
+        # initial deployment)
+        self.log.msg('Got buckets {buckets}', buckets=buckets,
+                     path=self.partitioner_path)
+        self.got_buckets(buckets)
+
+    def health_check(self):
+        """
+        Do a health check on the partitioner service.
+
+        :return: a Deferred that fires with (Bool, `dict` of extra info).
+        """
+        if not self.running:
+            return succeed((False, {'reason': 'Not running'}))
+
+        if not self.partitioner.acquired:
+            # TODO: Until there is check added for not being allocated for long
+            # time it is fine to assume service is not healthy when it is
+            # allocating since allocating should happen only on deploy or
+            # network issues
+            return succeed((False, {'reason': 'Not acquired'}))
+
+        return succeed((True, {'buckets': self._get_current_buckets()}))
+
+    def _get_current_buckets(self):
+        """Retrieve the current buckets as a list."""
+        return list(self.partitioner)
+
+# def test_check_events_allocating(self):
+#     """
+#     `check_events` logs message and does not check events in buckets
+#     when buckets are still allocating.
+#     """
+#     self.kz_partition.allocating = True
+#     self._start_service()
+#     self.scheduler_service.check_events(100)
+#     self.log.msg.assert_called_with('Partition allocating')
+
+#     # Ensure others are not called
+#     self.assertFalse(self.kz_partition.__iter__.called)
+#     self.assertFalse(self.check_events_in_bucket.called)
+
+# def test_check_events_release(self):
+#     """
+#     `check_events` logs message and does not check events in buckets
+#     when partitioning has changed. It calls release_set() to
+#     re-partition.
+#     """
+#     self.kz_partition.release = True
+#     self._start_service()
+#     self.scheduler_service.check_events(100)
+#     self.log.msg.assert_called_with('Partition changed. Repartitioning')
+#     self.kz_partition.release_set.assert_called_once_with()
+
+#     # Ensure others are not called
+#     self.assertFalse(self.kz_partition.__iter__.called)
+#     self.assertFalse(self.check_events_in_bucket.called)
+
+# def test_check_events_failed(self):
+#     """
+#     `check_events` logs message and does not check events in buckets
+#     when partitioning has failed. It creates a new partition.
+#     """
+#     self.kz_partition.failed = True
+#     self._start_service()
+
+#     # after starting change SetPartitioner return value to check if
+#     # new value is set in self.scheduler_service.kz_partition
+#     new_kz_partition = mock.MagicMock()
+#     self.kz_client.SetPartitioner.return_value = new_kz_partition
+
+#     self.scheduler_service.check_events(100)
+#     self.log.msg.assert_called_with('Partition failed. Starting new')
+
+#     # Called once when starting and now again when partition failed
+#     self.assertEqual(self.kz_client.SetPartitioner.call_args_list,
+#                      [mock.call(self.zk_partition_path,
+#                                 set=set(range(self.num_buckets)),
+#                                 time_boundary=self.time_boundary)] * 2)
+#     self.assertEqual(self.scheduler_service.kz_partition, new_kz_partition)
+
+#     # Ensure others are not called
+#     self.assertFalse(self.kz_partition.__iter__.called)
+#     self.assertFalse(new_kz_partition.__iter__.called)
+#     self.assertFalse(self.check_events_in_bucket.called)
+
+# def test_check_events_bad_state(self):
+#     """`self.kz_partition.state` is none of the exepected values.
+
+#     `check_events` logs it as err and starts a new partition
+
+#     """
+#     self.kz_partition.state = 'bad'
+#     self._start_service()
+
+#     # after starting change SetPartitioner return value to check if
+#     # new value is set in self.scheduler_service.kz_partition
+#     new_kz_partition = mock.MagicMock()
+#     self.kz_client.SetPartitioner.return_value = new_kz_partition
+
+#     self.scheduler_service.check_events(100)
+
+#     self.log.err.assert_called_with(
+#         'Unknown state bad. This cannot happen. Starting new')
+#     self.kz_partition.finish.assert_called_once_with()
+
+#     # Called once when starting and now again when got bad state
+#     self.assertEqual(self.kz_client.SetPartitioner.call_args_list,
+#                      [mock.call(self.zk_partition_path,
+#                                 set=set(range(self.buckets)),
+#                                 time_boundary=self.time_boundary)] * 2)
+#     self.assertEqual(self.scheduler_service.kz_partition, new_kz_partition)
+
+#     # Ensure others are not called
+#     self.assertFalse(self.kz_partition.__iter__.called)
+#     self.assertFalse(new_kz_partition.__iter__.called)
+#     self.assertFalse(self.check_events_in_bucket.called)
+
+# def test_get_buckets(self):
+#     log.msg.assert_called_once_with('Got buckets {buckets}',
+#                                     buckets=[2, 3], path='/part_path')
+
+# def test_stop_service_allocating(self):
+#     """
+#     stopService() does not stop the allocation (i.e. call finish) if
+#     it is not acquired.
+#     """
+#     self._start_service()
+#     d = self.scheduler_service.stopService()
+#     self.assertFalse(self.kz_partition.finish.called)
+#     self.assertIsNone(d)
+
+# def test_reset_path(self):
+#     self.assertEqual(self.scheduler_service.zk_partition_path, '/new_path')
+#     self.kz_client.SetPartitioner.assert_called_once_with(
+#         '/new_path',
+#         set=set(range(self.num_buckets)),
+#         time_boundary=self.time_boundary)
+#     self.assertEqual(self.scheduler_service.kz_partition,
+#                      self.kz_client.SetPartitioner.return_value)


### PR DESCRIPTION
This makes the partitioner logic a self-contained service so we can use it elsewhere, notably in the convergence code.

Sadly this is a pretty big change, but it's as small in scope as I could get it. It'll probably be useful to just browse the code in the branch to get an idea of the new SchedulerService code.