### PR TITLE
Fix hashability bug in metadata creation refactor.

### DIFF
--- a/otter/convergence/composition.py
+++ b/otter/convergence/composition.py
@@ -83,7 +83,8 @@ def prepare_server_launch_config(group_id, server_config, lb_descriptions):
         :class:`ILBDescription` providers
     """
     lbs = concat(lb_descriptions.values())
-    return server_config.set_in(
-        ('server', 'metadata'),
-        merge(get_in(('server', 'metadata'), server_config, {}),
-              NovaServer.generate_metadata(group_id, lbs)))
+    updated_metadata = freeze(merge(
+        get_in(('server', 'metadata'), server_config, {}),
+        NovaServer.generate_metadata(group_id, lbs)))
+
+    return server_config.set_in(('server', 'metadata'), updated_metadata)

--- a/otter/test/convergence/test_composition.py
+++ b/otter/test/convergence/test_composition.py
@@ -45,6 +45,15 @@ class JsonToLBConfigTests(SynchronousTestCase):
 class GetDesiredGroupStateTests(SynchronousTestCase):
     """Tests for :func:`get_desired_group_state`."""
 
+    def assert_server_config_hashable(self, state):
+        """
+        Assert that a :class:`DesiredGroupState` has a hashable server config.
+        """
+        try:
+            hash(state.server_config)
+        except TypeError as e:
+            self.fail("{0} in {1}".format(e, state.server_config))
+
     def test_convert(self):
         """
         An Otter launch config a :obj:`DesiredGroupState`, ignoring extra
@@ -81,6 +90,7 @@ class GetDesiredGroupStateTests(SynchronousTestCase):
                 desired_lbs=freeze({23: [
                     CLBDescription(lb_id='23', port=80),
                     CLBDescription(lb_id='23', port=90)]})))
+        self.assert_server_config_hashable(state)
 
     def test_no_lbs(self):
         """
@@ -104,6 +114,7 @@ class GetDesiredGroupStateTests(SynchronousTestCase):
                 server_config=expected_server_config,
                 capacity=2,
                 desired_lbs=pmap()))
+        self.assert_server_config_hashable(state)
 
 
 class FeatureFlagTest(SynchronousTestCase):


### PR DESCRIPTION
I was setting the metadata value to a dict, not a `pmap`, so even though the server config is a pyrsistent structure, the metadata value was not.

Add test to make sure prepared server config is hashable, since it is used in `CreateServer` which gets put into a pyrsistent structure.