### PR TITLE
moved error formatting to separate observer

### DIFF
--- a/otter/log/formatters.py
+++ b/otter/log/formatters.py
@@ -281,11 +281,6 @@ def ObserverWrapper(observer, hostname, seconds=None):
             "otter_facility": eventDict.get("system", "otter"),
         }
 
-        if "file" in eventDict:
-            log_params["file"] = eventDict["file"]
-        if "line" in eventDict:
-            log_params["line"] = eventDict["line"]
-
         for key, value in eventDict.iteritems():
             if key not in PRIMITIVE_FIELDS:
                 log_params[key] = value

--- a/otter/log/formatters.py
+++ b/otter/log/formatters.py
@@ -248,7 +248,7 @@ def ErrorFormattingWrapper(observer):
             "message": event.get("message", (message, )),
             "level": event.get("level", level)
         })
-        event.pop('isError', None)
+        [event.pop(k, None) for k in ERROR_FIELDS]
 
         observer(event)
 

--- a/otter/log/formatters.py
+++ b/otter/log/formatters.py
@@ -222,7 +222,13 @@ def audit_log_formatter(eventDict, timestamp, hostname):
 def ErrorFormattingWrapper(observer):
     """
     Return log observer that will format error if any and delegate it to
-    given `observer`
+    given `observer`.
+
+    If the event contains error, the formatter forms a decent message from
+    "failure" and "why" and replaces that as message if the event does not
+    already contain one. It also adds traceback and exception_type and removes
+    existing error fields: "isError", "why" and "failure". "level" is also
+    updated if not already found.
     """
 
     def error_formatting_observer(event):

--- a/otter/log/formatters.py
+++ b/otter/log/formatters.py
@@ -128,7 +128,7 @@ def PEP3101FormattingWrapper(observer):
 
 ERROR_FIELDS = {"isError", "failure", "why"}
 
-PRIMITIVE_FIELDS = {"time", "system", "id", "audit_log"}
+PRIMITIVE_FIELDS = {"time", "system", "id", "audit_log", "message"}
 
 AUDIT_LOG_FIELDS = {
     "audit_log": bool,
@@ -285,6 +285,7 @@ def ObserverWrapper(observer, hostname, seconds=None):
             "@timestamp": datetime.fromtimestamp(
                 eventDict.get("time", seconds())).isoformat(),
             "otter_facility": eventDict.get("system", "otter"),
+            "message": eventDict["message"]
         }
 
         for key, value in eventDict.iteritems():

--- a/otter/log/formatters.py
+++ b/otter/log/formatters.py
@@ -245,7 +245,7 @@ def ErrorFormattingWrapper(observer):
             level = 6
 
         event.update({
-            "message": event.get("message", (message, )),
+            "message": (''.join(event.get("message", '')) or message, ),
             "level": event.get("level", level)
         })
         [event.pop(k, None) for k in ERROR_FIELDS]

--- a/otter/log/setup.py
+++ b/otter/log/setup.py
@@ -1,15 +1,16 @@
 """
 Observer factories which will be used to configure twistd logging.
 """
-import sys
 import socket
+import sys
 
 from otter.log.formatters import (
+    ErrorFormattingWrapper,
     JSONObserverWrapper,
-    StreamObserverWrapper,
-    SystemFilterWrapper,
+    ObserverWrapper,
     PEP3101FormattingWrapper,
-    ObserverWrapper
+    StreamObserverWrapper,
+    SystemFilterWrapper
 )
 
 
@@ -19,12 +20,13 @@ def make_observer_chain(ultimate_observer, indent):
     """
     return PEP3101FormattingWrapper(
         SystemFilterWrapper(
-            ObserverWrapper(
-                JSONObserverWrapper(
-                    ultimate_observer,
-                    sort_keys=True,
-                    indent=indent or None),
-                hostname=socket.gethostname())))
+            ErrorFormattingWrapper(
+                ObserverWrapper(
+                    JSONObserverWrapper(
+                        ultimate_observer,
+                        sort_keys=True,
+                        indent=indent or None),
+                    hostname=socket.gethostname()))))
 
 
 def observer_factory():

--- a/otter/test/log/test_log.py
+++ b/otter/test/log/test_log.py
@@ -427,6 +427,20 @@ class ErrorFormatterTests(SynchronousTestCase):
         self.observer.assert_called_once_with(
             matches(ContainsDict({'message': Equals(('ValueError()',))})))
 
+    def test_message_why_iserror(self):
+        """
+        When message, why and isError is given, then message is updated
+        based on why if it is not already there
+        """
+        failure = Failure(ValueError())
+        self.wrapper({'message': ('mine', 'yours'), 'isError': True,
+                      'why': 'reason', 'failure': failure})
+        self.assertEqual(
+            self._formatted_event(),
+            {'message': ('mineyours',), 'level': 3,
+             'traceback': failure.getTraceback(),
+             'exception_type': 'ValueError'})
+
 
 class ObserverWrapperTests(SynchronousTestCase):
     """

--- a/otter/test/log/test_log.py
+++ b/otter/test/log/test_log.py
@@ -7,7 +7,12 @@ from datetime import datetime
 
 import mock
 
-from testtools.matchers import Contains, ContainsDict, Equals
+from testtools.matchers import (
+    Contains,
+    ContainsDict,
+    Equals,
+    MatchesAll,
+    Not)
 
 from twisted.python.failure import Failure
 from twisted.trial.unittest import SynchronousTestCase
@@ -15,6 +20,7 @@ from twisted.trial.unittest import SynchronousTestCase
 from otter.log import audit
 from otter.log.bound import BoundLog
 from otter.log.formatters import (
+    ErrorFormattingWrapper,
     JSONObserverWrapper,
     ObserverWrapper,
     PEP3101FormattingWrapper,
@@ -157,6 +163,16 @@ class JSONObserverWrapperTests(SynchronousTestCase):
         observer(eventDict)
         self.observer.assert_called_once_with(
             {'message': (SameJSON({'foo': str(failure)}),)})
+
+    def test_message_is_concatenated(self):
+        """
+        message tuple in event is concatenated before passing on
+        """
+        eventDict = {'message': ('mine',)}
+        observer = JSONObserverWrapper(self.observer)
+        observer(eventDict)
+        self.observer.assert_called_once_with(
+            {'message': (SameJSON({'message': 'mine'}),)})
 
 
 class StreamObserverWrapperTests(SynchronousTestCase):
@@ -310,10 +326,96 @@ class PEP3101FormattingWrapperTests(SynchronousTestCase):
         })
 
 
+class ErrorFormatterTests(SynchronousTestCase):
+    """
+    Test for ErrorFormatterTests
+    """
+
+    def setUp(self):
+        """
+        Set up a mock observer.
+        """
+        self.observer = mock.Mock()
+        self.wrapper = ErrorFormattingWrapper(self.observer)
+
+    def test_no_failure(self):
+        """
+        If event does not have failure, it sets level=6 and removes isError
+        """
+        self.wrapper({'isError': False, 'foo': 'bar'})
+        self.observer.assert_called_once_with(
+            matches(
+                MatchesAll(
+                    ContainsDict({'level': Equals(6)}),
+                    Not(Contains('isError')))))
+
+    def test_failure_include_traceback_in_event_dict(self):
+        """
+        The observer puts the traceback in the ``traceback`` key.
+        """
+        self.wrapper({'failure': Failure(ValueError()), 'isError': True})
+
+        self.observer.assert_called_once_with(
+            matches(ContainsDict({'traceback': Contains('Traceback')})))
+
+    def test_failure_repr_in_short_message(self):
+        """
+        The observer includes the repr of failure.value in short_message.
+        """
+        self.wrapper({'failure': Failure(ValueError()), 'isError': True})
+        self.observer.assert_called_once_with(
+            matches(ContainsDict({'message': Equals((repr(ValueError()),))})))
+
+    def test_isError_with_message_instead_of_failure(self):
+        """
+        The observer should use message when there is no failure.
+        """
+        self.wrapper({'message': ('uh oh',), 'isError': True})
+
+        self.observer.assert_called_once_with(
+            matches(ContainsDict({'message': Equals(('uh oh',))})))
+
+    def test_isError_sets_level_3(self):
+        """
+        The observer sets the level to 3 (syslog ERROR) when isError is true.
+        It also removes isError
+        """
+        self.wrapper({'failure': Failure(ValueError()), 'isError': True})
+
+        self.observer.assert_called_once_with(
+            matches(
+                MatchesAll(
+                    ContainsDict({'level': Equals(3)}),
+                    Not(Contains('isError')))))
+
+    def test_isError_includes_why_in_short_message(self):
+        """
+        The observer includes 'why' in the short_message when isError is true.
+        """
+        self.wrapper({'failure': Failure(ValueError()),
+                      'isError': True,
+                      'why': 'Everything is terrible.'})
+        self.observer.assert_called_once_with(
+            matches(
+                ContainsDict(
+                    {'message': Equals(
+                        ('Everything is terrible.: ValueError()',))})))
+
+    def test_contains_exception_type(self):
+        """
+        The observer includes "exception_type" if event contains error
+        """
+        self.wrapper({'failure': Failure(ValueError()),
+                      'isError': True})
+        self.observer.assert_called_once_with(
+            matches(ContainsDict({'exception_type': Equals("ValueError")})))
+
+
 class ObserverWrapperTests(SynchronousTestCase):
     """
     Test the ObserverWrapper.
     """
+
     def setUp(self):
         """
         Set up a mock observer.
@@ -333,60 +435,10 @@ class ObserverWrapperTests(SynchronousTestCase):
         self.observer.assert_called_once_with({
             'host': 'localhost',
             '@version': 1,
-            'message': 'Hello',
+            'message': ('Hello',),
             'otter_facility': 'otter',
-            '@timestamp': datetime.fromtimestamp(0).isoformat(),
-            'level': 6,
+            '@timestamp': datetime.fromtimestamp(0).isoformat()
         })
-
-    def test_failure_include_traceback_in_event_dict(self):
-        """
-        The observer puts the traceback in the ``traceback`` key.
-        """
-        self.wrapper({'failure': Failure(ValueError()), 'isError': True})
-
-        self.observer.assert_called_once_with(
-            matches(ContainsDict({'traceback': Contains('Traceback')})))
-
-    def test_failure_repr_in_short_message(self):
-        """
-        The observer includes the repr of failure.value in short_message.
-        """
-        self.wrapper({'failure': Failure(ValueError()), 'isError': True})
-        self.observer.assert_called_once_with(
-            matches(ContainsDict({'message': Equals(repr(ValueError()))})))
-
-    def test_isError_with_message_instead_of_failure(self):
-        """
-        The observer should use message when there is no failure.
-        """
-        self.wrapper({'message': ('uh oh',), 'isError': True})
-
-        self.observer.assert_called_once_with(
-            matches(ContainsDict({'message': Equals('uh oh')})))
-
-    def test_isError_sets_level_3(self):
-        """
-        The observer sets the level to 3 (syslog ERROR) when isError is true.
-        """
-
-        self.wrapper({'failure': Failure(ValueError()), 'isError': True})
-
-        self.observer.assert_called_once_with(
-            matches(ContainsDict({'level': Equals(3)})))
-
-    def test_isError_includes_why_in_short_message(self):
-        """
-        The observer includes 'why' in the short_message when isError is true.
-        """
-        self.wrapper({'failure': Failure(ValueError()),
-                      'isError': True,
-                      'why': 'Everything is terrible.'})
-
-        self.observer.assert_called_once_with(
-            matches(
-                ContainsDict(
-                    {'message': Contains('Everything is terrible.')})))
 
     def test_includes_structured_data(self):
         """

--- a/otter/test/log/test_log.py
+++ b/otter/test/log/test_log.py
@@ -429,8 +429,8 @@ class ErrorFormatterTests(SynchronousTestCase):
 
     def test_message_why_iserror(self):
         """
-        When message, why and isError is given, then message is updated
-        based on why if it is not already there
+        When message, why and isError is given, then message takes precedence
+        and why and isError is ignored to construct message
         """
         failure = Failure(ValueError())
         self.wrapper({'message': ('mine', 'yours'), 'isError': True,

--- a/otter/test/log/test_log.py
+++ b/otter/test/log/test_log.py
@@ -418,6 +418,15 @@ class ErrorFormatterTests(SynchronousTestCase):
         self.observer.assert_called_once_with(
             matches(ContainsDict({'exception_type': Equals("ValueError")})))
 
+    def test_empty_message(self):
+        """
+        Empty message in event is overwritten with failure message
+        """
+        self.wrapper({'message': (), 'isError': True,
+                      'failure': Failure(ValueError())})
+        self.observer.assert_called_once_with(
+            matches(ContainsDict({'message': Equals(('ValueError()',))})))
+
 
 class ObserverWrapperTests(SynchronousTestCase):
     """

--- a/otter/test/log/test_log.py
+++ b/otter/test/log/test_log.py
@@ -166,11 +166,11 @@ class JSONObserverWrapperTests(SynchronousTestCase):
         """
         message tuple in event is concatenated before passing on
         """
-        eventDict = {'message': ('mine',)}
+        eventDict = {'message': ('mine', 'yours')}
         observer = JSONObserverWrapper(self.observer)
         observer(eventDict)
         self.observer.assert_called_once_with(
-            {'message': (SameJSON({'message': 'mine'}),)})
+            {'message': (SameJSON({'message': 'mineyours'}),)})
 
 
 class StreamObserverWrapperTests(SynchronousTestCase):


### PR DESCRIPTION
And also logging `exception_type` which is the name of the exception class in `Failure`. 

This will help in implementing #1116