### PR TITLE
Move to-nova-server to the NovaServer model

### DIFF
--- a/otter/convergence/composition.py
+++ b/otter/convergence/composition.py
@@ -11,7 +11,7 @@ from toolz.itertoolz import concat
 from otter.convergence.model import (
     CLBDescription,
     DesiredGroupState,
-    NovaServer)
+    generate_metadata)
 
 
 def tenant_is_enabled(tenant_id, get_config_value):
@@ -85,6 +85,6 @@ def prepare_server_launch_config(group_id, server_config, lb_descriptions):
     lbs = concat(lb_descriptions.values())
     updated_metadata = freeze(merge(
         get_in(('server', 'metadata'), server_config, {}),
-        NovaServer.generate_metadata(group_id, lbs)))
+        generate_metadata(group_id, lbs)))
 
     return server_config.set_in(('server', 'metadata'), updated_metadata)

--- a/otter/convergence/gathering.py
+++ b/otter/convergence/gathering.py
@@ -13,7 +13,8 @@ from otter.convergence.model import (
     CLBNodeCondition,
     CLBNodeType,
     NovaServer,
-    ServerState)
+    ServerState,
+    group_id_from_metadata)
 from otter.http import service_request
 from otter.indexer import atom
 from otter.util.http import append_segments
@@ -79,7 +80,7 @@ def get_scaling_group_servers(server_predicate=identity):
         return 'metadata' in s and isinstance(s['metadata'], dict)
 
     def group_id(s):
-        return NovaServer.group_id_from_metadata(s['metadata'])
+        return group_id_from_metadata(s['metadata'])
 
     servers_apply = compose(keyfilter(lambda k: k is not None),
                             groupby(group_id),

--- a/otter/convergence/gathering.py
+++ b/otter/convergence/gathering.py
@@ -13,7 +13,6 @@ from otter.convergence.model import (
     CLBNodeCondition,
     CLBNodeType,
     NovaServer,
-    ServerState,
     group_id_from_metadata)
 from otter.http import service_request
 from otter.indexer import atom

--- a/otter/convergence/model.py
+++ b/otter/convergence/model.py
@@ -171,7 +171,6 @@ def _lbs_from_metadata(metadata):
     return pset(desired_lbs)
 
 
-
 @attributes(['id', 'state', 'created', 'image_id', 'flavor_id',
              # because type(pvector()) is pvectorc.PVector,
              # which != pyrsistent.PVector

--- a/otter/convergence/model.py
+++ b/otter/convergence/model.py
@@ -7,7 +7,7 @@ import re
 
 from characteristic import Attribute, attributes
 
-from pyrsistent import PMap, freeze, pmap
+from pyrsistent import PMap, freeze, pmap, pvector
 
 from toolz.dicttoolz import get_in
 from toolz.itertoolz import groupby
@@ -172,6 +172,10 @@ def _lbs_from_metadata(metadata):
 
 
 @attributes(['id', 'state', 'created', 'image_id', 'flavor_id',
+             # because type(pvector()) is pvectorc.PVector,
+             # which != pyrsistent.PVector
+             Attribute('links', default_factory=pvector,
+                       instance_of=type(pvector())),
              Attribute('desired_lbs', default_factory=pmap, instance_of=PMap),
              Attribute('servicenet_address',
                        default_value='',
@@ -218,6 +222,7 @@ class NovaServer(object):
             created=timestamp_to_epoch(server_json['created']),
             image_id=server_json.get('image', {}).get('id'),
             flavor_id=server_json['flavor']['id'],
+            links=freeze(server_json['links']),
             desired_lbs=_lbs_from_metadata(server_json.get('metadata')),
             servicenet_address=_servicenet_address(server_json))
 

--- a/otter/convergence/model.py
+++ b/otter/convergence/model.py
@@ -226,45 +226,45 @@ class NovaServer(object):
             desired_lbs=_lbs_from_metadata(server_json.get('metadata')),
             servicenet_address=_servicenet_address(server_json))
 
-    @classmethod
-    def group_id_from_metadata(cls, metadata):
-        """
-        Get the group ID of a server based on the metadata.
 
-        The old key was ``rax:auto_scaling_group_id``, but the new key is
-        ``rax:autoscale:group:id``.  Try pulling from the new key first, and
-        if it doesn't exist, pull from the old.
-        """
-        return metadata.get(
-            "rax:autoscale:group:id",
-            metadata.get("rax:auto_scaling_group_id", None))
+def group_id_from_metadata(metadata):
+    """
+    Get the group ID of a server based on the metadata.
 
-    @classmethod
-    def generate_metadata(cls, group_id, lb_descriptions):
-        """
-        Generate autoscale-specific Nova server metadata given the group ID and
-        an iterable of :class:`ILBDescription` providers.
+    The old key was ``rax:auto_scaling_group_id``, but the new key is
+    ``rax:autoscale:group:id``.  Try pulling from the new key first, and
+    if it doesn't exist, pull from the old.
+    """
+    return metadata.get(
+        "rax:autoscale:group:id",
+        metadata.get("rax:auto_scaling_group_id", None))
 
-        NOTE: Currently this ignores RCv3 settings and draining timeout
-        settings, since they haven't been implemented yet.
 
-        :return: a metadata `dict` containing the group ID and LB information
-        """
-        metadata = {
-            'rax:auto_scaling_group_id': group_id,
-            'rax:autoscale:group:id': group_id
-        }
+def generate_metadata(group_id, lb_descriptions):
+    """
+    Generate autoscale-specific Nova server metadata given the group ID and
+    an iterable of :class:`ILBDescription` providers.
 
-        descriptions = groupby(lambda desc: (desc.lb_id, type(desc)),
-                               lb_descriptions)
+    NOTE: Currently this ignores RCv3 settings and draining timeout
+    settings, since they haven't been implemented yet.
 
-        for (lb_id, desc_type), descs in descriptions.iteritems():
-            if desc_type == CLBDescription:
-                key = 'rax:autoscale:lb:CloudLoadBalancer:{0}'.format(lb_id)
-                metadata[key] = json.dumps([
-                    {'port': desc.port} for desc in descs])
+    :return: a metadata `dict` containing the group ID and LB information
+    """
+    metadata = {
+        'rax:auto_scaling_group_id': group_id,
+        'rax:autoscale:group:id': group_id
+    }
 
-        return metadata
+    descriptions = groupby(lambda desc: (desc.lb_id, type(desc)),
+                           lb_descriptions)
+
+    for (lb_id, desc_type), descs in descriptions.iteritems():
+        if desc_type == CLBDescription:
+            key = 'rax:autoscale:lb:CloudLoadBalancer:{0}'.format(lb_id)
+            metadata[key] = json.dumps([
+                {'port': desc.port} for desc in descs])
+
+    return metadata
 
 
 @attributes(['server_config', 'capacity',

--- a/otter/test/convergence/test_gathering.py
+++ b/otter/test/convergence/test_gathering.py
@@ -6,6 +6,8 @@ from functools import partial
 from effect import Constant, Effect
 from effect.testing import Stub
 
+from pyrsistent import freeze
+
 from twisted.trial.unittest import SynchronousTestCase
 
 from otter.constants import ServiceType
@@ -362,14 +364,16 @@ class GetAllConvergenceDataTests(SynchronousTestCase):
              'flavor': {'id': 'flavor'},
              'created': '1970-01-01T00:00:00Z',
              'addresses': {'private': [{'addr': u'10.0.0.1',
-                                        'version': 4}]}},
+                                        'version': 4}]},
+             'links': [{'href': 'link1', 'rel': 'self'}]},
             {'id': 'b',
              'status': 'ACTIVE',
              'image': {'id': 'image'},
              'flavor': {'id': 'flavor'},
              'created': '1970-01-01T00:00:01Z',
              'addresses': {'private': [{'addr': u'10.0.0.2',
-                                        'version': 4}]}}
+                                        'version': 4}]},
+             'links': [{'href': 'link2', 'rel': 'self'}]}
         ]
 
     def test_success(self):
@@ -391,13 +395,15 @@ class GetAllConvergenceDataTests(SynchronousTestCase):
                        image_id='image',
                        flavor_id='flavor',
                        created=0,
-                       servicenet_address='10.0.0.1'),
+                       servicenet_address='10.0.0.1',
+                       links=freeze([{'href': 'link1', 'rel': 'self'}])),
             NovaServer(id='b',
                        state=ServerState.ACTIVE,
                        image_id='image',
                        flavor_id='flavor',
                        created=1,
-                       servicenet_address='10.0.0.2'),
+                       servicenet_address='10.0.0.2',
+                       links=freeze([{'href': 'link2', 'rel': 'self'}]))
         ]
         self.assertEqual(resolve_stubs(eff), (expected_servers, lb_nodes))
 

--- a/otter/test/convergence/test_gathering.py
+++ b/otter/test/convergence/test_gathering.py
@@ -6,8 +6,6 @@ from functools import partial
 from effect import Constant, Effect
 from effect.testing import Stub
 
-from pyrsistent import pmap
-
 from twisted.trial.unittest import SynchronousTestCase
 
 from otter.constants import ServiceType
@@ -16,10 +14,7 @@ from otter.convergence.gathering import (
     extract_CLB_drained_at,
     get_all_server_details,
     get_clb_contents,
-    get_scaling_group_servers,
-    to_nova_server,
-    _private_ipv4_addresses,
-    _servicenet_address)
+    get_scaling_group_servers)
 from otter.convergence.model import (
     CLBDescription,
     CLBNode,
@@ -353,186 +348,6 @@ class GetLBContentsTests(SynchronousTestCase):
                      description=make_desc(lb_id='1')),
              CLBNode(node_id='21', address='a21',
                      description=make_desc(lb_id='2'))])
-
-
-class ToNovaServerTests(SynchronousTestCase):
-    """
-    Tests for :func:`to_nova_server`
-    """
-    def setUp(self):
-        """
-        Sample servers
-        """
-        self.createds = [('2020-10-10T10:00:00Z', 1602324000),
-                         ('2020-10-20T11:30:00Z', 1603193400)]
-        self.servers = [{'id': 'a',
-                         'status': 'ACTIVE',
-                         'created': self.createds[0][0],
-                         'image': {'id': 'valid_image'},
-                         'flavor': {'id': 'valid_flavor'}},
-                        {'id': 'b',
-                         'status': 'BUILD',
-                         'image': {'id': 'valid_image'},
-                         'flavor': {'id': 'valid_flavor'},
-                         'created': self.createds[1][0],
-                         'addresses': {'private': [{'addr': u'10.0.0.1',
-                                                    'version': 4}]}}]
-
-    def test_without_address(self):
-        """
-        Handles server json that does not have "addresses" in it.
-        """
-        self.assertEqual(
-            to_nova_server(self.servers[0]),
-            NovaServer(id='a',
-                       state=ServerState.ACTIVE,
-                       image_id='valid_image',
-                       flavor_id='valid_flavor',
-                       created=self.createds[0][1],
-                       servicenet_address=''))
-
-    def test_without_private(self):
-        """
-        Creates server that does not have private/servicenet IP in it.
-        """
-        self.servers[0]['addresses'] = {'public': 'p'}
-        self.assertEqual(
-            to_nova_server(self.servers[0]),
-            NovaServer(id='a',
-                       state=ServerState.ACTIVE,
-                       image_id='valid_image',
-                       flavor_id='valid_flavor',
-                       created=self.createds[0][1],
-                       servicenet_address=''))
-
-    def test_with_servicenet(self):
-        """
-        Create server that has servicenet IP in it.
-        """
-        self.assertEqual(
-            to_nova_server(self.servers[1]),
-            NovaServer(id='b',
-                       state=ServerState.BUILD,
-                       image_id='valid_image',
-                       flavor_id='valid_flavor',
-                       created=self.createds[1][1],
-                       servicenet_address='10.0.0.1'))
-
-    def test_without_image_id(self):
-        """
-        Create server that has missing image in it in various ways.
-        (for the case of BFV)
-        """
-        for image in ({}, {'id': None}):
-            self.servers[0]['image'] = image
-            self.assertEqual(
-                to_nova_server(self.servers[0]),
-                NovaServer(id='a',
-                           state=ServerState.ACTIVE,
-                           image_id=None,
-                           flavor_id='valid_flavor',
-                           created=self.createds[0][1],
-                           servicenet_address=''))
-        del self.servers[0]['image']
-        self.assertEqual(
-            to_nova_server(self.servers[0]),
-            NovaServer(id='a',
-                       state=ServerState.ACTIVE,
-                       image_id=None,
-                       flavor_id='valid_flavor',
-                       created=self.createds[0][1],
-                       servicenet_address=''))
-
-    def test_with_lb_metadata(self):
-        """
-        Create a server that has load balancer config metadata in it.
-        The only desired load balancers created are the ones with valid
-        data.
-        """
-        self.servers[0]['metadata'] = {
-            # correct lb config
-            'rax:autoscale:lb:CloudLoadBalancer:01234':
-            '[{"port":80},{"port":90}]',
-            # two correct lbconfigs and one incorrect one
-            'rax:autoscale:lb:CloudLoadBalancer:12345':
-            '[{"port":80},{"bad":"1"},{"port":90}]',
-            # a dictionary instead of a list
-            'rax:autoscale:lb:CloudLoadBalancer:23456': '{"port": 80}',
-            # not even valid json
-            'rax:autoscale:lb:CloudLoadBalancer:34567': 'invalid json string'
-        }
-        self.assertEqual(
-            to_nova_server(self.servers[0]),
-            NovaServer(id='a',
-                       state=ServerState.ACTIVE,
-                       image_id='valid_image',
-                       flavor_id='valid_flavor',
-                       created=self.createds[0][1],
-                       desired_lbs=pmap({
-                           '01234': [CLBDescription(lb_id='01234', port=80),
-                                     CLBDescription(lb_id='01234', port=90)]
-                       }),
-                       servicenet_address=''))
-
-
-class IPAddressTests(SynchronousTestCase):
-    """
-    Tests for utility functions that extract IP addresses from server
-    dicts.
-    """
-    def setUp(self):
-        """
-        Set up a bunch of addresses and a server dict.
-        """
-        self.addresses = {
-            'private': [
-                {'addr': '192.168.1.1', 'version': 4},
-                {'addr': '10.0.0.1', 'version': 4},
-                {'addr': '10.0.0.2', 'version': 4},
-                {'addr': '::1', 'version': 6}
-            ],
-            'public': [
-                {'addr': '50.50.50.50', 'version': 4},
-                {'addr': '::::', 'version': 6}
-            ]}
-        self.server_dict = {'addresses': self.addresses}
-
-    def test_private_ipv4_addresses(self):
-        """
-        :func:`_private_ipv4_addresses` returns all private IPv4 addresses
-        from a complete server body.
-        """
-        result = _private_ipv4_addresses(self.server_dict)
-        self.assertEqual(result, ['192.168.1.1', '10.0.0.1', '10.0.0.2'])
-
-    def test_no_private_ip_addresses(self):
-        """
-        :func:`_private_ipv4_addresses` returns an empty list if the given
-        server has no private IPv4 addresses.
-        """
-        del self.addresses["private"]
-        result = _private_ipv4_addresses(self.server_dict)
-        self.assertEqual(result, [])
-
-    def test_servicenet_address(self):
-        """
-        :func:`_servicenet_address` returns the correct ServiceNet
-        address, which is the first IPv4 address in the ``private``
-        group in the 10.x.x.x range.
-
-        It even does this when there are other addresses in the
-        ``private`` group. This happens when the tenant specifies
-        their own network named ``private``.
-        """
-        self.assertEqual(_servicenet_address(self.server_dict), "10.0.0.1")
-
-    def test_no_servicenet_address(self):
-        """
-        :func:`_servicenet_address` returns :data:`None` if the server has no
-        ServiceNet address.
-        """
-        del self.addresses["private"]
-        self.assertEqual(_servicenet_address(self.server_dict), "")
 
 
 class GetAllConvergenceDataTests(SynchronousTestCase):

--- a/otter/test/convergence/test_model.py
+++ b/otter/test/convergence/test_model.py
@@ -23,7 +23,9 @@ from otter.convergence.model import (
     ServerState,
     _private_ipv4_addresses,
     _servicenet_address,
-    get_service_metadata
+    get_service_metadata,
+    generate_metadata,
+    group_id_from_metadata
 )
 
 
@@ -293,12 +295,12 @@ class AutoscaleMetadataTests(SynchronousTestCase):
     """
     def test_get_group_id_from_metadata(self):
         """
-        :func:`NovaServer.group_id_from_metadata` returns the group ID from
+        :func:`group_id_from_metadata` returns the group ID from
         metadata no matter if it's old style or new style.
         """
         for key in ("rax:autoscale:group:id", "rax:auto_scaling_group_id"):
             self.assertEqual(
-                NovaServer.group_id_from_metadata({key: "group_id"}),
+                group_id_from_metadata({key: "group_id"}),
                 "group_id")
 
     def test_invalid_group_id_key_returns_none(self):
@@ -309,9 +311,9 @@ class AutoscaleMetadataTests(SynchronousTestCase):
         for key in (":rax:autoscale:group:id", "rax:autoscaling_group_id",
                     "completely_wrong"):
             self.assertIsNone(
-                NovaServer.group_id_from_metadata({key: "group_id"}))
+                group_id_from_metadata({key: "group_id"}))
 
-        self.assertIsNone(NovaServer.group_id_from_metadata({}))
+        self.assertIsNone(group_id_from_metadata({}))
 
     def test_generate_metadata(self):
         """
@@ -331,7 +333,7 @@ class AutoscaleMetadataTests(SynchronousTestCase):
             'rax:autoscale:lb:CloudLoadBalancer:234': '[{"port": 80}]'
         }
 
-        self.assertEqual(NovaServer.generate_metadata('group_id', lbs),
+        self.assertEqual(generate_metadata('group_id', lbs),
                          expected)
 
 

--- a/otter/test/convergence/test_model.py
+++ b/otter/test/convergence/test_model.py
@@ -5,7 +5,7 @@ from uuid import uuid4
 
 from characteristic import attributes
 
-from pyrsistent import pmap
+from pyrsistent import freeze, pmap
 
 from twisted.trial.unittest import SynchronousTestCase
 
@@ -345,18 +345,26 @@ class ToNovaServerTests(SynchronousTestCase):
         """
         self.createds = [('2020-10-10T10:00:00Z', 1602324000),
                          ('2020-10-20T11:30:00Z', 1603193400)]
+        self.links = [
+            [{'href': 'link1', 'rel': 'self'},
+             {'href': 'otherlink1', 'rel': 'bookmark'}],
+            [{'href': 'link2', 'rel': 'self'},
+             {'href': 'otherlink2', 'rel': 'bookmark'}]
+        ]
         self.servers = [{'id': 'a',
                          'status': 'ACTIVE',
                          'created': self.createds[0][0],
                          'image': {'id': 'valid_image'},
-                         'flavor': {'id': 'valid_flavor'}},
+                         'flavor': {'id': 'valid_flavor'},
+                         'links': self.links[0]},
                         {'id': 'b',
                          'status': 'BUILD',
                          'image': {'id': 'valid_image'},
                          'flavor': {'id': 'valid_flavor'},
                          'created': self.createds[1][0],
                          'addresses': {'private': [{'addr': u'10.0.0.1',
-                                                    'version': 4}]}}]
+                                                    'version': 4}]},
+                         'links': self.links[1]}]
 
     def test_without_address(self):
         """
@@ -369,7 +377,8 @@ class ToNovaServerTests(SynchronousTestCase):
                        image_id='valid_image',
                        flavor_id='valid_flavor',
                        created=self.createds[0][1],
-                       servicenet_address=''))
+                       servicenet_address='',
+                       links=freeze(self.links[0])))
 
     def test_without_private(self):
         """
@@ -383,7 +392,8 @@ class ToNovaServerTests(SynchronousTestCase):
                        image_id='valid_image',
                        flavor_id='valid_flavor',
                        created=self.createds[0][1],
-                       servicenet_address=''))
+                       servicenet_address='',
+                       links=freeze(self.links[0])))
 
     def test_with_servicenet(self):
         """
@@ -396,7 +406,8 @@ class ToNovaServerTests(SynchronousTestCase):
                        image_id='valid_image',
                        flavor_id='valid_flavor',
                        created=self.createds[1][1],
-                       servicenet_address='10.0.0.1'))
+                       servicenet_address='10.0.0.1',
+                       links=freeze(self.links[1])))
 
     def test_without_image_id(self):
         """
@@ -412,7 +423,8 @@ class ToNovaServerTests(SynchronousTestCase):
                            image_id=None,
                            flavor_id='valid_flavor',
                            created=self.createds[0][1],
-                           servicenet_address=''))
+                           servicenet_address='',
+                           links=freeze(self.links[0])))
         del self.servers[0]['image']
         self.assertEqual(
             NovaServer.from_server_details_json(self.servers[0]),
@@ -421,7 +433,8 @@ class ToNovaServerTests(SynchronousTestCase):
                        image_id=None,
                        flavor_id='valid_flavor',
                        created=self.createds[0][1],
-                       servicenet_address=''))
+                       servicenet_address='',
+                       links=freeze(self.links[0])))
 
     def test_with_lb_metadata(self):
         """
@@ -455,7 +468,8 @@ class ToNovaServerTests(SynchronousTestCase):
                            '1': [CLBDescription(lb_id='1', port=80),
                                  CLBDescription(lb_id='1', port=90)]
                        }),
-                       servicenet_address=''))
+                       servicenet_address='',
+                       links=freeze(self.links[0])))
 
     def test_lbs_from_metadata_ignores_unsupported_lb_types(self):
         """
@@ -473,7 +487,8 @@ class ToNovaServerTests(SynchronousTestCase):
                        flavor_id='valid_flavor',
                        created=self.createds[0][1],
                        desired_lbs=pmap(),
-                       servicenet_address=''))
+                       servicenet_address='',
+                       links=freeze(self.links[0])))
 
 
 class IPAddressTests(SynchronousTestCase):

--- a/otter/worker/launch_server_v1.py
+++ b/otter/worker/launch_server_v1.py
@@ -32,7 +32,7 @@ from twisted.internet.task import deferLater
 from twisted.python.failure import Failure
 
 from otter.auth import public_endpoint_url
-from otter.convergence.gathering import _servicenet_address
+from otter.convergence.model import _servicenet_address
 from otter.convergence.steps import set_server_name
 from otter.util import logging_treq as treq
 from otter.util.config import config_value


### PR DESCRIPTION
This just moves all the nova detail parsing functionality to the model as a classmethod that constructs a `NovaServer` given server details JSON.

It also moves the `group_id_from_metadata` and `generate_metadata` functions to top level module functions as previously suggested by @radix.

This fixes #1106 