### PR TITLE
Change delete group to submit a for real launch config and not None

### DIFF
--- a/otter/models/interface.py
+++ b/otter/models/interface.py
@@ -263,12 +263,14 @@ class IScalingGroup(Interface):
     uuid = Attribute("UUID of the scaling group - immutable.")
     tenant_id = Attribute("Rackspace Tenant ID of the owner of this group.")
 
-    def view_manifest(with_webhooks=False):
+    def view_manifest(with_policies=True, with_webhooks=False):
         """
         The manifest contains everything required to configure this scaling:
         the config, the launch config, and all the scaling policies.
 
-        :param bool with_webhooks: Should webhooks information be included?
+        :param bool with_policies: Should policies information be included?
+        :param bool with_webhooks: If policies are included, should webhooks
+            information be included?
 
         :return: a dictionary corresponding to the JSON schema at
             :data:`otter.json_schema.model_schemas.manifest`

--- a/otter/models/interface.py
+++ b/otter/models/interface.py
@@ -250,10 +250,14 @@ class ScalingGroupStatus(Names):
     """
     Status of scaling group
     """
-    ACTIVE = NamedConstant()    # Group is active and executing policies/converging
-    ERROR = NamedConstant()     # Group has errored due to (mostly) invalid
-                                # launch configuration and has stopped executing
-                                # policies/converging
+    ACTIVE = NamedConstant()
+    "Group is active and executing policies/converging"
+
+    ERROR = NamedConstant()
+    """
+    Group has errored due to (mostly) invalid launch configuration and has
+    stopped executing policies/converging
+    """
 
 
 class IScalingGroup(Interface):

--- a/otter/test/models/test_cass_models.py
+++ b/otter/test/models/test_cass_models.py
@@ -2000,6 +2000,52 @@ class CassScalingGroupTests(CassScalingGroupTestCase):
             for webhook in webhooks[2:]]
         self.assertEqual(resp['scalingPolicies'], exp_policies)
 
+    @mock.patch('otter.models.cass.assemble_webhooks_in_policies')
+    @mock.patch('otter.models.cass.verified_view')
+    def test_view_manifest_no_policies(self, verified_view, mock_awip):
+        """
+        Viewing manifest ``with_policies=False`` returns a manifest view with
+        no policies and no webhooks, even though ``with_webhooks=True``.
+        """
+        verified_view.return_value = defer.succeed({
+            'tenantId': self.tenant_id,
+            "groupId": self.group_id,
+            'id': "12345678g",
+            'group_config': serialize_json_data(self.config, 1.0),
+            'launch_config': serialize_json_data(self.launch_config, 1.0),
+            'active': '{"A":"R"}',
+            'pending': '{"P":"R"}',
+            'groupTouched': '2014-01-01T00:00:05Z.1234',
+            'policyTouched': '{"PT":"R"}',
+            'paused': '\x00',
+            'desired': 0,
+            'created_at': 23
+        })
+
+        # Getting policies
+        self.group._naive_list_policies = mock.Mock()
+        # Getting webhooks
+        self.group._naive_list_all_webhooks = mock.Mock()
+
+        # Getting the result and comparing
+        d = self.group.view_manifest(with_policies=False, with_webhooks=True)
+        resp = self.successResultOf(d)
+        self.assertEqual(resp, {
+            'groupConfiguration': self.config,
+            'launchConfiguration': self.launch_config,
+            'id': "12345678g",
+            'state': GroupState(
+                self.tenant_id,
+                self.group_id,
+                'a', {'A': 'R'},
+                {'P': 'R'}, '2014-01-01T00:00:05Z.1234',
+                {'PT': 'R'}, False)
+        })
+
+        self.assertFalse(mock_awip.called)
+        self.assertFalse(self.group._naive_list_policies.called)
+        self.assertFalse(self.group._naive_list_all_webhooks.called)
+
     @mock.patch('otter.models.cass.verified_view',
                 return_value=defer.fail(NoSuchScalingGroupError(2, 3)))
     def test_view_manifest_no_such_group(self, verified_view):


### PR DESCRIPTION
This involved changing some parts of the cass model around.  :|  I just modified view_manifest to optionally not get the state, since we just want both the config and the launch config.

Kinda ugly, and the whole rest/cass model could use a big cleanup after convergence, but this was the smallest change I could think of.  I had originally intended changing `modify_state` to use this function too, so every time the state is modified the state, the launch config, and the config will be passed as one (hence the branch name), but that change turned out to be much bigger because of all the tests.

Still 2 failing functional tests, but the tracebacks are gone (fixes #1120)