### PR TITLE
Return None in controller.converge only if delta is zero.

### DIFF
--- a/otter/controller.py
+++ b/otter/controller.py
@@ -148,10 +148,13 @@ def converge(log, transaction_id, config, scaling_group, state, launch_config,
         are to be made to the group, None will synchronously be returned.
     """
     if tenant_is_enabled(scaling_group.tenant_id, config_value):
-        apply_delta(log, state.desired, state, config, policy)
+        delta = apply_delta(log, state.desired, state, config, policy)
         get_converger().start_convergence(log, scaling_group, state,
                                           launch_config)
-        return None
+        if delta == 0:
+            return None
+        else:
+            return defer.succeed(None)
 
     delta = calculate_delta(log, state, config, policy)
     execute_log = log.bind(server_delta=delta)

--- a/otter/controller.py
+++ b/otter/controller.py
@@ -149,12 +149,12 @@ def converge(log, transaction_id, config, scaling_group, state, launch_config,
     """
     if tenant_is_enabled(scaling_group.tenant_id, config_value):
         delta = apply_delta(log, state.desired, state, config, policy)
-        get_converger().start_convergence(log, scaling_group, state,
-                                          launch_config)
         if delta == 0:
             return None
-        else:
-            return defer.succeed(None)
+
+        get_converger().start_convergence(log, scaling_group, state,
+                                          launch_config)
+        return defer.succeed(None)
 
     delta = calculate_delta(log, state, config, policy)
     execute_log = log.bind(server_delta=delta)

--- a/otter/test/test_controller.py
+++ b/otter/test/test_controller.py
@@ -1105,7 +1105,6 @@ class ConvergeTestCase(SynchronousTestCase):
         result = controller.converge(log, 'txn-id', group_config, self.group,
                                      state, 'launch', policy,
                                      config_value=config_data.get)
-        self.assertIsInstance(result, defer.Deferred)
         self.assertIs(self.successResultOf(result), None)
         self.converger_mock.start_convergence.assert_called_once_with(
             log, self.group, state, 'launch')

--- a/otter/test/test_controller.py
+++ b/otter/test/test_controller.py
@@ -988,8 +988,8 @@ class MaybeExecuteScalingPolicyTestCase(SynchronousTestCase):
 
 class ConvergeTestCase(SynchronousTestCase):
     """
-    Tests for :func:`otter.controller.converge`, currently using the Otter
-    launch_server backend.
+    Tests for :func:`otter.controller.converge`, using both the Otter
+    launch_server backend and the real convergence backend.
     """
 
     def setUp(self):
@@ -1089,16 +1089,41 @@ class ConvergeTestCase(SynchronousTestCase):
             active_capacity=3, desired_capacity=5, pending_capacity=2,
             audit_log=True)
 
-    def test_real_convergence(self):
+    def test_real_convergence_nonzero_delta(self):
         """
-        When a tenant is configured to for convergence, the Convergence
-        service's ``converge`` method is invoked, and None is returned.
+        When a tenant is configured to for convergence, if the delta is
+        non-zero, the Convergence service's ``converge`` method is invoked and
+        a Deferred that fires with `None` is returned.
         """
         log = mock_log()
         state = GroupState('tenant', 'group-id', "test", [], [], None, {},
                            False)
         group_config = {'maxEntities': 100, 'minEntities': 0}
         policy = {'change': 5}
+        config_data = {'convergence-tenants': ['tenant']}
+
+        result = controller.converge(log, 'txn-id', group_config, self.group,
+                                     state, 'launch', policy,
+                                     config_value=config_data.get)
+        self.assertIsInstance(result, defer.Deferred)
+        self.assertIs(self.successResultOf(result), None)
+        self.converger_mock.start_convergence.assert_called_once_with(
+            log, self.group, state, 'launch')
+
+        # And execute_launch_config is _not_ called
+        self.assertFalse(self.mocks['execute_launch_config'].called)
+
+    def test_real_convergence_zero_delta(self):
+        """
+        When a tenant is configured to for convergence, if the delta is zero,
+        the Convergence service's ``converge`` method is invoked and
+        `None` is returned.
+        """
+        log = mock_log()
+        state = GroupState('tenant', 'group-id', "test", [], [], None, {},
+                           False)
+        group_config = {'maxEntities': 100, 'minEntities': 0}
+        policy = {'change': 0}
         config_data = {'convergence-tenants': ['tenant']}
 
         result = controller.converge(log, 'txn-id', group_config, self.group,

--- a/otter/test/test_controller.py
+++ b/otter/test/test_controller.py
@@ -1116,7 +1116,7 @@ class ConvergeTestCase(SynchronousTestCase):
     def test_real_convergence_zero_delta(self):
         """
         When a tenant is configured to for convergence, if the delta is zero,
-        the Convergence service's ``converge`` method is invoked and
+        the Convergence service's ``converge`` method is not invoked and
         `None` is returned.
         """
         log = mock_log()
@@ -1130,8 +1130,5 @@ class ConvergeTestCase(SynchronousTestCase):
                                      state, 'launch', policy,
                                      config_value=config_data.get)
         self.assertIs(result, None)
-        self.converger_mock.start_convergence.assert_called_once_with(
-            log, self.group, state, 'launch')
-
-        # And execute_launch_config is _not_ called
+        self.assertFalse(self.converger_mock.start_convergence.called)
         self.assertFalse(self.mocks['execute_launch_config'].called)


### PR DESCRIPTION
Fixes #1126

I am not doing audit logging in this case because there is already some existing convergence logging story.  Not sure if this is a good idea.

This should fix the remaining functional test failures.