### PR TITLE
RCv3 models for converegence

### DIFF
--- a/otter/convergence/model.py
+++ b/otter/convergence/model.py
@@ -414,3 +414,48 @@ class CLBNode(object):
         See :func:`ILBNode.is_active`.
         """
         return self.description.condition != CLBNodeCondition.DISABLED
+
+
+@implementer(ILBDescription)
+@attributes([Attribute("lb_id", instance_of=str)])
+class RCv3Description(object):
+    """
+    Information representing a RackConnect V3/server mapping: how a particular
+    server *should* be added a RackConnect V3 load balancer pool.
+
+    RackConnect V3 nodes aren't really configurable, so only has the load
+    balancer ID.
+
+    :ivar int lb_id: The Load Balancer ID.
+    """
+    def equivalent_definition(self, other_description):
+        """
+        Given that no customization is available, is the same as testing
+        equivalence.
+
+        See :func:`ILBDescription.equivalent_definition`.
+        """
+        return self == other_description
+
+
+@implementer(ILBNode)
+@attributes([Attribute("node_id", instance_of=str),
+             Attribute("description", instance_of=RCv3Description),
+             Attribute("cloud_server_id", instance_of=str)])
+class RCv3Node(object):
+    """
+    A RackConnect V3 node.
+
+    :ivar str node_id: See :obj:`ILBNode.node_id`.
+    :ivar description: See :obj:`ILBNode.description`.
+    :type description: :class:`RCv3Description`
+
+    :ivar str cloud_server_id: The ID of the cloud server represented by this
+        node
+    """
+    def matches(self, server):
+        """
+        See :func:`ILBNode.matches`.
+        """
+        return (isinstance(server, NovaServer) and
+                server.id == self.cloud_server_id)

--- a/otter/convergence/planning.py
+++ b/otter/convergence/planning.py
@@ -138,7 +138,8 @@ def _drain_and_delete(server, timeout, current_lb_nodes, now):
     # if there are no load balancers that are waiting on draining timeouts or
     # connections, just delete the server too
     if (len(lb_draining_steps) == len(current_lb_nodes) and
-        all([isinstance(step, RemoveNodesFromCLB)
+        all([isinstance(step, RemoveNodesFromCLB) or
+             isinstance(step, BulkRemoveFromRCv3)
              for step in lb_draining_steps])):
         return lb_draining_steps + [DeleteServer(server_id=server.id)]
 

--- a/otter/convergence/planning.py
+++ b/otter/convergence/planning.py
@@ -8,9 +8,12 @@ from toolz.curried import filter, groupby
 from toolz.itertoolz import concat, concatv, mapcat
 
 from otter.convergence.model import (
-    CLBDescription, CLBNode, CLBNodeCondition, IDrainable, ServerState)
+    CLBDescription, CLBNode, CLBNodeCondition, IDrainable,
+    RCv3Description, RCv3Node, ServerState)
 from otter.convergence.steps import (
     AddNodesToCLB,
+    BulkAddToRCv3,
+    BulkRemoveFromRCv3,
     ChangeCLBNode,
     CreateServer,
     DeleteServer,
@@ -216,7 +219,7 @@ def converge(desired_state, servers_with_cheese, load_balancer_contents, now,
     delete_error_steps = (
         [DeleteServer(server_id=server.id) for server in servers_in_error] +
         [RemoveNodesFromCLB(lb_id=lb_node.description.lb_id,
-                            node_ids=(lb_node.node_id,))
+                            node_ids=pset([lb_node.node_id]))
          for server in servers_in_error
          for lb_node in load_balancer_contents if lb_node.matches(server)])
 
@@ -361,6 +364,9 @@ def add_server_to_lb(server, description):
                 lb_id=description.lb_id,
                 address_configs=pset(
                     [(server.servicenet_address, description)]))
+    elif isinstance(description, RCv3Description):
+        return BulkAddToRCv3(lb_node_pairs=pset(
+            [(description.lb_id, server.id)]))
 
 
 def remove_node_from_lb(node):
@@ -372,7 +378,10 @@ def remove_node_from_lb(node):
     """
     if isinstance(node, CLBNode):
         return RemoveNodesFromCLB(lb_id=node.description.lb_id,
-                                  node_ids=(node.node_id,))
+                                  node_ids=pset([node.node_id]))
+    elif isinstance(node, RCv3Node):
+        return BulkRemoveFromRCv3(lb_node_pairs=pset(
+            [(node.description.lb_id, node.cloud_server_id)]))
 
 
 def change_lb_node(node, description):

--- a/otter/test/convergence/test_planning.py
+++ b/otter/test/convergence/test_planning.py
@@ -60,14 +60,14 @@ class RemoveFromLBWithDrainingTests(SynchronousTestCase):
                             servicenet_address='1.1.1.1',
                             desired_lbs=s(desc))]),
                 set([CLBNode(node_id='123', address='1.1.1.1',
-                     description=desc)]),
+                             description=desc)]),
                 now=0)),
-            pbag([RemoveNodesFromCLB(lb_id='5', node_ids=('123',))]))
+            pbag([RemoveNodesFromCLB(lb_id='5', node_ids=s('123'))]))
 
     def test_disabled_state_is_removed(self):
         """
-        Nodes in disabled state are just removed from the load balancer even
-        if the timeout is positive.
+        Drainable nodes in disabled state are just removed from the load
+        balancer even if the timeout is positive.
         """
         desired = s(CLBDescription(lb_id='5', port=80))
         current = [CLBNode(node_id='123', address='1.1.1.1',
@@ -83,11 +83,12 @@ class RemoveFromLBWithDrainingTests(SynchronousTestCase):
                             desired_lbs=desired)]),
                 set(current),
                 now=0)),
-            pbag([RemoveNodesFromCLB(lb_id='5', node_ids=('123',))]))
+            pbag([RemoveNodesFromCLB(lb_id='5', node_ids=s('123'))]))
 
-    def test_enabled_state_is_drained(self):
+    def test_drainable_enabled_state_is_drained(self):
         """
-        Nodes in enabled state are put into draining.
+        Drainable nodes in enabled state are put into draining, while
+        undrainable nodes are just removed.
         """
         desc = CLBDescription(lb_id='5', port=80)
         current = [CLBNode(node_id='123', address='1.1.1.1', description=desc)]
@@ -146,7 +147,7 @@ class RemoveFromLBWithDrainingTests(SynchronousTestCase):
                             desired_lbs=desired)]),
                 set(current),
                 now=5)),
-            pbag([RemoveNodesFromCLB(lb_id='5', node_ids=('123',))]))
+            pbag([RemoveNodesFromCLB(lb_id='5', node_ids=s('123'))]))
 
     def test_draining_state_remains_if_connections_none_before_timeout(self):
         """
@@ -190,7 +191,7 @@ class RemoveFromLBWithDrainingTests(SynchronousTestCase):
                             desired_lbs=desired)]),
                 set(current),
                 now=15)),
-            pbag([RemoveNodesFromCLB(lb_id='5', node_ids=('123',))]))
+            pbag([RemoveNodesFromCLB(lb_id='5', node_ids=s('123'))]))
 
     def test_draining_state_removed_if_connections_and_timeout_expired(self):
         """
@@ -212,7 +213,7 @@ class RemoveFromLBWithDrainingTests(SynchronousTestCase):
                             desired_lbs=desired)]),
                 set(current),
                 now=15)),
-            pbag([RemoveNodesFromCLB(lb_id='5', node_ids=('123',))]))
+            pbag([RemoveNodesFromCLB(lb_id='5', node_ids=s('123'))]))
 
     def test_all_clb_changes_together(self):
         """
@@ -266,9 +267,9 @@ class RemoveFromLBWithDrainingTests(SynchronousTestCase):
                 ChangeCLBNode(lb_id='1', node_id='1', weight=1,
                               condition=CLBNodeCondition.DRAINING,
                               type=CLBNodeType.PRIMARY),
-                RemoveNodesFromCLB(lb_id='2', node_ids=('2',)),
-                RemoveNodesFromCLB(lb_id='4', node_ids=('4',)),
-                RemoveNodesFromCLB(lb_id='5', node_ids=('5',)),
+                RemoveNodesFromCLB(lb_id='2', node_ids=s('2')),
+                RemoveNodesFromCLB(lb_id='4', node_ids=s('4')),
+                RemoveNodesFromCLB(lb_id='5', node_ids=s('5')),
             ]))
 
 
@@ -338,7 +339,7 @@ class ConvergeLBStateTests(SynchronousTestCase):
                             desired_lbs=pset())]),
                 set(current),
                 0),
-            pbag([RemoveNodesFromCLB(lb_id='5', node_ids=('123',))]))
+            pbag([RemoveNodesFromCLB(lb_id='5', node_ids=s('123'))]))
 
     def test_do_nothing(self):
         """
@@ -386,7 +387,7 @@ class ConvergeLBStateTests(SynchronousTestCase):
                 ChangeCLBNode(lb_id='6', node_id='234', weight=2,
                               condition=CLBNodeCondition.ENABLED,
                               type=CLBNodeType.PRIMARY),
-                RemoveNodesFromCLB(lb_id='5', node_ids=('123',))
+                RemoveNodesFromCLB(lb_id='5', node_ids=s('123'))
             ]))
 
     def test_same_lb_multiple_ports(self):
@@ -468,7 +469,7 @@ class DrainAndDeleteServerTests(SynchronousTestCase):
                 0),
             pbag([
                 DeleteServer(server_id='abc'),
-                RemoveNodesFromCLB(lb_id='1', node_ids=('1',))
+                RemoveNodesFromCLB(lb_id='1', node_ids=s('1'))
             ]))
 
     def test_draining_server_can_be_deleted_if_all_lbs_can_be_removed(self):
@@ -490,7 +491,7 @@ class DrainAndDeleteServerTests(SynchronousTestCase):
                 0),
             pbag([
                 DeleteServer(server_id='abc'),
-                RemoveNodesFromCLB(lb_id='1', node_ids=('1',))
+                RemoveNodesFromCLB(lb_id='1', node_ids=s('1'))
             ]))
 
     def test_draining_server_ignored_if_waiting_for_timeout(self):
@@ -682,8 +683,8 @@ class ConvergeTests(SynchronousTestCase):
                 0),
             pbag([
                 DeleteServer(server_id='abc'),
-                RemoveNodesFromCLB(lb_id='5', node_ids=('3',)),
-                RemoveNodesFromCLB(lb_id='5', node_ids=('5',)),
+                RemoveNodesFromCLB(lb_id='5', node_ids=s('3')),
+                RemoveNodesFromCLB(lb_id='5', node_ids=s('5')),
                 CreateServer(server_config=pmap()),
             ]))
 

--- a/otter/test/convergence/test_planning.py
+++ b/otter/test/convergence/test_planning.py
@@ -33,7 +33,7 @@ from otter.convergence.steps import (
     SetMetadataItemOnServer)
 
 
-def copy_clbdesc(clb_desc, condition=CLBNodeCondition.ENABLED, weight=1):
+def copy_clb_desc(clb_desc, condition=CLBNodeCondition.ENABLED, weight=1):
     """
     Produce a :class:`CLBDescription` from another, but with the given
     condition changed to the one given
@@ -136,7 +136,7 @@ class RemoveFromLBWithDrainingTests(SynchronousTestCase):
         """
         clb_desc = CLBDescription(lb_id='5', port=80)
         clb_node = CLBNode(node_id='123', address=self.address,
-                           description=copy_clbdesc(
+                           description=copy_clb_desc(
                                clb_desc, condition=CLBNodeCondition.DISABLED))
         clb_step = RemoveNodesFromCLB(lb_id='5', node_ids=s('123'))
 
@@ -173,7 +173,7 @@ class RemoveFromLBWithDrainingTests(SynchronousTestCase):
         """
         clb_desc = CLBDescription(lb_id='5', port=80)
         clb_node = CLBNode(node_id='123', address=self.address,
-                           description=copy_clbdesc(
+                           description=copy_clb_desc(
                                clb_desc, condition=CLBNodeCondition.DRAINING),
                            drained_at=0.0, connections=1)
 
@@ -191,7 +191,7 @@ class RemoveFromLBWithDrainingTests(SynchronousTestCase):
         """
         clb_desc = CLBDescription(lb_id='5', port=80)
         clb_node = CLBNode(node_id='123', address=self.address,
-                           description=copy_clbdesc(
+                           description=copy_clb_desc(
                                clb_desc, condition=CLBNodeCondition.DRAINING),
                            drained_at=0.0, connections=0)
         clb_step = RemoveNodesFromCLB(lb_id='5', node_ids=s('123'))
@@ -210,7 +210,7 @@ class RemoveFromLBWithDrainingTests(SynchronousTestCase):
         """
         clb_desc = CLBDescription(lb_id='5', port=80)
         clb_node = CLBNode(node_id='123', address=self.address,
-                           description=copy_clbdesc(
+                           description=copy_clb_desc(
                                clb_desc, condition=CLBNodeCondition.DRAINING),
                            drained_at=0.0)
 
@@ -228,7 +228,7 @@ class RemoveFromLBWithDrainingTests(SynchronousTestCase):
         """
         clb_desc = CLBDescription(lb_id='5', port=80)
         clb_node = CLBNode(node_id='123', address=self.address,
-                           description=copy_clbdesc(
+                           description=copy_clb_desc(
                                clb_desc, condition=CLBNodeCondition.DRAINING),
                            drained_at=0.0)
         clb_step = RemoveNodesFromCLB(lb_id='5', node_ids=s('123'))
@@ -247,7 +247,7 @@ class RemoveFromLBWithDrainingTests(SynchronousTestCase):
         """
         clb_desc = CLBDescription(lb_id='5', port=80)
         clb_node = CLBNode(node_id='123', address=self.address,
-                           description=copy_clbdesc(
+                           description=copy_clb_desc(
                                clb_desc, condition=CLBNodeCondition.DRAINING),
                            drained_at=0.0, connections=10)
         clb_step = RemoveNodesFromCLB(lb_id='5', node_ids=s('123'))
@@ -277,21 +277,21 @@ class RemoveFromLBWithDrainingTests(SynchronousTestCase):
                     description=clb_descs[0]),
             # disabled, should be removed
             CLBNode(node_id='2', address=self.address,
-                    description=copy_clbdesc(
+                    description=copy_clb_desc(
                         clb_descs[1], condition=CLBNodeCondition.DISABLED)),
             # draining, still connections, should be ignored
             CLBNode(node_id='3', address='1.1.1.1',
-                    description=copy_clbdesc(
+                    description=copy_clb_desc(
                         clb_descs[2], condition=CLBNodeCondition.DRAINING),
                     connections=3, drained_at=5.0),
             # draining, no connections, should be removed
             CLBNode(node_id='4', address='1.1.1.1',
-                    description=copy_clbdesc(
+                    description=copy_clb_desc(
                         clb_descs[3], condition=CLBNodeCondition.DRAINING),
                     connections=0, drained_at=5.0),
             # draining, timeout exired, should be removed
             CLBNode(node_id='5', address='1.1.1.1',
-                    description=copy_clbdesc(
+                    description=copy_clb_desc(
                         clb_descs[4], condition=CLBNodeCondition.DRAINING),
                     connections=10, drained_at=0.0)]
 
@@ -357,7 +357,7 @@ class ConvergeLBStateTests(SynchronousTestCase):
             lb_id='c6fe49fa-114a-4ea4-9425-0af8b30ff1e7')
 
         current = [CLBNode(node_id='123', address='1.1.1.1',
-                           description=copy_clbdesc(clb_desc, weight=5)),
+                           description=copy_clb_desc(clb_desc, weight=5)),
                    RCv3Node(node_id='234', cloud_server_id='abc',
                             description=rcv3_desc)]
         self.assertEqual(
@@ -434,7 +434,7 @@ class ConvergeLBStateTests(SynchronousTestCase):
             CLBNode(node_id='123', address='1.1.1.1',
                     description=CLBDescription(lb_id='5', port=8080)),
             CLBNode(node_id='234', address='1.1.1.1',
-                    description=copy_clbdesc(descs[1], weight=1)),
+                    description=copy_clb_desc(descs[1], weight=1)),
             RCv3Node(node_id='345', cloud_server_id='abc',
                      description=RCv3Description(
                          lb_id='e762e42a-8a4e-4ffb-be17-f9dc672729b2'))
@@ -561,7 +561,7 @@ class DrainAndDeleteServerTests(SynchronousTestCase):
                             servicenet_address='1.1.1.1',
                             desired_lbs=s(self.clb_desc, self.rcv3_desc))]),
                 set([CLBNode(node_id='1', address='1.1.1.1',
-                             description=copy_clbdesc(
+                             description=copy_clb_desc(
                                  self.clb_desc,
                                  condition=CLBNodeCondition.DRAINING)),
                      RCv3Node(node_id='2', cloud_server_id='abc',
@@ -614,13 +614,13 @@ class DrainAndDeleteServerTests(SynchronousTestCase):
                 set([
                     # This node is in draining - nothing will be done to it
                     CLBNode(node_id='1', address='1.1.1.1',
-                            description=copy_clbdesc(
+                            description=copy_clb_desc(
                                 self.clb_desc,
                                 condition=CLBNodeCondition.DRAINING),
                             drained_at=1.0, connections=1),
                     # This node is done draining, it can be removed
                     CLBNode(node_id='2', address='1.1.1.1',
-                            description=copy_clbdesc(
+                            description=copy_clb_desc(
                                 other_clb_desc,
                                 condition=CLBNodeCondition.DRAINING),
                             drained_at=0.0),
@@ -681,7 +681,7 @@ class DrainAndDeleteServerTests(SynchronousTestCase):
                             servicenet_address='1.1.1.1',
                             desired_lbs=s(self.clb_desc, self.rcv3_desc))]),
                 set([CLBNode(node_id='1', address='1.1.1.1',
-                             description=copy_clbdesc(
+                             description=copy_clb_desc(
                                  self.clb_desc,
                                  condition=CLBNodeCondition.DRAINING),
                              connections=1, drained_at=0.0)]),

--- a/otter/test/convergence/test_planning.py
+++ b/otter/test/convergence/test_planning.py
@@ -35,8 +35,8 @@ from otter.convergence.steps import (
 
 def copy_clb_desc(clb_desc, condition=CLBNodeCondition.ENABLED, weight=1):
     """
-    Produce a :class:`CLBDescription` from another, but with the given
-    condition changed to the one given
+    Produce a :class:`CLBDescription` from another, but with the provided
+    conditions and weights instead of the original conditions and weights.
 
     :param clb_desc: the :class:`CLBDescription` to copy
     :param condition: the :class:`CLBNodeCondition` to use


### PR DESCRIPTION
This pull request addresses part of #821 and does the following:

- Add the RCv3 ILBDescription and ILBNode models
- Modifies the generic lb add and remove steps to produce `BulkAddToRCv3` and `BulkRemoveFromRCv3` steps
- Add RCv3 bits to the existing converge with LB tests, and adds some new tests
- Refactors some of the converge with LB tests

Still needed after this PR to complete #821 is to add RCv3 to gathering.