### PR TITLE
Cloudfeeds custom content type

### DIFF
--- a/otter/log/cloudfeeds.py
+++ b/otter/log/cloudfeeds.py
@@ -132,6 +132,8 @@ def add_event(event, tenant_id, region, log):
             service_request(
                 ServiceType.CLOUD_FEEDS, 'POST',
                 append_segments('autoscale', 'events'),
+                headers={
+                    'content-type': ['application/vnd.rackspace.atom+json']},
                 data=req, log=log, success_pred=has_code(201)),
             retry_times(5), exponential_backoff_interval(2))
         return Effect(TenantScope(tenant_id=tenant_id, effect=eff))

--- a/otter/test/log/test_cloudfeeds.py
+++ b/otter/test/log/test_cloudfeeds.py
@@ -200,6 +200,8 @@ class EventTests(SynchronousTestCase):
             eff,
             service_request(
                 ServiceType.CLOUD_FEEDS, 'POST', 'autoscale/events',
+                headers={
+                    'content-type': ['application/vnd.rackspace.atom+json']},
                 data=self._get_request('INFO', 'uuid'), log=log,
                 success_pred=has_code(201)))
 

--- a/otter/test/util/test_pure_http.py
+++ b/otter/test/util/test_pure_http.py
@@ -196,14 +196,14 @@ class AddHeadersTest(TestCase):
     """Tests for :func:`add_headers`."""
 
     def test_add_headers(self):
-        """Headers are merged, with fixed headers taking precedence."""
+        """Headers are merged, with passed headers taking precedence."""
         request_ = add_headers({'one': '1', 'two': '2'}, request)
         eff = request_('m', 'u', headers={'one': 'hey', 'three': '3'})
         self.assertEqual(
             resolve_stubs(eff).intent,
             Request(method='m',
                     url='u',
-                    headers={'one': '1', 'two': '2', 'three': '3'}))
+                    headers={'one': 'hey', 'two': '2', 'three': '3'}))
 
     def test_add_headers_optional(self):
         """It's okay if no headers are passed."""

--- a/otter/util/pure_http.py
+++ b/otter/util/pure_http.py
@@ -162,14 +162,14 @@ def add_headers(fixed_headers, request_func):
     Decorate a request function so that some fixed headers are added.
 
     :param fixed_headers: The headers that will be added to all requests
-        made with the resulting request function. These override any
-        headers passed to the request function.
+        made with the resulting request function. The headers passed
+        override fixed_headers
     """
     @wraps(request_func)
     def request(*args, **kwargs):
         headers = kwargs.pop('headers', {})
         headers = headers if headers is not None else {}
-        return request_func(*args, headers=merge(headers, fixed_headers),
+        return request_func(*args, headers=merge(fixed_headers, headers),
                             **kwargs)
     return request
 


### PR DESCRIPTION
Sending custom content type when talking to cloud feeds. Changed the preference of headers being passed in `add_headers` to do this. 