### PR TITLE
ISO8601 format time in event

### DIFF
--- a/otter/log/cloudfeeds.py
+++ b/otter/log/cloudfeeds.py
@@ -4,7 +4,6 @@ Publishing events to Cloud feeds
 
 import uuid
 from copy import deepcopy
-from datetime import datetime
 from functools import partial
 
 from characteristic import attributes

--- a/otter/log/cloudfeeds.py
+++ b/otter/log/cloudfeeds.py
@@ -25,6 +25,7 @@ from otter.util.retry import (
     exponential_backoff_interval,
     retry_effect,
     retry_times)
+from otter.util.timestamp import epoch_to_utctimestr
 
 
 class UnsuitableMessage(Exception):
@@ -76,8 +77,7 @@ def sanitize_event(event):
            'exception' in cf_event['message']):
             raise UnsuitableMessage(cf_event['message'])
 
-    return (cf_event, error,
-            datetime.utcfromtimestamp(event["time"]).isoformat())
+    return (cf_event, error, epoch_to_utctimestr(event["time"]))
 
 
 request_format = {

--- a/otter/test/log/test_cloudfeeds.py
+++ b/otter/test/log/test_cloudfeeds.py
@@ -74,7 +74,7 @@ class SanitizeEventTests(SynchronousTestCase):
         se, err, _time = sanitize_event(self.event)
         self.assertLessEqual(set(se.keys()), set(self.exp_cf_event))
         self.assertEqual(err, exp_err)
-        self.assertEqual(_time, '1970-01-01T00:00:00')
+        self.assertEqual(_time, '1970-01-01T00:00:00Z')
         for key, value in self.exp_cf_event.items():
             if key in se:
                 self.assertEqual(se[key], value)
@@ -143,7 +143,7 @@ class EventTests(SynchronousTestCase):
                         "@type": "http://docs.rackspace.com/core/event",
                         "id": "",
                         "version": "2",
-                        "eventTime": "1970-01-01T00:00:00",
+                        "eventTime": "1970-01-01T00:00:00Z",
                         "type": "INFO",
                         "region": "ord",
                         "product": {
@@ -208,7 +208,7 @@ class EventTests(SynchronousTestCase):
         `prepare_request` returns formatted request with error in type
         """
         req = prepare_request(
-            request_format, self.cf_event, True, "1970-01-01T00:00:00",
+            request_format, self.cf_event, True, "1970-01-01T00:00:00Z",
             'ord', 'uuid')
         self.assertEqual(req, self._get_request('ERROR', 'uuid'))
 

--- a/otter/test/test_util.py
+++ b/otter/test/test_util.py
@@ -373,6 +373,13 @@ class TimestampTests(SynchronousTestCase):
         self.assertTrue(parsed.tzinfo is not None)
         self.assertEqual(parsed.replace(tzinfo=None), datetime.min)
 
+    def test_epoch_to_utctimestr(self):
+        """
+        ``epoch_to_utctimestr`` generates correct ISO formatted string
+        """
+        self.assertEqual(
+            timestamp.epoch_to_utctimestr(0), '1970-01-01T00:00:00Z')
+
 
 class ConfigTest(SynchronousTestCase):
     """

--- a/otter/util/timestamp.py
+++ b/otter/util/timestamp.py
@@ -41,3 +41,13 @@ def timestamp_to_epoch(timestamp):
     :return: EPOCH seconds as float
     """
     return calendar.timegm(from_timestamp(timestamp).utctimetuple())
+
+
+def epoch_to_utctimestr(epoch):
+    """
+    Convert EPOCH seconds to a ISO8601 formatted time
+
+    :param float epoch: UTC EPOCH seconds
+    :return: ISO8601 formatted UTC time string
+    """
+    return '{}Z'.format(datetime.utcfromtimestamp(epoch).isoformat())


### PR DESCRIPTION
`datetime.isoformat` does not include `Z` for UTC time that causes problem when adding event in cloud feeds as it expects UTC time appended with `Z`.