### PR TITLE
event data logged as separate key `event_data`

### DIFF
--- a/otter/log/cloudfeeds.py
+++ b/otter/log/cloudfeeds.py
@@ -160,7 +160,7 @@ class CloudFeedsObserver(object):
             lambda k: k not in ('message', 'cloud_feed'), event_dict)
         log = self.log.bind(
             system='otter.cloud_feed', cf_msg=event_dict['message'][0],
-            **log_keys)
+            event_data=log_keys)
         try:
             eff = self.add_event(event_dict, self.tenant_id, self.region, log)
         except UnsuitableMessage as me:

--- a/otter/test/log/test_cloudfeeds.py
+++ b/otter/test/log/test_cloudfeeds.py
@@ -280,9 +280,9 @@ class CloudFeedsObserverTests(SynchronousTestCase):
         self.successResultOf(d)
         # log doesn't have cloud_feed in it
         self.log.err.assert_called_once_with(
-            CheckFailure(ValueError), "Failed to add event", event='dict',
-            system='otter.cloud_feed', cf_msg='m',
-            otter_msg_type='cf-add-failure')
+            CheckFailure(ValueError), "Failed to add event",
+            event_data={'event': 'dict'}, system='otter.cloud_feed',
+            cf_msg='m', otter_msg_type='cf-add-failure')
 
     def test_unsuitable_msg_logs(self):
         """
@@ -297,5 +297,6 @@ class CloudFeedsObserverTests(SynchronousTestCase):
         self.log.err.assert_called_once_with(
             None, ('Tried to add unsuitable message in cloud feeds: '
                    '{unsuitable_message}'),
-            unsuitable_message='bad', event='dict', system='otter.cloud_feed',
-            cf_msg='m', otter_msg_type='cf-unsuitable-message')
+            unsuitable_message='bad', event_data={'event': 'dict'},
+            system='otter.cloud_feed', cf_msg='m',
+            otter_msg_type='cf-unsuitable-message')


### PR DESCRIPTION
instead of directly binding the keys to the logs. This is because the log object got is alredy bound with system=otter and fails when we try to bind it again with system=otter.cloud_feed. This is better because the event data can be explicitly analyzed instead of confusing it with other parts of the log.