### PR TITLE
not listing outdated packages on travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ install:
     - pip install coveralls
 
 script:
-    - make lint
+    - make lint-code
     - make docbook
     - make coverage
 

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,9 @@ run:
 env:
 	./scripts/bootstrap-virtualenv.sh
 
-lint: listoutdated flake8diff
+lint: listoutdated lint-code
+
+lint-code: flake8diff
 	pyflakes ${PYDIRS}
 
 listoutdated:


### PR DESCRIPTION
Since no one *looks* at travis build log unless it fails, it is useless to list outdated packages. Instead travis will only lint code. The default `lint` target will still list outdated packages. This will have minor speedup in travis build time.