### PR TITLE
Cloud feeds uses single tenant authenticator

### DIFF
--- a/otter/tap/api.py
+++ b/otter/tap/api.py
@@ -2,6 +2,7 @@
 Twisted Application plugin for otter API nodes.
 """
 
+from copy import deepcopy
 from functools import partial
 
 import jsonfig
@@ -235,9 +236,12 @@ def makeService(config):
     # setup cloud feed
     cf_conf = config.get('cloudfeeds', None)
     if cf_conf is not None:
+        id_conf = deepcopy(config['identity'])
+        id_conf['strategy'] = 'single_tenant'
         addObserver(
             CloudFeedsObserver(
-                reactor=reactor, authenticator=authenticator,
+                reactor=reactor,
+                authenticator=generate_authenticator(reactor, id_conf),
                 region=region, tenant_id=cf_conf['tenant_id'],
                 service_configs=service_configs))
 

--- a/otter/test/tap/test_api.py
+++ b/otter/test/tap/test_api.py
@@ -14,7 +14,7 @@ from twisted.internet import defer
 from twisted.internet.task import Clock
 from twisted.trial.unittest import SynchronousTestCase
 
-from otter.auth import CachingAuthenticator
+from otter.auth import CachingAuthenticator, SingleTenantAuthenticator
 from otter.constants import ServiceType, get_service_configs
 from otter.log.cloudfeeds import CloudFeedsObserver
 from otter.models.cass import CassScalingGroupCollection as OriginalStore
@@ -480,6 +480,12 @@ class APIMakeServiceTests(SynchronousTestCase):
             region='ord', tenant_id='tid',
             service_configs=serv_confs)
         mock_addobserver.assert_called_once_with(cf)
+
+        # Observer has single tenant auth
+        real_cf = mock_addobserver.call_args[0][0]
+        self.assertIsInstance(
+            real_cf.authenticator._authenticator._authenticator._authenticator,
+            SingleTenantAuthenticator)
 
     @mock.patch('otter.tap.api.addObserver')
     def test_cloudfeeds_no_setup(self, mock_addobserver):


### PR DESCRIPTION
This is simpler than otter trying to impersonate itself.