### PR TITLE
Option to disable kazoo logs

### DIFF
--- a/otter/tap/api.py
+++ b/otter/tap/api.py
@@ -248,12 +248,14 @@ def makeService(config):
     # Setup Kazoo client
     if config_value('zookeeper'):
         threads = config_value('zookeeper.threads') or 10
+        disable_logs = config_value('zookeeper.no_logs')
         kz_client = TxKazooClient(
             hosts=config_value('zookeeper.hosts'),
             # Keep trying to connect until the end of time with
             # max interval of 10 minutes
             connection_retry=dict(max_tries=-1, max_delay=600),
-            threads=threads, txlog=log.bind(system='kazoo'))
+            threads=threads,
+            txlog=None if disable_logs else log.bind(system='kazoo'))
         # Don't timeout. Keep trying to connect forever
         d = kz_client.start(timeout=None)
 

--- a/otter/test/tap/test_api.py
+++ b/otter/test/tap/test_api.py
@@ -535,6 +535,14 @@ class APIMakeServiceTests(SynchronousTestCase):
                          sch.health_check)
         self.assertEqual(self.Otter.return_value.scheduler, sch)
 
+        # Check for no logs case also
+        mock_txkz.reset_mock()
+        config['zookeeper']['no_logs'] = True
+        parent = makeService(config)
+        mock_txkz.assert_called_once_with(
+            hosts='zk_hosts', threads=20,
+            connection_retry=dict(max_tries=-1, max_delay=600), txlog=None)
+
     @mock.patch('otter.tap.api.setup_scheduler')
     @mock.patch('otter.tap.api.TxKazooClient')
     def test_kazoo_client_failed(self, mock_txkz, mock_setup_scheduler):


### PR DESCRIPTION
Default is enabled. You've to specify `{"no_logs": true}` to disable it. This will helpful when running locally for testing feature