### PR TITLE
add GetScalingGroupInfo, an intent looks up all the info about a group

### DIFF
--- a/otter/models/intents.py
+++ b/otter/models/intents.py
@@ -23,7 +23,7 @@ def perform_modify_group_state(dispatcher, mgs_intent):
 
 @attributes(['tenant_id', 'group_id'])
 class GetScalingGroupInfo(object):
-    """Look up a scaling group, along with its `state` and launch config."""
+    """Get a scaling group and its manifest."""
 
 
 @deferred_performer
@@ -37,15 +37,14 @@ def perform_get_scaling_group_info(log, store, dispatcher, intent):
     :param dispatcher: dispatcher provided by perform
     :param GetScalingGroupInfo intent: the intent
     """
-    group = yield store.get_scaling_group(
-        log, intent.tenant_id, intent.group_id)
-    state = yield group.view_state()
-    lc = yield group.view_launch_config()
-    returnValue((group, state, lc))
+    group = store.get_scaling_group(log, intent.tenant_id, intent.group_id)
+    manifest = yield group.view_manifest(with_policies=False,
+                                         with_webhooks=False)
+    returnValue((group, manifest))
 
 
-def get_cassandra_dispatcher(log, store):
-    """Get a dispatcher that can handle all the cass-related intents."""
+def get_model_dispatcher(log, store):
+    """Get a dispatcher that can handle all the model-related intents."""
     return TypeDispatcher({
         ModifyGroupState:
             perform_modify_group_state,

--- a/otter/models/intents.py
+++ b/otter/models/intents.py
@@ -1,6 +1,11 @@
+from functools import partial
+
 from characteristic import attributes
 
+from effect import TypeDispatcher
 from effect.twisted import deferred_performer
+
+from twisted.internet.defer import inlineCallbacks, returnValue
 
 
 @attributes(['scaling_group', 'modifier'])
@@ -14,3 +19,35 @@ class ModifyGroupState(object):
 def perform_modify_group_state(dispatcher, mgs_intent):
     """Perform a :obj:`ModifyGroupState`."""
     return mgs_intent.scaling_group.modify_state(mgs_intent.modifier)
+
+
+@attributes(['tenant_id', 'group_id'])
+class GetScalingGroupInfo(object):
+    """Look up a scaling group, along with its `state` and launch config."""
+
+
+@deferred_performer
+@inlineCallbacks
+def perform_get_scaling_group_info(log, store, dispatcher, intent):
+    """
+    Perform :obj:`GetScalingGroupInfo`.
+
+    :param log: bound log
+    :param IScalingGroupCollection store: collection of groups
+    :param dispatcher: dispatcher provided by perform
+    :param GetScalingGroupInfo intent: the intent
+    """
+    group = yield store.get_scaling_group(
+        log, intent.tenant_id, intent.group_id)
+    state = yield group.view_state()
+    lc = yield group.view_launch_config()
+    returnValue((group, state, lc))
+
+
+def get_cassandra_dispatcher(log, store):
+    return TypeDispatcher({
+        ModifyGroupState:
+            perform_modify_group_state,
+        GetScalingGroupInfo:
+            partial(perform_get_scaling_group_info, log, store)
+    })

--- a/otter/models/intents.py
+++ b/otter/models/intents.py
@@ -45,6 +45,7 @@ def perform_get_scaling_group_info(log, store, dispatcher, intent):
 
 
 def get_cassandra_dispatcher(log, store):
+    """Get a dispatcher that can handle all the cass-related intents."""
     return TypeDispatcher({
         ModifyGroupState:
             perform_modify_group_state,

--- a/otter/test/models/test_intents.py
+++ b/otter/test/models/test_intents.py
@@ -1,10 +1,14 @@
 from effect import Effect, TypeDispatcher
-from effect.twisted import perform
+from effect import sync_perform
 
+from twisted.internet.defer import succeed
 from twisted.trial.unittest import SynchronousTestCase
 
-from otter.models.intents import ModifyGroupState, perform_modify_group_state
-from otter.test.utils import mock_group
+from otter.models.intents import (
+    GetScalingGroupInfo, ModifyGroupState,
+    get_cassandra_dispatcher,
+    perform_modify_group_state)
+from otter.test.utils import mock_group, mock_log
 
 
 class ModifyGroupStateTests(SynchronousTestCase):
@@ -15,6 +19,32 @@ class ModifyGroupStateTests(SynchronousTestCase):
                                modifier=lambda g, o: 'new state')
         dispatcher = TypeDispatcher({
             ModifyGroupState: perform_modify_group_state})
-        d = perform(dispatcher, Effect(mgs))
-        self.assertEqual(self.successResultOf(d), 'new state')
+        result = sync_perform(dispatcher, Effect(mgs))
+        self.assertEqual(result, 'new state')
         self.assertEqual(group.modify_state_values, ['new state'])
+
+
+class GetScalingGroupInfoTests(SynchronousTestCase):
+    """Tests for :obj:`GetScalingGroupInfo`."""
+    def test_perform(self):
+        """Performing returns the group, the state, and the launch config."""
+        log = mock_log()
+        state = object()
+        lc = object()
+        group = mock_group(state)
+        group.view_state.return_value = succeed(state)
+        group.view_launch_config.return_value = succeed(lc)
+
+        data = {('00', 'g1'): group}
+
+        class Store(object):
+            def get_scaling_group(s_self, _log, tenant_id, group_id):
+                self.assertEqual(_log, log)
+                return data[(tenant_id, group_id)]
+
+        store = Store()
+        dispatcher = get_cassandra_dispatcher(log, store)
+        info = sync_perform(
+            dispatcher,
+            Effect(GetScalingGroupInfo(tenant_id='00', group_id='g1')))
+        self.assertEqual(info, (group, state, lc))


### PR DESCRIPTION
This is necessary so the convergence code can get the group info at the start of each convergence cycle.

I didn't add the performers to `otter.effect_dispatcher` because I have some other changes coming to that file and I don't want to create unnecessary conflicts.