### PR TITLE
Miscellaneous testing utility fixes/improvements

### DIFF
--- a/otter/test/test_scheduler.py
+++ b/otter/test/test_scheduler.py
@@ -5,7 +5,6 @@ from datetime import datetime, timedelta
 
 import mock
 
-from twisted.application.service import Service
 from twisted.internet import defer
 from twisted.trial.unittest import SynchronousTestCase
 
@@ -27,6 +26,7 @@ from otter.scheduler import (
 from otter.test.utils import (
     CheckFailure,
     DeferredFunctionMixin,
+    FakePartitioner,
     iMock,
     mock_log,
     patch
@@ -47,20 +47,6 @@ class SchedulerTests(SynchronousTestCase):
         self.mock_generate_transaction_id = patch(
             self, 'otter.scheduler.generate_transaction_id',
             return_value='transaction-id')
-
-
-class FakePartitioner(Service):
-    """A fake version of a :obj:`Partitioner`."""
-    def __init__(self, log, callback):
-        self.log = log
-        self.got_buckets = callback
-        self.health = (True, {'buckets': []})
-
-    def reset_path(self, new_path):
-        return 'partitioner reset to {}'.format(new_path)
-
-    def health_check(self):
-        return defer.succeed(self.health)
 
 
 class SchedulerServiceTests(SchedulerTests, DeferredFunctionMixin):

--- a/otter/test/utils.py
+++ b/otter/test/utils.py
@@ -165,9 +165,9 @@ class CheckFailureValue(object):
     def __eq__(self, other):
         matcher = MatchesException(self.exception)
         return (
-            isinstance(other, Failure)
-            and other.check(type(self.exception)) is not None
-            and matcher.match((type(other.value), other.value, None)) is None)
+            isinstance(other, Failure) and
+            other.check(type(self.exception)) is not None and
+            matcher.match((type(other.value), other.value, None)) is None)
 
     def __ne__(self, other):
         return not self == other

--- a/otter/test/utils.py
+++ b/otter/test/utils.py
@@ -147,6 +147,9 @@ class CheckFailure(object):
         return isinstance(other, Failure) and other.check(
             self.exception_type)
 
+    def __ne__(self, other):
+        return not self == other
+
 
 class CheckFailureValue(object):
     """
@@ -161,9 +164,13 @@ class CheckFailureValue(object):
 
     def __eq__(self, other):
         matcher = MatchesException(self.exception)
-        return (isinstance(other, Failure)
-                and other.check(type(self.exception)) is not None
-                and matcher.match((type(other.value), other.value, None)) is None)
+        return (
+            isinstance(other, Failure)
+            and other.check(type(self.exception)) is not None
+            and matcher.match((type(other.value), other.value, None)) is None)
+
+    def __ne__(self, other):
+        return not self == other
 
 
 class IsCallable(object):
@@ -312,7 +319,11 @@ def mock_log(*args, **kwargs):
     Since in all likelyhood, testing that certain values are bound would be
     more important than testing the exact logged message.
     """
-    return BoundLog(mock.Mock(spec=[]), mock.Mock(spec=[]))
+    msg = mock.Mock(spec=[])
+    msg.return_value = None
+    err = mock.Mock(spec=[])
+    err.return_value = None
+    return BoundLog(msg, err)
 
 
 class StubResponse(object):
@@ -636,3 +647,37 @@ def defaults_by_name(fn):
     """Returns a mapping of args of fn to their default values."""
     args, _, _, defaults = getargspec(fn)
     return dict(zip(reversed(args), reversed(defaults)))
+
+
+class FakePartitioner(Service):
+    """A fake version of a :obj:`Partitioner`."""
+    def __init__(self, log, callback):
+        self.log = log
+        self.got_buckets = callback
+        self.health = (True, {'buckets': []})
+
+    def reset_path(self, new_path):
+        return 'partitioner reset to {}'.format(new_path)
+
+    def health_check(self):
+        return defer.succeed(self.health)
+
+
+def transform_eq(transformer, rhs):
+    """
+    Return an object that can be compared to another object after transforming
+    that other object.
+
+    :param transformer: a function that takes the compared objects and returns
+        a transformed version
+    :param rhs: the actual data that should be compared with the result of
+        transforming the compared object
+    """
+    class Foo(object):
+        def __eq__(self, other):
+            return transformer(other) == rhs
+
+        def __ne__(self, other):
+            return not self == other
+
+    return Foo()


### PR DESCRIPTION
- A number of classes with `__eq__` didn't support `__ne__`, which means they wouldn't do the right thing when != was used.
- move FakePartitioner from test_scheduler to utils.py, so it can be used in the forthcoming convergence service tests, which also use the partitioner.
- add a `transform_eq` function, which transforms an object before quality comparison.
- make mock_log's log.err and log.msg functions return None, like the real functions do.

e.g., if you have a data structure `d = {'foo': [1,2,3]}`, and you want to compare it in your tests, but you don't care about the order of the list, you can use

`self.assertEqual(d, {'foo': transform_eq(set, set([1,2,3]))})`