### PR TITLE
iMock test fixes

### DIFF
--- a/otter/models/interface.py
+++ b/otter/models/interface.py
@@ -855,7 +855,7 @@ class IAdmin(Interface):
     Interface to administrative information and actions.
     """
 
-    def get_metrics(self, log):
+    def get_metrics(log):
         """
         Returns total current count of policies, webhooks and groups in the
         following format::

--- a/otter/test/rest/test_policies.py
+++ b/otter/test/rest/test_policies.py
@@ -48,7 +48,7 @@ class AllPoliciesTestCase(RestAPITestMixin, SynchronousTestCase):
         """
         self.mock_group.list_policies.return_value = defer.succeed([])
         response_body = self.assert_status_code(200)
-        self.mock_group.list_policies.assert_called_once()
+        self.mock_group.list_policies.assert_called_once_with(limit=100)
 
         resp = json.loads(response_body)
         validate(resp, rest_schemas.list_policies_response)
@@ -65,7 +65,7 @@ class AllPoliciesTestCase(RestAPITestMixin, SynchronousTestCase):
         self.mock_group.list_policies.return_value = defer.succeed(
             [dict(id='5', **policy_examples()[0])])
         response_body = self.assert_status_code(200)
-        self.mock_group.list_policies.assert_called_once()
+        self.mock_group.list_policies.assert_called_once_with(limit=100)
 
         resp = json.loads(response_body)
         validate(resp, rest_schemas.list_policies_response)
@@ -110,7 +110,7 @@ class AllPoliciesTestCase(RestAPITestMixin, SynchronousTestCase):
             [dict(id='{}'.format(i), **policy_examples()[0])
              for i in range(1, 102)])
         response_body = self.assert_status_code(200)
-        self.mock_group.list_policies.assert_called_once()
+        self.mock_group.list_policies.assert_called_once_with(limit=100)
 
         resp = json.loads(response_body)
         validate(resp, rest_schemas.list_policies_response)

--- a/otter/test/test_testutils.py
+++ b/otter/test/test_testutils.py
@@ -1,11 +1,11 @@
 """
 Tests for :obj:`otter.test.utils`.
 """
-from otter.test.utils import iMock
-
 from twisted.trial.unittest import SynchronousTestCase
 
 from zope.interface import Attribute, Interface
+
+from otter.test.utils import iMock
 
 
 class _ITest1(Interface):

--- a/otter/test/test_testutils.py
+++ b/otter/test/test_testutils.py
@@ -1,0 +1,152 @@
+"""
+Tests for :obj:`otter.test.utils`.
+"""
+from otter.test.utils import iMock
+
+from twisted.trial.unittest import SynchronousTestCase
+
+from zope.interface import Attribute, Interface
+
+
+class _ITest1(Interface):
+    """I am a interface to be used for testing."""
+
+    first_attribute = Attribute("One attribute")
+
+    def method1(arg1_1, arg1_2, kwarg1_1=None, *args, **kwargs):
+        """method"""
+
+
+class _ITest2(Interface):
+    """I am a interface to be used for testing."""
+
+    second_attribute = Attribute("One attribute")
+
+    def method2(arg2_1, arg2_2, kwarg2_1=None):
+        """method"""
+
+
+class _ITest3(Interface):
+    """I am a interface to be used for testing."""
+
+    spec = Attribute("Funnily-named attribute")
+
+
+class IMockTests(SynchronousTestCase):
+    """
+    Tests for iMock, to ensure it produces a verified (signature-wise, and
+    only 1 level deep) fake.
+    """
+    def test_imock_does_not_include_interface_methods_or_attributes(self):
+        """
+        Mocking an interface produces only the attributes on the interface
+        provided, not attributes on other interfaces and not
+        :class:`Interface`-specific attributes and methods such as
+        :obj:`Interface.providedBy`.
+        """
+        im = iMock(_ITest1)
+        self.assertTrue(callable(im.method1))
+        self.assertFalse(callable(im.first_attribute))
+
+        with self.assertRaises(AttributeError):
+            im.providedBy(im)
+
+        with self.assertRaises(AttributeError):
+            im.second_attribute
+
+    def test_imock_provides_all_the_interfaces_passed_to_it(self):
+        """
+        All the attributes on all the interfaces passed to iMock are specced,
+        and the resultant mock provides the interfaces.
+        """
+        im = iMock(_ITest1, _ITest2)
+        self.assertTrue(_ITest1.providedBy(im))
+        self.assertTrue(_ITest2.providedBy(im))
+        self.assertTrue(callable(im.method1))
+        self.assertTrue(callable(im.method2))
+        self.assertFalse(callable(im.first_attribute))
+        self.assertFalse(callable(im.second_attribute))
+
+    def test_imock_methods_have_right_signature(self):
+        """
+        Passing the wrong number of arguments to methods will raise exceptions.
+        """
+        im = iMock(_ITest1, _ITest2)
+        self.assertRaises(TypeError, im.method1)
+        self.assertRaises(TypeError, 'arg1', callableObj=im.method1)
+        self.assertRaises(TypeError, 'arg1', 'arg2', 'arg3', 'arg4',
+                          callableObj=im.method2)
+        self.assertRaises(TypeError, callableObj=im.method2, arg2_1='good',
+                          arg2_2='good', nonexistant='bad')
+        im.method1('arg1', 'arg2', 'kwarg1', 'any', 'any', any='any')
+        im.method2('arg1', 'arg2')
+        im.method2(arg2_1='arg1', arg2_2='arg2', kwarg2_1='arg3')
+
+    def test_attributes_are_assignable(self):
+        """
+        Attributes can be assigned both after the imock is created, and during
+        creation via kwargs.
+        """
+        im = iMock(_ITest1)
+        im.first_attribute = "first"
+        self.assertEqual(im.first_attribute, "first")
+
+        im = iMock(_ITest1, first_attribute='whoosit')
+        self.assertEqual(im.first_attribute, 'whoosit')
+
+    def test_return_values_are_assignable(self):
+        """
+        Return values can be assigned both after the imock is created, and
+        during creation via kwargs.
+        """
+        im = iMock(_ITest1)
+        im.method1.return_value = 5
+        self.assertEqual(im.method1(1, 2), 5)
+
+        im = iMock(_ITest1, **{'method1.return_value': 'whoosit'})
+        self.assertEqual(im.method1(1, 2), 'whoosit')
+
+    def test_side_effects_are_assignable(self):
+        """
+        Side effects can be assigned both after the imock is created, and
+        during creation via kwargs, and do not interfere with method signature
+        checking.
+        """
+        im = iMock(_ITest1)
+        im.method1.side_effect = lambda *a, **kw: 5
+        self.assertEqual(im.method1(1, 2), 5)
+        self.assertRaises(TypeError, 1, callableObj=im.method1)
+
+        im = iMock(_ITest1, **{'method1.side_effect': lambda *a, **kw: 'meh'})
+        self.assertEqual(im.method1(1, 2), 'meh')
+        self.assertRaises(TypeError, 1, callableObj=im.method1)
+
+    def test_spec_arg_is_ignored_or_passed_to_interface_if_in_attributes(self):
+        """
+        If "spec" is passed, it is either ignored, or if one of the interfaces
+        has "spec" as an attribute, the attribute is set.  Either way, it is
+        not used for speccing a Mock.
+        """
+        spec = ['one', 'two', 'three']
+
+        for args in ([], [_ITest1], [_ITest3]):
+            im = iMock(*args, spec=spec)
+            with self.assertRaises(AttributeError):
+                im.one
+
+        im = iMock(_ITest3, spec=spec)
+        self.assertEqual(im.spec, spec)
+
+    def test_extra_attributes_and_config_passed_to_mock(self):
+        """
+        Any attributes and return values provided to iMock that are not
+        specified by the interface are passed directly to :class:`MagicMock`.
+        They can be ignored (for example if they are method return values for
+        methods not in the original spec) or set on the imock (if they are
+        just attributes)
+        """
+        with self.assertRaises(AttributeError):  # because method2 not in
+            im = iMock(_ITest1, **{'method2.return_value': 'whoosit'})
+
+        im = iMock(_ITest1, another_attribute='what')
+        self.assertEqual(im.another_attribute, 'what')

--- a/otter/test/utils.py
+++ b/otter/test/utils.py
@@ -214,12 +214,7 @@ def iMock(*ifaces, **kwargs):
     directlyProvides(imock, *ifaces)
 
     # autospec all the methods on the interface, and set attributes to None
-    # (just something not callable) - Mock will not do this because methods
-    # defined for an Interface aren't really methods, they're
-    # zopeInterface.interface.interface.Method objects.
-
-    # There are methods and attributes on Interface, but they are specific to
-    # the zope interface library, used by things checking an Interface class.
+    # (just something not callable)
     for iface in ifaces:
         for attr in iface:
             if isinstance(iface[attr], interface.Method):

--- a/otter/test/utils.py
+++ b/otter/test/utils.py
@@ -199,20 +199,18 @@ def iMock(*ifaces, **kwargs):
         as a provider of the interface
     :rtype: :class:``mock.MagicMock``
     """
-    # Interface classes themselves have other methods and attributes related
-    # to them being interfaces - spec the attributes and methods directly
-    all_attributes = [attrname for iface in ifaces for attrname in iface]
+    all_names = [name for iface in ifaces for name in iface.names()]
 
     attribute_kwargs = pmap()
     for k, v in list(kwargs.iteritems()):
         result = k.split('.', 1)
-        if result[0] in all_attributes:
+        if result[0] in all_names:
             attribute_kwargs = attribute_kwargs.set_in(result, v)
             kwargs.pop(k)
 
     kwargs.pop('spec', None)
 
-    imock = mock.MagicMock(spec=all_attributes, **kwargs)
+    imock = mock.MagicMock(spec=all_names, **kwargs)
     directlyProvides(imock, *ifaces)
 
     # autospec all the methods on the interface, and set attributes to None


### PR DESCRIPTION
When working on https://github.com/rackerlabs/otter/pull/1154 @radix discovered that iMock doesn't actually check the signature on the interface methods.

Add some fixes that auto-specs the methods, and also ensures that the attributes are not callable.

After this change, some of the unit tests were broken, so fix them.