### PR TITLE
Use pyrsistent data structures in all the steps

### DIFF
--- a/otter/convergence/steps.py
+++ b/otter/convergence/steps.py
@@ -4,14 +4,16 @@ import re
 
 from functools import partial
 
-from characteristic import attributes
+from characteristic import Attribute, attributes
 
 from effect import Effect, Func
 
-from pyrsistent import pset, thaw
+from pyrsistent import PMap, PSet, pset, thaw
 
 from toolz.dicttoolz import get_in
 from toolz.itertoolz import concat
+
+from twisted.python.constants import NamedConstant
 
 from zope.interface import Interface, implementer
 
@@ -51,7 +53,7 @@ def set_server_name(server_config_args, name_suffix):
 
 
 @implementer(IStep)
-@attributes(['server_config'])
+@attributes([Attribute('server_config', instance_of=PMap)])
 class CreateServer(object):
     """
     A server must be created.
@@ -83,7 +85,7 @@ class CreateServer(object):
 
 
 @implementer(IStep)
-@attributes(['server_id'])
+@attributes([Attribute('server_id', instance_of=str)])
 class DeleteServer(object):
     """
     A server must be deleted.
@@ -109,7 +111,9 @@ class DeleteServer(object):
 
 
 @implementer(IStep)
-@attributes(['server_id', 'key', 'value'])
+@attributes([Attribute('server_id', instance_of=str),
+             Attribute('key', instance_of=str),
+             Attribute('value', instance_of=str)])
 class SetMetadataItemOnServer(object):
     """
     A metadata key/value item must be set on a server.
@@ -166,7 +170,8 @@ def _check_clb_422(*regex_matches):
 
 
 @implementer(IStep)
-@attributes(['lb_id', 'address_configs'])
+@attributes([Attribute('lb_id', instance_of=str),
+             Attribute('address_configs', instance_of=PSet)])
 class AddNodesToCLB(object):
     """
     Multiple nodes must be added to a load balancer.
@@ -208,7 +213,8 @@ class AddNodesToCLB(object):
 
 
 @implementer(IStep)
-@attributes(['lb_id', 'node_ids'])
+@attributes([Attribute('lb_id', instance_of=str),
+             Attribute('node_ids', instance_of=PSet)])
 class RemoveNodesFromCLB(object):
     """
     One or more IPs must be removed from a load balancer.
@@ -274,7 +280,11 @@ def _clb_check_bulk_delete(lb_id, attempted_nodes, result):
 
 
 @implementer(IStep)
-@attributes(['lb_id', 'node_id', 'condition', 'weight', 'type'])
+@attributes([Attribute('lb_id', instance_of=str),
+             Attribute('node_id', instance_of=str),
+             Attribute('condition', instance_of=NamedConstant),
+             Attribute('weight', instance_of=int),
+             Attribute('type', instance_of=NamedConstant)])
 class ChangeCLBNode(object):
     """
     An existing port mapping on a load balancer must have its condition,
@@ -288,7 +298,7 @@ class ChangeCLBNode(object):
             'PUT',
             append_segments('loadbalancers', self.lb_id,
                             'nodes', self.node_id),
-            data={'condition': self.condition,
+            data={'condition': self.condition.name,
                   'weight': self.weight},
             success_pred=has_code(202))
 
@@ -338,7 +348,7 @@ _RCV3_LB_DOESNT_EXIST_PATTERN = _rcv3_re(
 
 
 @implementer(IStep)
-@attributes(['lb_node_pairs'])
+@attributes([Attribute('lb_node_pairs', instance_of=PSet)])
 class BulkAddToRCv3(object):
     """
     Some connections must be made between some combination of servers
@@ -404,7 +414,7 @@ def _rcv3_check_bulk_add(attempted_pairs, result):
 
 
 @implementer(IStep)
-@attributes(['lb_node_pairs'])
+@attributes([Attribute('lb_node_pairs', instance_of=PSet)])
 class BulkRemoveFromRCv3(object):
     """
     Some connections must be removed between some combination of nodes

--- a/otter/test/convergence/test_steps.py
+++ b/otter/test/convergence/test_steps.py
@@ -9,7 +9,11 @@ from pyrsistent import freeze, pset
 from twisted.trial.unittest import SynchronousTestCase
 
 from otter.constants import ServiceType
-from otter.convergence.model import CLBDescription, StepResult
+from otter.convergence.model import (
+    CLBDescription,
+    CLBNodeCondition,
+    CLBNodeType,
+    StepResult)
 from otter.convergence.steps import (
     AddNodesToCLB,
     BulkAddToRCv3,
@@ -26,7 +30,7 @@ from otter.convergence.steps import (
     _rcv3_check_bulk_add,
     _rcv3_check_bulk_delete)
 from otter.http import has_code, service_request
-from otter.test.utils import StubResponse, resolve_effect
+from otter.test.utils import StubResponse, resolve_effect, transform_eq
 from otter.util.hashkey import generate_server_name
 from otter.util.http import APIError
 
@@ -135,9 +139,9 @@ class StepAsEffectTests(SynchronousTestCase):
         changenode = ChangeCLBNode(
             lb_id='abc123',
             node_id='node1',
-            condition='DRAINING',
+            condition=CLBNodeCondition.DRAINING,
             weight=50,
-            type="PRIMARY")
+            type=CLBNodeType.PRIMARY)
         self.assertEqual(
             changenode.as_effect(),
             service_request(
@@ -248,7 +252,7 @@ class StepAsEffectTests(SynchronousTestCase):
         lb_id = "12345"
         node_ids = [str(i) for i in range(5)]
 
-        step = RemoveNodesFromCLB(lb_id=lb_id, node_ids=node_ids)
+        step = RemoveNodesFromCLB(lb_id=lb_id, node_ids=pset(node_ids))
         request = step.as_effect()
         self.assertEqual(
             request.intent,
@@ -256,7 +260,7 @@ class StepAsEffectTests(SynchronousTestCase):
                 ServiceType.CLOUD_LOAD_BALANCERS,
                 'DELETE',
                 "loadbalancers/12345/nodes",
-                params={'id': list(node_ids)},
+                params={'id': transform_eq(sorted, node_ids)},
                 json_response=True,
                 success_pred=ANY).intent)
 
@@ -268,7 +272,7 @@ class StepAsEffectTests(SynchronousTestCase):
         """
         lb_id = "12345"
         node_ids = [str(i) for i in range(5)]
-        step = RemoveNodesFromCLB(lb_id=lb_id, node_ids=node_ids)
+        step = RemoveNodesFromCLB(lb_id=lb_id, node_ids=pset(node_ids))
         request = step.as_effect()
 
         self.assertTrue(request.intent.json_response)
@@ -335,7 +339,7 @@ class StepAsEffectTests(SynchronousTestCase):
             "details": "The object is not valid"
         }
 
-        step = RemoveNodesFromCLB(lb_id=lb_id, node_ids=node_ids)
+        step = RemoveNodesFromCLB(lb_id=lb_id, node_ids=pset(node_ids))
         eff = resolve_effect(step.as_effect(),
                              (StubResponse(400, {}), error_body))
         self.assertEqual(
@@ -344,7 +348,7 @@ class StepAsEffectTests(SynchronousTestCase):
                 ServiceType.CLOUD_LOAD_BALANCERS,
                 'DELETE',
                 'loadbalancers/12345/nodes',
-                params={'id': ['0', '4']},
+                params={'id': transform_eq(sorted, ['0', '4'])},
                 success_pred=ANY,
                 json_response=True).intent)
 

--- a/otter/worker/_rcv3.py
+++ b/otter/worker/_rcv3.py
@@ -9,6 +9,8 @@ from operator import itemgetter
 from effect import Effect
 from effect.twisted import perform
 
+from pyrsistent import s
+
 from otter.convergence.steps import BulkAddToRCv3, BulkRemoveFromRCv3
 from otter.http import TenantScope
 from otter.util.pure_http import has_code
@@ -27,7 +29,7 @@ def _generic_rcv3_request(step_class, request_bag, lb_id, server_id):
         firing with the parsed result of the request, or :data:`None` if the
         request has no body.
     """
-    effect = step_class(lb_node_pairs=[(lb_id, server_id)])._bare_effect()
+    effect = step_class(lb_node_pairs=s((lb_id, server_id)))._bare_effect()
 
     if step_class is BulkAddToRCv3:
         svc_req = effect.intent


### PR DESCRIPTION
Fixes #1151.

Also fixes a discrepancy between what the `ChangeCLBNode` accepted and what planning passed.