### PR TITLE
Update effect_dispatcher to have a bunch more stuff

### DIFF
--- a/otter/effect_dispatcher.py
+++ b/otter/effect_dispatcher.py
@@ -6,6 +6,7 @@ from effect import (
     ComposedDispatcher,
     TypeDispatcher,
     base_dispatcher)
+from effect.ref import reference_dispatcher
 from effect.twisted import make_twisted_dispatcher
 
 from .auth import (
@@ -16,9 +17,10 @@ from .auth import (
 )
 from .http import TenantScope, perform_tenant_scope
 from .models.cass import CQLQueryExecute, perform_cql_query
-from .models.intents import ModifyGroupState, perform_modify_group_state
+from .models.intents import get_model_dispatcher
 from .util.pure_http import Request, perform_request
 from .util.retry import Retry, perform_retry
+from .util.zk import get_zk_dispatcher
 
 
 def get_simple_dispatcher(reactor):
@@ -38,20 +40,33 @@ def get_simple_dispatcher(reactor):
             InvalidateToken: perform_invalidate_token,
             Request: perform_request,
             Retry: perform_retry,
-            ModifyGroupState: perform_modify_group_state,
         }),
         make_twisted_dispatcher(reactor),
+        reference_dispatcher,
     ])
 
 
-def get_full_dispatcher(reactor, authenticator, log, service_config):
+def get_full_dispatcher(reactor, authenticator, log, service_configs,
+                        kz_client, store):
     """
     Return a dispatcher that can perform all of Otter's effects.
     """
     return ComposedDispatcher([
+        get_legacy_dispatcher(reactor, authenticator, log, service_configs),
+        get_zk_dispatcher(kz_client),
+        get_model_dispatcher(log, store),
+    ])
+
+
+def get_legacy_dispatcher(reactor, authenticator, log, service_configs):
+    """
+    Return a dispatcher that can perform effects that are needed by the old
+    worker code.
+    """
+    return ComposedDispatcher([
         TypeDispatcher({
             TenantScope: partial(perform_tenant_scope, authenticator, log,
-                                 service_config)}),
+                                 service_configs)}),
         get_simple_dispatcher(reactor),
     ])
 

--- a/otter/supervisor.py
+++ b/otter/supervisor.py
@@ -12,7 +12,7 @@ from twisted.internet.defer import succeed
 
 from zope.interface import Interface, implementer
 
-from otter.effect_dispatcher import get_full_dispatcher
+from otter.effect_dispatcher import get_legacy_dispatcher
 from otter.log import audit
 from otter.models.interface import NoSuchScalingGroupError
 from otter.undo import InMemoryUndoStack
@@ -104,8 +104,8 @@ class SupervisorService(object, Service):
         HTTP requests.
         """
         tenant_id = scaling_group.tenant_id
-        dispatcher = get_full_dispatcher(reactor, self.authenticator, log,
-                                         self.service_configs)
+        dispatcher = get_legacy_dispatcher(reactor, self.authenticator, log,
+                                           self.service_configs)
         lb_region = config_value('regionOverrides.cloudLoadBalancers')
 
         log.msg("Authenticating for tenant")

--- a/otter/tap/api.py
+++ b/otter/tap/api.py
@@ -197,8 +197,6 @@ def makeService(config):
     service_configs = get_service_configs(config)
 
     authenticator = generate_authenticator(reactor, config['identity'])
-    dispatcher = get_full_dispatcher(reactor, authenticator, log,
-                                     get_service_configs(config))
     supervisor = SupervisorService(authenticator, region, coiterate,
                                    service_configs)
     supervisor.setServiceParent(s)
@@ -260,6 +258,9 @@ def makeService(config):
         d = kz_client.start(timeout=None)
 
         def on_client_ready(_):
+            dispatcher = get_full_dispatcher(reactor, authenticator, log,
+                                             get_service_configs(config),
+                                             kz_client, store)
             # Setup scheduler service after starting
             scheduler = setup_scheduler(s, store, kz_client)
             health_checker.checks['scheduler'] = scheduler.health_check

--- a/otter/test/test_effect_dispatcher.py
+++ b/otter/test/test_effect_dispatcher.py
@@ -49,7 +49,7 @@ class FullDispatcherTests(SynchronousTestCase):
 
     def test_intent_support(self):
         """All intents are supported by the dispatcher."""
-        dispatcher = get_full_dispatcher(None, None, None, None)
+        dispatcher = get_full_dispatcher(None, None, None, None, None, None)
         for intent in all_intents():
             self.assertIsNot(dispatcher(intent), None)
 
@@ -58,7 +58,7 @@ class FullDispatcherTests(SynchronousTestCase):
         # This is not testing much, but at least that it calls
         # perform_tenant_scope in a vaguely working manner. There are
         # more specific TenantScope performer tests in otter.test.test_http
-        dispatcher = get_full_dispatcher(None, None, None, None)
+        dispatcher = get_full_dispatcher(None, None, None, None, None, None)
         scope = TenantScope(Effect(Constant('foo')), 1)
         eff = Effect(scope)
         self.assertEqual(sync_perform(dispatcher, eff), 'foo')

--- a/otter/test/test_effect_dispatcher.py
+++ b/otter/test/test_effect_dispatcher.py
@@ -47,6 +47,11 @@ def full_intents():
 
 
 class IntentSupportMixin(object):
+    """
+    Mixin for testing dispatchers. Subclasses must define ``get_dispatcher``
+    and ``get_intents``.
+    """
+
     def test_intent_support(self):
         """Pretty basic intents have performers in the dispatcher."""
         dispatcher = self.get_dispatcher()

--- a/otter/test/test_effect_dispatcher.py
+++ b/otter/test/test_effect_dispatcher.py
@@ -1,6 +1,7 @@
 """Tests for :module:`otter.effect_dispatcher`."""
 
 from effect import Constant, Delay, Effect, sync_perform
+from effect.ref import ReadReference, Reference
 from effect.twisted import deferred_performer
 
 import mock
@@ -10,11 +11,14 @@ from twisted.trial.unittest import SynchronousTestCase
 
 from otter.auth import Authenticate, InvalidateToken
 from otter.effect_dispatcher import (
-    get_cql_dispatcher, get_full_dispatcher, get_simple_dispatcher)
+    get_cql_dispatcher, get_full_dispatcher, get_legacy_dispatcher,
+    get_simple_dispatcher)
 from otter.http import TenantScope
 from otter.models.cass import CQLQueryExecute
+from otter.models.intents import GetScalingGroupInfo
 from otter.util.pure_http import Request
 from otter.util.retry import Retry
+from otter.util.zk import CreateOrSet
 
 
 def simple_intents():
@@ -25,33 +29,49 @@ def simple_intents():
         Retry(effect=Effect(Constant(None)), should_retry=lambda e: False),
         Delay(0),
         Constant(None),
+        ReadReference(ref=Reference(None)),
     ]
 
 
-def all_intents():
+def legacy_intents():
     return simple_intents() + [
         TenantScope(Effect(Constant(None)), 1)
     ]
 
 
-class SimpleDispatcherTests(SynchronousTestCase):
-    """Tests for :func:`get_simple_dispatcher"""
+def full_intents():
+    return legacy_intents() + [
+        CreateOrSet(path='foo', content='bar'),
+        GetScalingGroupInfo(tenant_id='foo', group_id='bar')
+    ]
 
+
+class IntentSupportMixin(object):
     def test_intent_support(self):
         """Pretty basic intents have performers in the dispatcher."""
-        dispatcher = get_simple_dispatcher(None)
-        for intent in simple_intents():
+        dispatcher = self.get_dispatcher()
+        for intent in self.get_intents():
             self.assertIsNot(dispatcher(intent), None)
 
 
-class FullDispatcherTests(SynchronousTestCase):
-    """Tests for :func:`get_full_dispatcher`."""
+class SimpleDispatcherTests(SynchronousTestCase, IntentSupportMixin):
+    """Tests for :func:`get_simple_dispatcher"""
 
-    def test_intent_support(self):
-        """All intents are supported by the dispatcher."""
-        dispatcher = get_full_dispatcher(None, None, None, None, None, None)
-        for intent in all_intents():
-            self.assertIsNot(dispatcher(intent), None)
+    def get_dispatcher(self):
+        return get_simple_dispatcher(None)
+
+    def get_intents(self):
+        return simple_intents()
+
+
+class LegacyDispatcherTests(SynchronousTestCase, IntentSupportMixin):
+    """Tests for :func:`get_legacy_dispatcher`."""
+
+    def get_dispatcher(self):
+        return get_legacy_dispatcher(None, None, None, None)
+
+    def get_intents(self):
+        return legacy_intents()
 
     def test_tenant_scope(self):
         """The :obj:`TenantScope` performer passes through to child effects."""
@@ -62,6 +82,16 @@ class FullDispatcherTests(SynchronousTestCase):
         scope = TenantScope(Effect(Constant('foo')), 1)
         eff = Effect(scope)
         self.assertEqual(sync_perform(dispatcher, eff), 'foo')
+
+
+class FullDispatcherTests(SynchronousTestCase, IntentSupportMixin):
+    """Tests for :func:`get_full_dispatcher`."""
+
+    def get_dispatcher(self):
+        return get_full_dispatcher(None, None, None, None, None, None)
+
+    def get_intents(self):
+        return full_intents()
 
 
 class CQLDispatcherTests(SynchronousTestCase):

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ jsonfig==0.1.1
 testtools==0.9.32
 croniter==0.3.5
 txkazoo==0.0.5
-effect==0.1a12
+effect==0.1a14
 characteristic==14.3.0
 toolz==0.7.1
 pyrsistent==0.7.0


### PR DESCRIPTION
- ZK dispatcher from otter.util.zk
- model dispatcher from otter.models.intents
- reference dispatcher from effect

also adds a get_legacy_dispatcher for use in supervisor, which doesn't need the new stuff.