### PR TITLE
StepResults in SetMetadataItem and AddNodesToCLB

### DIFF
--- a/otter/convergence/steps.py
+++ b/otter/convergence/steps.py
@@ -275,7 +275,7 @@ class AddNodesToCLB(object):
 
     def as_effect(self):
         """Produce a :obj:`Effect` to add nodes to CLB"""
-        return service_request(
+        eff = service_request(
             ServiceType.CLOUD_LOAD_BALANCERS,
             'POST',
             append_segments('loadbalancers', str(self.lb_id), "nodes"),
@@ -288,6 +288,14 @@ class AddNodesToCLB(object):
                 has_code(202, 413),
                 _check_clb_422(_CLB_DUPLICATE_NODES_PATTERN,
                                _CLB_PENDING_UPDATE_PATTERN)))
+
+        def report_success(result):
+            return StepResult.SUCCESS, []
+
+        def report_failure(result):
+            return StepResult.FAILURE, []
+
+        return eff.on(success=report_success, error=report_failure)
 
 
 @implementer(IStep)

--- a/otter/convergence/steps.py
+++ b/otter/convergence/steps.py
@@ -210,7 +210,7 @@ class SetMetadataItemOnServer(object):
             return StepResult.SUCCESS, []
 
         def report_failure(result):
-            return StepResult.RETRY, []
+            return StepResult.RETRY, [result[1]]
 
         return eff.on(success=report_success, error=report_failure)
 
@@ -304,14 +304,14 @@ class AddNodesToCLB(object):
             err_type, error, traceback = result
             if err_type == APIError and error.code == 413:
                 # over-limit, retry
-                return StepResult.RETRY, []
+                return StepResult.RETRY, [error]
             if err_type == APIError and error.code == 422:
                 # body has already become JSON
                 message = error.body.get("message", None)
                 if message and _CLB_PENDING_UPDATE_PATTERN.search(message):
-                    return StepResult.RETRY, []
+                    return StepResult.RETRY, [error]
 
-            return StepResult.FAILURE, []
+            return StepResult.FAILURE, [error]
 
         return eff.on(success=report_success, error=report_failure)
 

--- a/otter/convergence/steps.py
+++ b/otter/convergence/steps.py
@@ -291,7 +291,7 @@ class AddNodesToCLB(object):
                              'type': lbc.type.name}
                             for address, lbc in self.address_configs]},
             success_pred=predicate_any(
-                has_code(202, 413),
+                has_code(202),
                 _check_clb_422(_CLB_DUPLICATE_NODES_PATTERN)))
 
         def report_success(result):
@@ -302,6 +302,9 @@ class AddNodesToCLB(object):
             If the error is a 422 - PENDING UPDATE, retry.  Otherwise, fail.
             """
             err_type, error, traceback = result
+            if err_type == APIError and error.code == 413:
+                # over-limit, retry
+                return StepResult.RETRY, []
             if err_type == APIError and error.code == 422:
                 # body has already become JSON
                 message = error.body.get("message", None)

--- a/otter/convergence/steps.py
+++ b/otter/convergence/steps.py
@@ -137,9 +137,10 @@ class CreateServer(object):
 
         def report_failure(result):
             """
-            If the failure is an APIError with a 400 or 403, attempt to parse
-            the results and return a :obj:`StepResult.FAILURE` - if the errors
-            are unrecognized, return a :obj:`StepResult.RETRY` for now.
+            If the failure is an APIError with a recognized user error,
+            return a :obj:`StepResult.FAILURE` along with that user error as
+            a message, otherwise return a :obj:`StepResult.RETRY` without
+            a message.
             """
             err_type, error, traceback = result
             if err_type == APIError:

--- a/otter/test/convergence/test_steps.py
+++ b/otter/test/convergence/test_steps.py
@@ -427,8 +427,7 @@ class StepAsEffectTests(SynchronousTestCase):
 
         self.assertEqual(get_result(StubResponse(202, {}), ''),
                          (StepResult.SUCCESS, []))
-        self.assertEqual(get_result(StubResponse(413, {}), ''),
-                         (StepResult.SUCCESS, []))
+
         self.assertEqual(
             get_result(
                 StubResponse(422, {}),
@@ -458,7 +457,7 @@ class StepAsEffectTests(SynchronousTestCase):
                 }),
                 request)
 
-        # Retry on pending update
+        # Retry on pending update or on over-limit
         self.assertEqual(
             get_result(
                 StubResponse(422, {}),
@@ -468,6 +467,9 @@ class StepAsEffectTests(SynchronousTestCase):
                     "code": 422
                 }),
             (StepResult.RETRY, []))
+
+        self.assertEqual(get_result(StubResponse(413, {}), ''),
+                         (StepResult.RETRY, []))
 
         # Fail on everything else
         self.assertEqual(get_result(StubResponse(404, {}), ''),

--- a/otter/test/convergence/test_steps.py
+++ b/otter/test/convergence/test_steps.py
@@ -1,8 +1,7 @@
 """Tests for convergence steps."""
 import json
 
-from effect import Func, sync_perform
-from effect.testing import EQDispatcher
+from effect import Func, TypeDispatcher, sync_perform
 
 from mock import ANY
 
@@ -27,8 +26,11 @@ from otter.convergence.steps import (
     _RCV3_NODE_NOT_A_MEMBER_PATTERN,
     _rcv3_check_bulk_add,
     _rcv3_check_bulk_delete)
-from otter.http import has_code, service_request
-from otter.test.utils import StubResponse, resolve_effect
+from otter.http import ServiceRequest, has_code, service_request
+from otter.test.utils import (
+    StubResponse,
+    get_fake_service_request_performer,
+    resolve_effect)
 from otter.util.hashkey import generate_server_name
 from otter.util.http import APIError
 
@@ -401,17 +403,7 @@ class StepAsEffectTests(SynchronousTestCase):
              'weight': 1}
         ])
 
-        self.assertEqual(
-            resolve_effect(request, (None, {})),
-            (StepResult.SUCCESS, []))
-
-        self.assertEqual(
-            resolve_effect(request,
-                           (APIError, APIError(500, None, None), None),
-                           is_error=True),
-            (StepResult.FAILURE, []))
-
-    def test_add_nodes_to_clb_predicate(self):
+    def test_add_nodes_to_clb_success_response_codes(self):
         """
         :obj:`AddNodesToCLB` only accepts 202, 413, and some 422 responses.
         """
@@ -420,84 +412,81 @@ class StepAsEffectTests(SynchronousTestCase):
         step = AddNodesToCLB(lb_id=lb_id, address_configs=lb_nodes)
         request = step.as_effect()
 
-        self.assertTrue(request.intent.json_response)
+        def get_result(response, body):
+            return sync_perform(
+                TypeDispatcher({
+                    ServiceRequest:
+                    get_fake_service_request_performer((response, body))
+                }),
+                request)
 
-        predicate = request.intent.success_pred
+        self.assertEqual(get_result(StubResponse(202, {}), ''),
+                         (StepResult.SUCCESS, []))
+        self.assertEqual(get_result(StubResponse(413, {}), ''),
+                         (StepResult.SUCCESS, []))
+        self.assertEqual(
+            get_result(
+                StubResponse(422, {}),
+                {
+                    "message": "Duplicate nodes detected. One or more "
+                               "nodes already configured on load "
+                               "balancer.",
+                    "code": 422
+                }),
+            (StepResult.SUCCESS, []))
 
         self.assertEqual(
-            resolve_effect(request,
-                           (APIError, APIError(422, None, None), None),
-                           is_error=True),
-            (StepResult.FAILURE, []))
+            get_result(
+                StubResponse(422, {}),
+                {
+                    "message": "Load Balancer '12345' has a status of "
+                               "'PENDING_UPDATE' and is considered immutable.",
+                    "code": 422
+                }),
+            (StepResult.SUCCESS, []))
 
-        self.assertTrue(predicate(StubResponse(202, {}), None))
-        self.assertTrue(predicate(StubResponse(413, {}), None))
-        self.assertTrue(predicate(
-            StubResponse(422, {}),
-            {
-                "message": "Duplicate nodes detected. One or more "
-                           "nodes already configured on load "
-                           "balancer.",
-                "code": 422
-            }))
-        self.assertTrue(predicate(
-            StubResponse(422, {}),
-            {
-                "message": "Load Balancer '12345' has a status of "
-                           "'PENDING_UPDATE' and is considered immutable.",
-                "code": 422
-            }))
-
-        self.assertFalse(predicate(StubResponse(404, {}), None))
-        self.assertFalse(predicate(
-            StubResponse(422, {}),
-            {
-                "message": "The load balancer is deleted and considered "
-                           "immutable.",
-                "code": 422
-            }))
-        self.assertFalse(predicate(
-            StubResponse(422, {}),
-            {
-                "message": "Load Balancer '{0}' has a status of "
-                           "'PENDING_DELETE' and is considered immutable."
-                           .format(lb_id),
-                "code": 422
-            }))
-
-    def test_add_nodes_to_clb_422_success_and_failures(self):
+    def test_add_nodes_to_clb_failure_response_codes(self):
         """
-        :obj:`AddNodesToCLB` returns SUCCESS on recognized 422 failures, and
-        FAILURE on unrecognized 422 failures.
+        :obj:`AddNodesToCLB` fails on non-202, non-413, and non-422 recognized
+        response codes.
         """
         lb_id = "12345"
         lb_nodes = pset([('1.2.3.4', CLBDescription(lb_id=lb_id, port=80))])
         step = AddNodesToCLB(lb_id=lb_id, address_configs=lb_nodes)
-        eff = step.as_effect()
+        request = step.as_effect()
 
-        bad_response = ("Load Balancer '12345' has a status of "
-                        "'PENDING_DELETE' and is considered immutable.")
-        good_response = ("Load Balancer '12345' has a status of "
-                         "'PENDING_UPDATE' and is considered immutable.")
+        def get_result(response, body):
+            return sync_perform(
+                TypeDispatcher({
+                    ServiceRequest:
+                    get_fake_service_request_performer((response, body))
+                }),
+                request)
+
+        self.assertEqual(get_result(StubResponse(404, {}), ''),
+                         (StepResult.FAILURE, []))
+
+        self.assertEqual(get_result(StubResponse(400, {}), ''),
+                         (StepResult.FAILURE, []))
 
         self.assertEqual(
-            sync_perform(
-                EQDispatcher([(
-                    eff.intent,
-                    (StubResponse(422, {}),
-                     {'message': good_response, 'code': 422})
-                )]),
-                eff),
-            (StepResult.SUCCESS, []))
+            get_result(
+                StubResponse(422, {}),
+                {
+                    "message": "The load balancer is deleted and considered "
+                               "immutable.",
+                    "code": 422
+                }),
+            (StepResult.FAILURE, []))
 
         self.assertEqual(
-            sync_perform(
-                EQDispatcher([(
-                    eff.intent,
-                    (StubResponse(422, {}),
-                     {'message': bad_response, 'code': 422})
-                )]),
-                eff),
+            get_result(
+                StubResponse(422, {}),
+                {
+                    "message": "Load Balancer '12345' has a status of "
+                               "'PENDING_DELETE' and is considered immutable.",
+                    "code": 422
+                }),
             (StepResult.FAILURE, []))
 
     def test_remove_nodes_from_clb(self):

--- a/otter/test/utils.py
+++ b/otter/test/utils.py
@@ -726,7 +726,7 @@ def get_fake_service_request_performer(stub_response):
     if not isinstance(stub_response, basestring):
         try:
             stub_response = (stub_response[0], json.dumps(stub_response[-1]))
-        except:
+        except TypeError:
             stub_response = (stub_response[0], str(stub_response[-1]))
 
     @sync_performer

--- a/otter/test/utils.py
+++ b/otter/test/utils.py
@@ -6,7 +6,7 @@ import os
 from functools import partial, wraps
 from inspect import getargspec
 
-from effect import base_dispatcher
+from effect import base_dispatcher, sync_performer
 from effect.testing import (
     resolve_effect as eff_resolve_effect,
     resolve_stubs as eff_resolve_stubs)
@@ -27,6 +27,7 @@ from twisted.python.failure import Failure
 from zope.interface import directlyProvides, implementer, interface
 from zope.interface.verify import verifyObject
 
+from otter.http import concretize_service_request
 from otter.log.bound import BoundLog
 from otter.models.interface import IScalingGroup
 from otter.supervisor import ISupervisor
@@ -711,3 +712,41 @@ def transform_eq(transformer, rhs):
             return not self == other
 
     return Foo()
+
+
+def get_fake_service_request_performer(stub_response):
+    """
+    For sanity's sake, attempt to fake performing a service request, including
+    predicate handlers, so we can also test the predicate handlers.
+
+    :param service_request: the :class:`ServiceRequest` to "perform"
+    :param stub_response: a tuple of (:class:`StubResponse`, string body),
+        supposedly the "response" of an http request
+    """
+    if not isinstance(stub_response, basestring):
+        try:
+            stub_response = (stub_response[0], json.dumps(stub_response[-1]))
+        except:
+            stub_response = (stub_response[0], str(stub_response[-1]))
+
+    @sync_performer
+    def the_performer(_, service_request_intent):
+        service_configs = mock.MagicMock()
+        service_configs.__getitem__.return_value = {
+            'name': 'service_name',
+            'region': 'region',
+            'url': 'http://url'
+        }
+        eff = concretize_service_request(
+            authenticator=mock.MagicMock(),
+            log=mock.MagicMock(),
+            service_configs=service_configs,
+            tenant_id='000000',
+            service_request=service_request_intent)
+
+        # "authenticate"
+        eff = resolve_effect(eff, ('token', []))
+        # make request
+        return resolve_effect(eff, stub_response)
+
+    return the_performer


### PR DESCRIPTION
Fixes #1169 and #1170.

Modifies the tests to test for the StepResult as the final result.