### PR TITLE
Change instance_of=str to instance_of=basestring in models and steps

### DIFF
--- a/otter/convergence/model.py
+++ b/otter/convergence/model.py
@@ -377,7 +377,7 @@ class IDrainable(Interface):
 
 
 @implementer(ILBDescription)
-@attributes([Attribute("lb_id", instance_of=str),
+@attributes([Attribute("lb_id", instance_of=basestring),
              Attribute("port", instance_of=int),
              Attribute("weight", default_value=1, instance_of=int),
              Attribute("condition", default_value=CLBNodeCondition.ENABLED,
@@ -416,9 +416,9 @@ class CLBDescription(object):
 
 
 @implementer(ILBNode, IDrainable)
-@attributes([Attribute("node_id", instance_of=str),
+@attributes([Attribute("node_id", instance_of=basestring),
              Attribute("description", instance_of=CLBDescription),
-             Attribute("address", instance_of=str),
+             Attribute("address", instance_of=basestring),
              Attribute("drained_at", default_value=0.0, instance_of=float),
              Attribute("connections", default_value=None)])
 class CLBNode(object):
@@ -467,7 +467,7 @@ class CLBNode(object):
 
 
 @implementer(ILBDescription)
-@attributes([Attribute("lb_id", instance_of=str)])
+@attributes([Attribute("lb_id", instance_of=basestring)])
 class RCv3Description(object):
     """
     Information representing a RackConnect V3/server mapping: how a particular
@@ -489,9 +489,9 @@ class RCv3Description(object):
 
 
 @implementer(ILBNode)
-@attributes([Attribute("node_id", instance_of=str),
+@attributes([Attribute("node_id", instance_of=basestring),
              Attribute("description", instance_of=RCv3Description),
-             Attribute("cloud_server_id", instance_of=str)])
+             Attribute("cloud_server_id", instance_of=basestring)])
 class RCv3Node(object):
     """
     A RackConnect V3 node.

--- a/otter/convergence/steps.py
+++ b/otter/convergence/steps.py
@@ -156,7 +156,7 @@ class CreateServer(object):
 
 
 @implementer(IStep)
-@attributes([Attribute('server_id', instance_of=str)])
+@attributes([Attribute('server_id', instance_of=basestring)])
 class DeleteServer(object):
     """
     A server must be deleted.
@@ -182,9 +182,9 @@ class DeleteServer(object):
 
 
 @implementer(IStep)
-@attributes([Attribute('server_id', instance_of=str),
-             Attribute('key', instance_of=str),
-             Attribute('value', instance_of=str)])
+@attributes([Attribute('server_id', instance_of=basestring),
+             Attribute('key', instance_of=basestring),
+             Attribute('value', instance_of=basestring)])
 class SetMetadataItemOnServer(object):
     """
     A metadata key/value item must be set on a server.
@@ -241,7 +241,7 @@ def _check_clb_422(*regex_matches):
 
 
 @implementer(IStep)
-@attributes([Attribute('lb_id', instance_of=str),
+@attributes([Attribute('lb_id', instance_of=basestring),
              Attribute('address_configs', instance_of=PSet)])
 class AddNodesToCLB(object):
     """
@@ -284,7 +284,7 @@ class AddNodesToCLB(object):
 
 
 @implementer(IStep)
-@attributes([Attribute('lb_id', instance_of=str),
+@attributes([Attribute('lb_id', instance_of=basestring),
              Attribute('node_ids', instance_of=PSet)])
 class RemoveNodesFromCLB(object):
     """
@@ -351,8 +351,8 @@ def _clb_check_bulk_delete(lb_id, attempted_nodes, result):
 
 
 @implementer(IStep)
-@attributes([Attribute('lb_id', instance_of=str),
-             Attribute('node_id', instance_of=str),
+@attributes([Attribute('lb_id', instance_of=basestring),
+             Attribute('node_id', instance_of=basestring),
              Attribute('condition', instance_of=NamedConstant),
              Attribute('weight', instance_of=int),
              Attribute('type', instance_of=NamedConstant)])


### PR DESCRIPTION
Since a lot of this will come from unicode JSON bodies of previous requests.  Not sure if this fixes #1165, but it does get rid of some of the tracebacks when running functional tests.