### PR TITLE
Hopefully make a scheduler test less flaky

### DIFF
--- a/autoscale_cloudroast/test_repo/autoscale/fixtures.py
+++ b/autoscale_cloudroast/test_repo/autoscale/fixtures.py
@@ -407,23 +407,28 @@ class AutoscaleFixture(BaseTestFixture):
                     api=api, asserter=self))
 
     def wait_for_expected_group_state(self, group_id, expected_servers,
-                                      wait_time=180):
+                                      wait_time=180, interval=None):
         """
         :summary: verify the group state reached the expected servers count.
         :param group_id: Group id
         :param expected_servers: Number of servers expected
         """
+        if interval is None:
+            interval = self.interval_time
+
         end_time = time.time() + wait_time
         while time.time() < end_time:
-            group_state = self.autoscale_client.list_status_entities_sgroups(group_id).entity
+            group_state = self.autoscale_client.list_status_entities_sgroups(
+                group_id).entity
             if group_state.desiredCapacity == expected_servers:
                 return
-            time.sleep(self.interval_time)
+            time.sleep(interval)
         else:
             self.fail(
-                "wait_for_exepected_group_state ran for 180 seconds for group {0} and did not "
-                "observe the active server list achieving the expected servers count: {1}.".format(
-                    group_id, expected_servers))
+                "wait_for_exepected_group_state ran for 180 seconds for group "
+                "{0} and did not observe the active server list achieving the "
+                "expected servers count: {1}.  Got {2} instead.".format(
+                    group_id, expected_servers, group_state.desiredCapacity))
 
     def check_for_expected_number_of_building_servers(
         self, group_id, expected_servers,

--- a/autoscale_cloudroast/test_repo/autoscale/fixtures.py
+++ b/autoscale_cloudroast/test_repo/autoscale/fixtures.py
@@ -425,10 +425,11 @@ class AutoscaleFixture(BaseTestFixture):
             time.sleep(interval)
         else:
             self.fail(
-                "wait_for_exepected_group_state ran for 180 seconds for group "
-                "{0} and did not observe the active server list achieving the "
-                "expected servers count: {1}.  Got {2} instead.".format(
-                    group_id, expected_servers, group_state.desiredCapacity))
+                "wait_for_exepected_group_state ran for {0} seconds for group "
+                "{1} and did not observe the active server list achieving the "
+                "expected servers count: {2}.  Got {3} instead.".format(
+                    interval, group_id, expected_servers,
+                    group_state.desiredCapacity))
 
     def check_for_expected_number_of_building_servers(
         self, group_id, expected_servers,

--- a/autoscale_cloudroast/test_repo/autoscale/system/schedule_policies/test_system_update_scheduler.py
+++ b/autoscale_cloudroast/test_repo/autoscale/system/schedule_policies/test_system_update_scheduler.py
@@ -120,7 +120,7 @@ class UpdateSchedulerTests(AutoscaleFixture):
             sp_cooldown=0)
         self.wait_for_expected_group_state(
             self.group.id, self.group.groupConfiguration.minEntities + 1,
-            60 + self.scheduler_interval)
+            60 + self.scheduler_interval, 2)
         self._update_policy(
             self.group.id, cron_style_policy, self.cron_policy_args,
             change_value=2)


### PR DESCRIPTION
As per the issue, wait for a policy execution before updating the policy on this scheduled policy test, since it's possible that the policy executed before the policy gets updated.

Fixes #1100, hopefully.  @manishtomar?