### PR TITLE
Add a throttling observer wrapper to drastically reduce the amount of log spam

### DIFF
--- a/otter/log/setup.py
+++ b/otter/log/setup.py
@@ -10,7 +10,8 @@ from otter.log.formatters import (
     ObserverWrapper,
     PEP3101FormattingWrapper,
     StreamObserverWrapper,
-    SystemFilterWrapper
+    SystemFilterWrapper,
+    ThrottlingWrapper,
 )
 
 
@@ -18,15 +19,16 @@ def make_observer_chain(ultimate_observer, indent):
     """
     Return our feature observers wrapped our the ultimate_observer
     """
-    return PEP3101FormattingWrapper(
-        SystemFilterWrapper(
-            ErrorFormattingWrapper(
-                ObserverWrapper(
-                    JSONObserverWrapper(
-                        ultimate_observer,
-                        sort_keys=True,
-                        indent=indent or None),
-                    hostname=socket.gethostname()))))
+    return ThrottlingWrapper(
+        PEP3101FormattingWrapper(
+            SystemFilterWrapper(
+                ErrorFormattingWrapper(
+                    ObserverWrapper(
+                        JSONObserverWrapper(
+                            ultimate_observer,
+                            sort_keys=True,
+                            indent=indent or None),
+                        hostname=socket.gethostname())))))
 
 
 def observer_factory():

--- a/otter/log/setup.py
+++ b/otter/log/setup.py
@@ -11,7 +11,7 @@ from otter.log.formatters import (
     PEP3101FormattingWrapper,
     StreamObserverWrapper,
     SystemFilterWrapper,
-    ThrottlingWrapper,
+    throttling_wrapper,
 )
 
 
@@ -19,7 +19,7 @@ def make_observer_chain(ultimate_observer, indent):
     """
     Return our feature observers wrapped our the ultimate_observer
     """
-    return ThrottlingWrapper(
+    return throttling_wrapper(
         PEP3101FormattingWrapper(
             SystemFilterWrapper(
                 ErrorFormattingWrapper(


### PR DESCRIPTION
This fixes #1193.

This introduces a general throttling wrapper and adds throttling for three messages:

- sending ping to ZK
- received successful ping response from ZK
- fetching events from cassandra

It will wait for 50 events before letting a message through (which is actually not very long)