### PR TITLE
error details are logged

### DIFF
--- a/otter/log/formatters.py
+++ b/otter/log/formatters.py
@@ -261,7 +261,7 @@ def ErrorFormattingWrapper(observer):
                 message = repr(excp)
                 event['traceback'] = event['failure'].getTraceback()
                 event['exception_type'] = excp.__class__.__name__
-                details = getattr(excp, 'details', None)
+                details = serialize_exception(excp)
                 if details is not None:
                     event['error_details'] = details
 

--- a/otter/log/formatters.py
+++ b/otter/log/formatters.py
@@ -9,6 +9,8 @@ from pyrsistent import pmap
 
 from singledispatch import singledispatch
 
+from toolz.functoolz import identity
+
 from twisted.python.failure import Failure
 
 
@@ -247,12 +249,9 @@ def serialize_to_jsonable(obj):
     return None
 
 
-@serialize_to_jsonable.register(basestring)
-def serialize_str(s):
-    """
-    Serialize string
-    """
-    return s
+# serialize base types
+for t in (list, tuple, basestring, int, float, long):
+    serialize_to_jsonable.register(t, identity)
 
 
 def ErrorFormattingWrapper(observer):

--- a/otter/log/formatters.py
+++ b/otter/log/formatters.py
@@ -272,7 +272,7 @@ def ErrorFormattingWrapper(observer):
                 event['traceback'] = event['failure'].getTraceback()
                 event['exception_type'] = excp.__class__.__name__
                 details = serialize_to_jsonable(excp)
-                if details != repr(excp):
+                if details != message:
                     event['error_details'] = details
 
             if 'why' in event and event['why']:

--- a/otter/log/formatters.py
+++ b/otter/log/formatters.py
@@ -261,6 +261,9 @@ def ErrorFormattingWrapper(observer):
                 message = repr(excp)
                 event['traceback'] = event['failure'].getTraceback()
                 event['exception_type'] = excp.__class__.__name__
+                details = getattr(excp, 'details', None)
+                if details is not None:
+                    event['error_details'] = details
 
             if 'why' in event and event['why']:
                 message = '{0}: {1}'.format(event['why'], message)

--- a/otter/log/formatters.py
+++ b/otter/log/formatters.py
@@ -9,8 +9,6 @@ from pyrsistent import pmap
 
 from singledispatch import singledispatch
 
-from toolz.functoolz import identity
-
 from twisted.python.failure import Failure
 
 
@@ -246,12 +244,7 @@ def serialize_to_jsonable(obj):
     """
     Serialize any object to a JSONable form
     """
-    return None
-
-
-# serialize base types
-for t in (list, tuple, basestring, int, float, long):
-    serialize_to_jsonable.register(t, identity)
+    return repr(obj)
 
 
 def ErrorFormattingWrapper(observer):
@@ -279,7 +272,7 @@ def ErrorFormattingWrapper(observer):
                 event['traceback'] = event['failure'].getTraceback()
                 event['exception_type'] = excp.__class__.__name__
                 details = serialize_to_jsonable(excp)
-                if details is not None:
+                if details != repr(excp):
                     event['error_details'] = details
 
             if 'why' in event and event['why']:

--- a/otter/log/formatters.py
+++ b/otter/log/formatters.py
@@ -7,6 +7,8 @@ from datetime import datetime
 
 from pyrsistent import pmap
 
+from singledispatch import singledispatch
+
 from twisted.python.failure import Failure
 
 
@@ -237,6 +239,22 @@ def audit_log_formatter(eventDict, timestamp, hostname):
     return audit_log_params
 
 
+@singledispatch
+def serialize_to_jsonable(obj):
+    """
+    Serialize any object to a JSONable form
+    """
+    return None
+
+
+@serialize_to_jsonable.register(basestring)
+def serialize_str(s):
+    """
+    Serialize string
+    """
+    return s
+
+
 def ErrorFormattingWrapper(observer):
     """
     Return log observer that will format error if any and delegate it to
@@ -261,7 +279,7 @@ def ErrorFormattingWrapper(observer):
                 message = repr(excp)
                 event['traceback'] = event['failure'].getTraceback()
                 event['exception_type'] = excp.__class__.__name__
-                details = serialize_exception(excp)
+                details = serialize_to_jsonable(excp)
                 if details is not None:
                     event['error_details'] = details
 

--- a/otter/test/log/test_log.py
+++ b/otter/test/log/test_log.py
@@ -454,8 +454,6 @@ class ErrorFormatterTests(SynchronousTestCase):
             matches(ContainsDict({'error_details': Equals(err.details)})))
 
 
-
-
 class ObserverWrapperTests(SynchronousTestCase):
     """
     Test the ObserverWrapper.

--- a/otter/test/log/test_log.py
+++ b/otter/test/log/test_log.py
@@ -442,6 +442,19 @@ class ErrorFormatterTests(SynchronousTestCase):
              'traceback': failure.getTraceback(),
              'exception_type': 'ValueError'})
 
+    def test_details(self):
+        """
+        If exception has details property, it is extracted and logged as
+        "error_details"
+        """
+        err = ValueError('heh')
+        err.details = {'a': 2, 'b': 2}
+        self.wrapper({'message': (), 'isError': True, 'failure': Failure(err)})
+        self.observer.assert_called_once_with(
+            matches(ContainsDict({'error_details': Equals(err.details)})))
+
+
+
 
 class ObserverWrapperTests(SynchronousTestCase):
     """

--- a/otter/util/http.py
+++ b/otter/util/http.py
@@ -9,6 +9,7 @@ from urlparse import urlsplit, urlunsplit, parse_qs
 
 import treq
 
+from otter.log.formatters import serialize_to_jsonable
 from otter.util.config import config_value
 
 
@@ -110,6 +111,14 @@ class UpstreamError(Exception):
             d.update({'code': e.code, 'message': self.apierr_message, 'body': e.body,
                       'headers': e.headers})
         return d
+
+
+@serialize_to_jsonable.register(UpstreamError)
+def serialize_upstream_exception(upstream_error):
+    """
+    Serialize UpstreamError
+    """
+    return upstream_error.details
 
 
 def wrap_upstream_error(f, system, operation, url=None):

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ effect==0.1a14
 characteristic==14.3.0
 toolz==0.7.1
 pyrsistent==0.7.0
+singledispatch==3.4.0.3


### PR DESCRIPTION
If exception object has `details` property, it is extracted and logged as `error_details`