### PR TITLE
Rename otter.http to otter.cloud_client

### DIFF
--- a/otter/cloud_client.py
+++ b/otter/cloud_client.py
@@ -110,9 +110,9 @@ class ServiceRequest(object):
         # numbers, too. It's also not *thin* enough, since this will allow
         # lists and dicts of *anything*. But it's a good approximation of what
         # rackspace/openstack services can return.
-        return (isinstance(result, tuple)
-                and isinstance(result[1],
-                               (dict, list) if self.json_response else str))
+        return (isinstance(result, tuple) and
+                isinstance(result[1],
+                           (dict, list) if self.json_response else str))
 
 
 @attributes(['effect', 'tenant_id'], apply_with_init=False)

--- a/otter/convergence/gathering.py
+++ b/otter/convergence/gathering.py
@@ -10,6 +10,7 @@ from toolz.functoolz import compose, identity
 from toolz.itertoolz import concat
 
 from otter.auth import NoSuchEndpoint
+from otter.cloud_client import service_request
 from otter.constants import ServiceType
 from otter.convergence.model import (
     CLBDescription,
@@ -20,7 +21,6 @@ from otter.convergence.model import (
     RCv3Description,
     RCv3Node,
     group_id_from_metadata)
-from otter.http import service_request
 from otter.indexer import atom
 from otter.util.http import append_segments
 from otter.util.retry import (

--- a/otter/convergence/service.py
+++ b/otter/convergence/service.py
@@ -11,13 +11,13 @@ from pyrsistent import thaw
 
 from twisted.application.service import Service
 
+from otter.cloud_client import TenantScope
 from otter.constants import CONVERGENCE_LOCK_PATH
 from otter.convergence.composition import get_desired_group_state
 from otter.convergence.effecting import steps_to_effect
 from otter.convergence.gathering import get_all_convergence_data
 from otter.convergence.model import ServerState
 from otter.convergence.planning import plan
-from otter.http import TenantScope
 from otter.models.intents import ModifyGroupState
 from otter.util.deferredutils import with_lock
 from otter.util.fp import assoc_obj

--- a/otter/convergence/steps.py
+++ b/otter/convergence/steps.py
@@ -17,9 +17,9 @@ from twisted.python.constants import NamedConstant
 
 from zope.interface import Interface, implementer
 
+from otter.cloud_client import has_code, service_request
 from otter.constants import ServiceType
 from otter.convergence.model import StepResult
-from otter.http import has_code, service_request
 from otter.util.fp import predicate_any
 from otter.util.hashkey import generate_server_name
 from otter.util.http import APIError, append_segments

--- a/otter/effect_dispatcher.py
+++ b/otter/effect_dispatcher.py
@@ -15,7 +15,7 @@ from .auth import (
     perform_authenticate,
     perform_invalidate_token,
 )
-from .http import TenantScope, perform_tenant_scope
+from .cloud_client import TenantScope, perform_tenant_scope
 from .models.cass import CQLQueryExecute, perform_cql_query
 from .models.intents import get_model_dispatcher
 from .util.pure_http import Request, perform_request

--- a/otter/log/cloudfeeds.py
+++ b/otter/log/cloudfeeds.py
@@ -13,9 +13,9 @@ from effect.twisted import perform
 
 from toolz.dicttoolz import keyfilter
 
+from otter.cloud_client import TenantScope, service_request
 from otter.constants import ServiceType
 from otter.effect_dispatcher import get_full_dispatcher
-from otter.http import TenantScope, service_request
 from otter.log import log as otter_log
 from otter.log.formatters import PEP3101FormattingWrapper
 from otter.util.http import append_segments

--- a/otter/metrics.py
+++ b/otter/metrics.py
@@ -28,10 +28,10 @@ from twisted.internet.endpoints import clientFromString
 from twisted.python import usage
 
 from otter.auth import generate_authenticator
+from otter.cloud_client import TenantScope, service_request
 from otter.constants import ServiceType, get_service_configs
 from otter.convergence.gathering import get_scaling_group_servers
 from otter.effect_dispatcher import get_full_dispatcher
-from otter.http import TenantScope, service_request
 from otter.log import log as otter_log
 from otter.util.fp import predicate_all
 

--- a/otter/test/convergence/test_gathering.py
+++ b/otter/test/convergence/test_gathering.py
@@ -20,6 +20,7 @@ from pyrsistent import freeze
 from twisted.trial.unittest import SynchronousTestCase
 
 from otter.auth import NoSuchEndpoint
+from otter.cloud_client import service_request
 from otter.constants import ServiceType
 from otter.convergence.gathering import (
     extract_CLB_drained_at,
@@ -37,7 +38,6 @@ from otter.convergence.model import (
     RCv3Description,
     RCv3Node,
     ServerState)
-from otter.http import service_request
 from otter.test.utils import (
     patch,
     resolve_effect,

--- a/otter/test/convergence/test_service.py
+++ b/otter/test/convergence/test_service.py
@@ -9,12 +9,12 @@ from twisted.internet.defer import fail
 from twisted.internet.task import Clock
 from twisted.trial.unittest import SynchronousTestCase
 
+from otter.cloud_client import TenantScope, service_request
 from otter.constants import ServiceType
 from otter.convergence.model import (
     CLBDescription, CLBNode, NovaServer, ServerState)
 from otter.convergence.service import (
     Converger, determine_active, execute_convergence)
-from otter.http import TenantScope, service_request
 from otter.models.intents import ModifyGroupState
 from otter.models.interface import GroupState
 from otter.test.convergence.test_planning import server

--- a/otter/test/convergence/test_steps.py
+++ b/otter/test/convergence/test_steps.py
@@ -11,6 +11,7 @@ from testtools.matchers import IsInstance
 
 from twisted.trial.unittest import SynchronousTestCase
 
+from otter.cloud_client import ServiceRequest, has_code, service_request
 from otter.constants import ServiceType
 from otter.convergence.model import (
     CLBDescription,
@@ -33,7 +34,6 @@ from otter.convergence.steps import (
     _RCV3_NODE_NOT_A_MEMBER_PATTERN,
     _rcv3_check_bulk_add,
     _rcv3_check_bulk_delete)
-from otter.http import ServiceRequest, has_code, service_request
 from otter.test.utils import (
     StubResponse,
     get_fake_service_request_performer,

--- a/otter/test/log/test_cloudfeeds.py
+++ b/otter/test/log/test_cloudfeeds.py
@@ -13,8 +13,8 @@ import mock
 from twisted.internet.defer import fail, succeed
 from twisted.trial.unittest import SynchronousTestCase
 
+from otter.cloud_client import TenantScope, has_code, service_request
 from otter.constants import ServiceType
-from otter.http import TenantScope, has_code, service_request
 from otter.log.cloudfeeds import (
     CloudFeedsObserver,
     UnsuitableMessage,

--- a/otter/test/test_effect_dispatcher.py
+++ b/otter/test/test_effect_dispatcher.py
@@ -10,10 +10,10 @@ from twisted.internet.defer import succeed
 from twisted.trial.unittest import SynchronousTestCase
 
 from otter.auth import Authenticate, InvalidateToken
+from otter.cloud_client import TenantScope
 from otter.effect_dispatcher import (
     get_cql_dispatcher, get_full_dispatcher, get_legacy_dispatcher,
     get_simple_dispatcher)
-from otter.http import TenantScope
 from otter.models.cass import CQLQueryExecute
 from otter.models.intents import GetScalingGroupInfo
 from otter.util.pure_http import Request

--- a/otter/test/test_http.py
+++ b/otter/test/test_http.py
@@ -14,14 +14,14 @@ from effect import (
 from twisted.trial.unittest import SynchronousTestCase
 
 from otter.auth import Authenticate, InvalidateToken
-from otter.constants import ServiceType
-from otter.http import (
+from otter.cloud_client import (
     ServiceRequest,
     TenantScope,
     add_bind_service,
     concretize_service_request,
     perform_tenant_scope,
     service_request)
+from otter.constants import ServiceType
 from otter.test.utils import resolve_effect, stub_pure_response
 from otter.test.worker.test_launch_server_v1 import fake_service_catalog
 from otter.util.http import APIError, headers

--- a/otter/test/test_metrics.py
+++ b/otter/test/test_metrics.py
@@ -23,8 +23,8 @@ from twisted.internet.task import Clock
 from twisted.trial.unittest import SynchronousTestCase
 
 from otter.auth import IAuthenticator
+from otter.cloud_client import TenantScope
 from otter.constants import ServiceType
-from otter.http import TenantScope
 from otter.metrics import (
     GroupMetrics,
     MetricsService,

--- a/otter/test/test_supervisor.py
+++ b/otter/test/test_supervisor.py
@@ -15,8 +15,8 @@ from twisted.internet.task import Cooperator
 from zope.interface.verify import verifyObject
 
 from otter import supervisor
+from otter.cloud_client import TenantScope
 from otter.constants import ServiceType
-from otter.http import TenantScope
 from otter.models.interface import (
     GroupState, IScalingGroup, NoSuchScalingGroupError)
 from otter.supervisor import (

--- a/otter/test/utils.py
+++ b/otter/test/utils.py
@@ -27,7 +27,7 @@ from twisted.python.failure import Failure
 from zope.interface import directlyProvides, implementer, interface
 from zope.interface.verify import verifyObject
 
-from otter.http import concretize_service_request
+from otter.cloud_client import concretize_service_request
 from otter.log.bound import BoundLog
 from otter.models.interface import IScalingGroup
 from otter.supervisor import ISupervisor

--- a/otter/worker/_rcv3.py
+++ b/otter/worker/_rcv3.py
@@ -11,8 +11,8 @@ from effect.twisted import perform
 
 from pyrsistent import s
 
+from otter.cloud_client import TenantScope
 from otter.convergence.steps import BulkAddToRCv3, BulkRemoveFromRCv3
-from otter.http import TenantScope
 from otter.util.pure_http import has_code
 
 


### PR DESCRIPTION
As per discussion with @manishtomar and @radix last week, rename `otter.http`

As per discussion with @radix on slack, rename it to `otter.cloud_client`