### PR TITLE
Ignore znode deletion failures when we delete the lock path for a group

### DIFF
--- a/otter/models/cass.py
+++ b/otter/models/cass.py
@@ -26,6 +26,7 @@ from silverberg.client import ConsistencyLevel
 from toolz.dicttoolz import keymap
 
 from twisted.internet import defer
+from twisted.python.failure import Failure
 
 from zope.interface import implementer
 
@@ -1215,8 +1216,17 @@ class CassScalingGroup(object):
         def _delete_lock_znode(result):
             d = self.kz_client.delete(LOCK_PATH + '/' + self.uuid,
                                       recursive=True)
-            # If we fail to delete the node, ignore it.
-            d.addBoth(lambda _: result)
+
+            def return_result_ignore_errors(zk_delete_result):
+                # If we fail to delete the node, log and otherwise ignore it.
+                if isinstance(zk_delete_result, Failure):
+                    self.log.msg(
+                        "Error cleaning up lock path (when deleting group)",
+                        exc=zk_delete_result.value)
+
+                return result
+
+            d.addBoth(return_result_ignore_errors)
             return d
 
         lock = self.kz_client.Lock(LOCK_PATH + '/' + self.uuid)

--- a/otter/models/cass.py
+++ b/otter/models/cass.py
@@ -1215,7 +1215,8 @@ class CassScalingGroup(object):
         def _delete_lock_znode(result):
             d = self.kz_client.delete(LOCK_PATH + '/' + self.uuid,
                                       recursive=True)
-            d.addCallback(lambda _: result)
+            # If we fail to delete the node, ignore it.
+            d.addBoth(lambda _: result)
             return d
 
         lock = self.kz_client.Lock(LOCK_PATH + '/' + self.uuid)

--- a/otter/models/cass.py
+++ b/otter/models/cass.py
@@ -1220,8 +1220,7 @@ class CassScalingGroup(object):
                 lambda f: self.log.msg(
                     "Error cleaning up lock path (when deleting group)",
                     exc=f.value,
-                    otter_msg_type="ignore-delete-lock-error") or result)
-            d.addCallback(lambda _: result)
+                    otter_msg_type="ignore-delete-lock-error"))
             return d
 
         lock = self.kz_client.Lock(LOCK_PATH + '/' + self.uuid)
@@ -1232,6 +1231,7 @@ class CassScalingGroup(object):
                       release_timeout=30)
         # Cleanup /locks/<groupID> znode as it will not be required anymore
         d.addCallback(_delete_lock_znode)
+        d.addCallback(lambda _: None)
         return d
 
 

--- a/otter/test/models/test_cass_models.py
+++ b/otter/test/models/test_cass_models.py
@@ -2247,7 +2247,8 @@ class CassScalingGroupTests(CassScalingGroupTestCase):
                                                               mock_view_state):
         """
         ``delete_group``, if the rest is successful, attempts to delete the
-        lock znode but if that fails, succeeds anyway.
+        lock znode but if that fails, succeeds anyway. The znode deletion is
+        logged, though.
         """
         mock_view_state.return_value = defer.succeed(GroupState(
             self.tenant_id, self.group_id, '', {}, {}, None, {}, False))
@@ -2267,6 +2268,9 @@ class CassScalingGroupTests(CassScalingGroupTestCase):
         result = self.successResultOf(self.group.delete_group())
         self.assertIsNone(result)  # delete returns None
         self.assertEqual(len(called), 1)
+        self.group.log.msg.assert_called_with(
+            "Error cleaning up lock path (when deleting group)",
+            exc=matches(IsInstance(NotEmptyError)))
 
 
 class CassScalingGroupUpdatePolicyTests(CassScalingGroupTestCase):

--- a/otter/test/models/test_cass_models.py
+++ b/otter/test/models/test_cass_models.py
@@ -2270,7 +2270,8 @@ class CassScalingGroupTests(CassScalingGroupTestCase):
         self.assertEqual(len(called), 1)
         self.group.log.msg.assert_called_with(
             "Error cleaning up lock path (when deleting group)",
-            exc=matches(IsInstance(NotEmptyError)))
+            exc=matches(IsInstance(NotEmptyError)),
+            otter_msg_type="ignore-delete-lock-error")
 
 
 class CassScalingGroupUpdatePolicyTests(CassScalingGroupTestCase):


### PR DESCRIPTION
Addresses the immediate failure of #1192.

Not sure if we want to leave that issue open because we also want to do the reaping.