### PR TITLE
return the result of kazoo delete from DeleteNode

### DIFF
--- a/otter/test/util/test_zk.py
+++ b/otter/test/util/test_zk.py
@@ -78,7 +78,7 @@ class ZKCrudModel(object):
         if check is not None:
             return check
         del self.nodes[path]
-        return succeed(None)
+        return succeed('delete return value')
 
 
 class CreateOrSetTests(SynchronousTestCase):
@@ -192,4 +192,4 @@ class DeleteTests(SynchronousTestCase):
         dispatcher = TypeDispatcher({DeleteNode: performer})
         d = perform(dispatcher, eff)
         self.assertEqual(model.nodes, {})
-        self.assertEqual(self.successResultOf(d), None)
+        self.assertEqual(self.successResultOf(d), 'delete return value')

--- a/otter/util/zk.py
+++ b/otter/util/zk.py
@@ -110,7 +110,7 @@ def perform_delete_node(kz_client, dispatcher, intent):
     :param dispatcher: dispatcher, supplied by perform
     :param DeleteNode intent: the intent
     """
-    kz_client.delete(intent.path, version=intent.version)
+    return kz_client.delete(intent.path, version=intent.version)
 
 
 def get_zk_dispatcher(kz_client):


### PR DESCRIPTION
super trivial!

This means that 1) we'll know when a deletion is actually complete and 2) we'll get errors from it.