### PR TITLE
Completes reproduction of bug 1135

### DIFF
--- a/otter/integration/lib/autoscale.py
+++ b/otter/integration/lib/autoscale.py
@@ -34,6 +34,31 @@ class ScalingGroup(object):
     dispose of them upon integration test completion.
     """
 
+    def set_launch_config(self, rcs, launch_config):
+        """Changes the launch configuration used by the scaling group.
+
+        :param TestResources rcs: The integration test resources instance.
+            This provides useful information to complete the request, like
+            which endpoint to use to make the API request.
+
+        :param dict launch_config: The new launch configuration.
+
+        :return: A :class:`Deferred` which, upon firing, alters the scaling
+            group's launch configuration.  If successful, the test resources
+            provided will be returned.  Otherwise, an exception will rise.
+        """
+        return (
+            treq.put(
+                "%s/groups/%s/launch" % (
+                    str(rcs.endpoints["otter"]), self.group_id
+                ),
+                json.dumps(launch_config),
+                headers=headers(str(rcs.token)),
+                pool=self.pool
+            ).addCallback(check_success, [204])
+            .addCallback(lambda _: rcs)
+        )
+
     def stop(self, rcs):
         """Clean up a scaling group.  Although safe to call yourself, you
         should think twice about it.  Let :method:`start` handle registering
@@ -42,6 +67,10 @@ class ScalingGroup(object):
         At the present time, this function DOES NOT stop to verify
         servers are removed.  (This is because I haven't created
         any tests which create them yet.)
+
+        :param TestResources rcs: The integration test resources instance.
+            This provides useful information to complete the request, like
+            which endpoint to use to make the API request.
         """
 
         return self.delete_scaling_group(rcs)
@@ -49,6 +78,10 @@ class ScalingGroup(object):
     def delete_scaling_group(self, rcs):
         """Unconditionally delete the scaling group.  You may call this only
         once.
+
+        :param TestResources rcs: The integration test resources instance.
+            This provides useful information to complete the request, like
+            which endpoint to use to make the API request.
 
         :return: A :class:`Deferred` which, upon firing, disposes of the
             scaling group.
@@ -64,6 +97,10 @@ class ScalingGroup(object):
 
     def get_scaling_group_state(self, rcs):
         """Retrieve the state of the scaling group.
+
+        :param TestResources rcs: The integration test resources instance.
+            This provides useful information to complete the request, like
+            which endpoint to use to make the API request.
 
         :return: A :class:`Deferred` which, upon firing, returns the result
             code and, optionally, scaling group state as a 2-tuple, in that

--- a/otter/integration/tests/test_scaling.py
+++ b/otter/integration/tests/test_scaling.py
@@ -202,7 +202,7 @@ class TestScaling(unittest.TestCase):
         """
         rcs = TestResources()
 
-        def create_1st_load_balancer(self):
+        def create_1st_load_balancer():
             """First, we authenticate and create a single load balancer."""
             self.clb1 = cloud_load_balancer.CloudLoadBalancer(pool=self.pool)
 

--- a/otter/integration/tests/test_scaling.py
+++ b/otter/integration/tests/test_scaling.py
@@ -246,6 +246,8 @@ class TestScaling(unittest.TestCase):
                 self.scaling_group.start(rcs, self)
                 .addCallback(self.scale_up_policy.start, self)
                 .addCallback(self.scale_down_policy.start, self)
+                .addCallback(self.scale_up_policy.execute)
+                .addCallback(self.scaling_group.wait_for_N_servers, 2, timeout=1800)
             )
             return d
 
@@ -256,5 +258,4 @@ class TestScaling(unittest.TestCase):
             .addCallback(self.clb1.wait_for_state, "ACTIVE", 600)
         ).addCallback(finish_setup, self)
         return d
-
     test_policy_execution_after_adding_clb.timeout = 1800

--- a/otter/integration/tests/test_scaling.py
+++ b/otter/integration/tests/test_scaling.py
@@ -202,9 +202,23 @@ class TestScaling(unittest.TestCase):
         """
         rcs = TestResources()
 
-        self.clb1 = cloud_load_balancer.CloudLoadBalancer(pool=self.pool)
+        def create_1st_load_balancer(self):
+            """First, we authenticate and create a single load balancer."""
+            self.clb1 = cloud_load_balancer.CloudLoadBalancer(pool=self.pool)
 
-        def finish_setup(x, self):
+            return (
+                self.identity.authenticate_user(rcs)
+                .addCallback(find_end_point)
+                .addCallback(self.clb1.start, self)
+                .addCallback(self.clb1.wait_for_state, "ACTIVE", 600)
+            ).addCallback(add_2nd_load_balancer, self)
+
+        def add_2nd_load_balancer(_, self):
+            """After that, we scale up to two servers, then create the second
+            load balancer.
+            """
+            self.clb2 = cloud_load_balancer.CloudLoadBalancer(pool=self.pool)
+
             scaling_group_body = {
                 "launchConfiguration": {
                     "type": "launch_server",
@@ -247,15 +261,41 @@ class TestScaling(unittest.TestCase):
                 .addCallback(self.scale_up_policy.start, self)
                 .addCallback(self.scale_down_policy.start, self)
                 .addCallback(self.scale_up_policy.execute)
-                .addCallback(self.scaling_group.wait_for_N_servers, 2, timeout=1800)
+                .addCallback(self.scaling_group.wait_for_N_servers, 2,
+                             timeout=1800)
+                .addCallback(self.clb2.start, self)
+                .addCallback(self.clb2.wait_for_state, "ACTIVE", 600)
+            ).addCallback(scale_after_lc_changed, self)
+            return d
+
+        def scale_after_lc_changed(_, self):
+            """After that, we attempt to execute a scaling policy (doesn't
+            matter which one).  According to the bug report, this yields an
+            error.
+            """
+            lc_alt = {
+                "type": "launch_server",
+                "args": {
+                    "loadBalancers": [{
+                        "port": 80,
+                        "loadBalancerId": self.clb1.clb_id,
+                    }, {
+                        "port": 80,
+                        "loadBalancerId": self.clb2.clb_id,
+                    }],
+                    "server": {
+                        "flavorRef": flavor_ref,
+                        "imageRef": image_ref,
+                    }
+                }
+            }
+            d = (
+                self.scaling_group.set_launch_config(rcs, lc_alt)
+                .addCallback(self.scale_down_policy.execute)
+                .addCallback(self.scaling_group.wait_for_N_servers, 0,
+                             timeout=1800)
             )
             return d
 
-        d = (
-            self.identity.authenticate_user(rcs)
-            .addCallback(find_end_point)
-            .addCallback(self.clb1.start, self)
-            .addCallback(self.clb1.wait_for_state, "ACTIVE", 600)
-        ).addCallback(finish_setup, self)
-        return d
+        return create_1st_load_balancer()
     test_policy_execution_after_adding_clb.timeout = 1800


### PR DESCRIPTION
It's done.  It works.  Bug was _not_ reproduced, as per @cyli's findings.  But at least we have test automation for it!  And I have a general feel for how to write these kinds of test in the future.  Given the current state of the library, if I were to write a new test of this ilk, I'd wager I could complete it in about 4 to 6 hours now (including development testing time).

About the branch name -- no idea.  Haven't a clue.  But it was already in a state ready for working on bug #1135, so I figured I'd not waste the branch, and changing branch names after an initial push is, shall we say, invasive.  Might be for something I was thinking of working on during otterweek but never got to?  I don't even remember when I created this branch.
