### PR TITLE
AddNodesToCLB fails on known conditions only

### DIFF
--- a/otter/convergence/steps.py
+++ b/otter/convergence/steps.py
@@ -367,13 +367,8 @@ class AddNodesToCLB(object):
                     return StepResult.FAILURE, [error]
             return StepResult.RETRY, [error]
 
-        def report_retry((_t, error, tr)):
-            return StepResult.RETRY, [error]
-
-        return eff.on(
-            success=report_success,
-            error=catch(APIError, report_api_failure)).on(
-                error=report_retry)
+        return eff.on(success=report_success,
+                      error=catch(APIError, report_api_failure))
 
 
 @implementer(IStep)

--- a/otter/convergence/steps.py
+++ b/otter/convergence/steps.py
@@ -353,23 +353,27 @@ class AddNodesToCLB(object):
         def report_success(result):
             return StepResult.SUCCESS, []
 
-        def report_failure(result):
+        def report_api_failure(result):
             """
-            If the error is a 422 - PENDING UPDATE, retry.  Otherwise, fail.
+            If the error is a 404 or 422 PENDING_DELETE then fail.
+            Otherwise, retry.
             """
             err_type, error, traceback = result
-            if err_type == APIError and error.code == 413:
-                # over-limit, retry
-                return StepResult.RETRY, [error]
-            if err_type == APIError and error.code == 422:
-                # body has already become JSON
-                message = error.body.get("message", None)
-                if message and _CLB_PENDING_UPDATE_PATTERN.search(message):
-                    return StepResult.RETRY, [error]
+            if error.code == 404:
+                return StepResult.FAILURE, [error]
+            if error.code == 422:
+                message = error.body.get('message')
+                if message and _CLB_DELETED_PATTERN.search(message):
+                    return StepResult.FAILURE, [error]
+            return StepResult.RETRY, [error]
 
-            return StepResult.FAILURE, [error]
+        def report_retry((_t, error, tr)):
+            return StepResult.RETRY, [error]
 
-        return eff.on(success=report_success, error=report_failure)
+        return eff.on(
+            success=report_success,
+            error=catch(APIError, report_api_failure)).on(
+                error=report_retry)
 
 
 @implementer(IStep)

--- a/otter/test/convergence/test_steps.py
+++ b/otter/test/convergence/test_steps.py
@@ -582,7 +582,7 @@ class StepAsEffectTests(SynchronousTestCase):
                 }),
             (StepResult.FAILURE, [matches(IsInstance(APIError))]))
 
-        # Retry on everything else
+        # Retry on other API errors
         self.assertEqual(
             get_result(
                 StubResponse(422, {}),
@@ -596,11 +596,14 @@ class StepAsEffectTests(SynchronousTestCase):
                          (StepResult.RETRY, [matches(IsInstance(APIError))]))
         self.assertEqual(get_result(StubResponse(500, {}), ''),
                          (StepResult.RETRY, [matches(IsInstance(APIError))]))
-        self.assertEqual(
-            resolve_effect(
-                request, service_request_error_response(ValueError('no')),
-                is_error=True),
-            (StepResult.RETRY, [matches(IsInstance(ValueError))]))
+
+        # Any unknown errors are propogated
+        self.assertRaises(
+            ValueError,
+            resolve_effect,
+            request,
+            service_request_error_response(ValueError('no')),
+            is_error=True)
 
     def test_remove_nodes_from_clb(self):
         """


### PR DESCRIPTION
Earlier it was failing on unknown errors. This is incorrect since we should retry convergence on intermittent network failures. Now, it fails on known conditions only and return retry on any other error