### PR TITLE
General mechanism to optionally parse APIErrors by service type

### DIFF
--- a/otter/cloud_client.py
+++ b/otter/cloud_client.py
@@ -169,10 +169,10 @@ def concretize_service_request(
         else:
             request_ = add_bind_service(
                 catalog, service_name, region, log, request_)
-        if service_request.json_response:
-            request_ = add_json_response(request_)
         request_ = add_error_handling(
             service_request.success_pred, request_)
+        if service_request.json_response:
+            request_ = add_json_response(request_)
         return request_(
             service_request.method,
             service_request.url,

--- a/otter/cloud_client.py
+++ b/otter/cloud_client.py
@@ -14,6 +14,7 @@ from effect import (
     sync_performer)
 
 from otter.auth import Authenticate, InvalidateToken, public_endpoint_url
+from otter.util.http import APIError
 from otter.util.http import headers as otter_headers
 from otter.util.pure_http import (
     add_bind_root,

--- a/otter/cloud_client.py
+++ b/otter/cloud_client.py
@@ -154,9 +154,11 @@ def _add_service_error_parsing(parser, request_func):
     if parser is None:
         return request_func
 
-    request = lambda *args, **kwargs: request_func(*args, **kwargs).on(
-        error=catch(APIError, parser))
-    return wraps(request_func)(request)
+    @wraps(request_func)
+    def request(*args, **kwargs):
+        return request_func(*args, **kwargs).on(error=catch(APIError, parser))
+
+    return request
 
 
 def concretize_service_request(

--- a/otter/convergence/steps.py
+++ b/otter/convergence/steps.py
@@ -289,8 +289,9 @@ def _check_clb_422(*regex_matches):
         which it should be by default.
         """
         if response.code == 422:
-            message = content.get('message', '')
-            return any([regex.search(message) for regex in regex_matches])
+            message = try_json_with_keys(content, ('message',))
+            return any([regex.search(message or '')
+                        for regex in regex_matches])
         return False
 
     return check_response
@@ -349,8 +350,7 @@ class AddNodesToCLB(object):
                 # over-limit, retry
                 return StepResult.RETRY, [error]
             if err_type == APIError and error.code == 422:
-                # body has already become JSON
-                message = error.body.get("message", None)
+                message = try_json_with_keys(error.body, ("message",))
                 if message and _CLB_PENDING_UPDATE_PATTERN.search(message):
                     return StepResult.RETRY, [error]
 

--- a/otter/test/convergence/test_steps.py
+++ b/otter/test/convergence/test_steps.py
@@ -640,42 +640,42 @@ class StepAsEffectTests(SynchronousTestCase):
         self.assertTrue(predicate(StubResponse(413, {}), None))
         self.assertTrue(predicate(
             StubResponse(422, {}),
-            {
+            json.dumps({
                 "message": "The load balancer is deleted and considered "
                            "immutable.",
                 "code": 422
-            }))
+            })))
         self.assertTrue(predicate(
             StubResponse(422, {}),
-            {
+            json.dumps({
                 "message": "Load Balancer '12345' has a status of "
                            "'PENDING_UPDATE' and is considered immutable.",
                 "code": 422
-            }))
+            })))
         self.assertTrue(predicate(
             StubResponse(422, {}),
-            {
+            json.dumps({
                 "message": "Load Balancer '12345' has a status of "
                            "'PENDING_DELETE' and is considered immutable.",
                 "code": 422
-            }))
+            })))
 
         self.assertFalse(predicate(StubResponse(404, {}), None))
         self.assertFalse(predicate(
             StubResponse(422, {}),
-            {
+            json.dumps({
                 "message": "Duplicate nodes detected. One or more "
                            "nodes already configured on load "
                            "balancer.",
                 "code": 422
-            }))
+            })))
         # This one is just malformed but similar to a good message.
         self.assertFalse(predicate(
             StubResponse(422, {}),
-            {
+            json.dumps({
                 "message": "The load balancer is considered immutable.",
                 "code": 422
-            }))
+            })))
 
     def test_remove_nodes_from_clb_retry(self):
         """

--- a/otter/test/test_cloud_client.py
+++ b/otter/test/test_cloud_client.py
@@ -28,6 +28,25 @@ from otter.util.http import APIError, headers
 from otter.util.pure_http import Request, has_code
 
 
+class _NovaError(Exception):
+    """Fake Nova error to be raised"""
+
+
+class _CLBError(Exception):
+    """Fake CLB error to be raised"""
+
+
+def raise_callback(exception_class):
+    """
+    Take an exception class and return a error callback that raises the
+    provided exception.
+    """
+    def do_the_raise(*excinfo):
+        raise exception_class()
+
+    return do_the_raise
+
+
 def resolve_authenticate(eff, token='token'):
     """Resolve an Authenticate effect with test data."""
     return resolve_effect(eff, (token, fake_service_catalog))
@@ -92,17 +111,21 @@ class PerformServiceRequestTests(SynchronousTestCase):
         self.service_configs = {
             ServiceType.CLOUD_SERVERS: {
                 'name': 'cloudServersOpenStack',
+                'region': 'DFW'},
+            ServiceType.CLOUD_LOAD_BALANCERS: {
+                'name': 'cloudLoadBalancers',
                 'region': 'DFW'}
         }
         eff = service_request(ServiceType.CLOUD_SERVERS, 'GET', 'servers')
         self.svcreq = eff.intent
 
-    def _concrete(self, svcreq):
+    def _concrete(self, svcreq, **kwargs):
         """
         Call :func:`concretize_service_request` with premade test objects.
         """
         return concretize_service_request(
-            self.authenticator, self.log, self.service_configs, 1, svcreq)
+            self.authenticator, self.log, self.service_configs, 1, svcreq,
+            **kwargs)
 
     def test_authenticates(self):
         """Auth is done before making the request."""
@@ -193,6 +216,64 @@ class PerformServiceRequestTests(SynchronousTestCase):
             resolve_effect(next_eff, stub_response)
 
         self.assertEqual(cm.exception.body, "THIS IS A FAILURE")
+
+    def test_error_parsing_chosen_per_service_type(self):
+        """
+        If error parsers per service are provided, the right parser will
+        be called per service type, even if the same error response is returned
+        from the service.
+        """
+        parsers = {
+            ServiceType.CLOUD_SERVERS: raise_callback(_NovaError),
+            ServiceType.CLOUD_LOAD_BALANCERS: raise_callback(_CLBError)}
+
+        def resolve_svcreq_of_type(service_type):
+            svc_req = service_request(service_type, "GET", "athing").intent
+            eff = self._concrete(svc_req, service_error_parsers=parsers)
+            next_eff = resolve_authenticate(eff)
+            stub_response = stub_pure_response("FOO", code=400)
+            resolve_effect(next_eff, stub_response)
+
+        self.assertRaises(_NovaError, resolve_svcreq_of_type,
+                          ServiceType.CLOUD_SERVERS)
+
+        self.assertRaises(_CLBError, resolve_svcreq_of_type,
+                          ServiceType.CLOUD_LOAD_BALANCERS)
+
+    def test_error_parsing_no_service_raises_api_error(self):
+        """
+        If there is no error parser provided for a particular service,
+        :class:`APIError` will be returned.
+        """
+        parsers = {ServiceType.CLOUD_SERVERS: raise_callback(_NovaError)}
+
+        def resolve_svcreq_of_type(service_type):
+            svc_req = service_request(service_type, "GET", "athing").intent
+            eff = self._concrete(svc_req, service_error_parsers=parsers)
+            next_eff = resolve_authenticate(eff)
+            stub_response = stub_pure_response("FOO", code=400)
+            resolve_effect(next_eff, stub_response)
+
+        self.assertRaises(_NovaError, resolve_svcreq_of_type,
+                          ServiceType.CLOUD_SERVERS)
+
+        self.assertRaises(APIError, resolve_svcreq_of_type,
+                          ServiceType.CLOUD_LOAD_BALANCERS)
+
+    def test_error_parsing_only_applies_to_apierrors(self):
+        """
+        If the request results in a non-:class:`APIError`, the error parsing
+        is not called at all.
+        """
+        parsers = {ServiceType.CLOUD_SERVERS: raise_callback(_NovaError)}
+
+        eff = self._concrete(self.svcreq, service_error_parsers=parsers)
+        next_eff = resolve_authenticate(eff)
+        with self.assertRaises(Exception):
+            resolve_effect(
+                next_eff,
+                (Exception, Exception("Cannot make request!"), None),
+                is_error=True)
 
 
 class PerformTenantScopeTests(SynchronousTestCase):

--- a/otter/test/test_cloud_client.py
+++ b/otter/test/test_cloud_client.py
@@ -275,6 +275,19 @@ class PerformServiceRequestTests(SynchronousTestCase):
                 (Exception, Exception("Cannot make request!"), None),
                 is_error=True)
 
+    def test_raises_original_error_if_error_parser_doesnt_raise(self):
+        """
+        If the error parser provided does not raise an error, the original
+        error is raised.
+        """
+        parsers = {ServiceType.CLOUD_SERVERS: lambda *a: None}
+
+        eff = self._concrete(self.svcreq, service_error_parsers=parsers)
+        next_eff = resolve_authenticate(eff)
+        with self.assertRaises(APIError):
+            resolve_effect(
+                next_eff, stub_pure_response("FOO", 400))
+
 
 class PerformTenantScopeTests(SynchronousTestCase):
     """Tests for :func:`perform_tenant_scope`."""


### PR DESCRIPTION
This allows passing of a dictionary of parsers by service type to `concretize_service_request`.

If no parsers are passed, no parsing happens, but this should make it easier to incrementally implement parsers, etc, as part of #1189.

This also swaps the order in which JSON parsing/success predicate testing happens, since although on a successful request the body should be JSON, in error cases it's very possible the body will not be something JSON parseable (maybe a repose error, or some proxy error that returns HTML, etc.).