### PR TITLE
Re-auth on every create server and every delete server

### DIFF
--- a/otter/supervisor.py
+++ b/otter/supervisor.py
@@ -71,7 +71,7 @@ class ISupervisor(Interface):
 
 
 @attributes(['lb_region', 'region', 'dispatcher', 'tenant_id',
-             'auth_token', 'service_catalog'])
+             'auth_token', 'service_catalog', 're_auth'])
 class RequestBag(object):
     """A bag of data useful for making HTTP requests."""
 
@@ -119,9 +119,9 @@ class SupervisorService(object, Service):
                     dispatcher=dispatcher,
                     tenant_id=tenant_id,
                     auth_token=auth_token,
-                    service_catalog=service_catalog
+                    service_catalog=service_catalog,
+                    re_auth=authenticate,
                 )
-                bag.re_auth = authenticate
                 return bag
 
             return d.addCallback(when_authenticated)

--- a/otter/supervisor.py
+++ b/otter/supervisor.py
@@ -128,7 +128,8 @@ class SupervisorService(object, Service):
 
         return authenticate()
 
-    def execute_config(self, log, transaction_id, scaling_group, launch_config):
+    def execute_config(self, log, transaction_id, scaling_group,
+                       launch_config):
         """
         see :meth:`ISupervisor.execute_config`
         """

--- a/otter/test/test_supervisor.py
+++ b/otter/test/test_supervisor.py
@@ -57,13 +57,13 @@ class SupervisorTests(SynchronousTestCase):
         self.group.uuid = 'group-id'
         self.region = "ORD"
 
-        self.auth_token = ('auth-token1', 'auth-token2', 'auth-token3')
-        self._auth_token = list(self.auth_token)
+        self.auth_tokens = ('auth-token1', 'auth-token2', 'auth-token3')
+        self._auth_token_queue = list(self.auth_tokens)
         self.service_catalog = {}
         self.authenticator = iMock(IAuthenticator)
         self.auth_function = self.authenticator.authenticate_tenant
         self.auth_function.side_effect = lambda *a, **kw: succeed(
-            (self._auth_token.pop(0), self.service_catalog))
+            (self._auth_token_queue.pop(0), self.service_catalog))
 
         self.fake_server_details = {
             'server': {'id': 'server_id', 'links': ['links'], 'name': 'meh',
@@ -97,7 +97,7 @@ class SupervisorTests(SynchronousTestCase):
 
         :param request_bag: The :obj:`otter.supervisor.RequestBag` to check.
         """
-        self.assertIn(request_bag.auth_token, self.auth_token)
+        self.assertIn(request_bag.auth_token, self.auth_tokens)
         self.assertEqual(request_bag.service_catalog, self.service_catalog)
         self.assertEqual(request_bag.region, "ORD")
         self.assertEqual(request_bag.lb_region, "ORD")
@@ -356,7 +356,7 @@ class ScrubMetadataTests(SupervisorTests):
             "tenant-id", log=smells_like_log)
         self.scrub_otter_metadata.assert_called_once_with(
             smells_like_log,
-            self.auth_token[0],
+            self.auth_tokens[0],
             self.service_catalog,
             self.supervisor.region,
             "server-id")
@@ -389,7 +389,7 @@ class ValidateLaunchConfigTests(SupervisorTests):
             self.group.tenant_id, log=self.log.bind.return_value)
         self.validate_launch_server_config.assert_called_once_with(
             self.log.bind.return_value, 'ORD', self.service_catalog,
-            self.auth_token[0], 'launch_args')
+            self.auth_tokens[0], 'launch_args')
 
     def test_invalid_config_error_propagates(self):
         """

--- a/otter/test/test_supervisor.py
+++ b/otter/test/test_supervisor.py
@@ -15,6 +15,7 @@ from twisted.internet.task import Cooperator
 from zope.interface.verify import verifyObject
 
 from otter import supervisor
+from otter.auth import IAuthenticator
 from otter.cloud_client import TenantScope
 from otter.constants import ServiceType
 from otter.models.interface import (
@@ -56,12 +57,13 @@ class SupervisorTests(SynchronousTestCase):
         self.group.uuid = 'group-id'
         self.region = "ORD"
 
-        self.auth_token = 'auth-token'
+        self.auth_token = ('auth-token1', 'auth-token2', 'auth-token3')
+        self._auth_token = list(self.auth_token)
         self.service_catalog = {}
-        self.authenticator = mock.Mock()
+        self.authenticator = iMock(IAuthenticator)
         self.auth_function = self.authenticator.authenticate_tenant
-        self.auth_function.return_value = succeed((self.auth_token,
-                                                   self.service_catalog))
+        self.auth_function.side_effect = lambda *a, **kw: succeed(
+            (self._auth_token.pop(0), self.service_catalog))
 
         self.fake_server_details = {
             'server': {'id': 'server_id', 'links': ['links'], 'name': 'meh',
@@ -89,13 +91,13 @@ class SupervisorTests(SynchronousTestCase):
         """
         verifyObject(ISupervisor, self.supervisor)
 
-    def assertCorrectRequestFunc(self, request_bag):
+    def assertCorrectRequestBag(self, request_bag, test_reauth=True):
         """
         Asserts that the given request bag has all necessary data.
 
         :param request_bag: The :obj:`otter.supervisor.RequestBag` to check.
         """
-        self.assertEqual(request_bag.auth_token, self.auth_token)
+        self.assertIn(request_bag.auth_token, self.auth_token)
         self.assertEqual(request_bag.service_catalog, self.service_catalog)
         self.assertEqual(request_bag.region, "ORD")
         self.assertEqual(request_bag.lb_region, "ORD")
@@ -104,6 +106,14 @@ class SupervisorTests(SynchronousTestCase):
         # only provided by the full dispatcher
         tscope = TenantScope(Effect(Constant(1)), 'tenant_id')
         self.assertIsNot(request_bag.dispatcher(tscope), None)
+
+        if test_reauth:
+            # ensures that there is a re-auth callable that produces a new
+            # request bag exactly like this one, except the auth token is
+            # different
+            new_bag = self.successResultOf(request_bag.re_auth())
+            self.assertCorrectRequestBag(new_bag, test_reauth=False)
+            self.assertNotEqual(request_bag.auth_token, new_bag.auth_token)
 
 
 class HealthCheckTests(SupervisorTests):
@@ -181,7 +191,7 @@ class LaunchConfigTests(SupervisorTests):
         function.
         """
         expected = ValueError('auth failure')
-        self.auth_function.return_value = fail(expected)
+        self.auth_function.side_effect = lambda *a, **kw: fail(expected)
 
         d = self.supervisor.execute_config(self.log, 'transaction-id',
                                            self.group, self.launch_config)
@@ -206,7 +216,7 @@ class LaunchConfigTests(SupervisorTests):
         log, request_bag, scaling_group, launch_config, undo = args
         self.assertEqual(log, matches(IsBoundWith(tenant_id=11111,
                                                   worker='launch_server')))
-        self.assertCorrectRequestFunc(request_bag)
+        self.assertCorrectRequestBag(request_bag)
         self.assertEqual(scaling_group, self.group)
         self.assertEqual(launch_config, {'server': {}})
         self.assertEqual(undo, self.undo)
@@ -217,7 +227,7 @@ class LaunchConfigTests(SupervisorTests):
         when launch_server fails.
         """
         expected = ValueError('auth failure')
-        self.auth_function.return_value = fail(expected)
+        self.auth_function.side_effect = lambda *a, **kw: fail(expected)
 
         d = self.supervisor.execute_config(self.log, 'transaction-id',
                                            self.group, self.launch_config)
@@ -289,7 +299,7 @@ class DeleteServerTests(SupervisorTests):
         log, request_bag, instance_details = args
         self.assertEqual(log, matches(IsBoundWith(tenant_id=11111,
                                                   server_id='server_id')))
-        self.assertCorrectRequestFunc(request_bag)
+        self.assertCorrectRequestBag(request_bag)
         expected_details = self.fake_server['id'], self.fake_server['lb_info']
         self.assertEqual(instance_details, expected_details)
 
@@ -310,7 +320,7 @@ class DeleteServerTests(SupervisorTests):
         authentication function.
         """
         expected = ValueError('auth failure')
-        self.auth_function.return_value = fail(expected)
+        self.auth_function.side_effect = lambda *a, **kw: fail(expected)
 
         d = self.supervisor.execute_delete_server(
             self.log, 'transaction-id', self.group, self.fake_server)
@@ -346,7 +356,7 @@ class ScrubMetadataTests(SupervisorTests):
             "tenant-id", log=smells_like_log)
         self.scrub_otter_metadata.assert_called_once_with(
             smells_like_log,
-            self.auth_token,
+            self.auth_token[0],
             self.service_catalog,
             self.supervisor.region,
             "server-id")
@@ -379,7 +389,7 @@ class ValidateLaunchConfigTests(SupervisorTests):
             self.group.tenant_id, log=self.log.bind.return_value)
         self.validate_launch_server_config.assert_called_once_with(
             self.log.bind.return_value, 'ORD', self.service_catalog,
-            self.auth_token, 'launch_args')
+            self.auth_token[0], 'launch_args')
 
     def test_invalid_config_error_propagates(self):
         """

--- a/otter/test/worker/test_launch_server_v1.py
+++ b/otter/test/worker/test_launch_server_v1.py
@@ -199,8 +199,10 @@ class AddToCLBTests(LoadBalancersTestsMixin, SynchronousTestCase):
         self.auth_token = self.request_bag.auth_token
         self.json_content = {'nodes': [{'id': 1}]}
         self.treq = patch(self, 'otter.worker.launch_server_v1.treq',
-                          new=mock_treq(code=200, json_content=self.json_content,
-                                        content='{"message": "bad"}', method='post'))
+                          new=mock_treq(code=200,
+                                        json_content=self.json_content,
+                                        content='{"message": "bad"}',
+                                        method='post'))
         patch(self, 'otter.util.http.treq', new=self.treq)
         self.lb_config = {'loadBalancerId': 12345, 'port': 80}
 
@@ -310,8 +312,8 @@ class AddToCLBTests(LoadBalancersTestsMixin, SynchronousTestCase):
             [mock.call('http://dfw.lbaas/loadbalancers/12345/nodes',
                        headers=expected_headers(self.auth_token),
                        data=mock.ANY,
-                       log=matches(IsInstance(self.log.__class__)))]
-            * (LB_MAX_RETRIES + 1))
+                       log=matches(IsInstance(self.log.__class__)))] *
+            (LB_MAX_RETRIES + 1))
         self.rand_interval.assert_called_once_with(*LB_RETRY_INTERVAL_RANGE)
 
     def failed_add_to_clb(self, code=500):
@@ -338,8 +340,8 @@ class AddToCLBTests(LoadBalancersTestsMixin, SynchronousTestCase):
             [mock.call('http://dfw.lbaas/loadbalancers/12345/nodes',
                        headers=expected_headers(self.auth_token),
                        data=mock.ANY,
-                       log=matches(IsInstance(self.log.__class__)))]
-            * (self.max_retries + 1))
+                       log=matches(IsInstance(self.log.__class__)))] *
+            (self.max_retries + 1))
 
     def test_retries_log_unexpected_failure(self):
         """
@@ -755,8 +757,8 @@ class RemoveFromCLBTests(LoadBalancersTestsMixin, SynchronousTestCase):
             self.treq.delete.mock_calls,
             [mock.call('http://dfw.lbaas/loadbalancers/12345/nodes/a',
                        headers=expected_headers(self.request_bag.auth_token),
-                       log=matches(IsInstance(self.log.__class__)))]
-            * (self.max_retries + 1))
+                       log=matches(IsInstance(self.log.__class__)))] *
+            (self.max_retries + 1))
         # Expected logs?
         self.assertEqual(self.log.msg.mock_calls[0],
                          mock.call('Removing from load balancer',
@@ -787,8 +789,8 @@ class RemoveFromCLBTests(LoadBalancersTestsMixin, SynchronousTestCase):
             self.treq.delete.mock_calls,
             [mock.call('http://dfw.lbaas/loadbalancers/12345/nodes/a',
                        headers=expected_headers(self.request_bag.auth_token),
-                       log=matches(IsInstance(self.log.__class__)))]
-            * (LB_MAX_RETRIES + 1))
+                       log=matches(IsInstance(self.log.__class__)))] *
+            (LB_MAX_RETRIES + 1))
         # Expected logs?
         self.assertEqual(self.log.msg.mock_calls[0],
                          mock.call('Removing from load balancer',
@@ -1619,8 +1621,14 @@ class ServerTests(RequestBagTestMixin, SynchronousTestCase):
         log.bind.assert_called_once_with(server_id='1')
         add_to_load_balancers.assert_called_once_with(
             log.bind.return_value, self.bags[-1], prepared_load_balancers,
-            {'server': {'id': '1',
-                        'addresses': {'private': [{'version': 4, 'addr': '10.0.0.1'}]}}},
+            {
+                'server': {
+                    'id': '1',
+                    'addresses': {
+                        'private': [{'version': 4, 'addr': '10.0.0.1'}]
+                    }
+                }
+            },
             self.undo)
 
     @mock.patch('otter.worker.launch_server_v1.add_to_load_balancers')
@@ -1901,11 +1909,13 @@ class ServerTests(RequestBagTestMixin, SynchronousTestCase):
         self.assertEqual(
             mock_vd.mock_calls,
             # the undo stack is not re-wound, so original request bag is used
-            [mock.call(matches(IsInstance(self.log.__class__)), 'http://dfw.openstack/',
+            [mock.call(matches(IsInstance(self.log.__class__)),
+                       'http://dfw.openstack/',
                        self.request_bag, '1')] * 2)
         self.assertEqual(
             self.log.msg.mock_calls,
-            [mock.call('{server_id} errored, deleting and creating new server instead',
+            [mock.call('{server_id} errored, deleting and creating '
+                       'new server instead',
                        server_name='as000000', server_id='1')] * 2)
         self.assertFalse(mock_addlb.called)
 
@@ -2523,7 +2533,8 @@ class DeleteServerTests(RequestBagTestMixin, SynchronousTestCase):
         self.clock.advance(2)
         self.assertEqual(
             delete_and_verify.mock_calls,
-            [mock.call(matches(IsBoundWith(server_id='serverId')), 'http://url/',
+            [mock.call(matches(IsBoundWith(server_id='serverId')),
+                       'http://url/',
                        self.request_bag, 'serverId')] * 2)
         self.successResultOf(d)
 
@@ -2543,7 +2554,8 @@ class DeleteServerTests(RequestBagTestMixin, SynchronousTestCase):
         """
         delete_and_verify = patch(
             self, 'otter.worker.launch_server_v1.delete_and_verify')
-        delete_and_verify.side_effect = lambda *a, **kw: fail(DummyException("bad"))
+        delete_and_verify.side_effect = (
+            lambda *a, **kw: fail(DummyException("bad")))
 
         d = verified_delete(self.log, 'http://url/', self.request_bag,
                             'serverId', exp_start=2, max_retries=2,

--- a/otter/test/worker/test_launch_server_v1.py
+++ b/otter/test/worker/test_launch_server_v1.py
@@ -122,9 +122,9 @@ class RequestBagTestMixin(object):
                 dispatcher=mock.Mock(),
                 tenant_id=self.tenant_id,
                 auth_token="my-auth-token{0}".format(counter),
-                service_catalog=fake_service_catalog
+                service_catalog=fake_service_catalog,
+                re_auth=partial(new_bag, counter + 1),
             )
-            bag.re_auth = partial(new_bag, counter + 1)
             self.bags.append(bag)
             return succeed(bag)
 

--- a/otter/worker/_rcv3.py
+++ b/otter/worker/_rcv3.py
@@ -21,8 +21,7 @@ def _generic_rcv3_request(step_class, request_bag, lb_id, server_id):
     Perform a generic RCv3 bulk step on a single (lb, server) pair.
 
     :param IStep step_class: The step class to perform the action.
-    :param request_bag: An object with a bunch of useful data on it. Called
-        a ``request_func`` by other worker/supervisor code.
+    :param request_bag: An object with a bunch of useful data on it.
     :param str lb_id: The id of the RCv3 load balancer to act on.
     :param str server_id: The Nova server id to act on.
     :return: A deferred that will fire when the request has been performed,

--- a/otter/worker/launch_server_v1.py
+++ b/otter/worker/launch_server_v1.py
@@ -7,7 +7,6 @@ This launch config worker is responsible for:
 2) Adding the server to a load balancer.
 
 On delete, this worker:
-0) (TODO) Puts the server into draining mode on the load balancer
 1) Removes the the server from the load balancer(s)
 2) Deletes the server
 
@@ -413,13 +412,13 @@ def check_deleted_clb(f, clb_id, node_id=None):
     return f
 
 
-def add_to_load_balancer(log, request_func, lb_config, server_details, undo,
+def add_to_load_balancer(log, request_bag, lb_config, server_details, undo,
                          clock=None):
     """
     Adds a given server to a given load balancer.
 
     :param log: A bound logger.
-    :param callable request_func: A request function.
+    :param callable request_bag: A request function.
     :param str lb_config: An ``lb_config`` dictionary specifying which load
         balancer to add the server to.
     :param dict server_details: The server details, as returned by Nova.
@@ -429,17 +428,17 @@ def add_to_load_balancer(log, request_func, lb_config, server_details, undo,
     lb_type = lb_config.get("type", "CloudLoadBalancer")
     if lb_type == "CloudLoadBalancer":
         cloudLoadBalancers = config_value('cloudLoadBalancers')
-        endpoint = public_endpoint_url(request_func.service_catalog,
+        endpoint = public_endpoint_url(request_bag.service_catalog,
                                        cloudLoadBalancers,
-                                       request_func.lb_region)
-        auth_token = request_func.auth_token
+                                       request_bag.lb_region)
+        auth_token = request_bag.auth_token
         ip_address = _servicenet_address(server_details["server"])
         return add_to_clb(log, endpoint, auth_token, lb_config, ip_address,
                           undo, clock)
     elif lb_type == "RackConnectV3":
         lb_id = lb_config["loadBalancerId"]
         server_id = server_details["server"]["id"]
-        return add_to_rcv3(request_func, lb_id, server_id)
+        return add_to_rcv3(request_bag, lb_id, server_id)
     else:
         raise RuntimeError("Unknown cloud load balancer type! config: {}"
                            .format(lb_config))
@@ -499,12 +498,12 @@ def add_to_clb(log, endpoint, auth_token, lb_config, ip_address, undo, clock=Non
     return d.addCallback(treq.json_content).addCallback(when_done)
 
 
-def add_to_load_balancers(log, request_func, lb_configs, server, undo):
+def add_to_load_balancers(log, request_bag, lb_configs, server, undo):
     """
     Add the given server to the load balancers specified by ``lb_configs``.
 
     :param log: A bound logger.
-    :param callable request_func: A request function.
+    :param callable request_bag: A request function.
     :param list lb_configs: List of lb_config dictionaries.
     :param dict server: Server dict of the server to add, as per server details
         response from Nova.
@@ -513,7 +512,7 @@ def add_to_load_balancers(log, request_func, lb_configs, server, undo):
     :return: Deferred that fires with a list of 2-tuples of the load
         balancer configuration, and that load balancer's respective response.
     """
-    _add = partial(add_to_load_balancer, log, request_func,
+    _add = partial(add_to_load_balancer, log, request_bag,
                    server_details=server, undo=undo)
 
     dl = DeferredLock()
@@ -632,13 +631,14 @@ def scrub_otter_metadata(log, auth_token, service_catalog, region, server_id,
             .addCallback(_treq.content))
 
 
-def launch_server(log, request_func, scaling_group, launch_config, undo, clock=None):
+def launch_server(log, request_bag, scaling_group, launch_config, undo, clock=None):
     """
     Launch a new server given the launch config auth tokens and service catalog.
     Possibly adding the newly launched server to a load balancer.
 
     :param BoundLog log: A bound logger.
-    :param callable request_func: A request function.
+    :param request_bag: An object with a bunch of useful data on it, including
+        a callable to re-auth and get a new token.
     :param IScalingGroup scaling_group: The scaling group to add the launched
         server to.
     :param dict launch_config: A launch_config args structure as defined for
@@ -651,9 +651,9 @@ def launch_server(log, request_func, scaling_group, launch_config, undo, clock=N
     launch_config = prepare_launch_config(scaling_group.uuid, launch_config)
 
     cloudServersOpenStack = config_value('cloudServersOpenStack')
-    server_endpoint = public_endpoint_url(request_func.service_catalog,
+    server_endpoint = public_endpoint_url(request_bag.service_catalog,
                                           cloudServersOpenStack,
-                                          request_func.region)
+                                          request_bag.region)
 
     lb_config = launch_config.get('loadBalancers', [])
     server_config = launch_config['server']
@@ -690,24 +690,24 @@ def launch_server(log, request_func, scaling_group, launch_config, undo, clock=N
             auth_token,
             server_id).addCallback(check_metadata)
 
-    def add_lb(server, new_request_func):
+    def add_lb(server, new_request_bag):
         if lb_config:
             lbd = add_to_load_balancers(
-                ilog[0], new_request_func, lb_config, server, undo)
+                ilog[0], new_request_bag, lb_config, server, undo)
             lbd.addCallback(lambda lb_response: (server, lb_response))
             return lbd
 
         return (server, [])
 
-    def _real_create_server(new_request_func):
-        auth_token = new_request_func.auth_token
+    def _real_create_server(new_request_bag):
+        auth_token = new_request_bag.auth_token
         d = create_server(server_endpoint, auth_token, server_config, log=log)
         d.addCallback(wait_for_server, auth_token)
-        d.addCallback(add_lb, new_request_func)
+        d.addCallback(add_lb, new_request_bag)
         return d
 
     def create_server():
-        return request_func.re_auth().addCallback(_real_create_server)
+        return request_bag.re_auth().addCallback(_real_create_server)
 
     def check_error(f):
         f.trap(UnexpectedServerStatus)
@@ -715,7 +715,7 @@ def launch_server(log, request_func, scaling_group, launch_config, undo, clock=N
             log.msg('{server_id} errored, deleting and creating new server instead',
                     server_id=f.value.server_id)
             # trigger server delete and return True to allow retry
-            verified_delete(log, server_endpoint, request_func, f.value.server_id)
+            verified_delete(log, server_endpoint, request_bag, f.value.server_id)
             return True
         else:
             return False
@@ -726,13 +726,13 @@ def launch_server(log, request_func, scaling_group, launch_config, undo, clock=N
     return d
 
 
-def remove_from_load_balancer(log, request_func, lb_config, lb_response,
+def remove_from_load_balancer(log, request_bag, lb_config, lb_response,
                               clock=None):
     """
     Remove a node from a load balancer.
 
     :param BoundLog log: A bound logger.
-    :param callable request_func: A request function.
+    :param request_bag: A request function.
     :param dict lb_config: An ``lb_config`` dictionary.
     :param lb_response: The response the load balancer provided when the server
         being removed was added. Type and shape is dependant on type of load
@@ -746,10 +746,10 @@ def remove_from_load_balancer(log, request_func, lb_config, lb_response,
     lb_type = lb_config.get("type", "CloudLoadBalancer")
     if lb_type == "CloudLoadBalancer":
         cloudLoadBalancers = config_value('cloudLoadBalancers')
-        endpoint = public_endpoint_url(request_func.service_catalog,
+        endpoint = public_endpoint_url(request_bag.service_catalog,
                                        cloudLoadBalancers,
-                                       request_func.lb_region)
-        auth_token = request_func.auth_token
+                                       request_bag.lb_region)
+        auth_token = request_bag.auth_token
         loadbalancer_id = lb_config["loadBalancerId"]
         node_id = next(node_info["id"] for node_info in lb_response["nodes"])
         return _remove_from_clb(log, endpoint, auth_token, loadbalancer_id,
@@ -757,7 +757,7 @@ def remove_from_load_balancer(log, request_func, lb_config, lb_response,
     elif lb_type == "RackConnectV3":
         lb_id = lb_config["loadBalancerId"]
         node_id = next(pair["cloud_server"]["id"] for pair in lb_response)
-        return remove_from_rcv3(request_func, lb_id, node_id)
+        return remove_from_rcv3(request_bag, lb_id, node_id)
     else:
         raise RuntimeError("Unknown cloud load balancer type! config: {}"
                            .format(lb_config))
@@ -804,14 +804,14 @@ def _remove_from_clb(log, endpoint, auth_token, loadbalancer_id, node_id, clock=
     return d
 
 
-def delete_server(log, request_func, instance_details):
+def delete_server(log, request_bag, instance_details):
     """
     Delete the server specified by instance_details.
 
     TODO: Load balancer draining.
 
     :param BoundLog log: A bound logger.
-    :param callable request_func: A request function.
+    :param callable request_bag: A request function.
     :param tuple instance_details: A 2-tuple of the server_id and a list of
         2-tuples of load balancer configurations and respective load balancer
         responses. Example for some CLB load balancers::
@@ -834,7 +834,7 @@ def delete_server(log, request_func, instance_details):
     :return: TODO
 
     """
-    _remove_from_lb = partial(remove_from_load_balancer, log, request_func)
+    _remove_from_lb = partial(remove_from_load_balancer, log, request_bag)
     server_id, lb_details = _as_new_style_instance_details(instance_details)
     d = gatherResults([_remove_from_lb(lb_config, lb_response)
                        for (lb_config, lb_response) in lb_details],
@@ -842,10 +842,10 @@ def delete_server(log, request_func, instance_details):
 
     def when_removed_from_loadbalancers(_ignore):
         cloudServersOpenStack = config_value('cloudServersOpenStack')
-        server_endpoint = public_endpoint_url(request_func.service_catalog,
+        server_endpoint = public_endpoint_url(request_bag.service_catalog,
                                               cloudServersOpenStack,
-                                              request_func.region)
-        auth_token = request_func.auth_token
+                                              request_bag.region)
+        auth_token = request_bag.auth_token
         return verified_delete(log, server_endpoint, auth_token, server_id)
 
     d.addCallback(when_removed_from_loadbalancers)

--- a/otter/worker/launch_server_v1.py
+++ b/otter/worker/launch_server_v1.py
@@ -631,10 +631,11 @@ def scrub_otter_metadata(log, auth_token, service_catalog, region, server_id,
             .addCallback(_treq.content))
 
 
-def launch_server(log, request_bag, scaling_group, launch_config, undo, clock=None):
+def launch_server(log, request_bag, scaling_group, launch_config, undo,
+                  clock=None):
     """
-    Launch a new server given the launch config auth tokens and service catalog.
-    Possibly adding the newly launched server to a load balancer.
+    Launch a new server given the launch config auth tokens and service
+    catalog. Possibly adding the newly launched server to a load balancer.
 
     :param BoundLog log: A bound logger.
     :param request_bag: An object with a bunch of useful data on it, including
@@ -678,8 +679,8 @@ def launch_server(log, request_bag, scaling_group, launch_config, undo, clock=No
         server_id = server['server']['id']
 
         # NOTE: If server create is retried, each server delete will be pushed
-        # to undo stack even after it will be deleted in check_error which is fine
-        # since verified_delete succeeds on deleted server
+        # to undo stack even after it will be deleted in check_error which is
+        # fine since verified_delete succeeds on deleted server
         undo.push(
             verified_delete, log, server_endpoint, new_request_bag, server_id)
 
@@ -712,15 +713,17 @@ def launch_server(log, request_bag, scaling_group, launch_config, undo, clock=No
     def check_error(f):
         f.trap(UnexpectedServerStatus)
         if f.value.status == 'ERROR':
-            log.msg('{server_id} errored, deleting and creating new server instead',
-                    server_id=f.value.server_id)
+            log.msg('{server_id} errored, deleting and creating new '
+                    'server instead', server_id=f.value.server_id)
             # trigger server delete and return True to allow retry
-            verified_delete(log, server_endpoint, request_bag, f.value.server_id)
+            verified_delete(log, server_endpoint, request_bag,
+                            f.value.server_id)
             return True
         else:
             return False
 
-    d = retry(_create_server, can_retry=compose_retries(retry_times(3), check_error),
+    d = retry(_create_server,
+              can_retry=compose_retries(retry_times(3), check_error),
               next_interval=repeating_interval(15), clock=clock)
 
     return d

--- a/otter/worker/launch_server_v1.py
+++ b/otter/worker/launch_server_v1.py
@@ -961,7 +961,8 @@ def verified_delete(log,
         clock = reactor
 
     d = retry(
-        partial(delete_and_verify, serv_log, server_endpoint, request_bag, server_id),
+        partial(delete_and_verify, serv_log, server_endpoint, request_bag,
+                server_id),
         can_retry=retry_times(max_retries),
         next_interval=exponential_backoff_interval(exp_start),
         clock=clock)

--- a/otter/worker/launch_server_v1.py
+++ b/otter/worker/launch_server_v1.py
@@ -845,8 +845,7 @@ def delete_server(log, request_bag, instance_details):
         server_endpoint = public_endpoint_url(request_bag.service_catalog,
                                               cloudServersOpenStack,
                                               request_bag.region)
-        auth_token = request_bag.auth_token
-        return verified_delete(log, server_endpoint, auth_token, server_id)
+        return verified_delete(log, server_endpoint, request_bag, server_id)
 
     d.addCallback(when_removed_from_loadbalancers)
     return d


### PR DESCRIPTION
Re-auth (still using the cache, so by doing this re-auth ensures that the token is at most 5 minutes old) automatically every time we attempt to create a server or delete a server).

A job goes thusly now:
1.  Supervisor auths once for the batch of servers to be created, to make sure we have a token cached.
2.  When the job creates a server, it auths again.  The first time, it just gets the cached token from when the supervisor auth-ed.
3.  We poll Nova waiting for the server to go active, using the auth token we got right before we created the server.
3.  If the server goes into error, the job re-auths again and issues a delete.
4.  We re-auth yet again (will probably be a cached token from the delete), and retry creating a server.
5.  Rinse and repeat.

This is to deal with 401 errors from Nova when it takes a long time to build/go into error, and we retry.