### PR TITLE
fix CLB node gathering to expect the correct format

### DIFF
--- a/otter/convergence/gathering.py
+++ b/otter/convergence/gathering.py
@@ -117,8 +117,10 @@ def get_clb_contents():
         _response, body = result
         lbs = body['loadBalancers']
         lb_ids = [lb['id'] for lb in lbs]
-        lb_reqs = [lb_req('GET', _lb_path(lb_id)).on(_discard_response)
-                   for lb_id in lb_ids]
+        lb_reqs = [
+            lb_req('GET', _lb_path(lb_id)).on(
+                lambda (response, body): body['nodes'])
+            for lb_id in lb_ids]
         return parallel(lb_reqs).on(lambda all_nodes: (lb_ids, all_nodes))
 
     def fetch_drained_feeds((ids, all_lb_nodes)):

--- a/otter/test/convergence/test_gathering.py
+++ b/otter/test/convergence/test_gathering.py
@@ -235,16 +235,16 @@ class GetCLBContentsTests(SynchronousTestCase):
         self.reqs = {
             ('GET', 'loadbalancers', True): {'loadBalancers':
                                              [{'id': 1}, {'id': 2}]},
-            ('GET', 'loadbalancers/1/nodes', True): [
+            ('GET', 'loadbalancers/1/nodes', True): {'nodes': [
                 {'id': '11', 'port': 20, 'address': 'a11',
                  'weight': 2, 'condition': 'DRAINING', 'type': 'PRIMARY'},
                 {'id': '12', 'port': 20, 'address': 'a12',
-                 'weight': 2, 'condition': 'ENABLED', 'type': 'PRIMARY'}],
-            ('GET', 'loadbalancers/2/nodes', True): [
+                 'weight': 2, 'condition': 'ENABLED', 'type': 'PRIMARY'}]},
+            ('GET', 'loadbalancers/2/nodes', True): {'nodes': [
                 {'id': '21', 'port': 20, 'address': 'a21',
                  'weight': 3, 'condition': 'ENABLED', 'type': 'PRIMARY'},
                 {'id': '22', 'port': 20, 'address': 'a22',
-                 'weight': 3, 'condition': 'DRAINING', 'type': 'PRIMARY'}],
+                 'weight': 3, 'condition': 'DRAINING', 'type': 'PRIMARY'}]},
             ('GET', 'loadbalancers/1/nodes/11.atom', False): '11feed',
             ('GET', 'loadbalancers/2/nodes/22.atom', False): '22feed'
         }
@@ -334,8 +334,8 @@ class GetCLBContentsTests(SynchronousTestCase):
         self.reqs = {
             ('GET', 'loadbalancers', True): {'loadBalancers':
                                              [{'id': 1}, {'id': 2}]},
-            ('GET', 'loadbalancers/1/nodes', True): [],
-            ('GET', 'loadbalancers/2/nodes', True): []
+            ('GET', 'loadbalancers/1/nodes', True): {'nodes': []},
+            ('GET', 'loadbalancers/2/nodes', True): {'nodes': []},
         }
         eff = get_clb_contents()
         self.assertEqual(self._resolve_lb(eff), [])
@@ -347,14 +347,14 @@ class GetCLBContentsTests(SynchronousTestCase):
         self.reqs = {
             ('GET', 'loadbalancers', True): {'loadBalancers':
                                              [{'id': 1}, {'id': 2}]},
-            ('GET', 'loadbalancers/1/nodes', True): [
+            ('GET', 'loadbalancers/1/nodes', True): {'nodes': [
                 {'id': '11', 'port': 20, 'address': 'a11',
                  'weight': 2, 'condition': 'ENABLED', 'type': 'PRIMARY'}
-            ],
-            ('GET', 'loadbalancers/2/nodes', True): [
+            ]},
+            ('GET', 'loadbalancers/2/nodes', True): {'nodes': [
                 {'id': '21', 'port': 20, 'address': 'a21',
                  'weight': 2, 'condition': 'ENABLED', 'type': 'PRIMARY'}
-            ]
+            ]},
         }
         make_desc = partial(CLBDescription, port=20, weight=2,
                             condition=CLBNodeCondition.ENABLED,


### PR DESCRIPTION
listing LB nodes returns a JSON structure like {"nodes": [...]}, but the code was just expecting a list to be returned directly.

