### PR TITLE
Steps with unexpected errors should result in a RETRY

### DIFF
--- a/otter/convergence/effecting.py
+++ b/otter/convergence/effecting.py
@@ -2,7 +2,12 @@
 
 from effect import parallel
 
+from otter.convergence.model import StepResult
+
 
 def steps_to_effect(steps):
     """Turns a collection of :class:`IStep` providers into an effect."""
-    return parallel([s.as_effect() for s in steps])
+    # Treat unknown errors as RETRY.
+    return parallel([
+        s.as_effect().on(error=lambda e: (StepResult.RETRY, [e[1]]))
+        for s in steps])

--- a/otter/test/convergence/test_effecting.py
+++ b/otter/test/convergence/test_effecting.py
@@ -1,26 +1,41 @@
 """Tests for convergence effecting."""
 
-from effect import Constant, Effect, parallel
+from effect import Constant, Effect, ParallelEffects, ComposedDispatcher, TypeDispatcher, base_dispatcher, sync_perform, Error
+from effect.async import perform_parallel_async
 
 from twisted.trial.unittest import SynchronousTestCase
 
 from zope.interface import implementer
 
 from otter.convergence.effecting import steps_to_effect
+from otter.convergence.model import StepResult
 from otter.convergence.steps import IStep
+from otter.test.utils import transform_eq
 
 
 @implementer(IStep)
 class _Steppy(object):
+    def __init__(self, effect):
+        self.effect = effect
+
     def as_effect(self):
-        return Effect(Constant(None))
+        return self.effect
 
 
 class StepsToEffectTests(SynchronousTestCase):
     """Tests for :func:`steps_to_effect`"""
     def test_uses_step_request(self):
         """Steps are converted to requests."""
-        steps = [_Steppy(), _Steppy()]
-        expected_effects = [Effect(Constant(None))] * 2
+        steps = [_Steppy(Effect(Constant((StepResult.SUCCESS, 'foo')))),
+                 _Steppy(Effect(Error(RuntimeError('uh oh'))))]
         effect = steps_to_effect(steps)
-        self.assertEqual(effect, parallel(expected_effects))
+        self.assertIs(type(effect.intent), ParallelEffects)
+        dispatcher = ComposedDispatcher([
+            base_dispatcher,
+            TypeDispatcher({ParallelEffects: perform_parallel_async}),
+        ])
+        self.assertEqual(
+            sync_perform(dispatcher, effect),
+            [(StepResult.SUCCESS, 'foo'),
+             (StepResult.RETRY, [transform_eq(lambda e: (type(e), e.args),
+                                              (RuntimeError, ('uh oh',)))])])

--- a/otter/test/utils.py
+++ b/otter/test/utils.py
@@ -6,7 +6,10 @@ import os
 from functools import partial, wraps
 from inspect import getargspec
 
-from effect import base_dispatcher, sync_performer
+from effect import (
+    ComposedDispatcher, ParallelEffects, TypeDispatcher,
+    base_dispatcher, sync_performer)
+from effect.async import perform_parallel_async
 from effect.testing import (
     resolve_effect as eff_resolve_effect,
     resolve_stubs as eff_resolve_stubs)
@@ -672,6 +675,13 @@ def resolve_stubs(eff):
     dispatchers from Effect.
     """
     return eff_resolve_stubs(base_dispatcher, eff)
+
+
+def test_dispatcher():
+    return ComposedDispatcher([
+        base_dispatcher,
+        TypeDispatcher({ParallelEffects: perform_parallel_async}),
+    ])
 
 
 def defaults_by_name(fn):


### PR DESCRIPTION
This makes steps_to_effect wrap all the effects in an error handler that returns (StepResult.RETRY, [exception]).