### PR TITLE
repeat convergence if any steps return RETRY

### DIFF
--- a/otter/convergence/service.py
+++ b/otter/convergence/service.py
@@ -9,7 +9,7 @@ import time
 from functools import partial
 from hashlib import sha1
 
-from effect import Effect, FirstError, Func, catch, parallel
+from effect import Effect, FirstError, Func, parallel
 from effect.do import do, do_return
 from effect.ref import Reference
 from effect.twisted import exc_info_to_failure, perform

--- a/otter/test/convergence/test_service.py
+++ b/otter/test/convergence/test_service.py
@@ -575,8 +575,8 @@ class ExecuteConvergenceTests(SynchronousTestCase):
         for srv in self.servers:
             srv.desired_lbs = pmap()
 
-        tscope_eff = execute_convergence(self.tenant_id, self.group_id, log,
-                                         get_all_convergence_data=gacd)
+        eff = execute_convergence(self.tenant_id, self.group_id, log,
+                                  get_all_convergence_data=gacd)
 
         # Perform the GetScalingGroupInfo by raising an exception
         dispatcher = ComposedDispatcher([
@@ -588,9 +588,7 @@ class ExecuteConvergenceTests(SynchronousTestCase):
             self._get_dispatcher()])
 
         # And make sure that exception isn't wrapped in FirstError.
-        e = self.assertRaises(
-            RuntimeError,
-            sync_perform, dispatcher, tscope_eff.intent.effect)
+        e = self.assertRaises(RuntimeError, sync_perform, dispatcher, eff)
         self.assertEqual(str(e), 'foo')
 
     def test_returns_retry(self):
@@ -607,14 +605,11 @@ class ExecuteConvergenceTests(SynchronousTestCase):
                 ConvergeLater(),
                 TestStep(Effect(Constant((StepResult.SUCCESS, []))))])
 
-        tscope_eff = execute_convergence(
-            self.tenant_id, self.group_id, log,
-            plan=plan,
-            get_all_convergence_data=gacd)
+        eff = execute_convergence(self.tenant_id, self.group_id, log,
+                                  plan=plan,
+                                  get_all_convergence_data=gacd)
         dispatcher = self._get_dispatcher()
-        self.assertEqual(
-            sync_perform(dispatcher, tscope_eff.intent.effect),
-            StepResult.RETRY)
+        self.assertEqual(sync_perform(dispatcher, eff), StepResult.RETRY)
 
     def test_returns_failure(self):
         """
@@ -634,14 +629,11 @@ class ExecuteConvergenceTests(SynchronousTestCase):
                 TestStep(Effect(Constant((StepResult.SUCCESS, [])))),
             ])
 
-        tscope_eff = execute_convergence(
-            self.tenant_id, self.group_id, log,
-            plan=plan,
-            get_all_convergence_data=gacd)
+        eff = execute_convergence(self.tenant_id, self.group_id, log,
+                                  plan=plan,
+                                  get_all_convergence_data=gacd)
         dispatcher = self._get_dispatcher()
-        self.assertEqual(
-            sync_perform(dispatcher, tscope_eff.intent.effect),
-            StepResult.FAILURE)
+        self.assertEqual(sync_perform(dispatcher, eff), StepResult.FAILURE)
 
 
 class DetermineActiveTests(SynchronousTestCase):

--- a/otter/test/utils.py
+++ b/otter/test/utils.py
@@ -760,3 +760,17 @@ def get_fake_service_request_performer(stub_response):
         return resolve_effect(eff, stub_response)
 
     return the_performer
+
+
+def raise_(e):
+    """Raise the exception. Useful for lambdas."""
+    raise e
+
+
+class TestStep(object):
+    """A fake step that returns a canned Effect."""
+    def __init__(self, effect):
+        self.effect = effect
+
+    def as_effect(self):
+        return self.effect


### PR DESCRIPTION
This implements #844 and #956.

There are two changes here:

- execute_convergence now inspects the results of steps, and returns the most severe status found (FAILURE is more severe than RETRY is more severe than SUCCESS).
- converge_one_group now looks at the result of execute_convergence, and in the case of RETRY, simply doesn't delete the divergent flag from ZK, so convergence will be repeated.

These changes enable a lot more integration tests to run, but since I have to deal with a ton of lint in the existing tests, I'm separating that into another PR.