### PR TITLE
Lint most of the system tests

### DIFF
--- a/autoscale_cloudroast/test_repo/autoscale/system/group/test_force_delete_group.py
+++ b/autoscale_cloudroast/test_repo/autoscale/system/group/test_force_delete_group.py
@@ -1,8 +1,9 @@
 """
 System tests for force delete scaling group
 """
-from test_repo.autoscale.fixtures import AutoscaleFixture
 from cafe.drivers.unittest.decorators import tags
+
+from test_repo.autoscale.fixtures import AutoscaleFixture
 
 
 class ForceDeleteGroupTest(AutoscaleFixture):
@@ -13,73 +14,91 @@ class ForceDeleteGroupTest(AutoscaleFixture):
     """
 
     params = ['true', 'TRUE', 'TrUe', 'True', 'truE', True]
-    invalid_params = [0, '', '$%^#', 'false', 'False', False, 'anything', 'truee']
+    invalid_params = [0, '', '$%^#', 'false', 'False', False, 'anything',
+                      'truee']
 
     @tags(speed='slow')
-    def test_system_force_delete_group_with_minentities_over_zero(self):
+    def test_minentities_over_zero(self):
         """
-        Force deleting a scaling group with active servers, updates the desired capacity to be 0,
-        by deleting all the servers and then deletes the group.
+        Force deleting a scaling group with active servers, updates the desired
+        capacity to be 0, by deleting all the servers and then deletes the
+        group.
         """
         for param in self.params:
-            group = self._create_group_given_minentities(self.gc_min_entities_alt)
-            self.verify_group_state(group.id, group.groupConfiguration.minEntities)
-            delete_group_response = self.autoscale_client.delete_scaling_group(group.id, param)
-            self.assertEquals(delete_group_response.status_code, 204,
-                              msg='Force delete group {0} failed when there are no activer servers '
-                              'on the group and force is set to true'.format(group.id))
-            self.assert_servers_deleted_successfully(group.launchConfiguration.server.name)
+            group = self._create_group_given_minentities(
+                self.gc_min_entities_alt)
+            self.verify_group_state(group.id,
+                                    group.groupConfiguration.minEntities)
+            delete_group_response = self.autoscale_client.delete_scaling_group(
+                group.id, param)
+            self.assertEquals(
+                delete_group_response.status_code, 204,
+                msg='Force delete group {0} failed when there are no activer '
+                'servers on the group and force is set to true'.format(
+                    group.id))
+            self.assert_servers_deleted_successfully(
+                group.launchConfiguration.server.name)
 
     @tags(speed='quick')
-    def test_system_force_delete_group_with_force_as_true_with_0_minentities(self):
+    def test_force_as_true_with_0_minentities(self):
         """
-        Force deleting a scaling group with no active servers with force set to true,
-        in any case deletes the group even if there are active servers on the group.
+        Force deleting a scaling group with no active servers with force set to
+        true, in any case deletes the group even if there are active servers on
+        the group.
         """
         for param in self.params:
             group = self._create_group_given_minentities(0)
-            self.verify_group_state(group.id, group.groupConfiguration.minEntities)
-            delete_group_response = self.autoscale_client.delete_scaling_group(group.id, param)
-            self.assertEquals(delete_group_response.status_code, 204,
-                              msg='Force delete group {0} failed when there are no activer servers '
-                              'on the group and force is set to false'.format(group.id))
-            self.assert_servers_deleted_successfully(group.launchConfiguration.server.name)
+            self.verify_group_state(group.id,
+                                    group.groupConfiguration.minEntities)
+            delete_group_response = self.autoscale_client.delete_scaling_group(
+                group.id, param)
+            self.assertEquals(
+                delete_group_response.status_code, 204,
+                msg='Force delete group {0} failed when there are no activer '
+                'servers on the group and force is set to false'.format(
+                    group.id))
+            self.assert_servers_deleted_successfully(
+                group.launchConfiguration.server.name)
 
     @tags(speed='quick')
-    def test_system_force_delete_group_with_invalid_force_attribute_with_0_minentities(self):
+    def test_invalid_force_attribute_with_0_minentities(self):
         """
-        Force deleting a scaling group with no active servers with force set to invalid characters,
-        does not result in error 500.
+        Force deleting a scaling group with no active servers with force set to
+        invalid characters, does not result in error 500.
         """
         group = self._create_group_given_minentities(0)
         self.verify_group_state(group.id, group.groupConfiguration.minEntities)
         for param in self.invalid_params:
-            delete_group_response = self.autoscale_client.delete_scaling_group(group.id, param)
-            self.assertEquals(delete_group_response.status_code, 400,
-                              msg='Force deleted group {0} when active servers existed '
-                              'on it and force was set to invalid option'.format(group.id))
+            delete_group_response = self.autoscale_client.delete_scaling_group(
+                group.id, param)
+            self.assertEquals(
+                delete_group_response.status_code, 400,
+                msg='Force deleted group {0} when active servers existed '
+                'on it and force was set to invalid option'.format(group.id))
 
     @tags(speed='quick')
-    def test_system_force_delete_group_with_invalid_force_attribute(self):
+    def test_invalid_force_attribute(self):
         """
-        Force deleting a scaling group with active servers with force set to invalid characters,
-        does not result in error 500.
+        Force deleting a scaling group with active servers with force set to
+        invalid characters, does not result in error 500.
         """
         group = self._create_group_given_minentities(self.gc_min_entities_alt)
         self.verify_group_state(group.id, group.groupConfiguration.minEntities)
         for param in self.invalid_params:
-            delete_group_response = self.autoscale_client.delete_scaling_group(group.id, param)
-            self.assertEquals(delete_group_response.status_code, 400,
-                              msg='Force deleted group {0} when active servers existed '
-                              'on it and force was set to invalid option'.format(group.id))
+            delete_group_response = self.autoscale_client.delete_scaling_group(
+                group.id, param)
+            self.assertEquals(
+                delete_group_response.status_code, 400,
+                msg='Force deleted group {0} when active servers existed '
+                'on it and force was set to invalid option'.format(group.id))
 
     def _create_group_given_minentities(self, minentities):
         """
         Create a scaling group with the given minEntities
         """
-        create_group_response = self.autoscale_behaviors.create_scaling_group_given(
+        create_response = self.autoscale_behaviors.create_scaling_group_given(
             gc_min_entities=minentities)
-        self.assertEquals(create_group_response.status_code, 201)
-        group = create_group_response.entity
+        self.assertEquals(create_response.status_code, 201)
+        group = create_response.entity
         self.resources.add(group, self.empty_scaling_group)
         return group

--- a/autoscale_cloudroast/test_repo/autoscale/system/group/test_system_delete_group.py
+++ b/autoscale_cloudroast/test_repo/autoscale/system/group/test_system_delete_group.py
@@ -1,8 +1,9 @@
 """
 System tests for delete scaling group
 """
-from test_repo.autoscale.fixtures import AutoscaleFixture
 from cafe.drivers.unittest.decorators import tags
+
+from test_repo.autoscale.fixtures import AutoscaleFixture
 
 
 class DeleteGroupTest(AutoscaleFixture):
@@ -13,12 +14,13 @@ class DeleteGroupTest(AutoscaleFixture):
 
     def setUp(self):
         """
-        Create 2 scaling groups, one with minentities>0 with a scaling up policy and webhook
-        another with minentities=0
+        Create 2 scaling groups, one with minentities>0 with a scaling up
+        policy and webhook another with minentities=0
         """
         super(DeleteGroupTest, self).setUp()
-        self.create_group0_response = self.autoscale_behaviors.create_scaling_group_given(
-            gc_min_entities=0)
+        self.create_group0_response = \
+            self.autoscale_behaviors.create_scaling_group_given(
+                gc_min_entities=0)
         self.group0 = self.create_group0_response.entity
         self.assertEquals(self.create_group0_response.status_code, 201)
         self.policy_up_execute = {'change': 2}
@@ -26,8 +28,9 @@ class DeleteGroupTest(AutoscaleFixture):
             group_id=self.group0.id,
             policy_data=self.policy_up_execute,
             execute_policy=False)
-        self.create_group1_response = self.autoscale_behaviors.create_scaling_group_given(
-            gc_min_entities=self.gc_min_entities_alt)
+        self.create_group1_response = \
+            self.autoscale_behaviors.create_scaling_group_given(
+                gc_min_entities=self.gc_min_entities_alt)
         self.group1 = self.create_group1_response.entity
         self.assertEquals(self.create_group1_response.status_code, 201)
         self.resources.add(self.group0, self.empty_scaling_group)
@@ -42,9 +45,10 @@ class DeleteGroupTest(AutoscaleFixture):
             self.group1.id, self.group1.groupConfiguration.minEntities)
         delete_group_response = self.autoscale_client.delete_scaling_group(
             self.group1.id)
-        self.assertEquals(delete_group_response.status_code, 403,
-                          msg='Deleted group {0} while servers were building on the group'
-                          .format(self.group1.id))
+        self.assertEquals(
+            delete_group_response.status_code, 403,
+            msg='Deleted group {0} while servers were building on the group'
+            .format(self.group1.id))
 
     @tags(speed='quick')
     def test_system_delete_group_update_minentities_to_zero(self):
@@ -59,15 +63,17 @@ class DeleteGroupTest(AutoscaleFixture):
             min_entities=minentities,
             max_entities=self.group1.groupConfiguration.maxEntities,
             metadata={})
-        self.assertEquals(reduce_group_size_response.status_code, 204,
-                          msg='Update to 0 minentities failed with reason {0} for group {1}'
-                          .format(reduce_group_size_response.content, self.group1.id))
+        self.assertEquals(
+            reduce_group_size_response.status_code, 204,
+            msg='Update to 0 minentities failed with reason {0} for group {1}'
+            .format(reduce_group_size_response.content, self.group1.id))
         self.verify_group_state(self.group1.id, self.gc_min_entities_alt)
         delete_group_response = self.autoscale_client.delete_scaling_group(
             self.group1.id)
-        self.assertEquals(delete_group_response.status_code, 403,
-                          msg='Deleted group succeeded when servers exist on the group {0} due to {1}'
-                          .format(self.group1.id, delete_group_response.content))
+        self.assertEquals(
+            delete_group_response.status_code, 403,
+            msg='Deleted group succeeded when servers exist on the group {0} '
+            'due to {1}'.format(self.group1.id, delete_group_response.content))
 
     @tags(speed='quick')
     def test_system_delete_group_with_zero_minentities(self):
@@ -78,9 +84,10 @@ class DeleteGroupTest(AutoscaleFixture):
         self.verify_group_state(self.group0.id, 0)
         delete_group_response = self.autoscale_client.delete_scaling_group(
             self.group0.id)
-        self.assertEquals(delete_group_response.status_code, 204,
-                          msg='Delete group {0} failed even when group was empty'
-                          .format(self.group0.id))
+        self.assertEquals(
+            delete_group_response.status_code, 204,
+            msg='Delete group {0} failed even when group was empty'
+            .format(self.group0.id))
 
     @tags(speed='quick')
     def test_system_delete_group_zero_minentities_execute_webhook(self):
@@ -95,15 +102,16 @@ class DeleteGroupTest(AutoscaleFixture):
             self.group0.id, self.policy_up_execute['change'])
         delete_group_response = self.autoscale_client.delete_scaling_group(
             self.group0.id)
-        self.assertEquals(delete_group_response.status_code, 403,
-                          msg='Deleted group {0} while servers were building on the group'
-                          .format(self.group0.id))
+        self.assertEquals(
+            delete_group_response.status_code, 403,
+            msg='Deleted group {0} while servers were building on the group'
+            .format(self.group0.id))
 
     @tags(speed='quick')
     def test_system_delete_group_zero_minentities_execute_policy(self):
         """
-        Create a scaling group with zero min entities and execute a scaling policy,
-        the group cannot be deleted as it has active servers
+        Create a scaling group with zero min entities and execute a scaling
+        policy, the group cannot be deleted as it has active servers
         """
         execute_policy = self.autoscale_client.execute_policy(
             group_id=self.group0.id,
@@ -113,6 +121,7 @@ class DeleteGroupTest(AutoscaleFixture):
             self.group0.id, self.policy_up_execute['change'])
         delete_group_response = self.autoscale_client.delete_scaling_group(
             self.group0.id)
-        self.assertEquals(delete_group_response.status_code, 403,
-                          msg='Deleted group {0} while servers were building on the group'
-                          .format(self.group0.id))
+        self.assertEquals(
+            delete_group_response.status_code, 403,
+            msg='Deleted group {0} while servers were building on the group'
+            .format(self.group0.id))

--- a/autoscale_cloudroast/test_repo/autoscale/system/group/test_system_group.py
+++ b/autoscale_cloudroast/test_repo/autoscale/system/group/test_system_group.py
@@ -1,9 +1,11 @@
 """
 System tests for multiple scaling groups scenarios
 """
-from test_repo.autoscale.fixtures import AutoscaleFixture
 import base64
+
 from cafe.drivers.unittest.decorators import tags
+
+from test_repo.autoscale.fixtures import AutoscaleFixture
 
 
 class GroupFixture(AutoscaleFixture):
@@ -13,7 +15,7 @@ class GroupFixture(AutoscaleFixture):
     """
 
     @tags(speed='quick')
-    def test_system_update_minentities_to_scaleup(self):
+    def test_update_minentities_to_scaleup(self):
         """
         The scaling group scales up when the minentities are updated,
         to be more than 0
@@ -26,10 +28,10 @@ class GroupFixture(AutoscaleFixture):
         self.verify_group_state(group.id, upd_minentities)
 
     @tags(speed='quick')
-    def test_system_update_minentities_to_be_lesser_than_during_create_group(self):
+    def test_update_minentities_to_be_lesser_than_during_create_group(self):
         """
-        The scaling group does not scale down when the minenetities are updated,
-        to be lower than when created
+        The scaling group does not scale down when the minenetities are
+        updated, to be lower than when created
         """
         minentities = 4
         group = self._create_group(minentities=minentities)
@@ -39,11 +41,12 @@ class GroupFixture(AutoscaleFixture):
         self.verify_group_state(group.id, minentities)
 
     @tags(speed='slow')
-    def test_system_update_maxentities_less_than_desiredcapacity(self):
+    def test_update_maxentities_less_than_desiredcapacity(self):
         """
         Create a scaling group and execute a policy to be within maxentities,
-        reduce the max entities to be less than the active servers (desiredCapacity)
-        and the scaling group scales down to match the updated maxentities
+        reduce the max entities to be less than the active servers
+        (desiredCapacity) and the scaling group scales down to match the
+        updated maxentities
         """
         minentities = 0
         maxentities = 10
@@ -69,7 +72,7 @@ class GroupFixture(AutoscaleFixture):
             count=upd_maxentities)
 
     @tags(speed='quick')
-    def test_system_update_maxentities_and_execute_policy(self):
+    def test_update_maxentities_and_execute_policy(self):
         """
         Execute policy on scaling group such that the maxentities are met,
         update the maxentities and upon re-executing the scaling policy beyond
@@ -97,7 +100,7 @@ class GroupFixture(AutoscaleFixture):
         self.verify_group_state(group.id, total_servers)
 
     @tags(speed='quick')
-    def test_system_group_cooldown_enforced_when_reexecuting_same_policy(self):
+    def test_group_cooldown_enforced_when_reexecuting_same_policy(self):
         """
         The group cooldown is enforced when executing a scaling policy
         with zero policy cooldown, multiple times
@@ -113,17 +116,18 @@ class GroupFixture(AutoscaleFixture):
         reexecute_policy_response = self.autoscale_client.execute_policy(
             group_id=group.id,
             policy_id=policy['id'])
-        self.assertEquals(reexecute_policy_response.status_code, 403,
-                          msg='scaling policy failed execution with status {0}'
-                          ' for group {1}'
-                          .format(reexecute_policy_response.status_code, group.id))
+        self.assertEquals(
+            reexecute_policy_response.status_code, 403,
+            msg='scaling policy failed execution with status {0}'
+            ' for group {1}'
+            .format(reexecute_policy_response.status_code, group.id))
         self.verify_group_state(group.id, policy['change'])
 
     @tags(speed='quick')
-    def test_system_group_cooldown_enforced_when_executing_different_policies(self):
+    def test_group_cooldown_enforced_when_executing_different_policies(self):
         """
-        The group cooldown is enforced when executing different scaling policies,
-        multiple times
+        The group cooldown is enforced when executing different scaling
+        policies, multiple times
         """
         splist = [{
             'name': 'scale up by 3',
@@ -137,14 +141,15 @@ class GroupFixture(AutoscaleFixture):
         execute_policy2_response = self.autoscale_client.execute_policy(
             group_id=group.id,
             policy_id=policy2['id'])
-        self.assertEquals(execute_policy2_response.status_code, 403,
-                          msg='scaling policy failed execution with status {0}'
-                          ' for group {1}'
-                          .format(execute_policy2_response.status_code, group.id))
+        self.assertEquals(
+            execute_policy2_response.status_code, 403,
+            msg='scaling policy failed execution with status {0}'
+            ' for group {1}'
+            .format(execute_policy2_response.status_code, group.id))
         self.verify_group_state(group.id, policy['change'])
 
     @tags(speed='quick')
-    def test_system_update_group_cooldown_and_execute_policy(self):
+    def test_update_group_cooldown_and_execute_policy(self):
         """
         Different scaling policies can be executed when the group cooldown
         is updated to be 0
@@ -167,28 +172,31 @@ class GroupFixture(AutoscaleFixture):
         execute_policy2_response = self.autoscale_client.execute_policy(
             group_id=group.id,
             policy_id=policy2['id'])
-        self.assertEquals(execute_policy2_response.status_code, 403,
-                          msg='scaling policy failed execution with status {0}'
-                          ' for group {1}'
-                          .format(execute_policy2_response.status_code, group.id))
+        self.assertEquals(
+            execute_policy2_response.status_code, 403,
+            msg='scaling policy failed execution with status {0}'
+            ' for group {1}'
+            .format(execute_policy2_response.status_code, group.id))
         self._update_group(group=group, cooldown=0)
         execute_policy2_response = self.autoscale_client.execute_policy(
             group_id=group.id,
             policy_id=policy2['id'])
-        self.assertEquals(execute_policy2_response.status_code, 202,
-                          msg='policy failed execution even with group cooldown 0, with status {0}'
-                          ' for group {1}'
-                          .format(execute_policy2_response.status_code, group.id))
+        self.assertEquals(
+            execute_policy2_response.status_code, 202,
+            msg='policy failed execution even with group cooldown 0, '
+            'with status {0} for group {1}'
+            .format(execute_policy2_response.status_code, group.id))
         total_servers = policy2[
             'change'] + group.groupConfiguration.minEntities + policy['change']
         self.verify_group_state(group.id, total_servers)
 
     @tags(speed='quick')
-    def test_system_execute_policy_beyond_maxentities(self):
+    def test_execute_policy_beyond_maxentities(self):
         """
-        Scaling policy is executed when change + minentities > maxentities, upto
-        the maxentities. Re-executing policy when maxentities are met fails with 403.
-        The scaling policy can be executed when the maxentities is updated to be higher.
+        Scaling policy is executed when change + minentities > maxentities,
+        upto the maxentities. Re-executing policy when maxentities are met
+        fails with 403.  The scaling policy can be executed when the
+        maxentities is updated to be higher.
         """
         minentities = 2
         maxentities = 3
@@ -208,10 +216,11 @@ class GroupFixture(AutoscaleFixture):
         execute_policy_response = self.autoscale_client.execute_policy(
             group_id=group.id,
             policy_id=policy['id'])
-        self.assertEquals(execute_policy_response.status_code, 403,
-                          msg='Policy was executed even when max entities were met,'
-                          'with status {0} for group {1}'
-                          .format(execute_policy_response.status_code, group.id))
+        self.assertEquals(
+            execute_policy_response.status_code, 403,
+            msg='Policy was executed even when max entities were met,'
+            'with status {0} for group {1}'
+            .format(execute_policy_response.status_code, group.id))
         upd_maxentities = 10
         self._update_group(group=group, maxentities=upd_maxentities)
         self._execute_policy(group)
@@ -219,7 +228,7 @@ class GroupFixture(AutoscaleFixture):
         self.verify_group_state(group.id, total_servers)
 
     @tags(speed='quick')
-    def test_system_execute_policy_beyond_maxentities_when_min_equals_max(self):
+    def test_execute_policy_beyond_maxentities_when_min_equals_max(self):
         """
         Scaling group with minentities = maxentities cannot execute scale up
         policy. Update the maxentities and the scaling policy can be executed.
@@ -241,10 +250,11 @@ class GroupFixture(AutoscaleFixture):
         execute_policy_response = self.autoscale_client.execute_policy(
             group_id=group.id,
             policy_id=policy['id'])
-        self.assertEquals(execute_policy_response.status_code, 403,
-                          msg='policy was executed even when max entities were met, with status {0}'
-                          ' for group {1}'
-                          .format(execute_policy_response.status_code, group.id))
+        self.assertEquals(
+            execute_policy_response.status_code, 403,
+            msg='policy was executed even when max entities were met, '
+            'with status {0} for group {1}'
+            .format(execute_policy_response.status_code, group.id))
         upd_maxentities = 10
         self._update_group(group=group, maxentities=upd_maxentities)
         policy = self._execute_policy(group)
@@ -252,7 +262,7 @@ class GroupFixture(AutoscaleFixture):
         self.verify_group_state(group.id, total_servers)
 
     @tags(speed='quick')
-    def test_system_create_scaling_group_with_same_attributes(self):
+    def test_create_scaling_group_with_same_attributes(self):
         """
         Scaling groups can be created with the exact same attributes
         """
@@ -272,26 +282,28 @@ class GroupFixture(AutoscaleFixture):
             'change': 1,
             'cooldown': 100,
             'type': 'webhook'}]
-        create_group1_response = self.autoscale_behaviors.create_scaling_group_given(
-            gc_metadata=gc_metadata,
-            lc_personality=lc_personality,
-            lc_metadata=lc_metadata,
-            lc_disk_config=lc_disk_config,
-            lc_networks=lc_networks,
-            lc_load_balancers=lc_load_balancers,
-            sp_list=sp_list)
+        create_group1_response = \
+            self.autoscale_behaviors.create_scaling_group_given(
+                gc_metadata=gc_metadata,
+                lc_personality=lc_personality,
+                lc_metadata=lc_metadata,
+                lc_disk_config=lc_disk_config,
+                lc_networks=lc_networks,
+                lc_load_balancers=lc_load_balancers,
+                sp_list=sp_list)
         self.assertEquals(create_group1_response.status_code, 201)
         group1 = create_group1_response.entity
         self.resources.add(group1, self.empty_scaling_group)
-        create_group2_response = self.autoscale_behaviors.create_scaling_group_given(
-            gc_name=group1.groupConfiguration.name,
-            gc_metadata=gc_metadata,
-            lc_personality=lc_personality,
-            lc_metadata=lc_metadata,
-            lc_disk_config=lc_disk_config,
-            lc_networks=lc_networks,
-            lc_load_balancers=lc_load_balancers,
-            sp_list=sp_list)
+        create_group2_response = \
+            self.autoscale_behaviors.create_scaling_group_given(
+                gc_name=group1.groupConfiguration.name,
+                gc_metadata=gc_metadata,
+                lc_personality=lc_personality,
+                lc_metadata=lc_metadata,
+                lc_disk_config=lc_disk_config,
+                lc_networks=lc_networks,
+                lc_load_balancers=lc_load_balancers,
+                sp_list=sp_list)
         self.assertEquals(create_group2_response.status_code, 201)
         group2 = create_group2_response.entity
         self.resources.add(group2, self.empty_scaling_group)
@@ -299,12 +311,13 @@ class GroupFixture(AutoscaleFixture):
     def _create_group(self, minentities=None, maxentities=None, cooldown=None,
                       splist=None):
         """
-        Create a scaling group with the given minentities, maxentities, cooldown
-        and scaling policy and Return the group.
+        Create a scaling group with the given minentities, maxentities,
+        cooldown and scaling policy and Return the group.
         """
-        create_group_response = self.autoscale_behaviors.create_scaling_group_given(
-            gc_min_entities=minentities, gc_max_entities=maxentities,
-            gc_cooldown=cooldown, sp_list=splist)
+        create_group_response = \
+            self.autoscale_behaviors.create_scaling_group_given(
+                gc_min_entities=minentities, gc_max_entities=maxentities,
+                gc_cooldown=cooldown, sp_list=splist)
         group = create_group_response.entity
         self.assertEqual(create_group_response.status_code, 201,
                          msg='Create group failed with {0}'.format(group.id))
@@ -330,9 +343,10 @@ class GroupFixture(AutoscaleFixture):
             min_entities=minentities,
             max_entities=maxentities,
             metadata={})
-        self.assertEqual(update_group.status_code, 204,
-                         msg='Update group failed with {0} for group {1}'.format(
-                         update_group.status_code, group.id))
+        self.assertEqual(
+            update_group.status_code, 204,
+            msg='Update group failed with {0} for group {1}'.format(
+                update_group.status_code, group.id))
 
     def _execute_policy(self, group):
         """
@@ -344,8 +358,9 @@ class GroupFixture(AutoscaleFixture):
         execute_policy_response = self.autoscale_client.execute_policy(
             group_id=group.id,
             policy_id=policy['id'])
-        self.assertEquals(execute_policy_response.status_code, 202,
-                          msg='scaling policy failed execution with status {0}'
-                          ' for group {1}'.format(execute_policy_response.status_code,
-                                                  group.id))
+        self.assertEquals(
+            execute_policy_response.status_code, 202,
+            msg='scaling policy failed execution with status {0}'
+            ' for group {1}'.format(execute_policy_response.status_code,
+                                    group.id))
         return policy

--- a/autoscale_cloudroast/test_repo/autoscale/system/group/test_system_group_negative.py
+++ b/autoscale_cloudroast/test_repo/autoscale/system/group/test_system_group_negative.py
@@ -1,9 +1,11 @@
 """
 System tests for negative groups scenarios
 """
-from test_repo.autoscale.fixtures import AutoscaleFixture
 import unittest
+
 from cafe.drivers.unittest.decorators import tags
+
+from test_repo.autoscale.fixtures import AutoscaleFixture
 
 
 class NegativeGroupFixture(AutoscaleFixture):
@@ -21,204 +23,224 @@ class NegativeGroupFixture(AutoscaleFixture):
         cls.invalid_lbaas = [{'loadBalancerId': 0000, 'port': 0000}]
 
     @unittest.skip("Invalid LbaasID handling not implemented")
-    def test_system_create_delete_scaling_group_invalid_lbaasid(self):
+    def test_create_delete_scaling_group_invalid_lbaasid(self):
         """
         Verify scaling group fails when launch config has an invalid lbaasId
         and that it can be deleted
         """
-        create_group_response = self.autoscale_behaviors.create_scaling_group_given(
-            gc_min_entities=self.gc_min_entities_alt,
-            lc_load_balancers=self.invalid_lbaas)
+        create_group_response = \
+            self.autoscale_behaviors.create_scaling_group_given(
+                gc_min_entities=self.gc_min_entities_alt,
+                lc_load_balancers=self.invalid_lbaas)
         group = create_group_response.entity
-        self.assertEquals(create_group_response.status_code, 201,
-                          msg='Create group with invalid lbaas id failed with {0}'
-                          .format(create_group_response.status_code))
+        self.assertEquals(
+            create_group_response.status_code, 201,
+            msg='Create group with invalid lbaas id failed with {0}'
+            .format(create_group_response.status_code))
         # check active servers and wait for lbaas add node to fail
-        group_state_response = self.autoscale_client.list_status_entities_sgroups(
-            group.id)
+        group_state_response = \
+            self.autoscale_client.list_status_entities_sgroups(
+                group.id)
         self.assertEquals(group_state_response.status_code, 200)
         group_state = group_state_response.entity
         self.assertEquals(
             group_state.pendingCapacity +
             group_state.activeCapacity, 0,
-            msg='Group failed to attempt to create server with invalid lbaas id. Active+pending != min')
-        self.assertEqual(group_state.desiredCapacity, 0,
-                         msg='Desired capacity is not equal to the minentities on the group')
+            msg='Group failed to attempt to create server with invalid '
+                'lbaas id. Active+pending != min')
+        self.assertEqual(
+            group_state.desiredCapacity, 0,
+            msg='Desired capacity is not equal to the minentities on the group'
+        )
         delete_group_response = self.autoscale_client.delete_scaling_group(
             group.id)
-        self.assertEquals(delete_group_response.status_code, 204,
-                          msg='Deleted group failed for a group with invalid lbaas id with {0}'
-                          .format(delete_group_response.status_code))
+        self.assertEquals(
+            delete_group_response.status_code, 204,
+            msg='Deleted group failed for a group with invalid lbaas id with '
+            '{0}'.format(delete_group_response.status_code))
 
     @unittest.skip("Invalid LbaasID handling not implemented")
-    def test_system_execute_policy_with_invalid_lbaasid(self):
+    def test_execute_policy_with_invalid_lbaasid(self):
         """
-        Verify scaling policy execution fails when launch config has an invalid lbaasId
-        and that it can be deleted
+        Verify scaling policy execution fails when launch config has an invalid
+        lbaasId and that it can be deleted
         """
-        update_launch_config_response = self.autoscale_client.update_launch_config(
-            group_id=self.group.id,
-            name=self.group.launchConfiguration.server.name,
-            image_ref=self.group.launchConfiguration.server.imageRef,
-            flavor_ref=self.group.launchConfiguration.server.flavorRef,
-            load_balancers=self.invalid_lbaas)
-        self.assertEquals(update_launch_config_response.status_code, 204,
-                          msg='Updating launch config with invalid lbaas id failed with {0}'
-                          .format(update_launch_config_response))
+        update_launch_config_response = \
+            self.autoscale_client.update_launch_config(
+                group_id=self.group.id,
+                name=self.group.launchConfiguration.server.name,
+                image_ref=self.group.launchConfiguration.server.imageRef,
+                flavor_ref=self.group.launchConfiguration.server.flavorRef,
+                load_balancers=self.invalid_lbaas)
+        self.assertEquals(
+            update_launch_config_response.status_code, 204,
+            msg='Updating launch config with invalid lbaas id failed with {0}'
+            .format(update_launch_config_response))
         execute_policy_response = self.autoscale_client.execute_policy(
             group_id=self.group.id,
             policy_id=self.policy['id'])
-        self.assertEquals(execute_policy_response.status_code, 202,
-                          msg='Policy executed with an invalid lbaas id with status {0}'
-                          .format(execute_policy_response.status_code))
+        self.assertEquals(
+            execute_policy_response.status_code, 202,
+            msg='Policy executed with an invalid lbaas id with status {0}'
+            .format(execute_policy_response.status_code))
         # check active servers and wait for lbaas add node to fail
-        group_state_response = self.autoscale_client.list_status_entities_sgroups(
-            self.group.id)
+        group_state_response = \
+            self.autoscale_client.list_status_entities_sgroups(self.group.id)
         self.assertEquals(group_state_response.status_code, 200)
         group_state = group_state_response.entity
         self.assertEquals(
             group_state.pendingCapacity + group_state.activeCapacity,
             0,
-            msg='Active + Pending servers is not equal to expected number of servers')
-        self.assertEqual(group_state.desiredCapacity, 0,
-                         msg='Desired capacity is not equal to expected number of servers')
+            msg='Active + Pending servers is not equal to expected number of '
+            'servers')
+        self.assertEqual(
+            group_state.desiredCapacity, 0,
+            msg='Desired capacity is not equal to expected number of servers')
 
     @tags(speed='quick')
-    def test_system_user_delete_some_servers_out_of_band(self):
+    def test_user_delete_some_servers_out_of_band(self):
         """
-        Create a group with 4 minentities and verify the group state when user deletes one
-        of the servers on the group
+        Create a group with 4 minentities and verify the group state when user
+        deletes one of the servers on the group
         """
         server_count = 4
         group_response = self.autoscale_behaviors.create_scaling_group_given(
-            gc_min_entities=server_count, lc_metadata={'server_building': '30'})
+            gc_min_entities=server_count, lc_metadata={'server_building': '30'}
+        )
         group = group_response.entity
         self.resources.add(group, self.empty_scaling_group)
-        server_list = self.check_for_expected_number_of_building_servers(group.id, server_count)
-        self.assertEqual(len(server_list), server_count, msg='The number of servers building '
-                         'is {0}, but should be {1} for group {2}'.format(len(server_list), server_count,
-                                                                          group.id))
+        server_list = self.check_for_expected_number_of_building_servers(
+            group.id, server_count)
+        self.assertEqual(
+            len(server_list), server_count,
+            msg=('The number of servers building is {0}, but should be {1} '
+                 'for group {2}'.format(len(server_list), server_count,
+                                        group.id)))
         self.server_client.delete_server(server_list[0])
         self.wait_for_expected_group_state(group.id, server_count - 1)
-        updated_state = self.autoscale_client.list_status_entities_sgroups(group.id).entity
-        self.assertEqual(updated_state.pendingCapacity + updated_state.activeCapacity, server_count - 1,
-                         msg='{0} servers are building or active. Expected '
-                         '{1}'.format(updated_state.pendingCapacity + updated_state.activeCapacity,
-                                      server_count - 1))
+        updated_state = self.autoscale_client.list_status_entities_sgroups(
+            group.id).entity
+        self.assertEqual(
+            updated_state.pendingCapacity + updated_state.activeCapacity,
+            server_count - 1,
+            msg='{0} servers are building or active. Expected '
+            '{1}'.format(
+                updated_state.pendingCapacity + updated_state.activeCapacity,
+                server_count - 1))
 
-    def test_system_create_delete_scaling_group_server_building_indefinitely(self):
+    def test_create_delete_scaling_group_server_building_indefinitely(self):
         """
         Verify create delete scaling group when servers remain in 'build' state
         indefinitely
         """
         pass
 
-    def test_system_execute_policy_server_building_indefinitely(self):
+    def test_execute_policy_server_building_indefinitely(self):
         """
         Verify execute policy when servers remain in build indefinitely
         """
         pass
 
-    def test_system_execute_policy_one_ofthe_server_builds_indefinitely(self):
+    def test_execute_policy_one_ofthe_server_builds_indefinitely(self):
         """
         Verify execute policy when servers build indefinitely
         """
         pass
 
-    def test_system_create_delete_scaling_group_some_servers_error(self):
+    def test_create_delete_scaling_group_some_servers_error(self):
         """
         Verify create delete scaling group when servers some servers go
         into error state
         """
         pass
 
-    def test_system_create_delete_scaling_group_all_servers_error(self):
+    def test_create_delete_scaling_group_all_servers_error(self):
         """
         Verify create delete scaling group when all the servers go into
         error state
         """
         pass
 
-    def test_system_create_delete_scaling_group_server_rate_limit_met(self):
+    def test_create_delete_scaling_group_server_rate_limit_met(self):
         """
         Verify create delete group when maximum servers allowed already exist.
         """
         pass
 
-    def test_system_execute_policy_when_server_rate_limit_met(self):
+    def test_execute_policy_when_server_rate_limit_met(self):
         """
         Verify execute policy when maximum servers allowed already exist.
         """
         pass
 
-    def test_system_create_scaling_group_account_suspended(self):
+    def test_create_scaling_group_account_suspended(self):
         """
         Verify create scaling group when account is suspended
         """
         pass
 
-    def test_system_execute_policy_on_suspended_account(self):
+    def test_execute_policy_on_suspended_account(self):
         """
         Verify create scaling group when account is suspended
         """
         pass
 
-    def test_system_create_scaling_group_account_closed(self):
+    def test_create_scaling_group_account_closed(self):
         """
         Verify create scaling group when account is closed
         """
         pass
 
-    def test_system_execute_policy_on_closed_account(self):
+    def test_execute_policy_on_closed_account(self):
         """
         Verify create scaling group when account is closed
         """
         pass
 
-    def test_system_delete_group_unable_to_impersonate(self):
+    def test_delete_group_unable_to_impersonate(self):
         """
         Verify delete scaling group when impersonation fails
         """
         # AUTO - 284
         pass
 
-    def test_system_delete_group_when_nova_down(self):
+    def test_delete_group_when_nova_down(self):
         """
         Verify delete scaling group when nova is down
         """
         pass
 
-    def test_system_delete_group_when_lbaas_down(self):
+    def test_delete_group_when_lbaas_down(self):
         """
         Verify delete scaling group when lbaas is down
         """
         pass
 
-    def test_system_create_delete_scaling_group_with_deleted_lbaasid(self):
+    def test_create_delete_scaling_group_with_deleted_lbaasid(self):
         """
         Verify creation of scaling group with deleted lbaas id
         note : is this same as invalid id??
         """
         pass
 
-    def test_system_execute_policy_with_deleted_lbaasid(self):
+    def test_execute_policy_with_deleted_lbaasid(self):
         """
         Verify polic execution with deleted lbaas id
         note : is this same as invalid id??
         """
         pass
 
-    def test_system_delete_group_delete_all_servers(self):
+    def test_delete_group_delete_all_servers(self):
         """
-        Verify delete scaling group when user deletes all the servers on the group
-        Autoscaling will re create all the deleted servers
-        (try changing launch config jus before delete)
+        Verify delete scaling group when user deletes all the servers on the
+        group Autoscaling will re create all the deleted servers (try changing
+        launch config jus before delete)
         """
         pass
 
-    def test_system_delete_group_other_server_actions(self):
+    def test_delete_group_other_server_actions(self):
         """
-        Verify delete scaling group when user performs actions on the servers in the group
-        Autoscaling will continue, like no action occured
+        Verify delete scaling group when user performs actions on the servers
+        in the group Autoscaling will continue, like no action occured
         """
         pass

--- a/autoscale_cloudroast/test_repo/autoscale/system/group/test_system_launch_config.py
+++ b/autoscale_cloudroast/test_repo/autoscale/system/group/test_system_launch_config.py
@@ -3,9 +3,11 @@ System tests for launch config
 """
 import unittest
 
-from test_repo.autoscale.fixtures import AutoscaleFixture
 from cafe.drivers.unittest.decorators import tags
+
 from cloudcafe.common.tools.datagen import rand_name
+
+from test_repo.autoscale.fixtures import AutoscaleFixture
 
 
 class LaunchConfigTest(AutoscaleFixture):
@@ -25,11 +27,11 @@ class LaunchConfigTest(AutoscaleFixture):
         cls.upd_flavor_ref = "3"
 
     @tags(speed='quick')
-    def test_system_update_launchconfig_scale_up(self):
+    def test_update_launchconfig_scale_up(self):
         """
         Create a scaling group with a scaling policy, update the launch config.
-        Execute the scaling policy, the servers created from executing the policy
-        are with the updated launch config
+        Execute the scaling policy, the servers created from executing the
+        policy are with the updated launch config
         """
         minentities = 1
         group = self._create_group(minentities=minentities, policy=True)
@@ -37,22 +39,24 @@ class LaunchConfigTest(AutoscaleFixture):
             group_id=group.id,
             expected_servers=minentities)
         self._update_launch_config(
-            group, self.upd_server_name, self.upd_image_ref, self.upd_flavor_ref)
+            group, self.upd_server_name, self.upd_image_ref,
+            self.upd_flavor_ref)
         self._execute_policy(group)
-        active_list_after_upd = self.check_for_expected_number_of_building_servers(
+        active_list = self.check_for_expected_number_of_building_servers(
             group_id=group.id,
             expected_servers=self.sp_change,
             desired_capacity=minentities + self.sp_change)
         self._verify_server_list_for_launch_config(
-            active_list_after_upd, self.upd_server_name,
+            active_list, self.upd_server_name,
             self.upd_image_ref, self.upd_flavor_ref)
 
     @tags(speed='slow')
-    def test_system_update_launchconfig_scale_down(self):
+    def test_update_launchconfig_scale_down(self):
         """
-        Create a scaling group with a scale up and scale down policy. Execute the scale up
-        policy, update launch config. Then executing a scale down policy, deletes the oldest
-        server first. (note: there are no servers with latest config on the group)
+        Create a scaling group with a scale up and scale down policy. Execute
+        the scale up policy, update launch config. Then executing a scale down
+        policy, deletes the oldest server first. (note: there are no servers
+        with latest config on the group)
         """
         minentities = 1
         group = self._create_group(minentities=minentities, policy=True)
@@ -69,14 +73,16 @@ class LaunchConfigTest(AutoscaleFixture):
             group_id=group.id,
             expected_servers=minentities + self.sp_change)
         self._update_launch_config(
-            group, self.upd_server_name, self.upd_image_ref, self.upd_flavor_ref)
+            group, self.upd_server_name, self.upd_image_ref,
+            self.upd_flavor_ref)
         self._execute_policy(group, policy_down['id'])
         server_after_down = len(active_list_b4_upd) + scale_down_change
-        active_server_list_after_scale_down = self.wait_for_expected_number_of_active_servers(
-            group_id=group.id,
-            expected_servers=server_after_down)
-        self.assertEqual(set(active_server_list_after_scale_down), (
-            set(active_list_b4_upd) - set(first_server)))
+        active_server_list_after_scale_down = \
+            self.wait_for_expected_number_of_active_servers(
+                group_id=group.id, expected_servers=server_after_down)
+        self.assertEqual(
+            set(active_server_list_after_scale_down),
+            set(active_list_b4_upd) - set(first_server))
         self._verify_server_list_for_launch_config(
             active_server_list_after_scale_down,
             group.launchConfiguration.server.name,
@@ -87,12 +93,12 @@ class LaunchConfigTest(AutoscaleFixture):
             server_after_down)
 
     @tags(speed='slow')
-    def test_system_update_launchconfig_scale_up_down(self):
+    def test_update_launchconfig_scale_up_down(self):
         """
-        Create a scaling group with a scale up and scale down policy. Execute the scale up
-        policy, update launch config. Then executing the scale down and scale up policy,
-        deletes servers with older launch config and launches servers with the updated
-        launch config
+        Create a scaling group with a scale up and scale down policy. Execute
+        the scale up policy, update launch config. Then executing the scale
+        down and scale up policy, deletes servers with older launch config and
+        launches servers with the updated launch config
         """
         minentities = 1
         group = self._create_group(minentities=minentities, policy=True)
@@ -109,7 +115,8 @@ class LaunchConfigTest(AutoscaleFixture):
             group_id=group.id,
             expected_servers=minentities + self.sp_change)
         self._update_launch_config(
-            group, self.upd_server_name, self.upd_image_ref, self.upd_flavor_ref)
+            group, self.upd_server_name, self.upd_image_ref,
+            self.upd_flavor_ref)
         self._execute_policy(group)
         active_servers = minentities + (2 * self.sp_change)
         active_list_after_up = self.wait_for_expected_number_of_active_servers(
@@ -117,20 +124,22 @@ class LaunchConfigTest(AutoscaleFixture):
             expected_servers=active_servers)
         upd_lc_server = set(active_list_after_up) - set(active_list_b4_upd)
         self._verify_server_list_for_launch_config(
-            upd_lc_server, self.upd_server_name, self.upd_image_ref, self.upd_flavor_ref)
+            upd_lc_server, self.upd_server_name, self.upd_image_ref,
+            self.upd_flavor_ref)
         self._execute_policy(group, policy_down['id'])
         server_after_down = active_servers + scale_down_change
-        active_list_after_down = self.wait_for_expected_number_of_active_servers(
-            group_id=group.id,
-            expected_servers=server_after_down)
-        self.assertEqual(set(active_list_after_down), (
-            set(active_list_after_up) - set(first_server)))
+        active_list_after_down = \
+            self.wait_for_expected_number_of_active_servers(
+                group_id=group.id,
+                expected_servers=server_after_down)
+        self.assertEqual(set(active_list_after_down),
+                         set(active_list_after_up) - set(first_server))
         self.assert_servers_deleted_successfully(
             group.launchConfiguration.server.name,
             - scale_down_change)
 
     @tags(speed='quick', convergence='yes')
-    def test_system_server_details_name_and_metadata(self):
+    def test_server_details_name_and_metadata(self):
         """
         Server name is appended by random characters and metadata of servers
         includes the group id, for servers created by autoscale.
@@ -154,7 +163,7 @@ class LaunchConfigTest(AutoscaleFixture):
                 group.launchConfiguration.server.name in server.name)
 
     @tags(speed='quick', convergence='yes')
-    def test_system_launchconfig_without_server_name(self):
+    def test_launchconfig_without_server_name(self):
         """
         Create a scaling group with a scaling policy, without server name in
         the launch config.  Ensure servers were created on the scaling_group.
@@ -168,11 +177,12 @@ class LaunchConfigTest(AutoscaleFixture):
         group = group_response.entity
         self.resources.add(group, self.empty_scaling_group)
         self.verify_group_state(group.id, self.gc_min_entities_alt)
-        self.verify_server_count_using_server_metadata(group.id, self.gc_min_entities_alt)
+        self.verify_server_count_using_server_metadata(
+            group.id, self.gc_min_entities_alt)
 
     @unittest.skip('Requires an upgrade of cloudcafe to handle empty images')
     @tags(requires='mimic')
-    def test_system_launchconfig_with_boot_from_volume(self):
+    def test_launchconfig_with_boot_from_volume(self):
         """
         Create a scaling group with a launch config that has an empty image ID,
         and minEntities=1.  Ensure a server with an empty image ID was created
@@ -206,7 +216,7 @@ class LaunchConfigTest(AutoscaleFixture):
         self.assertEquals("", servers[0].image.id)
 
     @tags(speed='quick')
-    def test_system_update_launchconfig_while_group_building(self):
+    def test_update_launchconfig_while_group_building(self):
         """
         Updates to the launch config do not apply to the servers building,
         when the update is made
@@ -214,7 +224,8 @@ class LaunchConfigTest(AutoscaleFixture):
         minentities = 2
         group = self._create_group(minentities=minentities)
         self._update_launch_config(
-            group, self.upd_server_name, self.upd_image_ref, self.upd_flavor_ref)
+            group, self.upd_server_name, self.upd_image_ref,
+            self.upd_flavor_ref)
         servers_list = self.check_for_expected_number_of_building_servers(
             group_id=group.id,
             expected_servers=minentities,
@@ -226,22 +237,25 @@ class LaunchConfigTest(AutoscaleFixture):
             group.launchConfiguration.server.flavorRef)
 
     @tags(speed='slow')
-    def test_system_update_launchconfig_while_group_building_and_scale_down(self):
+    def test_update_launchconfig_while_group_building_and_scale_down(self):
         """
-        Create a scaling group and scale up. While servers are building, update launch config
-        and scale down. Servers with the latest launch config are deleted. (AUTO-384)
-        Note : Mimic sets the created server to be in building state for the time in seconds,
-        given in the server metadata 'server_building'.
+        Create a scaling group and scale up. While servers are building, update
+        launch config and scale down. Servers with the latest launch config are
+        deleted. (AUTO-384) Note : Mimic sets the created server to be in
+        building state for the time in seconds, given in the server metadata
+        'server_building'.
         """
         minentities = 1
         metadata = {'server_building': '30'}
         group = self._create_group(minentities=minentities, policy=True,
                                    metadata=metadata)
         group_before_upd = group
-        self.wait_for_expected_number_of_active_servers(group_before_upd.id, minentities)
+        self.wait_for_expected_number_of_active_servers(group_before_upd.id,
+                                                        minentities)
         # update launch config
         self._update_launch_config(
-            group, self.upd_server_name, self.upd_image_ref, self.upd_flavor_ref, metadata)
+            group, self.upd_server_name, self.upd_image_ref,
+            self.upd_flavor_ref, metadata)
         # execute scale up policy
         self._execute_policy(group)
         # create and then execute scale down policy
@@ -251,11 +265,12 @@ class LaunchConfigTest(AutoscaleFixture):
             sp_change=scale_down_change,
             sp_cooldown=0)
         self._execute_policy(group, policy_down['id'])
-        active_server_list_after_scale_down = self.wait_for_expected_number_of_active_servers(
-            group_id=group.id,
-            expected_servers=minentities)
-        # verify that the servers remaining after scale up and scale down are of older
-        # launch config.
+        active_server_list_after_scale_down = \
+            self.wait_for_expected_number_of_active_servers(
+                group_id=group.id,
+                expected_servers=minentities)
+        # verify that the servers remaining after scale up and scale down are
+        # of older launch config.
         self._verify_server_list_for_launch_config(
             active_server_list_after_scale_down,
             group_before_upd.launchConfiguration.server.name,
@@ -263,7 +278,7 @@ class LaunchConfigTest(AutoscaleFixture):
             group_before_upd.launchConfiguration.server.flavorRef)
 
     @tags(speed='quick')
-    def test_system_update_launchconfig_group_minentities(self):
+    def test_update_launchconfig_group_minentities(self):
         """
         Create a scaling group, update the launch config.
         Update the minentities to be more than when the group was created,
@@ -273,16 +288,18 @@ class LaunchConfigTest(AutoscaleFixture):
         minentities = 1
         upd_minentities = 3
         group = self._create_group(minentities=minentities)
-        servers_first_list = self.check_for_expected_number_of_building_servers(
-            group_id=group.id,
-            expected_servers=minentities)
+        servers_first_list = \
+            self.check_for_expected_number_of_building_servers(
+                group_id=group.id,
+                expected_servers=minentities)
         self._verify_server_list_for_launch_config(
             servers_first_list,
             group.launchConfiguration.server.name,
             group.launchConfiguration.server.imageRef,
             group.launchConfiguration.server.flavorRef)
         self._update_launch_config(
-            group, self.upd_server_name, self.upd_image_ref, self.upd_flavor_ref)
+            group, self.upd_server_name, self.upd_image_ref,
+            self.upd_flavor_ref)
         update_group_response = self.autoscale_client.update_group_config(
             group_id=group.id,
             name=group.groupConfiguration.name,
@@ -291,20 +308,24 @@ class LaunchConfigTest(AutoscaleFixture):
             max_entities=group.groupConfiguration.maxEntities,
             metadata={})
         self.assertEquals(update_group_response.status_code, 204)
-        servers_list_on_upd = self.check_for_expected_number_of_building_servers(
-            group_id=group.id,
-            expected_servers=upd_minentities - minentities,
-            desired_capacity=upd_minentities)
+        servers_list_on_upd = \
+            self.check_for_expected_number_of_building_servers(
+                group_id=group.id,
+                expected_servers=upd_minentities - minentities,
+                desired_capacity=upd_minentities)
         self._verify_server_list_for_launch_config(
-            servers_list_on_upd, self.upd_server_name, self.upd_image_ref, self.upd_flavor_ref)
+            servers_list_on_upd, self.upd_server_name, self.upd_image_ref,
+            self.upd_flavor_ref)
 
     @tags(speed='slow')
-    def test_system_update_launchconfig_group_maxentities(self):
+    def test_update_launchconfig_group_maxentities(self):
         """
-        Create a scaling group with scaling policy and with minentities=sp_change in the scaling policy.
-        Update the launch config, execute policy, new servers are of updated launch config.
-        Update the maxentities=minentities=sp_change, hence causing scale down by same number as
-        the scale up. Resulting servers are of updated launch config only. (sp_change from config)
+        Create a scaling group with scaling policy and with
+        minentities=sp_change in the scaling policy.  Update the launch config,
+        execute policy, new servers are of updated launch config.  Update the
+        maxentities=minentities=sp_change, hence causing scale down by same
+        number as the scale up. Resulting servers are of updated launch config
+        only. (sp_change from config)
         """
         minentities = self.sp_change
         group = self._create_group(
@@ -318,15 +339,18 @@ class LaunchConfigTest(AutoscaleFixture):
             group.launchConfiguration.server.imageRef,
             group.launchConfiguration.server.flavorRef)
         self._update_launch_config(
-            group, self.upd_server_name, self.upd_image_ref, self.upd_flavor_ref)
+            group, self.upd_server_name, self.upd_image_ref,
+            self.upd_flavor_ref)
         self._execute_policy(group)
-        active_list_after_upd_lc = self.wait_for_expected_number_of_active_servers(
-            group_id=group.id,
-            expected_servers=minentities + self.sp_change)
+        active_list_after_upd_lc = \
+            self.wait_for_expected_number_of_active_servers(
+                group_id=group.id,
+                expected_servers=minentities + self.sp_change)
         servers_after_scale_up = set(
             active_list_after_upd_lc) - set(servers_list_b4_upd)
         self._verify_server_list_for_launch_config(
-            servers_after_scale_up, self.upd_server_name, self.upd_image_ref, self.upd_flavor_ref)
+            servers_after_scale_up, self.upd_server_name, self.upd_image_ref,
+            self.upd_flavor_ref)
         update_group_response = self.autoscale_client.update_group_config(
             group_id=group.id,
             name=group.groupConfiguration.name,
@@ -335,21 +359,24 @@ class LaunchConfigTest(AutoscaleFixture):
             max_entities=group.groupConfiguration.minEntities,
             metadata={})
         self.assertEquals(update_group_response.status_code, 204)
-        servers_list_on_upd_group = self.wait_for_expected_number_of_active_servers(
-            group_id=group.id,
-            expected_servers=group.groupConfiguration.minEntities)
+        servers_list_on_upd_group = \
+            self.wait_for_expected_number_of_active_servers(
+                group_id=group.id,
+                expected_servers=group.groupConfiguration.minEntities)
         self.assertEquals(
             set(servers_list_on_upd_group), set(servers_after_scale_up))
         self._verify_server_list_for_launch_config(
-            servers_list_on_upd_group, self.upd_server_name, self.upd_image_ref,
-            self.upd_flavor_ref)
-        self.assert_servers_deleted_successfully(group.launchConfiguration.server.name)
+            servers_list_on_upd_group, self.upd_server_name,
+            self.upd_image_ref, self.upd_flavor_ref)
+        self.assert_servers_deleted_successfully(
+            group.launchConfiguration.server.name)
 
     @tags(speed='slow')
-    def test_system_scale_down_oldest_on_active_servers(self):
+    def test_scale_down_oldest_on_active_servers(self):
         """
-        Create a scaling group with minentities=scale up=scale_down=sp_change(from config).
-        Scale down and verify that the oldest server is scaled down first
+        Create a scaling group with minentities=scale up=scale_down=sp_change
+        (from config).  Scale down and verify that the oldest server is scaled
+        down first
         """
         minentities = self.sp_change
         group = self._create_group(minentities=minentities, policy=True)
@@ -362,26 +389,29 @@ class LaunchConfigTest(AutoscaleFixture):
             group_id=group.id,
             expected_servers=minentities)
         self._execute_policy(group)
-        active_list_after_scale_up = self.wait_for_expected_number_of_active_servers(
-            group_id=group.id,
-            expected_servers=minentities + self.sp_change)
+        active_list_after_scale_up = \
+            self.wait_for_expected_number_of_active_servers(
+                group_id=group.id,
+                expected_servers=minentities + self.sp_change)
         servers_from_scale_up = set(
             active_list_after_scale_up) - set(first_server)
         self._execute_policy(group, policy_down['id'])
-        active_server_list_after_scale_down = self.wait_for_expected_number_of_active_servers(
-            group_id=group.id,
-            expected_servers=self.sp_change)
+        active_server_list_after_scale_down = \
+            self.wait_for_expected_number_of_active_servers(
+                group_id=group.id,
+                expected_servers=self.sp_change)
         self.assertEqual(set(servers_from_scale_up), set(
             active_server_list_after_scale_down))
         self.assert_servers_deleted_successfully(
             group.launchConfiguration.server.name,
             self.sp_change)
 
-    def _create_group(self, minentities=None, maxentities=None, policy=False, metadata=None):
+    def _create_group(self, minentities=None, maxentities=None, policy=False,
+                      metadata=None):
         """
-        Create a scaling group with the given minentities, maxentities,
-        and cooldown as 0. Create group with scaling policy if policy is set to True.
-        Return the group.
+        Create a scaling group with the given minentities, maxentities, and
+        cooldown as 0. Create group with scaling policy if policy is set to
+        True.  Return the group.
         """
         if policy is True:
             sp_list = [{'name': "policy in group",
@@ -389,15 +419,15 @@ class LaunchConfigTest(AutoscaleFixture):
                         'cooldown': 0,
                         'type': 'webhook'
                         }]
-            create_group_response = self.autoscale_behaviors.create_scaling_group_given(
+            response = self.autoscale_behaviors.create_scaling_group_given(
                 gc_min_entities=minentities, gc_max_entities=maxentities,
                 gc_cooldown=0, sp_list=sp_list, lc_metadata=metadata)
         else:
-            create_group_response = self.autoscale_behaviors.create_scaling_group_given(
+            response = self.autoscale_behaviors.create_scaling_group_given(
                 gc_min_entities=minentities, gc_max_entities=maxentities,
                 gc_cooldown=0, lc_metadata=metadata)
-        group = create_group_response.entity
-        self.assertEqual(create_group_response.status_code, 201,
+        group = response.entity
+        self.assertEqual(response.status_code, 201,
                          msg='Create group failed with {0}'.format(group.id))
         self.resources.add(group, self.empty_scaling_group)
         return group
@@ -408,15 +438,16 @@ class LaunchConfigTest(AutoscaleFixture):
         Update the scaling group's launch configuration and
         assert the update was successful.
         """
-        update_launch_config_response = self.autoscale_client.update_launch_config(
+        response = self.autoscale_client.update_launch_config(
             group_id=group.id,
             name=rand_name(server_name),
             image_ref=image_ref,
             flavor_ref=flavor_ref,
             metadata=metadata)
-        self.assertEquals(update_launch_config_response.status_code, 204,
-                          msg='Updating launch config failed with {0} for group {1}'
-                          .format(update_launch_config_response, group.id))
+        self.assertEquals(
+            response.status_code, 204,
+            msg='Updating launch config failed with {0} for group {1}'
+            .format(response, group.id))
 
     def _verify_server_list_for_launch_config(self, server_list,
                                               upd_server_name,
@@ -441,6 +472,7 @@ class LaunchConfigTest(AutoscaleFixture):
         execute_policy_response = self.autoscale_client.execute_policy(
             group_id=group.id,
             policy_id=policy_id)
-        self.assertEquals(execute_policy_response.status_code, 202,
-                          msg='Policy failed to execute with status {0} for group {1}'
-                          .format(execute_policy_response.status_code, group.id))
+        self.assertEquals(
+            execute_policy_response.status_code, 202,
+            msg='Policy failed to execute with status {0} for group {1}'
+            .format(execute_policy_response.status_code, group.id))

--- a/autoscale_cloudroast/test_repo/autoscale/system/group/test_system_sgroup_multiples.py
+++ b/autoscale_cloudroast/test_repo/autoscale/system/group/test_system_sgroup_multiples.py
@@ -1,10 +1,13 @@
 """
 System tests for account with multiple scaling groups
 """
-from test_repo.autoscale.fixtures import AutoscaleFixture
-from cafe.drivers.unittest.decorators import tags
+
 import time
 import unittest
+
+from cafe.drivers.unittest.decorators import tags
+
+from test_repo.autoscale.fixtures import AutoscaleFixture
 
 
 class ScalingGroupMultiplesTest(AutoscaleFixture):
@@ -56,9 +59,11 @@ class ScalingGroupMultiplesTest(AutoscaleFixture):
         for each in [policy1, policy2, policy3]:
             execute_policies = self.autoscale_client.execute_policy(
                 self.first_scaling_group.id, each['id'])
-            self.assertEquals(execute_policies.status_code, 202,
-                              msg='Policy execution failed for group {0} with '
-                              '{1}'.format(self.first_scaling_group.id, execute_policies.status_code))
+            self.assertEquals(
+                execute_policies.status_code, 202,
+                msg='Policy execution failed for group {0} with '
+                '{1}'.format(self.first_scaling_group.id,
+                             execute_policies.status_code))
         sp1 = self.gc_min_entities + change
         sp2 = self.autoscale_behaviors.calculate_servers(sp1, percentage)
         sp3 = self.autoscale_behaviors.calculate_servers(sp2, percentage)
@@ -95,9 +100,11 @@ class ScalingGroupMultiplesTest(AutoscaleFixture):
         for each_webhook in [webhook_one, webhook_two, webhook_three]:
             execute_webhook = self.autoscale_client.execute_webhook(
                 each_webhook['links'].capability)
-            self.assertEquals(execute_webhook.status_code, 202,
-                              msg='Policy webhook execution failed for group {0} with '
-                              '{1}'.format(self.first_scaling_group.id, execute_webhook.status_code))
+            self.assertEquals(
+                execute_webhook.status_code, 202,
+                msg='Policy webhook execution failed for group {0} with '
+                '{1}'.format(self.first_scaling_group.id,
+                             execute_webhook.status_code))
         time.sleep(10)
         self.verify_group_state(
             self.first_scaling_group.id, (self.sp_change * 3))
@@ -110,17 +117,27 @@ class ScalingGroupMultiplesTest(AutoscaleFixture):
         Trying to create groups beyond max results in 422.
         """
         current_group_count = self.get_total_num_groups()
-        max_groups = self.limits_response.absolute.maxGroups - current_group_count
+        max_groups = (self.limits_response.absolute.maxGroups -
+                      current_group_count)
         for _ in range(max_groups):
-            create_group_reponse = self.autoscale_behaviors.create_scaling_group_min()
-            self.assertEquals(create_group_reponse.status_code, 201, msg='Create group'
-                              'returned response {0}'.format(create_group_reponse.status_code))
-            self.resources.add(create_group_reponse.entity, self.empty_scaling_group)
-        self.assertEquals(self.get_total_num_groups(), self.max_groups, msg='{0} groups'
-                          'exist'.format(self.get_total_num_groups()))
-        create_group_beyond_max = self.autoscale_behaviors.create_scaling_group_min()
-        self.assertEquals(create_group_beyond_max.status_code, 422,
-                          msg='{0} groups exist on the tenant'.format(self.get_total_num_groups()))
+            create_group_reponse = \
+                self.autoscale_behaviors.create_scaling_group_min()
+            self.assertEquals(
+                create_group_reponse.status_code, 201,
+                msg='Create group'
+                'returned response {0}'.format(
+                    create_group_reponse.status_code))
+            self.resources.add(create_group_reponse.entity,
+                               self.empty_scaling_group)
+        self.assertEquals(
+            self.get_total_num_groups(), self.max_groups,
+            msg='{0} groups exist'.format(self.get_total_num_groups()))
+        create_group_beyond_max = \
+            self.autoscale_behaviors.create_scaling_group_min()
+        self.assertEquals(
+            create_group_beyond_max.status_code, 422,
+            msg='{0} groups exist on the tenant'.format(
+                self.get_total_num_groups()))
 
     @tags(speed='quick')
     def test_system_max_webhook_policies_on_a_scaling_group(self):
@@ -129,11 +146,14 @@ class ScalingGroupMultiplesTest(AutoscaleFixture):
         Trying to create policies beyond max results in 422
         """
         for policy in range(self.max_policies):
-            self.autoscale_behaviors.create_policy_min(self.first_scaling_group.id)
-        self.assertEquals(self.get_total_num_policies(self.first_scaling_group.id),
-                          self.max_policies)
+            self.autoscale_behaviors.create_policy_min(
+                self.first_scaling_group.id)
+        self.assertEquals(
+            self.get_total_num_policies(self.first_scaling_group.id),
+            self.max_policies)
         policy_beyond_max = self.autoscale_client.create_policy(
-            self.first_scaling_group.id, 'test', 0, change=1, policy_type='webhook')
+            self.first_scaling_group.id, 'test', 0, change=1,
+            policy_type='webhook')
         self.assertEquals(policy_beyond_max.status_code, 422,
                           msg='Created {0} policies on the '
                           'group'.format(self.get_total_num_policies(
@@ -149,12 +169,14 @@ class ScalingGroupMultiplesTest(AutoscaleFixture):
             self.autoscale_behaviors.create_schedule_policy_given(
                 self.first_scaling_group.id,
                 sp_change_percent=100)
-        self.assertEquals(self.get_total_num_policies(self.first_scaling_group.id),
-                          self.max_policies,
-                          msg='Policies on the group {0} is under/over max '
-                          'allowed'.format(self.first_scaling_group.id))
+        self.assertEquals(
+            self.get_total_num_policies(self.first_scaling_group.id),
+            self.max_policies,
+            msg='Policies on the group {0} is under/over max '
+            'allowed'.format(self.first_scaling_group.id))
         policy_beyond_max = self.autoscale_client.create_policy(
-            self.first_scaling_group.id, 'test', 0, change=1, policy_type='schedule',
+            self.first_scaling_group.id, 'test', 0, change=1,
+            policy_type='schedule',
             args={'cron': '* * * * *'})
         self.assertEquals(policy_beyond_max.status_code, 422,
                           msg='Created {0} policies on the '
@@ -167,18 +189,24 @@ class ScalingGroupMultiplesTest(AutoscaleFixture):
         Verify the maximum scaling policies are allowed on a scaling policy.
         Trying to create webhooks beyond max results in 422
         """
-        policy = self.autoscale_behaviors.create_policy_min(self.first_scaling_group.id)
+        policy = self.autoscale_behaviors.create_policy_min(
+            self.first_scaling_group.id)
         for webhook in (range(self.max_webhooks)):
-            self.autoscale_client.create_webhook(self.first_scaling_group.id,
-                                                 policy['id'], 'wb_{0}'.format(webhook))
-        self.assertEquals(self.get_total_num_webhooks(self.first_scaling_group.id, policy['id']),
-                          self.max_webhooks,
-                          msg='Webhooks on the group {0} is under/over max allowed for policy '
-                          '{1}'.format(self.first_scaling_group.id, policy['id']))
-        webhook_beyond_max = self.autoscale_client.create_webhook(self.first_scaling_group.id,
-                                                                  policy['id'],
-                                                                  'wb_{0}'.format(webhook))
-        self.assertEquals(webhook_beyond_max.status_code, 422,
-                          msg='Created {0} webhooks on the '
-                          'policy'.format(self.get_total_num_webhooks(self.first_scaling_group.id,
-                                          policy['id'])))
+            self.autoscale_client.create_webhook(
+                self.first_scaling_group.id,
+                policy['id'], 'wb_{0}'.format(webhook))
+        self.assertEquals(
+            self.get_total_num_webhooks(self.first_scaling_group.id,
+                                        policy['id']),
+            self.max_webhooks,
+            msg='Webhooks on the group {0} is under/over max allowed for '
+            'policy {1}'.format(self.first_scaling_group.id, policy['id']))
+        webhook_beyond_max = self.autoscale_client.create_webhook(
+            self.first_scaling_group.id, policy['id'],
+            'wb_{0}'.format(webhook))
+        self.assertEquals(
+            webhook_beyond_max.status_code, 422,
+            msg='Created {0} webhooks on the '
+            'policy'.format(self.get_total_num_webhooks(
+                self.first_scaling_group.id,
+                policy['id'])))

--- a/autoscale_cloudroast/test_repo/autoscale/system/integration/test_system_integration_lbaas.py
+++ b/autoscale_cloudroast/test_repo/autoscale/system/integration/test_system_integration_lbaas.py
@@ -130,9 +130,9 @@ class AutoscaleLbaasFixture(AutoscaleFixture):
     @tags(speed='slow', type='lbaas')
     def test_update_launch_config_to_include_multiple_lbaas(self):
         """
-        Updating the launch config to add multiple load balancer to a group that had
-        only one load balancer, results in the new servers of that group to be added
-        as nodes to all the load balancers
+        Updating the launch config to add multiple load balancer to a group
+        that had only one load balancer, results in the new servers of that
+        group to be added as nodes to all the load balancers
         """
         policy_data = {'change': self.sp_change}
         group = self._create_group_given_lbaas_id(self.load_balancer_1)
@@ -160,8 +160,8 @@ class AutoscaleLbaasFixture(AutoscaleFixture):
     def test_update_launch_config_to_include_lbaas(self):
         """
         Update the launch config to add a load balancer to a group that did not
-        have a load balancer, results in the new servers of that group to be added
-        as nodes to the load balancers
+        have a load balancer, results in the new servers of that group to be
+        added as nodes to the load balancers
         """
         policy_data = {'change': self.sp_change}
         group = (self.autoscale_behaviors.create_scaling_group_given(
@@ -470,9 +470,10 @@ class AutoscaleLbaasFixture(AutoscaleFixture):
             disk_config=None,
             networks=None,
             load_balancers=lbaas_list)
-        self.assertEquals(update_lc_response.status_code, 204,
-                          msg='Update launch config with load balancer failed for group '
-                          '{0} with {1}'.format(group.id, update_lc_response.status_code))
+        self.assertEquals(
+            update_lc_response.status_code, 204,
+            msg='Update launch config with load balancer failed for group '
+            '{0} with {1}'.format(group.id, update_lc_response.status_code))
 
     def _create_lbaas_list(self, *lbaas_ids):
         """
@@ -492,26 +493,28 @@ class AutoscaleLbaasFixture(AutoscaleFixture):
         """
         return self.lbaas_client.list_nodes(load_balancer_id).entity
 
-    def _assert_lb_nodes_before_scale_persists_after_scale(self, lb_node_list_before_any_operation,
-                                                           load_balancer_id):
+    def _assert_lb_nodes_before_scale_persists_after_scale(
+            self, lb_node_list_before_any_operation, load_balancer_id):
         """
-        Gets the current list of lb nodes address and asserts that provided node
-        address list (which is before any scale operation) still exists within the
-        current list of lb node addresses
+        Gets the current list of lb nodes address and asserts that provided
+        node address list (which is before any scale operation) still exists
+        within the current list of lb node addresses
         """
         current_lb_node_list = [each_node.address for each_node in
                                 self._get_node_list_from_lb(load_balancer_id)]
-        self.assertTrue(set(lb_node_list_before_any_operation).issubset(set(current_lb_node_list)),
-                        msg='nodes {0} is not a subset of {1}'.format(set(
-                            lb_node_list_before_any_operation),
-                            set(current_lb_node_list)))
+        self.assertTrue(
+            set(lb_node_list_before_any_operation).issubset(
+                set(current_lb_node_list)),
+            msg='nodes {0} is not a subset of {1}'.format(
+                set(lb_node_list_before_any_operation),
+                set(current_lb_node_list)))
 
-    def _wait_for_servers_to_be_deleted_when_lb_invalid(self, group_id,
-                                                        servers_before_lb, server_after_lb=0):
+    def _wait_for_servers_to_be_deleted_when_lb_invalid(
+            self, group_id, servers_before_lb, server_after_lb=0):
         """
-        waits for servers_before_lb number of servers to be the desired capacity,
-        then waits for the desired capacity to be server_after_lb when a group with an
-        invalid load balancer is created.
+        waits for servers_before_lb number of servers to be the desired
+        capacity, then waits for the desired capacity to be server_after_lb
+        when a group with an invalid load balancer is created.
         """
         end_time = time.time() + 600
         group_state = (self.autoscale_client.list_status_entities_sgroups(
@@ -519,12 +522,14 @@ class AutoscaleLbaasFixture(AutoscaleFixture):
         if group_state.desiredCapacity is servers_before_lb:
             while time.time() < end_time:
                 time.sleep(10)
-                group_state = (self.autoscale_client.list_status_entities_sgroups(
-                    group_id)).entity
+                group_state = (
+                    self.autoscale_client.list_status_entities_sgroups(
+                        group_id)).entity
                 if group_state.desiredCapacity is server_after_lb:
                     return
             else:
-                self.fail('Servers not deleted from group even when group has invalid'
-                          ' load balancers!')
+                self.fail('Servers not deleted from group even when group has '
+                          'invalid load balancers!')
         else:
-            self.fail('Number of servers building on the group are not as expected')
+            self.fail(
+                'Number of servers building on the group are not as expected')

--- a/autoscale_cloudroast/test_repo/autoscale/system/policies/test_system_execute_multiple_policies.py
+++ b/autoscale_cloudroast/test_repo/autoscale/system/policies/test_system_execute_multiple_policies.py
@@ -1,9 +1,11 @@
 """
 System tests for execute multiple policies
 """
-from test_repo.autoscale.fixtures import AutoscaleFixture
 from time import sleep
+
 from cafe.drivers.unittest.decorators import tags
+
+from test_repo.autoscale.fixtures import AutoscaleFixture
 
 
 class ExecuteMultiplePoliciesTest(AutoscaleFixture):
@@ -14,31 +16,38 @@ class ExecuteMultiplePoliciesTest(AutoscaleFixture):
 
     def setUp(self):
         """
-        Create a scaling group with minentities > 0, with multiple scaling policies
-        and execute one scale up policy to create 2 servers
+        Create a scaling group with minentities > 0, with multiple scaling
+        policies and execute one scale up policy to create 2 servers
         """
         super(ExecuteMultiplePoliciesTest, self).setUp()
-        self.create_group_response = self.autoscale_behaviors.create_scaling_group_given(
-            gc_min_entities=self.gc_min_entities_alt,
-            gc_cooldown=0)
+        self.create_group_response = \
+            self.autoscale_behaviors.create_scaling_group_given(
+                gc_min_entities=self.gc_min_entities_alt,
+                gc_cooldown=0)
         self.group = self.create_group_response.entity
         self.change = 2
         self.change_percent = 50
         self.cooldown = 3
         self.policy_up_change = self.autoscale_behaviors.create_policy_given(
-            group_id=self.group.id, sp_change=self.change, sp_cooldown=self.cooldown)
+            group_id=self.group.id, sp_change=self.change,
+            sp_cooldown=self.cooldown)
         self.policy_down_change = self.autoscale_behaviors.create_policy_given(
-            group_id=self.group.id, sp_change=-(self.change - 1), sp_cooldown=self.cooldown)
-        self.policy_up_change_percent = self.autoscale_behaviors.create_policy_given(
-            group_id=self.group.id, sp_change_percent=self.change_percent, sp_cooldown=self.cooldown)
-        self.policy_down_change_percent = self.autoscale_behaviors.create_policy_given(
-            group_id=self.group.id,
-            sp_change_percent=-(self.change_percent),
+            group_id=self.group.id, sp_change=-(self.change - 1),
             sp_cooldown=self.cooldown)
-        self.policy_desired_capacity = self.autoscale_behaviors.create_policy_given(
-            group_id=self.group.id,
-            sp_desired_capacity=self.group.groupConfiguration.minEntities,
-            sp_cooldown=self.cooldown)
+        self.policy_up_change_percent = \
+            self.autoscale_behaviors.create_policy_given(
+                group_id=self.group.id, sp_change_percent=self.change_percent,
+                sp_cooldown=self.cooldown)
+        self.policy_down_change_percent = \
+            self.autoscale_behaviors.create_policy_given(
+                group_id=self.group.id,
+                sp_change_percent=-(self.change_percent),
+                sp_cooldown=self.cooldown)
+        self.policy_desired_capacity = \
+            self.autoscale_behaviors.create_policy_given(
+                group_id=self.group.id,
+                sp_desired_capacity=self.group.groupConfiguration.minEntities,
+                sp_cooldown=self.cooldown)
         self.policy_up_execute = {
             'change': self.change, 'cooldown': self.cooldown}
         self.policy_executed = self.autoscale_behaviors.create_policy_webhook(
@@ -48,64 +57,72 @@ class ExecuteMultiplePoliciesTest(AutoscaleFixture):
         self.resources.add(self.group, self.empty_scaling_group)
 
     @tags(speed='quick')
-    def test_system_policy_up_cooldown(self):
+    def test_policy_up_cooldown(self):
         """
-        Execute a scale up policy with cooldown > 0 more than once within the cooldown period,
-        and policy execution fails when cooldown is not met
+        Execute a scale up policy with cooldown > 0 more than once within the
+        cooldown period, and policy execution fails when cooldown is not met
         """
         execute_on_cooldown = self.autoscale_client.execute_policy(
             self.group.id,
             self.policy_executed['policy_id'])
-        self.assertEquals(execute_on_cooldown.status_code, 403,
-                          msg='Scale up policy executed sucessfully for group {0}'
-                          ' when cooldown is not met: {1}'
-                          .format(self.group.id, execute_on_cooldown.status_code))
+        self.assertEquals(
+            execute_on_cooldown.status_code, 403,
+            msg='Scale up policy executed sucessfully for group {0}'
+            ' when cooldown is not met: {1}'
+            .format(self.group.id, execute_on_cooldown.status_code))
 
     @tags(speed='quick')
-    def test_system_policy_down_cooldown(self):
+    def test_policy_down_cooldown(self):
         """
-        Execute a scale down policy with cooldown > 0 more than once within the cooldown period,
-        and policy execution fails when cooldown is not met
+        Execute a scale down policy with cooldown > 0 more than once within the
+        cooldown period, and policy execution fails when cooldown is not met
         """
         execute_scale_down = self.autoscale_client.execute_policy(
             self.group.id,
             self.policy_down_change['id'])
-        self.assertEquals(execute_scale_down.status_code, 202,
-                          msg='Policy down failed to execute for group {0} with {1}'
-                          .format(self.group.id, execute_scale_down.status_code))
+        self.assertEquals(
+            execute_scale_down.status_code, 202,
+            msg='Policy down failed to execute for group {0} with {1}'
+            .format(self.group.id, execute_scale_down.status_code))
         execute_on_cooldown = self.autoscale_client.execute_policy(
             self.group.id,
             self.policy_down_change['id'])
-        self.assertEquals(execute_on_cooldown.status_code, 403,
-                          msg='Scale down policy executed when cooldown is not met with {0}'
-                          ' for group {1}'
-                          .format(execute_on_cooldown.status_code, self.group.id))
+        self.assertEquals(
+            execute_on_cooldown.status_code, 403,
+            msg='Scale down policy executed when cooldown is not met with {0}'
+            ' for group {1}'
+            .format(execute_on_cooldown.status_code, self.group.id))
 
     @tags(speed='slow')
-    def test_system_execute_different_policies_simaltaneously(self):
+    def test_execute_different_policies_simaltaneously(self):
         """
-        The policy cooldown times are not enforced when executing different policies,
-        and executing such polcies result in active servers as expected
+        The policy cooldown times are not enforced when executing different
+        policies, and executing such polcies result in active servers as
+        expected
         """
         execute_change_percent_scale_up = self.autoscale_client.execute_policy(
             self.group.id,
             self.policy_up_change_percent['id'])
-        self.assertEquals(execute_change_percent_scale_up.status_code, 202,
-                          msg='Scale up policy execution for group {0} failed with {1}'
-                          .format(self.group.id, execute_change_percent_scale_up.status_code))
+        self.assertEquals(
+            execute_change_percent_scale_up.status_code, 202,
+            msg='Scale up policy execution for group {0} failed with {1}'
+            .format(self.group.id, execute_change_percent_scale_up.status_code)
+        )
         execute_change_scale_down = self.autoscale_client.execute_policy(
             self.group.id,
             self.policy_down_change['id'])
-        self.assertEquals(execute_change_scale_down.status_code, 202,
-                          msg='Scale down policy execution for group {0} failed with {1}'
-                          .format(self.group.id, execute_change_scale_down.status_code))
+        self.assertEquals(
+            execute_change_scale_down.status_code, 202,
+            msg='Scale down policy execution for group {0} failed with {1}'
+            .format(self.group.id, execute_change_scale_down.status_code))
         execute_desired_capacity_scale = self.autoscale_client.execute_policy(
             self.group.id,
             self.policy_desired_capacity['id'])
-        self.assertEquals(execute_desired_capacity_scale.status_code, 202,
-                          msg='Policy with desired capacity=minentities failed to execute with {0}'
-                          ' for group {1}'
-                          .format(execute_desired_capacity_scale.status_code, self.group.id))
+        self.assertEquals(
+            execute_desired_capacity_scale.status_code, 202,
+            msg='Policy with desired capacity=minentities failed to execute '
+            'with {0} for group {1}'
+            .format(execute_desired_capacity_scale.status_code, self.group.id))
         self.wait_for_expected_number_of_active_servers(
             group_id=self.group.id,
             expected_servers=self.group.groupConfiguration.minEntities)
@@ -114,10 +131,10 @@ class ExecuteMultiplePoliciesTest(AutoscaleFixture):
             self.group.groupConfiguration.minEntities)
 
     @tags(speed='slow')
-    def test_system_scale_up_scale_down_multiple_policies_in_sequence(self):
+    def test_scale_up_scale_down_multiple_policies_in_sequence(self):
         """
-        Different scale up and scale down policies on the scaling group can be executed
-        in sequence after each policy's cooldown time
+        Different scale up and scale down policies on the scaling group can be
+        executed in sequence after each policy's cooldown time
         """
         self._execute_policy_after_cooldown(
             self.group.id, self.policy_executed['policy_id'])
@@ -141,35 +158,39 @@ class ExecuteMultiplePoliciesTest(AutoscaleFixture):
             self.group.groupConfiguration.minEntities)
 
     @tags(speed='quick')
-    def test_system_multiple_webhook_policies_in_group_in_different_requests(self):
+    def test_multiple_webhook_policies_in_group_in_different_requests(self):
         """
-        Creating multiple webhook policies with the same payload, using multiple
-        create policy requests is successful.
+        Creating multiple webhook policies with the same payload, using
+        multiple create policy requests is successful.
         """
         policy_count = 3
         group = (self.autoscale_behaviors.create_scaling_group_min()).entity
         self.resources.add(group, self.empty_scaling_group)
         policy_id_list = []
         for _ in range(policy_count):
-            create_policy_response = self.autoscale_behaviors.create_policy_given(
-                group_id=group.id,
-                sp_name='multi_web_policy',
-                sp_change=1)
-            self.assertEquals(create_policy_response['status_code'], 201,
-                              msg='Created multiple scaling policies with same policy data'
-                              ', response code: {0}'.format(create_policy_response['status_code']))
+            create_policy_response = \
+                self.autoscale_behaviors.create_policy_given(
+                    group_id=group.id,
+                    sp_name='multi_web_policy',
+                    sp_change=1)
+            self.assertEquals(
+                create_policy_response['status_code'], 201,
+                msg='Created multiple scaling policies with same policy data'
+                    ', response code: {0}'.format(
+                        create_policy_response['status_code']))
             policy_id_list.append(create_policy_response['id'])
         self.assertEqual(len(set(policy_id_list)), policy_count)
 
     def _execute_policy_after_cooldown(self, group_id, policy_id):
         """
-        After the cooldown period, executes the policy and asserts if the policy
-        was executed successfully
+        After the cooldown period, executes the policy and asserts if the
+        policy was executed successfully
         """
         sleep(self.cooldown)
         execute_policy = self.autoscale_client.execute_policy(
             self.group.id,
             policy_id)
-        self.assertEquals(execute_policy.status_code, 202,
-                          msg='Execution of the policy after cooldown failed with {0} for group {1}'
-                          .format(execute_policy.status_code, self.group.id))
+        self.assertEquals(
+            execute_policy.status_code, 202,
+            msg='Execution of the policy after cooldown failed with {0} '
+            'for group {1}'.format(execute_policy.status_code, self.group.id))

--- a/autoscale_cloudroast/test_repo/autoscale/system/policies/test_system_execute_policy_down.py
+++ b/autoscale_cloudroast/test_repo/autoscale/system/policies/test_system_execute_policy_down.py
@@ -1,8 +1,9 @@
 """
 System tests for execute scale down policies
 """
-from test_repo.autoscale.fixtures import AutoscaleFixture
 from cafe.drivers.unittest.decorators import tags
+
+from test_repo.autoscale.fixtures import AutoscaleFixture
 
 
 class ExecutePoliciesDownTest(AutoscaleFixture):
@@ -17,9 +18,10 @@ class ExecutePoliciesDownTest(AutoscaleFixture):
         """
         super(ExecutePoliciesDownTest, self).setUp()
         minentities = 2
-        self.create_group_response = self.autoscale_behaviors.create_scaling_group_given(
-            gc_min_entities=minentities,
-            gc_cooldown=0)
+        self.create_group_response = \
+            self.autoscale_behaviors.create_scaling_group_given(
+                gc_min_entities=minentities,
+                gc_cooldown=0)
         self.group = self.create_group_response.entity
         self.policy_up = {'change': 2}
         self.autoscale_behaviors.create_policy_webhook(
@@ -29,19 +31,23 @@ class ExecutePoliciesDownTest(AutoscaleFixture):
         self.resources.add(self.group, self.empty_scaling_group)
 
     @tags(speed='slow')
-    def test_system_scale_down_policy_execution_change(self):
+    def test_scale_down_policy_execution_change(self):
         """
         A scale down policy with change can be executed
         """
         policy_down = {'change': - self.policy_up['change']}
-        execute_scale_down_policy = self.autoscale_behaviors.create_policy_webhook(
-            group_id=self.group.id,
-            policy_data=policy_down,
-            execute_policy=True)
-        self.assertEquals(execute_scale_down_policy[
-                          'execute_response'], 202,
-                          msg='Scale down policy execution with change for group {0} failed with {1}'
-                          .format(self.group.id, execute_scale_down_policy['execute_response']))
+        execute_scale_down_policy = \
+            self.autoscale_behaviors.create_policy_webhook(
+                group_id=self.group.id,
+                policy_data=policy_down,
+                execute_policy=True)
+        self.assertEquals(
+            execute_scale_down_policy[
+                'execute_response'], 202,
+            msg='Scale down policy execution with change for group {0} '
+            'failed with {1}'.format(
+                self.group.id,
+                execute_scale_down_policy['execute_response']))
         self.wait_for_expected_number_of_active_servers(
             group_id=self.group.id,
             expected_servers=self.group.groupConfiguration.minEntities)
@@ -50,15 +56,16 @@ class ExecutePoliciesDownTest(AutoscaleFixture):
             self.group.groupConfiguration.minEntities)
 
     @tags(speed='slow')
-    def test_system_scale_down_policy_execution_change_percent(self):
+    def test_scale_down_policy_execution_change_percent(self):
         """
         A scale down policy with change percent can be executed
         """
         policy_down = {'change_percent': -60}
-        execute_change_percent_policy = self.autoscale_behaviors.create_policy_webhook(
-            group_id=self.group.id,
-            policy_data=policy_down,
-            execute_policy=True)
+        execute_change_percent_policy = \
+            self.autoscale_behaviors.create_policy_webhook(
+                group_id=self.group.id,
+                policy_data=policy_down,
+                execute_policy=True)
         self.assertEquals(execute_change_percent_policy[
                           'execute_response'], 202)
         servers_from_scale_down = self.autoscale_behaviors.calculate_servers(
@@ -73,16 +80,17 @@ class ExecutePoliciesDownTest(AutoscaleFixture):
             servers_from_scale_down)
 
     @tags(speed='slow')
-    def test_system_scale_down_policy_execution_desired_capacity(self):
+    def test_scale_down_policy_execution_desired_capacity(self):
         """
         A scale down policy with desired capacity can be executed
         """
         policy_down = {
             'desired_capacity': self.group.groupConfiguration.minEntities}
-        execute_desired_capacity_policy = self.autoscale_behaviors.create_policy_webhook(
-            group_id=self.group.id,
-            policy_data=policy_down,
-            execute_policy=True)
+        execute_desired_capacity_policy = \
+            self.autoscale_behaviors.create_policy_webhook(
+                group_id=self.group.id,
+                policy_data=policy_down,
+                execute_policy=True)
         self.assertEquals(execute_desired_capacity_policy[
                           'execute_response'], 202)
         self.wait_for_expected_number_of_active_servers(
@@ -93,39 +101,43 @@ class ExecutePoliciesDownTest(AutoscaleFixture):
             policy_down['desired_capacity'])
 
     @tags(speed='slow')
-    def test_system_execute_scale_down_below_minentities_change(self):
+    def test_execute_scale_down_below_minentities_change(self):
         """
-        Executing a scale down when change results in servers less than minentities of
-        the scaling group, results in a scaling group with active servers=minentities
+        Executing a scale down when change results in servers less than
+        minentities of the scaling group, results in a scaling group with
+        active servers=minentities
         """
         policy_down = {'change': - 100}
         execute_change_policy = self.autoscale_behaviors.create_policy_webhook(
             group_id=self.group.id,
             policy_data=policy_down,
             execute_policy=True)
-        self.assertEquals(execute_change_policy['execute_response'], 202,
-                          msg='Scale down policy execution failed when minentities limit is met: {0}'
-                          'for group {1}'
-                          .format(execute_change_policy['execute_response'], self.group.id))
+        self.assertEquals(
+            execute_change_policy['execute_response'], 202,
+            msg='Scale down policy execution failed when minentities limit '
+            'is met: {0} for group {1}'
+            .format(execute_change_policy['execute_response'], self.group.id))
         self.wait_for_expected_number_of_active_servers(
             group_id=self.group.id,
             expected_servers=self.group.groupConfiguration.minEntities)
 
     @tags(speed='slow')
-    def test_system_execute_scale_down_below_minentities_change_percent(self):
+    def test_execute_scale_down_below_minentities_change_percent(self):
         """
-        Executing a scale down when change percent results in servers less than minentities of
-        the scaling group, results in a scaling group with active servers=minentities
+        Executing a scale down when change percent results in servers less than
+        minentities of the scaling group, results in a scaling group with
+        active servers=minentities
         """
         policy_down = {'change_percent': - 300}
         execute_change_policy = self.autoscale_behaviors.create_policy_webhook(
             group_id=self.group.id,
             policy_data=policy_down,
             execute_policy=True)
-        self.assertEquals(execute_change_policy['execute_response'], 202,
-                          msg='Scale down policy execution failed when minentities limit is met: {0}'
-                          ' for group {1}'
-                          .format(execute_change_policy['execute_response'], self.group.id))
+        self.assertEquals(
+            execute_change_policy['execute_response'], 202,
+            msg='Scale down policy execution failed when minentities limit '
+            'is met: {0} for group {1}'
+            .format(execute_change_policy['execute_response'], self.group.id))
         self.wait_for_expected_number_of_active_servers(
             group_id=self.group.id,
             expected_servers=self.group.groupConfiguration.minEntities)
@@ -134,10 +146,11 @@ class ExecutePoliciesDownTest(AutoscaleFixture):
             self.group.groupConfiguration.minEntities)
 
     @tags(speed='slow')
-    def test_system_execute_scale_down_below_minentities_desired_capacity(self):
+    def test_execute_scale_down_below_minentities_desired_capacity(self):
         """
-        Executing a scale down when desired capacity results in servers less than minentities of
-        the scaling group, results in a scaling group with active servers=minentities
+        Executing a scale down when desired capacity results in servers less
+        than minentities of the scaling group, results in a scaling group with
+        active servers=minentities
         """
         policy_down = {
             'desired_capacity': self.group.groupConfiguration.minEntities - 1}
@@ -145,10 +158,11 @@ class ExecutePoliciesDownTest(AutoscaleFixture):
             group_id=self.group.id,
             policy_data=policy_down,
             execute_policy=True)
-        self.assertEquals(execute_change_policy['execute_response'], 202,
-                          msg='Scale down policy execution failed when minentities limit is met: {0}'
-                          ' for group {1}'
-                          .format(execute_change_policy['execute_response'], self.group.id))
+        self.assertEquals(
+            execute_change_policy['execute_response'], 202,
+            msg='Scale down policy execution failed when minentities limit '
+            'is met: {0} for group {1}'
+            .format(execute_change_policy['execute_response'], self.group.id))
         self.wait_for_expected_number_of_active_servers(
             group_id=self.group.id,
             expected_servers=self.group.groupConfiguration.minEntities)

--- a/autoscale_cloudroast/test_repo/autoscale/system/policies/test_system_execute_policy_up.py
+++ b/autoscale_cloudroast/test_repo/autoscale/system/policies/test_system_execute_policy_up.py
@@ -1,8 +1,9 @@
 """
 System tests for execute policy
 """
-from test_repo.autoscale.fixtures import AutoscaleFixture
 from cafe.drivers.unittest.decorators import tags
+
+from test_repo.autoscale.fixtures import AutoscaleFixture
 
 
 class ExecutePoliciesUpTest(AutoscaleFixture):
@@ -13,12 +14,14 @@ class ExecutePoliciesUpTest(AutoscaleFixture):
 
     def setUp(self):
         """
-        Create a scaling group with minentities over zero and maxentities two times minentities
+        Create a scaling group with minentities over zero and maxentities two
+        times minentities
         """
         super(ExecutePoliciesUpTest, self).setUp()
-        self.create_group_response = self.autoscale_behaviors.create_scaling_group_given(
-            gc_min_entities=self.gc_min_entities_alt,
-            gc_max_entities=self.gc_min_entities_alt * 2)
+        self.create_group_response = \
+            self.autoscale_behaviors.create_scaling_group_given(
+                gc_min_entities=self.gc_min_entities_alt,
+                gc_max_entities=self.gc_min_entities_alt * 2)
         self.group = self.create_group_response.entity
         self.resources.add(self.group, self.empty_scaling_group)
 
@@ -36,7 +39,8 @@ class ExecutePoliciesUpTest(AutoscaleFixture):
                           'execute_response'], 202)
         self.check_for_expected_number_of_building_servers(
             group_id=self.group.id,
-            expected_servers=policy_up['change'] + self.group.groupConfiguration.minEntities)
+            expected_servers=(policy_up['change'] +
+                              self.group.groupConfiguration.minEntities))
 
     @tags(speed='quick')
     def test_system_scale_up_policy_execution_change_percent(self):
@@ -44,10 +48,11 @@ class ExecutePoliciesUpTest(AutoscaleFixture):
         A scale up policy with change percent can be executed
         """
         policy_up = {'change_percent': 50}
-        execute_change_percent_policy = self.autoscale_behaviors.create_policy_webhook(
-            group_id=self.group.id,
-            policy_data=policy_up,
-            execute_policy=True)
+        execute_change_percent_policy = \
+            self.autoscale_behaviors.create_policy_webhook(
+                group_id=self.group.id,
+                policy_data=policy_up,
+                execute_policy=True)
         self.assertEquals(execute_change_percent_policy[
                           'execute_response'], 202)
         servers_from_scale_up = self.autoscale_behaviors.calculate_servers(
@@ -64,10 +69,11 @@ class ExecutePoliciesUpTest(AutoscaleFixture):
         """
         desired_capacity = self.group.groupConfiguration.maxEntities
         policy_up = {'desired_capacity': desired_capacity}
-        execute_desired_capacity_policy = self.autoscale_behaviors.create_policy_webhook(
-            group_id=self.group.id,
-            policy_data=policy_up,
-            execute_policy=True)
+        execute_desired_capacity_policy = \
+            self.autoscale_behaviors.create_policy_webhook(
+                group_id=self.group.id,
+                policy_data=policy_up,
+                execute_policy=True)
         self.assertEquals(execute_desired_capacity_policy[
                           'execute_response'], 202)
         self.check_for_expected_number_of_building_servers(
@@ -77,18 +83,20 @@ class ExecutePoliciesUpTest(AutoscaleFixture):
     @tags(speed='quick')
     def test_system_execute_scale_up_meets_maxentities_change(self):
         """
-        Executing a scale up policy when change exceeds maxentities of the scaling group,
-        results in a scaling group with active servers=maxentities
+        Executing a scale up policy when change exceeds maxentities of the
+        scaling group, results in a scaling group with active
+        servers=maxentities
         """
         policy_up = {'change': self.group.groupConfiguration.maxEntities}
         execute_change_policy = self.autoscale_behaviors.create_policy_webhook(
             group_id=self.group.id,
             policy_data=policy_up,
             execute_policy=True)
-        self.assertEquals(execute_change_policy['execute_response'], 202,
-                          msg='Scale up policy execution failed when change exceeds maxentities '
-                          'with {0} for group {1}'
-                          .format(execute_change_policy['execute_response'], self.group.id))
+        self.assertEquals(
+            execute_change_policy['execute_response'], 202,
+            msg='Scale up policy execution failed when change '
+            'exceeds maxentities with {0} for group {1}'
+            .format(execute_change_policy['execute_response'], self.group.id))
         self.check_for_expected_number_of_building_servers(
             group_id=self.group.id,
             expected_servers=self.group.groupConfiguration.maxEntities)
@@ -96,19 +104,22 @@ class ExecutePoliciesUpTest(AutoscaleFixture):
     @tags(speed='quick')
     def test_system_execute_scale_up_meets_maxentities_change_percent(self):
         """
-        Executing a scale up policy when change percent exceeds maxentities of the scaling group,
-        results in a scaling group with active servers=maxentities
+        Executing a scale up policy when change percent exceeds maxentities of
+        the scaling group, results in a scaling group with active
+        servers=maxentities
         """
         policy_up = {'change_percent': 300}
-        execute_change_percent_policy = self.autoscale_behaviors.create_policy_webhook(
-            group_id=self.group.id,
-            policy_data=policy_up,
-            execute_policy=True)
+        execute_change_percent_policy = \
+            self.autoscale_behaviors.create_policy_webhook(
+                group_id=self.group.id,
+                policy_data=policy_up,
+                execute_policy=True)
         self.assertEquals(
             execute_change_percent_policy['execute_response'], 202,
-            msg='Scale up execution failed when changepercent exceeds maxentities with {0}'
-            ' for group {1}'
-            .format(execute_change_percent_policy['execute_response'], self.group.id))
+            msg='Scale up execution failed when changepercent '
+            'exceeds maxentities with {0} for group {1}'
+            .format(execute_change_percent_policy['execute_response'],
+                    self.group.id))
         self.check_for_expected_number_of_building_servers(
             group_id=self.group.id,
             expected_servers=self.group.groupConfiguration.maxEntities)
@@ -116,20 +127,23 @@ class ExecutePoliciesUpTest(AutoscaleFixture):
     @tags(speed='quick')
     def test_system_execute_scale_up_meets_maxentities_desired_capacity(self):
         """
-        Executing a scale up policy when desired capacity exceeds maxentities of the scaling group,
-        results in a scaling group with active servers=maxentities
+        Executing a scale up policy when desired capacity exceeds maxentities
+        of the scaling group, results in a scaling group with active
+        servers=maxentities
         """
         policy_up = {
             'desired_capacity': self.group.groupConfiguration.maxEntities + 1}
-        execute_desired_capacity_policy = self.autoscale_behaviors.create_policy_webhook(
-            group_id=self.group.id,
-            policy_data=policy_up,
-            execute_policy=True)
+        execute_desired_capacity_policy = \
+            self.autoscale_behaviors.create_policy_webhook(
+                group_id=self.group.id,
+                policy_data=policy_up,
+                execute_policy=True)
         self.assertEquals(
             execute_desired_capacity_policy['execute_response'], 202,
-            msg='Scale up execution failed when desiredcapacity over maxentities with {0}'
-            ' for group {1}'
-            .format(execute_desired_capacity_policy['execute_response'], self.group.id))
+            msg='Scale up execution failed when desiredcapacity '
+            'over maxentities with {0} for group {1}'
+            .format(execute_desired_capacity_policy['execute_response'],
+                    self.group.id))
         self.check_for_expected_number_of_building_servers(
             group_id=self.group.id,
             expected_servers=self.group.groupConfiguration.maxEntities)

--- a/autoscale_cloudroast/test_repo/autoscale/system/policies/test_system_execute_updated_policies.py
+++ b/autoscale_cloudroast/test_repo/autoscale/system/policies/test_system_execute_updated_policies.py
@@ -1,9 +1,11 @@
 """
 System tests for execute updated policies
 """
-from test_repo.autoscale.fixtures import AutoscaleFixture
 from time import sleep
+
 from cafe.drivers.unittest.decorators import tags
+
+from test_repo.autoscale.fixtures import AutoscaleFixture
 
 
 class ExecuteUpdatedPoliciesTest(AutoscaleFixture):
@@ -15,14 +17,15 @@ class ExecuteUpdatedPoliciesTest(AutoscaleFixture):
 
     def setUp(self):
         """
-        Create a scaling group with min entities>0, scale up with cooldown=1 second
-        and execute the policy
+        Create a scaling group with min entities>0, scale up with cooldown=1
+        second and execute the policy
         """
         super(ExecuteUpdatedPoliciesTest, self).setUp()
         self.cooldown = 1
-        self.create_group_response = self.autoscale_behaviors.create_scaling_group_given(
-            gc_min_entities=self.gc_min_entities_alt,
-            gc_cooldown=0)
+        self.create_group_response = \
+            self.autoscale_behaviors.create_scaling_group_given(
+                gc_min_entities=self.gc_min_entities_alt,
+                gc_cooldown=0)
         self.group = self.create_group_response.entity
         self.policy_up = {'change': 2, 'cooldown': self.cooldown}
         self.policy = self.autoscale_behaviors.create_policy_webhook(
@@ -32,20 +35,22 @@ class ExecuteUpdatedPoliciesTest(AutoscaleFixture):
         self.resources.add(self.group, self.empty_scaling_group)
 
     @tags(speed='slow')
-    def test_system_update_policy_from_change_to_desired_capacity_scale_down(self):
+    def test_update_policy_from_change_to_desired_capacity_scale_down(self):
         """
         Update the existing scale up policy from change to desired capacity,
         dc set to minentities so that the policy when executed scales down
         """
         upd_desired_capacity = self.group.groupConfiguration.minEntities
         sleep(self.cooldown)
-        upd_policy_to_desired_capacity_execute = self._update_execute_policy_dc(
-            self.group.id,
-            self.policy['policy_id'], upd_desired_capacity)
-        self.assertEquals(upd_policy_to_desired_capacity_execute, 202,
-                          msg='Executing the updated policy with desired capacity failed with {0}'
-                          ' for group {1}'
-                          .format(upd_policy_to_desired_capacity_execute, self.group.id))
+        upd_policy_to_desired_capacity_execute = \
+            self._update_execute_policy_dc(
+                self.group.id,
+                self.policy['policy_id'], upd_desired_capacity)
+        self.assertEquals(
+            upd_policy_to_desired_capacity_execute, 202,
+            msg='Executing the updated policy with desired capacity failed '
+            'with {0} for group {1}'
+            .format(upd_policy_to_desired_capacity_execute, self.group.id))
         self.wait_for_expected_number_of_active_servers(
             group_id=self.group.id,
             expected_servers=self.group.groupConfiguration.minEntities)
@@ -54,7 +59,7 @@ class ExecuteUpdatedPoliciesTest(AutoscaleFixture):
             self.group.groupConfiguration.minEntities)
 
     @tags(speed='quick')
-    def test_system_update_policy_from_change_to_desired_capacity_scale_up(self):
+    def test_update_policy_from_change_to_desired_capacity_scale_up(self):
         """
         Update the existing scale up policy from change to desired capacity,
         such that the policy when executed scales up
@@ -62,71 +67,79 @@ class ExecuteUpdatedPoliciesTest(AutoscaleFixture):
         upd_desired_capacity = self.group.groupConfiguration.minEntities + \
             self.policy_up['change'] + 1
         sleep(self.cooldown)
-        upd_policy_to_desired_capacity_execute = self._update_execute_policy_dc(
-            self.group.id,
-            self.policy['policy_id'], upd_desired_capacity)
-        self.assertEquals(upd_policy_to_desired_capacity_execute, 202,
-                          msg='Executing the updated policy with desired capacity failed with {0}'
-                          ' for group {1}'
-                          .format(upd_policy_to_desired_capacity_execute, self.group.id))
+        upd_policy_to_desired_capacity_execute = \
+            self._update_execute_policy_dc(
+                self.group.id,
+                self.policy['policy_id'], upd_desired_capacity)
+        self.assertEquals(
+            upd_policy_to_desired_capacity_execute, 202,
+            msg='Executing the updated policy with desired capacity failed '
+            'with {0} for group {1}'
+            .format(upd_policy_to_desired_capacity_execute, self.group.id))
         self.check_for_expected_number_of_building_servers(
             group_id=self.group.id,
             expected_servers=upd_desired_capacity)
 
     @tags(speed='slow')
-    def test_system_update_policy_desired_capacity_below_minentities(self):
+    def test_update_policy_desired_capacity_below_minentities(self):
         """
-        Update a scale up via 'change', to a scale down policy via 'desiredCapacity', with
-        desiredCapacity set to be less than minentities and execute the policy.
-        (results in active servers=minentities)
+        Update a scale up via 'change', to a scale down policy via
+        'desiredCapacity', with desiredCapacity set to be less than minentities
+        and execute the policy.  (results in active servers=minentities)
         """
         upd_desired_capacity = self.group.groupConfiguration.minEntities - 1
         sleep(self.cooldown)
-        upd_policy_to_desired_capacity_execute = self._update_execute_policy_dc(
-            self.group.id,
-            self.policy['policy_id'], upd_desired_capacity)
-        self.assertEquals(upd_policy_to_desired_capacity_execute, 202,
-                          msg='Executing the updated policy with desired capacity failed with {0}'
-                          ' for group {1}'
-                          .format(upd_policy_to_desired_capacity_execute, self.group.id))
+        upd_policy_to_desired_capacity_execute = \
+            self._update_execute_policy_dc(
+                self.group.id,
+                self.policy['policy_id'], upd_desired_capacity)
+        self.assertEquals(
+            upd_policy_to_desired_capacity_execute, 202,
+            msg='Executing the updated policy with desired capacity failed '
+            'with {0} for group {1}'
+            .format(upd_policy_to_desired_capacity_execute, self.group.id))
         self.wait_for_expected_number_of_active_servers(
             group_id=self.group.id,
             expected_servers=self.group.groupConfiguration.minEntities)
 
     @tags(speed='quick')
-    def test_system_update_policy_desired_capacity_over_25(self):
+    def test_update_policy_desired_capacity_over_25(self):
         """
-        Update the desired capacity to scale up by setting desired capacity > 25
-        and execute. (Results in active servers = 26 in the scaling group)
+        Update the desired capacity to scale up by setting desired capacity >
+        25 and execute. (Results in active servers = 26 in the scaling group)
         """
         sleep(self.cooldown)
         upd_desired_capacity = 26
         sleep(self.cooldown)
-        upd_policy_to_desired_capacity_execute = self._update_execute_policy_dc(
-            self.group.id,
-            self.policy['policy_id'], upd_desired_capacity)
-        self.assertEquals(upd_policy_to_desired_capacity_execute, 202,
-                          msg='Executing the updated policy with desired capacity failed with {0}'
-                          ' for group {1}'
-                          .format(upd_policy_to_desired_capacity_execute, self.group.id))
+        upd_policy_to_desired_capacity_execute = \
+            self._update_execute_policy_dc(
+                self.group.id,
+                self.policy['policy_id'], upd_desired_capacity)
+        self.assertEquals(
+            upd_policy_to_desired_capacity_execute, 202,
+            msg='Executing the updated policy with desired capacity failed '
+            'with {0} for group {1}'
+            .format(upd_policy_to_desired_capacity_execute, self.group.id))
         self.check_for_expected_number_of_building_servers(
             group_id=self.group.id,
             expected_servers=26)
 
     @tags(speed='slow')
-    def test_system_update_scale_up_to_scale_down(self):
+    def test_update_scale_up_to_scale_down(self):
         """
         Update a scale up policy to scale down by the same change and execute
-        such a policy to result in active servers = minentities on the scaling group
+        such a policy to result in active servers = minentities on the scaling
+        group
         """
         change = - self.policy_up['change']
         sleep(self.cooldown)
         upd_to_scale_down_execute = self._update_execute_policy(
             self.group.id,
             self.policy['policy_id'], change)
-        self.assertEquals(upd_to_scale_down_execute, 202,
-                          msg='Executing the updated scale down policy failed with {0} for group {1}'
-                          .format(upd_to_scale_down_execute, self.group.id))
+        self.assertEquals(
+            upd_to_scale_down_execute, 202,
+            msg='Executing the updated scale down policy failed with {0} '
+            'for group {1}'.format(upd_to_scale_down_execute, self.group.id))
         self.wait_for_expected_number_of_active_servers(
             group_id=self.group.id,
             expected_servers=self.group.groupConfiguration.minEntities)
@@ -135,10 +148,10 @@ class ExecuteUpdatedPoliciesTest(AutoscaleFixture):
             self.group.groupConfiguration.minEntities)
 
     @tags(speed='slow')
-    def test_system_update_minentities_and_scale_down(self):
+    def test_update_minentities_and_scale_down(self):
         """
-        Create a scaling group with min entities > 0, scale up (setup)
-        update new_minentities to be 1, verify active servers = minentities+scale up.
+        Create a scaling group with min entities > 0, scale up (setup) update
+        new_minentities to be 1, verify active servers = minentities+scale up.
         Execute scale down with change = new_minenetities and verify scale down
         """
         new_minentities = 1
@@ -151,16 +164,18 @@ class ExecuteUpdatedPoliciesTest(AutoscaleFixture):
             metadata={})
         self.wait_for_expected_number_of_active_servers(
             group_id=self.group.id,
-            expected_servers=self.group.groupConfiguration.minEntities + self.policy_up['change'])
+            expected_servers=(self.group.groupConfiguration.minEntities +
+                              self.policy_up['change']))
         change = - (self.policy_up[
                     'change'] + self.group.groupConfiguration.minEntities) + 1
         sleep(self.cooldown)
         upd_to_scale_down_execute = self._update_execute_policy(
             self.group.id,
             self.policy['policy_id'], change)
-        self.assertEquals(upd_to_scale_down_execute, 202,
-                          msg='Executing the updated scale down policy failed with {0} for group {1}'
-                          .format(upd_to_scale_down_execute, self.group.id))
+        self.assertEquals(
+            upd_to_scale_down_execute, 202,
+            msg='Executing the updated scale down policy failed with {0} '
+            'for group {1}'.format(upd_to_scale_down_execute, self.group.id))
         self.wait_for_expected_number_of_active_servers(
             group_id=self.group.id,
             expected_servers=new_minentities)

--- a/autoscale_cloudroast/test_repo/autoscale/system/policies/test_system_execute_webhook_scaledown.py
+++ b/autoscale_cloudroast/test_repo/autoscale/system/policies/test_system_execute_webhook_scaledown.py
@@ -27,8 +27,8 @@ class ScalingDownExecuteWebhookTest(AutoscaleFixture):
             group_id=self.group.id,
             policy_data=self.policy_up,
             execute_webhook=True)
-        self.servers_before_scaledown = (self.gc_min_entities_alt
-                                         + self.policy_up['change'])
+        self.servers_before_scaledown = (self.gc_min_entities_alt +
+                                         self.policy_up['change'])
         self.resources.add(self.group, self.empty_scaling_group)
 
     @tags(speed='slow')

--- a/autoscale_cloudroast/test_repo/autoscale/system/policies/test_system_execute_webhook_scaledown.py
+++ b/autoscale_cloudroast/test_repo/autoscale/system/policies/test_system_execute_webhook_scaledown.py
@@ -1,8 +1,9 @@
 """
 System tests for scaling policies
 """
-from test_repo.autoscale.fixtures import AutoscaleFixture
 from cafe.drivers.unittest.decorators import tags
+
+from test_repo.autoscale.fixtures import AutoscaleFixture
 
 
 class ScalingDownExecuteWebhookTest(AutoscaleFixture):
@@ -16,16 +17,18 @@ class ScalingDownExecuteWebhookTest(AutoscaleFixture):
         Create a scaling group with scale up policy and execute its webhook
         """
         super(ScalingDownExecuteWebhookTest, self).setUp()
-        self.create_group_response = self.autoscale_behaviors.create_scaling_group_given(
-            gc_min_entities=self.gc_min_entities_alt,
-            gc_cooldown=0)
+        self.create_group_response = \
+            self.autoscale_behaviors.create_scaling_group_given(
+                gc_min_entities=self.gc_min_entities_alt,
+                gc_cooldown=0)
         self.group = self.create_group_response.entity
         self.policy_up = {'change': 2}
         self.autoscale_behaviors.create_policy_webhook(
             group_id=self.group.id,
             policy_data=self.policy_up,
             execute_webhook=True)
-        self.servers_before_scaledown = self.gc_min_entities_alt + self.policy_up['change']
+        self.servers_before_scaledown = (self.gc_min_entities_alt
+                                         + self.policy_up['change'])
         self.resources.add(self.group, self.empty_scaling_group)
 
     @tags(speed='slow')
@@ -36,14 +39,16 @@ class ScalingDownExecuteWebhookTest(AutoscaleFixture):
         min entities
         """
         policy_down = {'change': - self.policy_up['change']}
-        execute_scale_down_webhook = self.autoscale_behaviors.create_policy_webhook(
-            group_id=self.group.id,
-            policy_data=policy_down,
-            execute_webhook=True)
+        execute_scale_down_webhook = \
+            self.autoscale_behaviors.create_policy_webhook(
+                group_id=self.group.id,
+                policy_data=policy_down,
+                execute_webhook=True)
         self.assertEquals(execute_scale_down_webhook[
                           'execute_response'], 202)
-        self.wait_for_expected_group_state(self.group.id,
-                                           self.group.groupConfiguration.minEntities)
+        self.wait_for_expected_group_state(
+            self.group.id,
+            self.group.groupConfiguration.minEntities)
         self.assert_servers_deleted_successfully(
             self.group.launchConfiguration.server.name,
             self.group.groupConfiguration.minEntities)
@@ -54,10 +59,11 @@ class ScalingDownExecuteWebhookTest(AutoscaleFixture):
         Execute a webhook with scale down with change percentage 60
         """
         policy_down = {'change_percent': -60}
-        execute_webhook_in_change_percent_policy = self.autoscale_behaviors.create_policy_webhook(
-            group_id=self.group.id,
-            policy_data=policy_down,
-            execute_webhook=True)
+        execute_webhook_in_change_percent_policy = \
+            self.autoscale_behaviors.create_policy_webhook(
+                group_id=self.group.id,
+                policy_data=policy_down,
+                execute_webhook=True)
         self.assertEquals(execute_webhook_in_change_percent_policy[
                           'execute_response'], 202)
         servers_from_scale_down = self.autoscale_behaviors.calculate_servers(
@@ -78,10 +84,11 @@ class ScalingDownExecuteWebhookTest(AutoscaleFixture):
         """
         policy_down = {
             'desired_capacity': self.group.groupConfiguration.minEntities}
-        execute_webhook_desired_capacity = self.autoscale_behaviors.create_policy_webhook(
-            group_id=self.group.id,
-            policy_data=policy_down,
-            execute_webhook=True)
+        execute_webhook_desired_capacity = \
+            self.autoscale_behaviors.create_policy_webhook(
+                group_id=self.group.id,
+                policy_data=policy_down,
+                execute_webhook=True)
         self.assertEquals(execute_webhook_desired_capacity[
                           'execute_response'], 202)
         self.wait_for_expected_group_state(self.group.id,

--- a/autoscale_cloudroast/test_repo/autoscale/system/policies/test_system_execute_webhook_scaleup.py
+++ b/autoscale_cloudroast/test_repo/autoscale/system/policies/test_system_execute_webhook_scaleup.py
@@ -1,8 +1,9 @@
 """
 System tests for scaling policies
 """
-from test_repo.autoscale.fixtures import AutoscaleFixture
 from cafe.drivers.unittest.decorators import tags
+
+from test_repo.autoscale.fixtures import AutoscaleFixture
 
 
 class ScalingUpExecuteWebhookTest(AutoscaleFixture):

--- a/autoscale_cloudroast/test_repo/autoscale/system/policies/test_system_execute_webhook_scaleup.py
+++ b/autoscale_cloudroast/test_repo/autoscale/system/policies/test_system_execute_webhook_scaleup.py
@@ -16,8 +16,9 @@ class ScalingUpExecuteWebhookTest(AutoscaleFixture):
         Create a scaling group with minentities over zero
         """
         super(ScalingUpExecuteWebhookTest, self).setUp()
-        self.create_group_response = self.autoscale_behaviors.create_scaling_group_given(
-            gc_min_entities=self.gc_min_entities_alt)
+        self.create_group_response = \
+            self.autoscale_behaviors.create_scaling_group_given(
+                gc_min_entities=self.gc_min_entities_alt)
         self.group = self.create_group_response.entity
         self.resources.add(self.group, self.empty_scaling_group)
 
@@ -27,15 +28,17 @@ class ScalingUpExecuteWebhookTest(AutoscaleFixture):
         Create a scale up policy with change and execute its webhook
         """
         policy_up = {'change': 1}
-        execute_webhook_in_change_policy = self.autoscale_behaviors.create_policy_webhook(
-            group_id=self.group.id,
-            policy_data=policy_up,
-            execute_webhook=True)
+        execute_webhook_in_change_policy = \
+            self.autoscale_behaviors.create_policy_webhook(
+                group_id=self.group.id,
+                policy_data=policy_up,
+                execute_webhook=True)
         self.assertEquals(execute_webhook_in_change_policy[
                           'execute_response'], 202)
         self.check_for_expected_number_of_building_servers(
             group_id=self.group.id,
-            expected_servers=policy_up['change'] + self.group.groupConfiguration.minEntities)
+            expected_servers=policy_up['change'] +
+            self.group.groupConfiguration.minEntities)
 
     @tags(speed='quick')
     def test_system_execute_webhook_scale_up_change_percent(self):
@@ -43,10 +46,11 @@ class ScalingUpExecuteWebhookTest(AutoscaleFixture):
         Execute a webhook for scale up policy with change percent.
         """
         policy_up = {'change_percent': 100}
-        execute_webhook_in_change_percent_policy = self.autoscale_behaviors.create_policy_webhook(
-            group_id=self.group.id,
-            policy_data=policy_up,
-            execute_webhook=True)
+        execute_webhook_in_change_percent_policy = \
+            self.autoscale_behaviors.create_policy_webhook(
+                group_id=self.group.id,
+                policy_data=policy_up,
+                execute_webhook=True)
         self.assertEquals(execute_webhook_in_change_percent_policy[
                           'execute_response'], 202)
         servers_from_scale_up = self.autoscale_behaviors.calculate_servers(
@@ -63,10 +67,11 @@ class ScalingUpExecuteWebhookTest(AutoscaleFixture):
         """
         desired_capacity = self.group.groupConfiguration.minEntities + 1
         policy_up = {'desired_capacity': desired_capacity}
-        execute_webhook_in_desired_capacity_policy = self.autoscale_behaviors.create_policy_webhook(
-            group_id=self.group.id,
-            policy_data=policy_up,
-            execute_webhook=True)
+        execute_webhook_in_desired_capacity_policy = \
+            self.autoscale_behaviors.create_policy_webhook(
+                group_id=self.group.id,
+                policy_data=policy_up,
+                execute_webhook=True)
         self.assertEquals(execute_webhook_in_desired_capacity_policy[
                           'execute_response'], 202)
         self.check_for_expected_number_of_building_servers(

--- a/autoscale_cloudroast/test_repo/autoscale/system/policies/test_system_policies_negative.py
+++ b/autoscale_cloudroast/test_repo/autoscale/system/policies/test_system_policies_negative.py
@@ -1,8 +1,9 @@
 """
 System tests for scaling policies negative scenarios
 """
-from test_repo.autoscale.fixtures import AutoscaleFixture
 from cafe.drivers.unittest.decorators import tags
+
+from test_repo.autoscale.fixtures import AutoscaleFixture
 
 
 class ScalingPoliciesNegativeFixture(AutoscaleFixture):
@@ -16,9 +17,10 @@ class ScalingPoliciesNegativeFixture(AutoscaleFixture):
         Create a scaling group with minentities = maxentities, scale up by 2
         """
         super(ScalingPoliciesNegativeFixture, self).setUp()
-        self.create_group_response = self.autoscale_behaviors.create_scaling_group_given(
-            gc_min_entities=2,
-            gc_cooldown=0)
+        self.create_group_response = \
+            self.autoscale_behaviors.create_scaling_group_given(
+                gc_min_entities=2,
+                gc_cooldown=0)
         self.group = self.create_group_response.entity
         self.policy_up_data = {'change': 2}
         self.policy_up = self.autoscale_behaviors.create_policy_webhook(
@@ -33,66 +35,75 @@ class ScalingPoliciesNegativeFixture(AutoscaleFixture):
         self.resources.add(self.group, self.empty_scaling_group)
 
     @tags(speed='quick')
-    def test_system_execute_policy_when_maxentities_equals_minentities(self):
+    def test_execute_policy_when_maxentities_equals_minentities(self):
         """
         Update minentities=maxentities and execution of a scale up policy
         fails with a 403
         """
-        self._update_group_min_max_entities(group=self.group,
-                                            maxentities=self.group.groupConfiguration.minEntities)
-        execute_policy_up = self.autoscale_client.execute_policy(self.group.id,
-                                                                 self.policy_up['policy_id'])
-        self.assertEquals(execute_policy_up.status_code, 403,
-                          msg='Scale up policy executed when minentities=maxentities: {0} for group {1}'
-                          .format(execute_policy_up.status_code, self.group.id))
+        self._update_group_min_max_entities(
+            group=self.group,
+            maxentities=self.group.groupConfiguration.minEntities)
+        execute_policy_up = self.autoscale_client.execute_policy(
+            self.group.id,
+            self.policy_up['policy_id'])
+        self.assertEquals(
+            execute_policy_up.status_code, 403,
+            msg='Scale up policy executed when minentities=maxentities: {0} '
+            'for group {1}'.format(
+                execute_policy_up.status_code, self.group.id))
 
     @tags(speed='quick')
-    def test_system_execute_scale_down_on_newly_created_group_with_minentities(self):
+    def test_execute_scale_down_on_newly_created_group_with_minentities(self):
         """
         Update minentities=maxentities and execution of a scale down policy
         fails with a 403
         """
-        self._update_group_min_max_entities(group=self.group,
-                                            maxentities=self.group.groupConfiguration.minEntities)
+        self._update_group_min_max_entities(
+            group=self.group,
+            maxentities=self.group.groupConfiguration.minEntities)
         execute_policy_down = self.autoscale_client.execute_policy(
             self.group.id,
             self.policy_down['policy_id'])
-        self.assertEquals(execute_policy_down.status_code, 403,
-                          msg='Scale down policy executed when minentities=maxentities'
-                          ' on the group {0} with response code {1}'
-                          .format(self.group.id, execute_policy_down.status_code))
+        self.assertEquals(
+            execute_policy_down.status_code, 403,
+            msg='Scale down policy executed when minentities=maxentities'
+            ' on the group {0} with response code {1}'
+            .format(self.group.id, execute_policy_down.status_code))
 
     @tags(speed='quick')
-    def test_system_delete_policy_during_execution(self):
+    def test_delete_policy_during_execution(self):
         """
-        Policy execution is not affected/paused when the policy is deleted during execution.
-        (Also, verify if otter refers to the policy id after it has executed the policy and
-        raises exception.)
+        Policy execution is not affected/paused when the policy is deleted
+        during execution.  (Also, verify if otter refers to the policy id after
+        it has executed the policy and raises exception.)
         """
-        execute_policy_up = self.autoscale_client.execute_policy(self.group.id,
-                                                                 self.policy_up['policy_id'])
+        execute_policy_up = self.autoscale_client.execute_policy(
+            self.group.id,
+            self.policy_up['policy_id'])
         delete_policy = self.autoscale_client.delete_scaling_policy(
             self.group.id,
             self.policy_up['policy_id'])
-        self.assertEquals(delete_policy.status_code, 204,
-                          msg='Deleting the scaling policy while its executing failed {0}'
-                          ' for group {1}'
-                          .format(delete_policy.status_code, self.group.id))
-        self.assertEquals(execute_policy_up.status_code, 202,
-                          msg='Scale up policy failed for group {0} cause policy was deleted'
-                          ' during execution: {1}'
-                          .format(self.group.id, execute_policy_up.status_code))
+        self.assertEquals(
+            delete_policy.status_code, 204,
+            msg='Deleting the scaling policy while its executing failed {0}'
+            ' for group {1}'
+            .format(delete_policy.status_code, self.group.id))
+        self.assertEquals(
+            execute_policy_up.status_code, 202,
+            msg='Scale up policy failed for group {0} cause policy was deleted'
+            ' during execution: {1}'
+            .format(self.group.id, execute_policy_up.status_code))
         self.check_for_expected_number_of_building_servers(
             group_id=self.group.id,
             expected_servers=self.group.groupConfiguration.minEntities +
             self.policy_up_data['change'])
 
     @tags(speed='quick')
-    def test_system_execute_scale_up_after_maxentities_met(self):
+    def test_execute_scale_up_after_maxentities_met(self):
         """
-        Update max entities of the scaling group to be 3 and execute scale up policy
-        once to update active servers = maxentities successfully and reexecuting the
-        policy when max entities are already met fails with 403
+        Update max entities of the scaling group to be 3 and execute scale up
+        policy once to update active servers = maxentities successfully and
+        reexecuting the policy when max entities are already met fails with 403
         """
         upd_maxentities = 3
         self._update_group_min_max_entities(group=self.group,
@@ -104,62 +115,70 @@ class ScalingPoliciesNegativeFixture(AutoscaleFixture):
             group_id=self.group.id,
             policy_data=policy_up,
             execute_policy=True)
-        self.assertEquals(execute_policy['execute_response'], 202,
-                          msg='Scale up policy execution failed for group {0}'
-                          'when change delta < maxentities with response: {1}'
-                          .format(self.group.id, execute_policy['execute_response']))
+        self.assertEquals(
+            execute_policy['execute_response'], 202,
+            msg='Scale up policy execution failed for group {0}'
+            'when change delta < maxentities with response: {1}'
+            .format(self.group.id, execute_policy['execute_response']))
         reexecute_scale_up = self.autoscale_client.execute_policy(
             self.group.id,
             execute_policy['policy_id'])
-        self.assertEquals(reexecute_scale_up.status_code, 403,
-                          msg='Scale up policy executed for group {0} when group already'
-                          ' has maxentities, response code: {1}'
-                          .format(self.group.id, reexecute_scale_up.status_code))
+        self.assertEquals(
+            reexecute_scale_up.status_code, 403,
+            msg='Scale up policy executed for group {0} when group already'
+            ' has maxentities, response code: {1}'
+            .format(self.group.id, reexecute_scale_up.status_code))
 
     @tags(speed='slow')
-    def test_system_scaleup_update_min_max_0_delete_group(self):
+    def test_scaleup_update_min_max_0_delete_group(self):
         """
-        Create a scaling group and update min and max entities to be 0 and delete
-        the group (while the servers from the create group are still building).
-        The user will be able to delete the group and autoscaling will delete the
-        servers on the group (AUTO-339)
+        Create a scaling group and update min and max entities to be 0 and
+        delete the group (while the servers from the create group are still
+        building).  The user will be able to delete the group and autoscaling
+        will delete the servers on the group (AUTO-339)
         """
         server_name = self.group.launchConfiguration.server.name
         self._update_group_min_max_entities(group=self.group,
                                             maxentities=0, minentities=0)
         delete_group = self.autoscale_client.delete_scaling_group(
             self.group.id)
-        self.assertEquals(delete_group.status_code, 204,
-                          msg='Delete group failed for group {0} when min and maxentities '
-                          'is update to 0 with response {1}'
-                          .format(self.group.id, delete_group.status_code))
+        self.assertEquals(
+            delete_group.status_code, 204,
+            msg='Delete group failed for group {0} when min and maxentities '
+            'is update to 0 with response {1}'
+            .format(self.group.id, delete_group.status_code))
         self.assert_servers_deleted_successfully(server_name)
 
     @tags(speed='quick')
-    def test_system_scaleup_update_min_scale_down(self):
+    def test_scaleup_update_min_scale_down(self):
         """
-        Create a scaling group and execute a scale up policy, update min = current desired capacity.
-        Then executing a scale down policy results in 403
+        Create a scaling group and execute a scale up policy, update min =
+        current desired capacity.  Then executing a scale down policy results
+        in 403
         """
-        execute_policy_up = self.autoscale_client.execute_policy(self.group.id,
-                                                                 self.policy_up['policy_id'])
-        self.assertEquals(execute_policy_up.status_code, 202,
-                          msg='Scale up policy execution failed for group {0} '
-                          'when change delta < maxentities with response: {1}'
-                          .format(self.group.id, execute_policy_up.status_code))
-        self._update_group_min_max_entities(group=self.group,
-                                            minentities=self.group.groupConfiguration.minEntities +
-                                            self.policy_up_data['change'])
+        execute_policy_up = self.autoscale_client.execute_policy(
+            self.group.id,
+            self.policy_up['policy_id'])
+        self.assertEquals(
+            execute_policy_up.status_code, 202,
+            msg='Scale up policy execution failed for group {0} '
+            'when change delta < maxentities with response: {1}'
+            .format(self.group.id, execute_policy_up.status_code))
+        self._update_group_min_max_entities(
+            group=self.group,
+            minentities=self.group.groupConfiguration.minEntities +
+            self.policy_up_data['change'])
         execute_policy_down = self.autoscale_client.execute_policy(
             self.group.id,
             self.policy_down['policy_id'])
-        self.assertEquals(execute_policy_down.status_code, 403,
-                          msg='Scale down policy executed when minentities=maxentities'
-                          ' on the group {0} with response code {1}'
-                          .format(self.group.id, execute_policy_down.status_code))
+        self.assertEquals(
+            execute_policy_down.status_code, 403,
+            msg='Scale down policy executed when minentities=maxentities'
+            ' on the group {0} with response code {1}'
+            .format(self.group.id, execute_policy_down.status_code))
 
     @tags(speed='quick')
-    def test_system_update_webhook_policy_to_at_style_scheduler(self):
+    def test_update_webhook_policy_to_at_style_scheduler(self):
         """
         Policy update fails when a webhook type policy is updated to be of type
         at style scheduler, with error 400
@@ -178,7 +197,7 @@ class ScalingPoliciesNegativeFixture(AutoscaleFixture):
                               self.group.id, upd_policy_response.status_code))
 
     @tags(speed='quick')
-    def test_system_update_webhook_policy_to_cron_style_scheduler(self):
+    def test_update_webhook_policy_to_cron_style_scheduler(self):
         """
         Policy update fails when a webhook type policy is updated to be of type
         cron style scheduler, with error 400
@@ -196,10 +215,11 @@ class ScalingPoliciesNegativeFixture(AutoscaleFixture):
                           ' on the group {0} with response code {1}'.format(
                               self.group.id, upd_policy_response.status_code))
 
-    def _update_group_min_max_entities(self, group, maxentities=None, minentities=None):
+    def _update_group_min_max_entities(self, group, maxentities=None,
+                                       minentities=None):
         """
-        Updates the scaling groups min/maxentities to the given and asserts the update
-        was successful
+        Updates the scaling groups min/maxentities to the given and asserts the
+        update was successful
         """
         if minentities is None:
             minentities = group.groupConfiguration.minEntities
@@ -212,7 +232,8 @@ class ScalingPoliciesNegativeFixture(AutoscaleFixture):
             min_entities=minentities,
             max_entities=maxentities,
             metadata={})
-        self.assertEquals(update_group.status_code, 204,
-                          msg='Updating minentities and/or maxentities in the group config'
-                          ' for {0} failed: {1}'
-                          .format(group.id, update_group.status_code))
+        self.assertEquals(
+            update_group.status_code, 204,
+            msg='Updating minentities and/or maxentities in the group config'
+            ' for {0} failed: {1}'
+            .format(group.id, update_group.status_code))

--- a/autoscale_cloudroast/test_repo/autoscale/system/policies/test_system_update_policy_execute_webhook.py
+++ b/autoscale_cloudroast/test_repo/autoscale/system/policies/test_system_update_policy_execute_webhook.py
@@ -1,9 +1,11 @@
 """
 System tests to test execute webhook after the policy is updated
 """
-from test_repo.autoscale.fixtures import AutoscaleFixture
 from time import sleep
+
 from cafe.drivers.unittest.decorators import tags
+
+from test_repo.autoscale.fixtures import AutoscaleFixture
 
 
 class UpdatePoliciesExecuteWebhookTest(AutoscaleFixture):
@@ -14,13 +16,15 @@ class UpdatePoliciesExecuteWebhookTest(AutoscaleFixture):
 
     def setUp(self):
         """
-        Create a scaling group with min entities > 0, scale up with cooldown 1 sec
+        Create a scaling group with min entities > 0, scale up with cooldown 1
+        sec
         """
         super(UpdatePoliciesExecuteWebhookTest, self).setUp()
         self.cooldown = 1
-        self.create_group_response = self.autoscale_behaviors.create_scaling_group_given(
-            gc_min_entities=self.gc_min_entities_alt,
-            gc_cooldown=0)
+        self.create_group_response = \
+            self.autoscale_behaviors.create_scaling_group_given(
+                gc_min_entities=self.gc_min_entities_alt,
+                gc_cooldown=0)
         self.group = self.create_group_response.entity
         self.policy_up = {'change': 2, 'cooldown': self.cooldown}
         self.policy = self.autoscale_behaviors.create_policy_webhook(
@@ -31,38 +35,43 @@ class UpdatePoliciesExecuteWebhookTest(AutoscaleFixture):
         self.resources.add(self.group, self.empty_scaling_group)
 
     @tags(speed='quick')
-    def test_system_update_scale_up_execute_webhook(self):
+    def test_scale_up_execute_webhook(self):
         """
-        Update a scale up policy and verify execution of such a policy using its webhook
+        Update a scale up policy and verify execution of such a policy using
+        its webhook
         """
         change = self.policy_up['change'] + 1
         sleep(self.cooldown)
         upd_scale_up_execute_webhook = self._update_policy_execute_webhook(
             self.group.id,
             self.policy['policy_id'], change, self.policy['webhook_url'])
-        self.assertEquals(upd_scale_up_execute_webhook, 202,
-                          msg='Executing the updated scale up policy using the webhook failed with {0}'
-                          'for group {1}'
-                          .format(upd_scale_up_execute_webhook, self.group.id))
+        self.assertEquals(
+            upd_scale_up_execute_webhook, 202,
+            msg='Executing the updated scale up policy using the '
+            'webhook failed with {0} for group {1}'
+            .format(upd_scale_up_execute_webhook, self.group.id))
         self.check_for_expected_number_of_building_servers(
             group_id=self.group.id,
             expected_servers=self.group.groupConfiguration.minEntities +
             self.policy_up['change'] + change)
 
     @tags(speed='slow')
-    def test_system_update_scale_up_to_scale_down_execute_webhook(self):
+    def test_scale_up_to_scale_down_execute_webhook(self):
         """
-        Update a scale up policy to scale down by the same change value and verify execution
-        of such a policy using its webhook
+        Update a scale up policy to scale down by the same change value and
+        verify execution of such a policy using its webhook
         """
         change = - self.policy_up['change']
         sleep(self.cooldown)
-        upd_to_scale_down_execute_webhook = self._update_policy_execute_webhook(
-            self.group.id,
-            self.policy['policy_id'], change, self.policy['webhook_url'])
-        self.assertEquals(upd_to_scale_down_execute_webhook, 202,
-                          msg='Executing the updated scale down policy failed with {0} for group {1}'
-                          .format(upd_to_scale_down_execute_webhook, self.group.id))
+        upd_to_scale_down_execute_webhook = \
+            self._update_policy_execute_webhook(
+                self.group.id,
+                self.policy['policy_id'], change, self.policy['webhook_url'])
+        self.assertEquals(
+            upd_to_scale_down_execute_webhook, 202,
+            msg='Executing the updated scale down policy failed with {0} '
+            'for group {1}'
+            .format(upd_to_scale_down_execute_webhook, self.group.id))
         sleep(0.1)
         self.wait_for_expected_number_of_active_servers(
             group_id=self.group.id,
@@ -72,20 +81,24 @@ class UpdatePoliciesExecuteWebhookTest(AutoscaleFixture):
             self.group.groupConfiguration.minEntities)
 
     @tags(speed='slow')
-    def test_system_update_policy_from_change_to_change_percent_scale_down_execute_webhook(self):
+    def test_from_change_to_change_percent_scale_down_execute_webhook(self):
         """
-        Update the existing scale up policy from change to change percent,such that
-        is scales down by 50%. Execute the webhook to execute the updated policy.
+        Update the existing scale up policy from change to change percent,such
+        that is scales down by 50%. Execute the webhook to execute the updated
+        policy.
         """
         upd_change_percent = - 50
         sleep(self.cooldown)
-        upd_policy_to_change_percent_capacity_execute_webhook = self._update_policy_cp_execute_webhook(
-            self.group.id,
-            self.policy['policy_id'], upd_change_percent, self.policy['webhook_url'])
-        self.assertEquals(upd_policy_to_change_percent_capacity_execute_webhook, 202,
-                          msg='Executing the updated policy using the webhook failed with {0}'
-                          ' for group {1}'
-                          .format(upd_policy_to_change_percent_capacity_execute_webhook, self.group.id))
+        upd_policy_to_change_percent_capacity_execute_webhook = \
+            self._update_policy_cp_execute_webhook(
+                self.group.id, self.policy['policy_id'],
+                upd_change_percent, self.policy['webhook_url'])
+        self.assertEquals(
+            upd_policy_to_change_percent_capacity_execute_webhook, 202,
+            msg='Executing the updated policy using the webhook failed '
+            'with {0} for group {1}'
+            .format(upd_policy_to_change_percent_capacity_execute_webhook,
+                    self.group.id))
         servers_from_scale_down = self.autoscale_behaviors.calculate_servers(
             current=self.group.groupConfiguration.minEntities +
             self.policy_up['change'],
@@ -98,7 +111,8 @@ class UpdatePoliciesExecuteWebhookTest(AutoscaleFixture):
             self.group.launchConfiguration.server.name,
             servers_from_scale_down)
 
-    def _update_policy_cp_execute_webhook(self, group_id, policy_id, policy_data, webhook_url):
+    def _update_policy_cp_execute_webhook(self, group_id, policy_id,
+                                          policy_data, webhook_url):
         """
         Updates any given policy to change percent and executes the webhook.
         Returns the response code of the updated policy's execution
@@ -113,11 +127,12 @@ class UpdatePoliciesExecuteWebhookTest(AutoscaleFixture):
             cooldown=policy_b4_update.cooldown,
             change_percent=policy_data,
             policy_type=policy_b4_update.type)
-        execute_upd_policy_using_webhook = self.autoscale_client.execute_webhook(
-            webhook_url)
+        execute_upd_policy_using_webhook = \
+            self.autoscale_client.execute_webhook(webhook_url)
         return execute_upd_policy_using_webhook.status_code
 
-    def _update_policy_execute_webhook(self, group_id, policy_id, policy_data, webhook_url):
+    def _update_policy_execute_webhook(self, group_id, policy_id, policy_data,
+                                       webhook_url):
         """
         Updates any given policy to change and executes the webhook.
         Returns the response code of the updated policy's execution
@@ -132,6 +147,6 @@ class UpdatePoliciesExecuteWebhookTest(AutoscaleFixture):
             cooldown=policy_b4_update.cooldown,
             change=policy_data,
             policy_type=policy_b4_update.type)
-        execute_upd_policy_using_webhook = self.autoscale_client.execute_webhook(
-            webhook_url)
+        execute_upd_policy_using_webhook = \
+            self.autoscale_client.execute_webhook(webhook_url)
         return execute_upd_policy_using_webhook.status_code


### PR DESCRIPTION
Everything but the scheduler tests.

I had to change some test method names to get them to fit under 80 columns. Most of them were full of redundant information (like beginning with `test_system` when they're obviously system tests since they're in the system directory...)