### PR TITLE
Add meaningful `reasons` lists and get rid of redundant error handlers in steps

### DIFF
--- a/otter/convergence/steps.py
+++ b/otter/convergence/steps.py
@@ -144,7 +144,7 @@ class CreateServer(object):
                 if message is not None:
                     return StepResult.FAILURE, [message]
 
-            return StepResult.RETRY, [result[1]]
+            return StepResult.RETRY, [error]
 
         return eff.on(got_name).on(success=report_success,
                                    error=report_failure)

--- a/otter/convergence/steps.py
+++ b/otter/convergence/steps.py
@@ -129,7 +129,7 @@ class CreateServer(object):
             a while, and we need to retry convergence to ensure it goes into
             active.
             """
-            return StepResult.RETRY, []
+            return StepResult.RETRY, ['waiting for server to become active']
 
         def report_failure(result):
             """
@@ -144,7 +144,7 @@ class CreateServer(object):
                 if message is not None:
                     return StepResult.FAILURE, [message]
 
-            return StepResult.RETRY, []
+            return StepResult.RETRY, [result[1]]
 
         return eff.on(got_name).on(success=report_success,
                                    error=report_failure)
@@ -219,10 +219,7 @@ class DeleteServer(object):
         def report_success(result):
             return StepResult.SUCCESS, []
 
-        def report_failure(result):
-            return StepResult.RETRY, []
-
-        return eff.on(success=report_success, error=report_failure)
+        return eff.on(success=report_success)
 
 
 @implementer(IStep)
@@ -252,10 +249,7 @@ class SetMetadataItemOnServer(object):
         def report_success(result):
             return StepResult.SUCCESS, []
 
-        def report_failure(result):
-            return StepResult.RETRY, [result[1]]
-
-        return eff.on(success=report_success, error=report_failure)
+        return eff.on(success=report_success)
 
 
 _CLB_DUPLICATE_NODES_PATTERN = re.compile(

--- a/otter/test/convergence/test_steps.py
+++ b/otter/test/convergence/test_steps.py
@@ -122,7 +122,7 @@ class CreateServerTests(SynchronousTestCase):
 
         self.assertEqual(
             resolve_effect(eff, (StubResponse(202, {}), {"server": {}})),
-            (StepResult.RETRY, []))
+            (StepResult.RETRY, ['waiting for server to become active']))
 
     def test_create_server_400_parseable_failures(self):
         """
@@ -184,7 +184,7 @@ class CreateServerTests(SynchronousTestCase):
             self.assertEqual(
                 resolve_effect(eff, service_request_error_response(api_error),
                                is_error=True),
-                (StepResult.RETRY, []))
+                (StepResult.RETRY, [api_error]))
 
     def test_create_server_403_json_parseable_failures(self):
         """
@@ -277,7 +277,7 @@ class CreateServerTests(SynchronousTestCase):
             self.assertEqual(
                 resolve_effect(eff, service_request_error_response(api_error),
                                is_error=True),
-                (StepResult.RETRY, []))
+                (StepResult.RETRY, [api_error]))
 
     def test_create_server_non_400_or_403_failures(self):
         """
@@ -293,7 +293,7 @@ class CreateServerTests(SynchronousTestCase):
         self.assertEqual(
             resolve_effect(eff, service_request_error_response(api_error),
                            is_error=True),
-            (StepResult.RETRY, []))
+            (StepResult.RETRY, [api_error]))
 
 
 class DeleteServerTests(SynchronousTestCase):
@@ -319,12 +319,6 @@ class DeleteServerTests(SynchronousTestCase):
         self.assertEqual(
             resolve_effect(eff, (None, {})),
             (StepResult.SUCCESS, []))
-
-        self.assertEqual(
-            resolve_effect(eff,
-                           (APIError, APIError(500, None, None), None),
-                           is_error=True),
-            (StepResult.RETRY, []))
 
     def test_delete_and_verify_del_404(self):
         """
@@ -438,13 +432,6 @@ class StepAsEffectTests(SynchronousTestCase):
         self.assertEqual(
             resolve_effect(eff, (None, {})),
             (StepResult.SUCCESS, []))
-
-        err = APIError(500, None, None)
-        self.assertEqual(
-            resolve_effect(eff,
-                           (APIError, err, None),
-                           is_error=True),
-            (StepResult.RETRY, [err]))
 
     def test_change_load_balancer_node(self):
         """

--- a/otter/util/http.py
+++ b/otter/util/http.py
@@ -6,6 +6,8 @@ from itertools import chain
 from urllib import quote, urlencode
 from urlparse import parse_qs, urlsplit, urlunsplit
 
+from characteristic import Attribute, attributes
+
 from toolz.dicttoolz import get_in
 
 import treq
@@ -159,6 +161,8 @@ def append_segments(uri, *segments):
     return uri
 
 
+@attributes(['code', 'body',
+             Attribute('headers', default_value=None)], apply_with_init=False)
 class APIError(Exception):
     """
     An error raised when a non-success response is returned by the API.


### PR DESCRIPTION
Few related changes

- CreateServer's success-case RETRY now returns `RETRY, ['waiting for server to become active']`, so we can distinguing between RETRY due to error and RETRY due to success.
- got rid of a few `report_failure` errbacks that were just handling arbitrary errors that were written before I added that logic to steps_to_effect.
- add exception to results list in CreateServer