### PR TITLE
Add `convergence` tags to a bunch of system integration tests

### DIFF
--- a/autoscale_cloudroast/test_repo/autoscale/system/group/test_force_delete_group.py
+++ b/autoscale_cloudroast/test_repo/autoscale/system/group/test_force_delete_group.py
@@ -17,7 +17,7 @@ class ForceDeleteGroupTest(AutoscaleFixture):
     invalid_params = [0, '', '$%^#', 'false', 'False', False, 'anything',
                       'truee']
 
-    @tags(speed='slow')
+    @tags(speed='slow', convergence='yes')
     def test_minentities_over_zero(self):
         """
         Force deleting a scaling group with active servers, updates the desired
@@ -39,7 +39,7 @@ class ForceDeleteGroupTest(AutoscaleFixture):
             self.assert_servers_deleted_successfully(
                 group.launchConfiguration.server.name)
 
-    @tags(speed='quick')
+    @tags(speed='quick', convergence='yes')
     def test_force_as_true_with_0_minentities(self):
         """
         Force deleting a scaling group with no active servers with force set to
@@ -60,7 +60,7 @@ class ForceDeleteGroupTest(AutoscaleFixture):
             self.assert_servers_deleted_successfully(
                 group.launchConfiguration.server.name)
 
-    @tags(speed='quick')
+    @tags(speed='quick', convergence='yes')
     def test_invalid_force_attribute_with_0_minentities(self):
         """
         Force deleting a scaling group with no active servers with force set to
@@ -76,7 +76,7 @@ class ForceDeleteGroupTest(AutoscaleFixture):
                 msg='Force deleted group {0} when active servers existed '
                 'on it and force was set to invalid option'.format(group.id))
 
-    @tags(speed='quick')
+    @tags(speed='quick', convergence='yes')
     def test_invalid_force_attribute(self):
         """
         Force deleting a scaling group with active servers with force set to

--- a/autoscale_cloudroast/test_repo/autoscale/system/group/test_group_servers.py
+++ b/autoscale_cloudroast/test_repo/autoscale/system/group/test_group_servers.py
@@ -131,15 +131,10 @@ class ServersTests(AutoscaleFixture):
         Calling `DELETE serverId` when number of servers are at minimum returns
         403
         """
-        print "\nhere we go."
-        print ""
         server_id = self.wait_for_expected_number_of_active_servers(
             self.groupid, 1)[0]
-        print "got a server_id", server_id
-        print "'bout to delete it through otter-api"
         resp = self.autoscale_client.delete_server(self.groupid, server_id,
                                                    replace='false')
-        print "resp was", resp
         self.assertEqual(resp.status_code, 403,
                          'Delete server status is {}. Expected 403'.format(
                              resp.status_code))

--- a/autoscale_cloudroast/test_repo/autoscale/system/group/test_group_servers.py
+++ b/autoscale_cloudroast/test_repo/autoscale/system/group/test_group_servers.py
@@ -46,7 +46,7 @@ class ServersTests(AutoscaleFixture):
         self.fail('Server {} in group {} not deleted'.format(server_id,
                                                              self.groupid))
 
-    @tags(speed='slow')
+    @tags(speed='slow', convergence='error')
     def test_delete_removes_and_replaces(self, replace=None):
         """
         `DELETE serverId` actually deletes the server and replaces with new
@@ -66,7 +66,7 @@ class ServersTests(AutoscaleFixture):
         # New server replaced?
         self.verify_group_state(self.groupid, 1)
 
-    @tags(speed='slow')
+    @tags(speed='slow', convergence='error')
     def test_delete_removed_replaced_arg(self):
         """
         `DELETE serverId?replace=true` actually deletes the server and
@@ -74,7 +74,7 @@ class ServersTests(AutoscaleFixture):
         """
         self.test_delete_removes_and_replaces('true')
 
-    @tags(speed='slow')
+    @tags(speed='slow', convergence='error')
     def test_delete_removed_not_replaced(self):
         """
         `DELETE serverId?replace=false` removes the sever and does not replace
@@ -97,6 +97,7 @@ class ServersTests(AutoscaleFixture):
         # New server not replaced?
         self.verify_group_state(self.groupid, 1)
 
+    @tags(convergence='yes')
     def test_delete_server_not_found(self):
         """
         `DELETE invalid_serverId` returns 404
@@ -107,6 +108,7 @@ class ServersTests(AutoscaleFixture):
                          'Delete server status is {}. Expected 404'.format(
                              resp.status_code))
 
+    @tags(convergence='yes')
     def test_delete_server_not_found_in_diff_group(self):
         """
         `DELETE serverId` on server in same tenant but different group returns
@@ -123,22 +125,27 @@ class ServersTests(AutoscaleFixture):
                          'Delete server status is {}. Expected 404'.format(
                              resp.status_code))
 
-    @tags(speed='slow')
+    @tags(speed='slow', convergence='yes')
     def test_delete_below_min(self):
         """
         Calling `DELETE serverId` when number of servers are at minimum returns
         403
         """
+        print "\nhere we go."
+        print ""
         server_id = self.wait_for_expected_number_of_active_servers(
             self.groupid, 1)[0]
+        print "got a server_id", server_id
+        print "'bout to delete it through otter-api"
         resp = self.autoscale_client.delete_server(self.groupid, server_id,
                                                    replace='false')
+        print "resp was", resp
         self.assertEqual(resp.status_code, 403,
                          'Delete server status is {}. Expected 403'.format(
                              resp.status_code))
         self.assertIn('CannotDeleteServerBelowMinError', resp.content)
 
-    @tags(speed='slow')
+    @tags(speed='slow', convergence='yes')
     def test_delete_server_invalid_replace_args(self):
         """
         `DELETE serverId?replace=bad` returns 400 with InvalidQueryArgument

--- a/autoscale_cloudroast/test_repo/autoscale/system/group/test_system_delete_group.py
+++ b/autoscale_cloudroast/test_repo/autoscale/system/group/test_system_delete_group.py
@@ -36,7 +36,7 @@ class DeleteGroupTest(AutoscaleFixture):
         self.resources.add(self.group0, self.empty_scaling_group)
         self.resources.add(self.group1, self.empty_scaling_group)
 
-    @tags(speed='quick')
+    @tags(speed='quick', convergence='error')
     def test_system_delete_group_with_minentities_over_zero(self):
         """
         A scaling group cannot be deleted when minentities > zero
@@ -50,7 +50,7 @@ class DeleteGroupTest(AutoscaleFixture):
             msg='Deleted group {0} while servers were building on the group'
             .format(self.group1.id))
 
-    @tags(speed='quick')
+    @tags(speed='quick', convergence='error')
     def test_system_delete_group_update_minentities_to_zero(self):
         """
         When minenetities of the group are updated to be zero,
@@ -75,7 +75,7 @@ class DeleteGroupTest(AutoscaleFixture):
             msg='Deleted group succeeded when servers exist on the group {0} '
             'due to {1}'.format(self.group1.id, delete_group_response.content))
 
-    @tags(speed='quick')
+    @tags(speed='quick', convergence='yes')
     def test_system_delete_group_with_zero_minentities(self):
         """
         A scaling group of zero minentities and no active servers,
@@ -89,7 +89,7 @@ class DeleteGroupTest(AutoscaleFixture):
             msg='Delete group {0} failed even when group was empty'
             .format(self.group0.id))
 
-    @tags(speed='quick')
+    @tags(speed='quick', convergence='error')
     def test_system_delete_group_zero_minentities_execute_webhook(self):
         """
         Create a scaling group with zero minentities and execute a webhook,
@@ -107,7 +107,7 @@ class DeleteGroupTest(AutoscaleFixture):
             msg='Deleted group {0} while servers were building on the group'
             .format(self.group0.id))
 
-    @tags(speed='quick')
+    @tags(speed='quick', convergence='error')
     def test_system_delete_group_zero_minentities_execute_policy(self):
         """
         Create a scaling group with zero min entities and execute a scaling

--- a/autoscale_cloudroast/test_repo/autoscale/system/group/test_system_group.py
+++ b/autoscale_cloudroast/test_repo/autoscale/system/group/test_system_group.py
@@ -14,7 +14,7 @@ class GroupFixture(AutoscaleFixture):
     System tests to verify scaling group scenarios
     """
 
-    @tags(speed='quick')
+    @tags(speed='quick', convergence='yes')
     def test_update_minentities_to_scaleup(self):
         """
         The scaling group scales up when the minentities are updated,
@@ -27,7 +27,7 @@ class GroupFixture(AutoscaleFixture):
         self._update_group(group=group, minentities=upd_minentities)
         self.verify_group_state(group.id, upd_minentities)
 
-    @tags(speed='quick')
+    @tags(speed='quick', convergence='yes')
     def test_update_minentities_to_be_lesser_than_during_create_group(self):
         """
         The scaling group does not scale down when the minenetities are
@@ -40,7 +40,7 @@ class GroupFixture(AutoscaleFixture):
         self._update_group(group=group, minentities=upd_minentities)
         self.verify_group_state(group.id, minentities)
 
-    @tags(speed='slow')
+    @tags(speed='slow', convergence='yes')
     def test_update_maxentities_less_than_desiredcapacity(self):
         """
         Create a scaling group and execute a policy to be within maxentities,
@@ -71,7 +71,7 @@ class GroupFixture(AutoscaleFixture):
             group.launchConfiguration.server.name,
             count=upd_maxentities)
 
-    @tags(speed='quick')
+    @tags(speed='quick', convergence='yes')
     def test_update_maxentities_and_execute_policy(self):
         """
         Execute policy on scaling group such that the maxentities are met,
@@ -99,7 +99,7 @@ class GroupFixture(AutoscaleFixture):
         total_servers = maxentities + policy['change']
         self.verify_group_state(group.id, total_servers)
 
-    @tags(speed='quick')
+    @tags(speed='quick', convergence='yes')
     def test_group_cooldown_enforced_when_reexecuting_same_policy(self):
         """
         The group cooldown is enforced when executing a scaling policy
@@ -123,7 +123,7 @@ class GroupFixture(AutoscaleFixture):
             .format(reexecute_policy_response.status_code, group.id))
         self.verify_group_state(group.id, policy['change'])
 
-    @tags(speed='quick')
+    @tags(speed='quick', convergence='yes')
     def test_group_cooldown_enforced_when_executing_different_policies(self):
         """
         The group cooldown is enforced when executing different scaling
@@ -148,7 +148,7 @@ class GroupFixture(AutoscaleFixture):
             .format(execute_policy2_response.status_code, group.id))
         self.verify_group_state(group.id, policy['change'])
 
-    @tags(speed='quick')
+    @tags(speed='quick', convergence='yes')
     def test_update_group_cooldown_and_execute_policy(self):
         """
         Different scaling policies can be executed when the group cooldown
@@ -190,7 +190,7 @@ class GroupFixture(AutoscaleFixture):
             'change'] + group.groupConfiguration.minEntities + policy['change']
         self.verify_group_state(group.id, total_servers)
 
-    @tags(speed='quick')
+    @tags(speed='quick', convergence='error')
     def test_execute_policy_beyond_maxentities(self):
         """
         Scaling policy is executed when change + minentities > maxentities,
@@ -227,7 +227,7 @@ class GroupFixture(AutoscaleFixture):
         total_servers = maxentities + policy['change']
         self.verify_group_state(group.id, total_servers)
 
-    @tags(speed='quick')
+    @tags(speed='quick', convergence='error')
     def test_execute_policy_beyond_maxentities_when_min_equals_max(self):
         """
         Scaling group with minentities = maxentities cannot execute scale up
@@ -261,7 +261,7 @@ class GroupFixture(AutoscaleFixture):
         total_servers = maxentities + policy['change']
         self.verify_group_state(group.id, total_servers)
 
-    @tags(speed='quick')
+    @tags(speed='quick', convergence='yes')
     def test_create_scaling_group_with_same_attributes(self):
         """
         Scaling groups can be created with the exact same attributes

--- a/autoscale_cloudroast/test_repo/autoscale/system/group/test_system_group_negative.py
+++ b/autoscale_cloudroast/test_repo/autoscale/system/group/test_system_group_negative.py
@@ -97,7 +97,7 @@ class NegativeGroupFixture(AutoscaleFixture):
             group_state.desiredCapacity, 0,
             msg='Desired capacity is not equal to expected number of servers')
 
-    @tags(speed='quick')
+    @tags(speed='quick', convergence='impatient-timeout')
     def test_user_delete_some_servers_out_of_band(self):
         """
         Create a group with 4 minentities and verify the group state when user

--- a/autoscale_cloudroast/test_repo/autoscale/system/group/test_system_group_negative.py
+++ b/autoscale_cloudroast/test_repo/autoscale/system/group/test_system_group_negative.py
@@ -97,7 +97,7 @@ class NegativeGroupFixture(AutoscaleFixture):
             group_state.desiredCapacity, 0,
             msg='Desired capacity is not equal to expected number of servers')
 
-    @tags(speed='quick', convergence='impatient-timeout')
+    @tags(speed='quick', convergence='error')
     def test_user_delete_some_servers_out_of_band(self):
         """
         Create a group with 4 minentities and verify the group state when user

--- a/autoscale_cloudroast/test_repo/autoscale/system/group/test_system_launch_config.py
+++ b/autoscale_cloudroast/test_repo/autoscale/system/group/test_system_launch_config.py
@@ -50,7 +50,7 @@ class LaunchConfigTest(AutoscaleFixture):
             active_list, self.upd_server_name,
             self.upd_image_ref, self.upd_flavor_ref)
 
-    @tags(speed='slow', convergence='timeout')
+    @tags(speed='slow', convergence='error')
     def test_update_launchconfig_scale_down(self):
         """
         Create a scaling group with a scale up and scale down policy. Execute
@@ -92,7 +92,7 @@ class LaunchConfigTest(AutoscaleFixture):
             group.launchConfiguration.server.name,
             server_after_down)
 
-    @tags(speed='slow', convergence='timeout')
+    @tags(speed='slow', convergence='error')
     def test_update_launchconfig_scale_up_down(self):
         """
         Create a scaling group with a scale up and scale down policy. Execute
@@ -215,7 +215,7 @@ class LaunchConfigTest(AutoscaleFixture):
         self.assertEquals(1, len(servers))
         self.assertEquals("", servers[0].image.id)
 
-    @tags(speed='quick', convergence='timeout')
+    @tags(speed='quick', convergence='error')
     def test_update_launchconfig_while_group_building(self):
         """
         Updates to the launch config do not apply to the servers building,
@@ -236,7 +236,7 @@ class LaunchConfigTest(AutoscaleFixture):
             group.launchConfiguration.server.imageRef,
             group.launchConfiguration.server.flavorRef)
 
-    @tags(speed='slow', convergence='impatient-timeout')
+    @tags(speed='slow', convergence='error')
     def test_update_launchconfig_while_group_building_and_scale_down(self):
         """
         Create a scaling group and scale up. While servers are building, update
@@ -317,7 +317,7 @@ class LaunchConfigTest(AutoscaleFixture):
             servers_list_on_upd, self.upd_server_name, self.upd_image_ref,
             self.upd_flavor_ref)
 
-    @tags(speed='slow', convergence='impatient-timeout')
+    @tags(speed='slow', convergence='error')
     def test_update_launchconfig_group_maxentities(self):
         """
         Create a scaling group with scaling policy and with
@@ -371,7 +371,7 @@ class LaunchConfigTest(AutoscaleFixture):
         self.assert_servers_deleted_successfully(
             group.launchConfiguration.server.name)
 
-    @tags(speed='slow', convergence='impatient-timeout')
+    @tags(speed='slow', convergence='error')
     def test_scale_down_oldest_on_active_servers(self):
         """
         Create a scaling group with minentities=scale up=scale_down=sp_change

--- a/autoscale_cloudroast/test_repo/autoscale/system/group/test_system_launch_config.py
+++ b/autoscale_cloudroast/test_repo/autoscale/system/group/test_system_launch_config.py
@@ -26,7 +26,7 @@ class LaunchConfigTest(AutoscaleFixture):
         cls.upd_image_ref = cls.lc_image_ref_alt
         cls.upd_flavor_ref = "3"
 
-    @tags(speed='quick')
+    @tags(speed='quick', convergence='yes')
     def test_update_launchconfig_scale_up(self):
         """
         Create a scaling group with a scaling policy, update the launch config.
@@ -50,7 +50,7 @@ class LaunchConfigTest(AutoscaleFixture):
             active_list, self.upd_server_name,
             self.upd_image_ref, self.upd_flavor_ref)
 
-    @tags(speed='slow')
+    @tags(speed='slow', convergence='timeout')
     def test_update_launchconfig_scale_down(self):
         """
         Create a scaling group with a scale up and scale down policy. Execute
@@ -92,7 +92,7 @@ class LaunchConfigTest(AutoscaleFixture):
             group.launchConfiguration.server.name,
             server_after_down)
 
-    @tags(speed='slow')
+    @tags(speed='slow', convergence='timeout')
     def test_update_launchconfig_scale_up_down(self):
         """
         Create a scaling group with a scale up and scale down policy. Execute
@@ -215,7 +215,7 @@ class LaunchConfigTest(AutoscaleFixture):
         self.assertEquals(1, len(servers))
         self.assertEquals("", servers[0].image.id)
 
-    @tags(speed='quick')
+    @tags(speed='quick', convergence='timeout')
     def test_update_launchconfig_while_group_building(self):
         """
         Updates to the launch config do not apply to the servers building,
@@ -236,7 +236,7 @@ class LaunchConfigTest(AutoscaleFixture):
             group.launchConfiguration.server.imageRef,
             group.launchConfiguration.server.flavorRef)
 
-    @tags(speed='slow')
+    @tags(speed='slow', convergence='impatient-timeout')
     def test_update_launchconfig_while_group_building_and_scale_down(self):
         """
         Create a scaling group and scale up. While servers are building, update
@@ -277,7 +277,7 @@ class LaunchConfigTest(AutoscaleFixture):
             group_before_upd.launchConfiguration.server.imageRef,
             group_before_upd.launchConfiguration.server.flavorRef)
 
-    @tags(speed='quick')
+    @tags(speed='quick', convergence='yes')
     def test_update_launchconfig_group_minentities(self):
         """
         Create a scaling group, update the launch config.
@@ -317,7 +317,7 @@ class LaunchConfigTest(AutoscaleFixture):
             servers_list_on_upd, self.upd_server_name, self.upd_image_ref,
             self.upd_flavor_ref)
 
-    @tags(speed='slow')
+    @tags(speed='slow', convergence='impatient-timeout')
     def test_update_launchconfig_group_maxentities(self):
         """
         Create a scaling group with scaling policy and with
@@ -371,7 +371,7 @@ class LaunchConfigTest(AutoscaleFixture):
         self.assert_servers_deleted_successfully(
             group.launchConfiguration.server.name)
 
-    @tags(speed='slow')
+    @tags(speed='slow', convergence='impatient-timeout')
     def test_scale_down_oldest_on_active_servers(self):
         """
         Create a scaling group with minentities=scale up=scale_down=sp_change

--- a/autoscale_cloudroast/test_repo/autoscale/system/group/test_system_sgroup_multiples.py
+++ b/autoscale_cloudroast/test_repo/autoscale/system/group/test_system_sgroup_multiples.py
@@ -36,7 +36,7 @@ class ScalingGroupMultiplesTest(AutoscaleFixture):
         self.first_scaling_group = first_group.entity
         self.resources.add(self.first_scaling_group, self.empty_scaling_group)
 
-    @tags(speed='quick')
+    @tags(speed='quick', convergence='yes')
     def test_system_create_group_with_multiple_policies(self):
         """
         Scaling group can have multiple policies and can be executed
@@ -69,7 +69,7 @@ class ScalingGroupMultiplesTest(AutoscaleFixture):
         sp3 = self.autoscale_behaviors.calculate_servers(sp2, percentage)
         self.verify_group_state(self.first_scaling_group.id, sp3)
 
-    @tags(speed='quick')
+    @tags(speed='quick', convergence='yes')
     def test_system_create_policy_with_multiple_webhooks(self):
         """
         Scaling policy in a group can have multiple webhooks and they can be
@@ -139,7 +139,7 @@ class ScalingGroupMultiplesTest(AutoscaleFixture):
             msg='{0} groups exist on the tenant'.format(
                 self.get_total_num_groups()))
 
-    @tags(speed='quick')
+    @tags(speed='quick', convergence='yes')
     def test_system_max_webhook_policies_on_a_scaling_group(self):
         """
         Verify maximum scaling policies are allowed on a scaling group.
@@ -159,7 +159,7 @@ class ScalingGroupMultiplesTest(AutoscaleFixture):
                           'group'.format(self.get_total_num_policies(
                                          self.first_scaling_group.id)))
 
-    @tags(speed='quick')
+    @tags(speed='quick', convergence='yes')
     def test_system_max_scheduler_policies_on_a_scaling_group(self):
         """
         Verify maximum scaling policies are allowed on a scaling group.
@@ -183,7 +183,7 @@ class ScalingGroupMultiplesTest(AutoscaleFixture):
                           'group'.format(self.get_total_num_policies(
                                          self.first_scaling_group.id)))
 
-    @tags(speed='quick')
+    @tags(speed='quick', convergence='yes')
     def test_system_max_webhooks_on_a_scaling_policy(self):
         """
         Verify the maximum scaling policies are allowed on a scaling policy.

--- a/autoscale_cloudroast/test_repo/autoscale/system/integration/test_system_integration_lbaas.py
+++ b/autoscale_cloudroast/test_repo/autoscale/system/integration/test_system_integration_lbaas.py
@@ -45,7 +45,7 @@ class AutoscaleLbaasFixture(AutoscaleFixture):
                           cls.lbaas_client.delete_load_balancer)
         cls.lb_other_region = 0000
 
-    @tags(speed='slow', type='lbaas')
+    @tags(speed='slow', type='lbaas', convergence='error')
     def test_delete_server_if_deleted_load_balancer_during_scale_down(self):
         """
         Create a load balancer and provide it in the launch config during
@@ -80,7 +80,7 @@ class AutoscaleLbaasFixture(AutoscaleFixture):
             group.launchConfiguration.server.name, 1)
         self.assertEquals(actual_remaining_servers, remaining_servers)
 
-    @tags(speed='slow', type='lbaas')
+    @tags(speed='slow', type='lbaas', convergence='error')
     def test_delete_server_if_deleted_load_balancer_during_scale_up(self):
         """
         Create a load balancer and provide it in the launch config during
@@ -109,7 +109,7 @@ class AutoscaleLbaasFixture(AutoscaleFixture):
             group.launchConfiguration.server.name,
             self.gc_min_entities_alt)
 
-    @tags(speed='slow', type='lbaas')
+    @tags(speed='slow', type='lbaas', convergence='yes')
     def test_add_multiple_lbaas_to_group(self):
         """
         Adding multiple load balancers within the launch config when creating
@@ -127,7 +127,7 @@ class AutoscaleLbaasFixture(AutoscaleFixture):
             active_server_list, self.load_balancer_1, self.load_balancer_2,
             self.load_balancer_3)
 
-    @tags(speed='slow', type='lbaas')
+    @tags(speed='slow', type='lbaas', convergence='yes')
     def test_update_launch_config_to_include_multiple_lbaas(self):
         """
         Updating the launch config to add multiple load balancer to a group
@@ -156,7 +156,7 @@ class AutoscaleLbaasFixture(AutoscaleFixture):
             active_servers_from_scale, self.load_balancer_1,
             self.load_balancer_2, self.load_balancer_3)
 
-    @tags(speed='slow', type='lbaas')
+    @tags(speed='slow', type='lbaas', convergence='yes')
     def test_update_launch_config_to_include_lbaas(self):
         """
         Update the launch config to add a load balancer to a group that did not
@@ -186,7 +186,7 @@ class AutoscaleLbaasFixture(AutoscaleFixture):
             active_servers_from_scale, self.load_balancer_1,
             self.load_balancer_2, self.load_balancer_3)
 
-    @tags(speed='slow', type='lbaas')
+    @tags(speed='slow', type='lbaas', convergence='error')
     def test_update_existing_lbaas_in_launch_config(self):
         """
         Create a scaling group with a given load balancer and verify the
@@ -233,7 +233,7 @@ class AutoscaleLbaasFixture(AutoscaleFixture):
                             self.load_balancer_1)]
         self.assertTrue(set(scaled_down_server_ip) not in set(lb_node_list))
 
-    @tags(speed='slow', type='lbaas')
+    @tags(speed='slow', type='lbaas', convergence='error')
     def test_delete_group_when_autoscale_server_is_the_last_node_on_lb(self):
         """
         Create a scaling group with load balancer.  After the servers on the
@@ -259,7 +259,7 @@ class AutoscaleLbaasFixture(AutoscaleFixture):
         lb_node_after_del = self._get_node_list_from_lb(load_balancer)
         self.assertEquals(len(lb_node_after_del), 0)
 
-    @tags(speed='slow', type='lbaas')
+    @tags(speed='slow', type='lbaas', convergence='error')
     def test_existing_nodes_on_lb_unaffected_by_scaling(self):
         """
         Get load balancer node id list before anyscale operation, create a
@@ -291,7 +291,7 @@ class AutoscaleLbaasFixture(AutoscaleFixture):
             lb_node_list_before_scale, load_balancer
         )
 
-    @tags(speed='slow', type='lbaas')
+    @tags(speed='slow', type='lbaas', convergence='yes')
     def test_remove_existing_lbaas_in_launch_config(self):
         """
         Remove lbaas id in the launch config and verify a scale up after the
@@ -320,7 +320,7 @@ class AutoscaleLbaasFixture(AutoscaleFixture):
         self.assertTrue(all([server_ip not in node_list_on_lb
                              for server_ip in server_ip_list]))
 
-    @tags(speed='slow', type='lbaas')
+    @tags(speed='slow', type='lbaas', convergence='error')
     def test_force_delete_group_with_load_balancer(self):
         """
         Force delete a scaling group with active servers and load balancer,
@@ -347,7 +347,7 @@ class AutoscaleLbaasFixture(AutoscaleFixture):
         self.assertTrue(all([server_ip not in node_list_on_lb for server_ip
                              in server_ip_list]))
 
-    @tags(speed='slow', type='lbaas')
+    @tags(speed='slow', type='lbaas', convergence='impatient-timeout')
     def test_negative_create_group_with_invalid_load_balancer(self):
         """
         Create group with a random number/lb from a differnt region as the load
@@ -363,7 +363,7 @@ class AutoscaleLbaasFixture(AutoscaleFixture):
             self.assert_servers_deleted_successfully(
                 group.launchConfiguration.server.name)
 
-    @tags(speed='slow', type='lbaas')
+    @tags(speed='slow', type='lbaas', convergence='impatient-timeout')
     def test_load_balancer_pending_update_or_error_state(self):
         """
         Ensure all the servers are created and added to the load balancer and
@@ -402,7 +402,7 @@ class AutoscaleLbaasFixture(AutoscaleFixture):
             group.launchConfiguration.server.name,
             self.gc_min_entities_alt)
 
-    @tags(speed='slow', type='lbaas')
+    @tags(speed='slow', type='lbaas', convergence='impatient-timeout')
     def test_group_with_invalid_load_balancer_among_multiple_load_balancers(
             self):
         """

--- a/autoscale_cloudroast/test_repo/autoscale/system/integration/test_system_integration_lbaas.py
+++ b/autoscale_cloudroast/test_repo/autoscale/system/integration/test_system_integration_lbaas.py
@@ -347,7 +347,7 @@ class AutoscaleLbaasFixture(AutoscaleFixture):
         self.assertTrue(all([server_ip not in node_list_on_lb for server_ip
                              in server_ip_list]))
 
-    @tags(speed='slow', type='lbaas', convergence='impatient-timeout')
+    @tags(speed='slow', type='lbaas', convergence='error')
     def test_negative_create_group_with_invalid_load_balancer(self):
         """
         Create group with a random number/lb from a differnt region as the load
@@ -363,7 +363,7 @@ class AutoscaleLbaasFixture(AutoscaleFixture):
             self.assert_servers_deleted_successfully(
                 group.launchConfiguration.server.name)
 
-    @tags(speed='slow', type='lbaas', convergence='impatient-timeout')
+    @tags(speed='slow', type='lbaas', convergence='error')
     def test_load_balancer_pending_update_or_error_state(self):
         """
         Ensure all the servers are created and added to the load balancer and
@@ -402,7 +402,7 @@ class AutoscaleLbaasFixture(AutoscaleFixture):
             group.launchConfiguration.server.name,
             self.gc_min_entities_alt)
 
-    @tags(speed='slow', type='lbaas', convergence='impatient-timeout')
+    @tags(speed='slow', type='lbaas', convergence='error')
     def test_group_with_invalid_load_balancer_among_multiple_load_balancers(
             self):
         """


### PR DESCRIPTION
This adds 28 convergence='yes', and a bunch of convergence='error' tags on tests that I ran and which either didn't complete or failed.