### PR TITLE
Update active after delete

### DIFF
--- a/autoscale_cloudroast/test_repo/autoscale/system/group/test_group_servers.py
+++ b/autoscale_cloudroast/test_repo/autoscale/system/group/test_group_servers.py
@@ -47,6 +47,9 @@ class ServersTests(AutoscaleFixture):
                                                              self.groupid))
 
     @tags(speed='slow', convergence='error')
+    # TODO: https://github.com/rackerlabs/otter/issues/1238
+    # DELETE doesn't work on servers created with convergence.
+    # This affects a lot of tests in this module!
     def test_delete_removes_and_replaces(self, replace=None):
         """
         `DELETE serverId` actually deletes the server and replaces with new

--- a/autoscale_cloudroast/test_repo/autoscale/system/group/test_system_launch_config.py
+++ b/autoscale_cloudroast/test_repo/autoscale/system/group/test_system_launch_config.py
@@ -50,7 +50,7 @@ class LaunchConfigTest(AutoscaleFixture):
             active_list, self.upd_server_name,
             self.upd_image_ref, self.upd_flavor_ref)
 
-    @tags(speed='slow', convergence='error')
+    @tags(speed='slow', convergence='yes')
     def test_update_launchconfig_scale_down(self):
         """
         Create a scaling group with a scale up and scale down policy. Execute
@@ -92,7 +92,7 @@ class LaunchConfigTest(AutoscaleFixture):
             group.launchConfiguration.server.name,
             server_after_down)
 
-    @tags(speed='slow', convergence='error')
+    @tags(speed='slow', convergence='yes')
     def test_update_launchconfig_scale_up_down(self):
         """
         Create a scaling group with a scale up and scale down policy. Execute
@@ -215,7 +215,13 @@ class LaunchConfigTest(AutoscaleFixture):
         self.assertEquals(1, len(servers))
         self.assertEquals("", servers[0].image.id)
 
-    @tags(speed='quick', convergence='error')
+    @tags(speed='quick', convergence='needs-consideration')
+    # This test creates a group and then immediately changes the launch
+    # config. Since group creation is now asynchronous with convergence, it's
+    # likely that the change takes place before the first convergence iteration
+    # happens, so it will actually use the updated config, causing this test to
+    # fail.  However, maybe we can still get this test to pass by adding a
+    # {'server_building': '30'} to the server metadata.
     def test_update_launchconfig_while_group_building(self):
         """
         Updates to the launch config do not apply to the servers building,
@@ -236,7 +242,9 @@ class LaunchConfigTest(AutoscaleFixture):
             group.launchConfiguration.server.imageRef,
             group.launchConfiguration.server.flavorRef)
 
-    @tags(speed='slow', convergence='error')
+    @tags(speed='slow', convergence='needs-consideration')
+    # This relies on https://github.com/rackerlabs/otter/issues/1235
+    # but it also might have the same problem as the previous test.
     def test_update_launchconfig_while_group_building_and_scale_down(self):
         """
         Create a scaling group and scale up. While servers are building, update
@@ -317,7 +325,7 @@ class LaunchConfigTest(AutoscaleFixture):
             servers_list_on_upd, self.upd_server_name, self.upd_image_ref,
             self.upd_flavor_ref)
 
-    @tags(speed='slow', convergence='error')
+    @tags(speed='slow', convergence='yes')
     def test_update_launchconfig_group_maxentities(self):
         """
         Create a scaling group with scaling policy and with
@@ -371,7 +379,7 @@ class LaunchConfigTest(AutoscaleFixture):
         self.assert_servers_deleted_successfully(
             group.launchConfiguration.server.name)
 
-    @tags(speed='slow', convergence='error')
+    @tags(speed='slow', convergence='yes')
     def test_scale_down_oldest_on_active_servers(self):
         """
         Create a scaling group with minentities=scale up=scale_down=sp_change

--- a/otter/convergence/service.py
+++ b/otter/convergence/service.py
@@ -132,13 +132,14 @@ def execute_convergence(tenant_id, group_id, log,
             results=zip(steps, results),
             worst_status=worst_status)
 
-    if worst_status in (StepResult.SUCCESS, StepResult.FAILURE):
+    if worst_status == StepResult.SUCCESS:
         # Do one last gathering + writing to `active` so we get updated
         # based on any DELETEs or other stuff that happened.
-        gather_eff = get_all_convergence_data(group_id)
         (servers, lb_nodes) = yield gather_eff
         active = determine_active(servers, lb_nodes)
         yield _update_active(scaling_group, active)
+        # given that we're gathering in this case, wouldn't it make sense to
+        # also plan, and then to execute that plan if something is found...?
 
     yield do_return(worst_status)
 

--- a/otter/test/convergence/test_service.py
+++ b/otter/test/convergence/test_service.py
@@ -674,7 +674,7 @@ class ExecuteConvergenceTests(SynchronousTestCase):
         log = mock_log()
 
         def get_all_convergence_data(group_id):
-            return Effect('get-all-data')
+            return Effect(('get-all-data', group_id))
 
         def plan(*args, **kwargs):
             return pbag([TestStep(Effect('some-boring-step'))])
@@ -694,7 +694,7 @@ class ExecuteConvergenceTests(SynchronousTestCase):
              lambda i: (self.group, self.manifest)),
 
             # gather convergence data
-            ('get-all-data', lambda i: ([server1], [])),
+            (('get-all-data', 'group-id'), lambda i: ([server1], [])),
 
             # update active based on that data
             (ModifyGroupState(
@@ -707,7 +707,7 @@ class ExecuteConvergenceTests(SynchronousTestCase):
             ('some-boring-step', lambda i: (StepResult.SUCCESS, [])),
 
             # gather convergence data again, since everything was SUCCESS
-            ('get-all-data', lambda i: ([server1, server2], [])),
+            (('get-all-data', 'group-id'), lambda i: ([server1, server2], [])),
 
             # update active on the group with the new results
             (ModifyGroupState(

--- a/otter/test/convergence/test_service.py
+++ b/otter/test/convergence/test_service.py
@@ -5,7 +5,7 @@ from effect import (
     TypeDispatcher, base_dispatcher, sync_perform)
 from effect.async import perform_parallel_async
 from effect.ref import Reference, reference_dispatcher
-from effect.testing import EQDispatcher, EQFDispatcher
+from effect.testing import EQDispatcher, EQFDispatcher, SequenceDispatcher
 
 from kazoo.exceptions import BadVersionError
 
@@ -41,6 +41,7 @@ from otter.test.utils import (
     matches,
     mock_group, mock_log,
     raise_,
+    test_dispatcher,
     transform_eq)
 from otter.util.zk import CreateOrSet, DeleteNode, GetChildrenWithStats
 
@@ -514,11 +515,11 @@ class ExecuteConvergenceTests(SynchronousTestCase):
         ]
         gsgi = GetScalingGroupInfo(tenant_id='tenant-id',
                                    group_id='group-id')
-        manifest = {  # Many details elided!
+        self.manifest = {  # Many details elided!
             'state': self.state,
             'launchConfiguration': self.lc,
         }
-        gsgi_result = (self.group, manifest)
+        gsgi_result = (self.group, self.manifest)
         self.expected_intents = [(gsgi, gsgi_result)]
 
     def _get_dispatcher(self, expected_intents=None):
@@ -663,6 +664,66 @@ class ExecuteConvergenceTests(SynchronousTestCase):
                                   get_all_convergence_data=gacd)
         dispatcher = self._get_dispatcher()
         self.assertEqual(sync_perform(dispatcher, eff), StepResult.FAILURE)
+
+    def test_update_active_after_success(self):
+        """
+        When all steps are successful, one last gathering is performed and the
+        group's ``active`` servers are updated based on it, so that things like
+        successful server deletion get reflected in the active servers list.
+        """
+        log = mock_log()
+
+        def plan(*args, **kwargs):
+            return pbag([
+                TestStep(Effect('some-boring-step')),
+            ])
+
+        def results_in_active(active):
+            return transform_eq(
+                lambda modifier: modifier(self.group, self.state).active,
+                active)
+
+        server1 = server('id1', ServerState.ACTIVE)
+        server2 = server('id2', ServerState.ACTIVE)
+
+        sequence = SequenceDispatcher([
+
+            # Look up group in Cass
+            (GetScalingGroupInfo(tenant_id='tenant-id', group_id='group-id'),
+             lambda i: (self.group, self.manifest)),
+
+            # gather convergence data
+            ('get-all', lambda i: ([server1], [])),
+
+            # update active based on that data
+            (ModifyGroupState(
+                scaling_group=self.group,
+                modifier=results_in_active(
+                    {'id1': {'id': 'id1', 'links': []}})),
+             lambda i: None),
+
+            # run the steps
+            ('some-boring-step', lambda i: (StepResult.SUCCESS, [])),
+
+            # gather convergence data again, since everything was SUCCESS
+            ('get-all', lambda i: ([server1, server2], [])),
+
+            # update active on the group with the new results
+            (ModifyGroupState(
+                scaling_group=self.group,
+                modifier=results_in_active(
+                    {'id1': {'id': 'id1', 'links': []},
+                     'id2': {'id': 'id2', 'links': []}})),
+             lambda i: None),
+        ])
+
+        dispatcher = ComposedDispatcher([test_dispatcher(), sequence])
+
+        eff = execute_convergence(
+            self.tenant_id, self.group_id, log,
+            plan=plan,
+            get_all_convergence_data=lambda gid: Effect('get-all'))
+        self.assertEqual(sync_perform(dispatcher, eff), StepResult.SUCCESS)
 
 
 class DetermineActiveTests(SynchronousTestCase):

--- a/otter/test/convergence/test_service.py
+++ b/otter/test/convergence/test_service.py
@@ -673,10 +673,11 @@ class ExecuteConvergenceTests(SynchronousTestCase):
         """
         log = mock_log()
 
+        def get_all_convergence_data(group_id):
+            return Effect('get-all-data')
+
         def plan(*args, **kwargs):
-            return pbag([
-                TestStep(Effect('some-boring-step')),
-            ])
+            return pbag([TestStep(Effect('some-boring-step'))])
 
         def results_in_active(active):
             return transform_eq(
@@ -693,7 +694,7 @@ class ExecuteConvergenceTests(SynchronousTestCase):
              lambda i: (self.group, self.manifest)),
 
             # gather convergence data
-            ('get-all', lambda i: ([server1], [])),
+            ('get-all-data', lambda i: ([server1], [])),
 
             # update active based on that data
             (ModifyGroupState(
@@ -706,7 +707,7 @@ class ExecuteConvergenceTests(SynchronousTestCase):
             ('some-boring-step', lambda i: (StepResult.SUCCESS, [])),
 
             # gather convergence data again, since everything was SUCCESS
-            ('get-all', lambda i: ([server1, server2], [])),
+            ('get-all-data', lambda i: ([server1, server2], [])),
 
             # update active on the group with the new results
             (ModifyGroupState(
@@ -722,7 +723,7 @@ class ExecuteConvergenceTests(SynchronousTestCase):
         eff = execute_convergence(
             self.tenant_id, self.group_id, log,
             plan=plan,
-            get_all_convergence_data=lambda gid: Effect('get-all'))
+            get_all_convergence_data=get_all_convergence_data)
         self.assertEqual(sync_perform(dispatcher, eff), StepResult.SUCCESS)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ jsonfig==0.1.1
 testtools==0.9.32
 croniter==0.3.5
 txkazoo==0.0.5
-effect==0.1a14
+effect==0.1a15
 characteristic==14.3.0
 toolz==0.7.1
 pyrsistent==0.7.0


### PR DESCRIPTION
Fixes #1234

This adds an extra gathering step after getting SUCCESS from all steps so we can update the `active` servers list.

- I've updated a few integration tests that pass with this change
- I've also improved the error reporting in check_for_expected_number_of_building_servers in the integration tests a bit, since it was somewhat misleading and also lacked some interesting information

