### PR TITLE
ChangeCLBNode should return success, [reasons]

### DIFF
--- a/otter/convergence/steps.py
+++ b/otter/convergence/steps.py
@@ -455,7 +455,7 @@ def _clb_check_change_node(result):
     """
     Check to what extent a :class:`ChangeCLBNode` response was successful.
     """
-    return None
+    return StepResult.SUCCESS, []
 
 
 def _rackconnect_bulk_request(lb_node_pairs, method, success_pred):

--- a/otter/convergence/steps.py
+++ b/otter/convergence/steps.py
@@ -451,11 +451,16 @@ class ChangeCLBNode(object):
         return eff.on(_clb_check_change_node)
 
 
-def _clb_check_change_node(result):
+def _clb_check_change_node(step, result):
     """
     Check to what extent a :class:`ChangeCLBNode` response was successful.
     """
-    return StepResult.SUCCESS, []
+    response, body = result
+
+    if response.code == 202:
+        return StepResult.SUCCESS, []
+    else:
+        return StepResult.RETRY, []
 
 
 def _rackconnect_bulk_request(lb_node_pairs, method, success_pred):

--- a/otter/convergence/steps.py
+++ b/otter/convergence/steps.py
@@ -440,6 +440,7 @@ class ChangeCLBNode(object):
 
     def as_effect(self):
         """Produce a :obj:`Effect` to modify a load balancer node."""
+        handled_codes = _clb_check_change_node_handlers.keys()
         eff = service_request(
             ServiceType.CLOUD_LOAD_BALANCERS,
             'PUT',
@@ -447,7 +448,7 @@ class ChangeCLBNode(object):
                             'nodes', self.node_id),
             data={'condition': self.condition.name,
                   'weight': self.weight},
-            success_pred=has_code(202))
+            success_pred=has_code(*handled_codes))
         return eff.on(partial(_clb_check_change_node, self))
 
 

--- a/otter/convergence/steps.py
+++ b/otter/convergence/steps.py
@@ -448,7 +448,7 @@ class ChangeCLBNode(object):
             data={'condition': self.condition.name,
                   'weight': self.weight},
             success_pred=has_code(202))
-        return eff.on(_clb_check_change_node)
+        return eff.on(partial(_clb_check_change_node, self))
 
 
 def _clb_check_change_node(step, result):

--- a/otter/convergence/steps.py
+++ b/otter/convergence/steps.py
@@ -461,6 +461,9 @@ def _clb_check_change_node(step, result):
 
 
 def _clb_check_change_node_retry_on_404(step, result):
+    """
+    When updating a node results in a 404, convergence should be retried.
+    """
     return StepResult.RETRY, [{'reason': 'CLB node not found',
                                'lb': step.lb_id,
                                'node': step.node_id}]

--- a/otter/convergence/steps.py
+++ b/otter/convergence/steps.py
@@ -456,13 +456,20 @@ def _clb_check_change_node(step, result):
     Check to what extent a :class:`ChangeCLBNode` response was successful.
     """
     response, body = result
+    handler = _clb_check_change_node_handlers[response.code]
+    return handler(step, result)
 
-    if response.code == 202:
-        return StepResult.SUCCESS, []
-    else:
-        return StepResult.RETRY, [{'reason': 'CLB node not found',
-                                   'lb': step.lb_id,
-                                   'node': step.node_id}]
+
+def _clb_check_change_node_retry_on_404(step, result):
+    return StepResult.RETRY, [{'reason': 'CLB node not found',
+                               'lb': step.lb_id,
+                               'node': step.node_id}]
+
+
+_clb_check_change_node_handlers = {
+    202: lambda _step, _result: (StepResult.SUCCESS, []),
+    404: _clb_check_change_node_retry_on_404
+}
 
 
 def _rackconnect_bulk_request(lb_node_pairs, method, success_pred):

--- a/otter/convergence/steps.py
+++ b/otter/convergence/steps.py
@@ -440,7 +440,7 @@ class ChangeCLBNode(object):
 
     def as_effect(self):
         """Produce a :obj:`Effect` to modify a load balancer node."""
-        return service_request(
+        eff = service_request(
             ServiceType.CLOUD_LOAD_BALANCERS,
             'PUT',
             append_segments('loadbalancers', self.lb_id,
@@ -448,6 +448,14 @@ class ChangeCLBNode(object):
             data={'condition': self.condition.name,
                   'weight': self.weight},
             success_pred=has_code(202))
+        return eff.on(_clb_check_change_node)
+
+
+def _clb_check_change_node(result):
+    """
+    Check to what extent a :class:`ChangeCLBNode` response was successful.
+    """
+    return StepResult.SUCCESS, []
 
 
 def _rackconnect_bulk_request(lb_node_pairs, method, success_pred):

--- a/otter/convergence/steps.py
+++ b/otter/convergence/steps.py
@@ -455,7 +455,7 @@ def _clb_check_change_node(result):
     """
     Check to what extent a :class:`ChangeCLBNode` response was successful.
     """
-    return StepResult.SUCCESS, []
+    return None
 
 
 def _rackconnect_bulk_request(lb_node_pairs, method, success_pred):

--- a/otter/convergence/steps.py
+++ b/otter/convergence/steps.py
@@ -460,7 +460,9 @@ def _clb_check_change_node(step, result):
     if response.code == 202:
         return StepResult.SUCCESS, []
     else:
-        return StepResult.RETRY, []
+        return StepResult.RETRY, [{'reason': 'CLB node not found',
+                                   'lb': step.lb_id,
+                                   'node': step.node_id}]
 
 
 def _rackconnect_bulk_request(lb_node_pairs, method, success_pred):

--- a/otter/test/convergence/test_steps.py
+++ b/otter/test/convergence/test_steps.py
@@ -30,7 +30,7 @@ from otter.convergence.steps import (
     SetMetadataItemOnServer,
     UnexpectedServerStatus,
     _clb_check_change_node,
-    _clb_check_change_node_retry_handlers,
+    _clb_check_change_node_handlers,
     _RCV3_LB_DOESNT_EXIST_PATTERN,
     _RCV3_LB_INACTIVE_PATTERN,
     _RCV3_NODE_ALREADY_A_MEMBER_PATTERN,
@@ -461,7 +461,7 @@ class StepAsEffectTests(SynchronousTestCase):
             type=CLBNodeType.PRIMARY)
         eff = change_node.as_effect()
 
-        handled_codes = _clb_check_change_node_retry_handlers.keys()
+        handled_codes = _clb_check_change_node_handlers.keys()
         expected_intent = service_request(
             ServiceType.CLOUD_LOAD_BALANCERS,
             'PUT',

--- a/otter/test/convergence/test_steps.py
+++ b/otter/test/convergence/test_steps.py
@@ -459,16 +459,14 @@ class StepAsEffectTests(SynchronousTestCase):
             weight=50,
             type=CLBNodeType.PRIMARY)
         expected_eff = service_request(
-                ServiceType.CLOUD_LOAD_BALANCERS,
-                'PUT',
-                'loadbalancers/abc123/nodes/node1',
-                data={'condition': 'DRAINING',
-                      'weight': 50},
-                success_pred=has_code(202)).on(_clb_check_change_node)
+            ServiceType.CLOUD_LOAD_BALANCERS,
+            'PUT',
+            'loadbalancers/abc123/nodes/node1',
+            data={'condition': 'DRAINING',
+                  'weight': 50},
+            success_pred=has_code(202)).on(_clb_check_change_node)
 
-        self.assertEqual(
-            change_node.as_effect(),
-            expected_eff)
+        self.assertEqual(change_node.as_effect(), expected_eff)
 
     def test_add_nodes_to_clb(self):
         """

--- a/otter/test/convergence/test_steps.py
+++ b/otter/test/convergence/test_steps.py
@@ -785,8 +785,7 @@ class StepAsEffectTests(SynchronousTestCase):
         for removing any combination of nodes from any combination of RCv3
         load balancers.
         """
-        self._generic_bulk_rcv3_step_test(
-            BulkRemoveFromRCv3, "DELETE")
+        self._generic_bulk_rcv3_step_test(BulkRemoveFromRCv3, "DELETE")
 
 
 class CLBCheckChangeNodeTests(SynchronousTestCase):

--- a/otter/test/convergence/test_steps.py
+++ b/otter/test/convergence/test_steps.py
@@ -791,6 +791,12 @@ class StepAsEffectTests(SynchronousTestCase):
             BulkRemoveFromRCv3, "DELETE")
 
 
+class CLBCheckChangeNodeTests(SynchronousTestCase):
+    """
+    Tests for :func:`_clb_check_change_node`.
+    """
+
+
 _RCV3_TEST_DATA = {
     _RCV3_NODE_NOT_A_MEMBER_PATTERN: [
         ('Node d6d3aa7c-dfa5-4e61-96ee-1d54ac1075d2 is not a member of '

--- a/otter/test/convergence/test_steps.py
+++ b/otter/test/convergence/test_steps.py
@@ -29,6 +29,7 @@ from otter.convergence.steps import (
     RemoveNodesFromCLB,
     SetMetadataItemOnServer,
     UnexpectedServerStatus,
+    _clb_check_change_node,
     _RCV3_LB_DOESNT_EXIST_PATTERN,
     _RCV3_LB_INACTIVE_PATTERN,
     _RCV3_NODE_ALREADY_A_MEMBER_PATTERN,

--- a/otter/test/convergence/test_steps.py
+++ b/otter/test/convergence/test_steps.py
@@ -793,6 +793,14 @@ class CLBCheckChangeNodeTests(SynchronousTestCase):
     """
     Tests for :func:`_clb_check_change_node`.
     """
+    def test_good_response(self):
+        """
+        If the response code indicates success, the response was successful.
+        """
+        response = StubResponse(202, {})
+        body = None
+        result = _clb_check_change_node((response, body))
+        self.assertEqual(result, (StepResult.SUCCESS, []))
 
 
 _RCV3_TEST_DATA = {

--- a/otter/test/convergence/test_steps.py
+++ b/otter/test/convergence/test_steps.py
@@ -457,15 +457,17 @@ class StepAsEffectTests(SynchronousTestCase):
             condition=CLBNodeCondition.DRAINING,
             weight=50,
             type=CLBNodeType.PRIMARY)
-        self.assertEqual(
-            service_request(
+        expected_eff = service_request(
                 ServiceType.CLOUD_LOAD_BALANCERS,
                 'PUT',
                 'loadbalancers/abc123/nodes/node1',
                 data={'condition': 'DRAINING',
                       'weight': 50},
-                success_pred=has_code(202)))
+                success_pred=has_code(202)).on(_clb_check_change_node)
+
+        self.assertEqual(
             change_node.as_effect(),
+            expected_eff)
 
     def test_add_nodes_to_clb(self):
         """

--- a/otter/test/convergence/test_steps.py
+++ b/otter/test/convergence/test_steps.py
@@ -30,6 +30,7 @@ from otter.convergence.steps import (
     SetMetadataItemOnServer,
     UnexpectedServerStatus,
     _clb_check_change_node,
+    _clb_check_change_node_retry_handlers,
     _RCV3_LB_DOESNT_EXIST_PATTERN,
     _RCV3_LB_INACTIVE_PATTERN,
     _RCV3_NODE_ALREADY_A_MEMBER_PATTERN,
@@ -460,13 +461,14 @@ class StepAsEffectTests(SynchronousTestCase):
             type=CLBNodeType.PRIMARY)
         eff = change_node.as_effect()
 
+        handled_codes = _clb_check_change_node_retry_handlers.keys()
         expected_intent = service_request(
             ServiceType.CLOUD_LOAD_BALANCERS,
             'PUT',
             'loadbalancers/abc123/nodes/node1',
             data={'condition': 'DRAINING',
                   'weight': 50},
-            success_pred=has_code(202)).intent
+            success_pred=has_code(*handled_codes)).intent
         self.assertEqual(eff.intent, expected_intent)
 
         (on_success, on_error), = eff.callbacks

--- a/otter/test/convergence/test_steps.py
+++ b/otter/test/convergence/test_steps.py
@@ -818,7 +818,7 @@ class CLBCheckChangeNodeTests(SynchronousTestCase):
         self.assertEqual(
             result,
             (StepResult.RETRY, [{"reason": "CLB node not found",
-                                 "node": self.example_step.node_id
+                                 "node": self.example_step.node_id,
                                  "lb": self.example_step.lb_id}]))
 
 

--- a/otter/test/convergence/test_steps.py
+++ b/otter/test/convergence/test_steps.py
@@ -805,7 +805,7 @@ class CLBCheckChangeNodeTests(SynchronousTestCase):
         """
         response = StubResponse(202, {})
         body = None
-        result = _clb_check_change_node((response, body))
+        result = _clb_check_change_node(self.example_step, (response, body))
         self.assertEqual(result, (StepResult.SUCCESS, []))
 
     def test_disappearing_server(self):

--- a/otter/test/convergence/test_steps.py
+++ b/otter/test/convergence/test_steps.py
@@ -451,14 +451,13 @@ class StepAsEffectTests(SynchronousTestCase):
         :obj:`ChangeCLBNode.as_effect` produces a request for
         modifying a load balancer node.
         """
-        changenode = ChangeCLBNode(
+        change_node = ChangeCLBNode(
             lb_id='abc123',
             node_id='node1',
             condition=CLBNodeCondition.DRAINING,
             weight=50,
             type=CLBNodeType.PRIMARY)
         self.assertEqual(
-            changenode.as_effect(),
             service_request(
                 ServiceType.CLOUD_LOAD_BALANCERS,
                 'PUT',
@@ -466,6 +465,7 @@ class StepAsEffectTests(SynchronousTestCase):
                 data={'condition': 'DRAINING',
                       'weight': 50},
                 success_pred=has_code(202)))
+            change_node.as_effect(),
 
     def test_add_nodes_to_clb(self):
         """


### PR DESCRIPTION
Closes #1172. (Tagged in commit.)

This adds basic support for handling CLB Change Node responses. Specifically, it knows how to handle 202 (all good) and 404 (missing server). This does not cover all the cases. According to the docs, the following error response codes exist:

- loadbalancerFault (400, 500), which is an exciting one. Despite being grouped together, it seems like 400 should be a hard failure (see below), and 500 should be a retry, although the fact that they group them together seems to imply that they reserve the right to throw 400 on internal problems... Filed a ticket: #1241.
- serviceUnavailable (503), which should be a retry. Filed a ticket: #1242.
- badRequest (400), which should probably be a hard failure, except how do I know if it's a transient fault in the LB? Filed a ticket:  #1243.
- unauthorized (401), handled by the underlying reauth logic.
- overLimit (413), which is really hard to handle. Filed a ticket: #1244.
- itemNotFound (404), handled by this PR.

I used a dict to store the ways different error codes are handled. This was useful so that we can statically verify that we have the correct codes in the `success_pred` of `ChangeCLBNode.as_effect`.