### PR TITLE
Parse some generic CLB errors, mainly for single node changes

### DIFF
--- a/otter/cloud_client.py
+++ b/otter/cloud_client.py
@@ -1,9 +1,10 @@
 """
 Integration point for HTTP clients in otter.
 """
-from functools import wraps
+import re
+from functools import partial, wraps
 
-from characteristic import attributes
+from characteristic import Attribute, attributes
 
 from effect import (
     ComposedDispatcher,
@@ -17,7 +18,7 @@ import six
 
 from otter.auth import Authenticate, InvalidateToken, public_endpoint_url
 from otter.constants import ServiceType
-from otter.util.http import APIError
+from otter.util.http import APIError, append_segments, try_json_with_keys
 from otter.util.http import headers as otter_headers
 from otter.util.pure_http import (
     add_bind_root,
@@ -218,9 +219,129 @@ def perform_tenant_scope(
     perform(new_disp, tenant_scope.effect.on(box.succeed, box.fail))
 
 
-def parse_clb_errors(*excinfo):
+# ----- CLB requests and error parsing -----
+
+_CLB_PENDING_UPDATE_PATTERN = re.compile(
+    "^Load Balancer '\d+' has a status of 'PENDING_UPDATE' and is considered "
+    "immutable.$")
+_CLB_DELETED_PATTERN = re.compile(
+    "^(Load Balancer '\d+' has a status of 'PENDING_DELETE' and is|"
+    "The load balancer is deleted and) considered immutable.$")
+_CLB_NO_SUCH_NODE_PATTERN = re.compile(
+    "^Node with id #\d+ not found for loadbalancer #\d+$")
+_CLB_NO_SUCH_LB_PATTERN = re.compile(
+    "^Load balancer not found.$")
+
+
+@attributes([Attribute('lb_id', instance_of=six.text_type)])
+class CLBPendingUpdateError(Exception):
     """
-    Fake stub currently that just raises a ValueError, to be used for testing.
-    This should be completed in the next PR.
+    Error to be raised when the CLB is in PENDING_UPDATE status and is
+    immutable (temporarily).
     """
-    raise ValueError("Fake!")
+
+
+@attributes([Attribute('lb_id', instance_of=six.text_type)])
+class CLBDeletedError(Exception):
+    """
+    Error to be raised when the CLB has been deleted or is being deleted.
+    This is distinct from it not existing.
+    """
+
+
+@attributes([Attribute('lb_id', instance_of=six.text_type)])
+class NoSuchCLBError(Exception):
+    """
+    Error to be raised when the CLB never existed in the first place (or it
+    has been deleted so long that there is no longer a record of it).
+    """
+
+
+@attributes([Attribute('lb_id', instance_of=six.text_type),
+             Attribute('node_id', instance_of=six.text_type)])
+class NoSuchCLBNodeError(Exception):
+    """
+    Error to be raised when attempting to modify a CLB node that no longer
+    exists.
+    """
+
+
+@attributes([Attribute('lb_id', instance_of=six.text_type)])
+class CLBRateLimitError(Exception):
+    """
+    Error to be raised when CLB returns 413 (rate limiting).
+    """
+
+
+def change_clb_node(lb_id, node_id, condition, weight):
+    """
+    Generate effect to change a node on a load balancer.
+
+    :param str lb_id: The load balancer ID to add the nodes to
+    :param str node_id: The node id to change.
+    :param str condition: The condition to change to: one of "ENABLED",
+        "DRAINING", or "DISABLED"
+    :param int weight: The weight to change to.
+
+    Note: this does not support "type" yet, since it doesn't make sense to add
+    autoscaled servers as secondary.
+
+    :return: :class:`ServiceRequest` effect
+
+    :raises: :class:`CLBPendingUpdateError`, :class:`CLBDeletedError`,
+        :class:`NoSuchCLBError`, :class:`NoSuchCLBNodeError`, :class:`APIError`
+    """
+    eff = service_request(
+        ServiceType.CLOUD_LOAD_BALANCERS,
+        'PUT',
+        append_segments('loadbalancers', lb_id, 'nodes', node_id),
+        data={'condition': condition, 'weight': weight},
+        success_pred=has_code(202))
+
+    def _check_no_such_node(api_error_code, json_body):
+        if (api_error_code == 404 and _CLB_NO_SUCH_NODE_PATTERN.match(
+                json_body.get('message', ''))):
+            raise NoSuchCLBNodeError(lb_id=lb_id, node_id=node_id)
+
+    parse_err = partial(_process_clb_api_error, lb_id=lb_id,
+                        extra_parsing=_check_no_such_node)
+
+    return eff.on(error=catch(APIError, parse_err))
+
+
+def _process_clb_api_error(exc_info, lb_id, extra_parsing):
+    """
+    Attempt to parse generic CLB API error messages, and raise recognized
+    exceptions in their place.  If that doesn't work, calls the
+    ``extra_parsing`` callable with the HTTP status code, and parsed JSON body.
+
+    If that still doesn't cut it, re-raise the original exception.
+
+    :param string lb_id: The load balancer ID
+    :param int api_error_code: The status code from the HTTP request
+    :param dict error_json: The error message, parsed as a JSON dict.
+
+    :raises: :class:`CLBPendingUpdateError`, :class:`CLBDeletedError`,
+        :class:`NoSuchCLBError`, :class:`APIError` by itself
+    """
+    api_error = exc_info[1]
+    message = try_json_with_keys(api_error.body, ['message'])
+
+    if message:
+        if api_error.code == 413:
+            raise CLBRateLimitError(message, lb_id=lb_id)
+
+        generic_mappings = [
+            (422, _CLB_DELETED_PATTERN, CLBDeletedError),
+            (422, _CLB_PENDING_UPDATE_PATTERN, CLBPendingUpdateError),
+            (404, _CLB_NO_SUCH_LB_PATTERN, NoSuchCLBError)
+        ]
+        for status, pattern, exc_type in generic_mappings:
+            if status == api_error.code and pattern.match(message):
+                raise exc_type(message, lb_id=lb_id)
+
+        # No generic exceptions were raised - try the extra_parsing.
+        extra_parsing(api_error.code, try_json_with_keys(api_error.body, []))
+
+    # No? Re-raise, then
+    six.reraise(*exc_info)

--- a/otter/test/test_cloud_client.py
+++ b/otter/test/test_cloud_client.py
@@ -10,27 +10,67 @@ from effect import (
     TypeDispatcher,
     base_dispatcher,
     sync_perform)
+from effect.testing import EQFDispatcher
 
 from twisted.trial.unittest import SynchronousTestCase
 
 from otter.auth import Authenticate, InvalidateToken
 from otter.cloud_client import (
+    CLBDeletedError,
+    CLBPendingUpdateError,
+    CLBRateLimitError,
+    NoSuchCLBError,
+    NoSuchCLBNodeError,
     ServiceRequest,
     TenantScope,
     add_bind_service,
+    change_clb_node,
     concretize_service_request,
     perform_tenant_scope,
     service_request)
 from otter.constants import ServiceType
-from otter.test.utils import resolve_effect, stub_pure_response
+from otter.test.utils import (
+    resolve_effect,
+    stub_pure_response)
 from otter.test.worker.test_launch_server_v1 import fake_service_catalog
 from otter.util.http import APIError, headers
 from otter.util.pure_http import Request, has_code
 
 
+fake_service_configs = {
+    ServiceType.CLOUD_SERVERS: {
+        'name': 'cloudServersOpenStack',
+        'region': 'DFW'},
+    ServiceType.CLOUD_LOAD_BALANCERS: {
+        'name': 'cloudLoadBalancers',
+        'region': 'DFW'}
+}
+
+
 def resolve_authenticate(eff, token='token'):
     """Resolve an Authenticate effect with test data."""
     return resolve_effect(eff, (token, fake_service_catalog))
+
+
+def service_request_eqf(stub_response):
+    """
+    Return a function to be used as the value matching a ServiceRequest in
+    :class:`EQFDispatcher`.
+    """
+    def resolve_service_request(service_request_intent):
+        eff = concretize_service_request(
+            authenticator=object(),
+            log=object(),
+            service_configs=fake_service_configs,
+            tenant_id='000000',
+            service_request=service_request_intent)
+
+        # "authenticate"
+        eff = resolve_authenticate(eff)
+        # make request
+        return resolve_effect(eff, stub_response)
+
+    return resolve_service_request
 
 
 class BindServiceTests(SynchronousTestCase):
@@ -254,3 +294,113 @@ class PerformTenantScopeTests(SynchronousTestCase):
             sync_perform(self.dispatcher, Effect(tscope)),
             ('concretized', self.authenticator, self.log, self.service_configs,
              1, ereq.intent))
+
+
+class CLBClientTests(SynchronousTestCase):
+    """
+    """
+    @property
+    def lb_id(self):
+        """What is my LB ID"""
+        return u"123456"
+
+    def assert_parses_common_clb_errors(self, intent, eff):
+        """
+        Assert that the effect produced performs the common CLB error parsing:
+        :class:`CLBPendingUpdateError`, :class:`CLBDescription`,
+        :class:`NoSuchCLBError`, :class:`CLBRateLimitError`,
+        :class:`APIError`
+        """
+        json_responses_and_errs = [
+            ("Load Balancer '{0}' has a status of 'PENDING_UPDATE' and is "
+             "considered immutable.", 422, CLBPendingUpdateError),
+            ("Load Balancer '{0}' has a status of 'PENDING_DELETE' and is "
+             "considered immutable.", 422, CLBDeletedError),
+            ("The load balancer is deleted and considered immutable.",
+             422, CLBDeletedError),
+            ("Load balancer not found.", 404, NoSuchCLBError),
+            ("OverLimit Retry...", 413, CLBRateLimitError)
+        ]
+
+        for msg, code, err in json_responses_and_errs:
+            msg = msg.format(self.lb_id)
+            resp = stub_pure_response(
+                json.dumps({'message': msg, 'code': code, 'details': ''}),
+                code)
+            with self.assertRaises(err) as cm:
+                sync_perform(
+                    EQFDispatcher([(intent, service_request_eqf(resp))]),
+                    eff)
+            self.assertEqual(cm.exception, err(msg, lb_id=self.lb_id))
+
+        bad_resps = [
+            stub_pure_response(
+                json.dumps({
+                    'message': ("Load Balancer '{0}' has a status of 'BROKEN' "
+                                "and is considered immutable."),
+                    'code': 422}),
+                422),
+            stub_pure_response(
+                json.dumps({
+                    'message': ("The load balancer is deleted and considered "
+                                "immutable"),
+                    'code': 404}),
+                404),
+            stub_pure_response(
+                json.dumps({
+                    'message': "Cloud load balancers is down",
+                    'code': 500}),
+                500),
+            stub_pure_response("random repose error message", 404),
+            stub_pure_response("random repose error message", 413)
+        ]
+
+        for resp in bad_resps:
+            with self.assertRaises(APIError) as cm:
+                sync_perform(
+                    EQFDispatcher([(intent, service_request_eqf(resp))]),
+                    eff)
+            self.assertEqual(
+                cm.exception,
+                APIError(headers={}, code=resp[0].code, body=resp[1]))
+
+    def test_change_clb_node(self):
+        """
+        Produce a request for modifying a load balancer, which returns a
+        successful result on 202.
+
+        Parse the common CLB errors, and :class:`NoSuchCLBNodeError`.
+        """
+        eff = change_clb_node(lb_id=self.lb_id, node_id=u'1234',
+                              condition="DRAINING", weight=50)
+        expected = service_request(
+            ServiceType.CLOUD_LOAD_BALANCERS,
+            'PUT',
+            'loadbalancers/{0}/nodes/1234'.format(self.lb_id),
+            data={'condition': 'DRAINING',
+                  'weight': 50},
+            success_pred=has_code(202))
+
+        # success
+        dispatcher = EQFDispatcher([(
+            expected.intent,
+            service_request_eqf(stub_pure_response('', 202)))])
+        self.assertEqual(sync_perform(dispatcher, eff),
+                         stub_pure_response(None, 202))
+
+        # NoSuchCLBNode failure
+        msg = "Node with id #1234 not found for loadbalancer #{0}".format(
+            self.lb_id)
+        no_such_node = stub_pure_response(
+            json.dumps({'message': msg, 'code': 404}), 404)
+        dispatcher = EQFDispatcher([(
+            expected.intent, service_request_eqf(no_such_node))])
+
+        with self.assertRaises(NoSuchCLBNodeError) as cm:
+            sync_perform(dispatcher, eff)
+        self.assertEqual(
+            cm.exception,
+            NoSuchCLBNodeError(msg, lb_id=self.lb_id, node_id=u'1234'))
+
+        # all the common failures
+        self.assert_parses_common_clb_errors(expected.intent, eff)

--- a/otter/test/test_cloud_client.py
+++ b/otter/test/test_cloud_client.py
@@ -298,6 +298,7 @@ class PerformTenantScopeTests(SynchronousTestCase):
 
 class CLBClientTests(SynchronousTestCase):
     """
+    Tests for CLB client functions, such as :obj:`change_clb_node`.
     """
     @property
     def lb_id(self):

--- a/otter/test/utils.py
+++ b/otter/test/utils.py
@@ -370,6 +370,16 @@ class StubResponse(object):
         # Data is not part of twisted response object
         self._data = data
 
+    def __eq__(self, other):
+        return (
+            isinstance(other, self.__class__) and
+            self.code == other.code and
+            self.headers == other.headers and
+            self._data == other._data)
+
+    def __neq__(self, other):
+        return self != other
+
 
 def stub_pure_response(body, code=200, response_headers=None):
     """
@@ -732,6 +742,9 @@ def get_fake_service_request_performer(stub_response):
     :param service_request: the :class:`ServiceRequest` to "perform"
     :param stub_response: a tuple of (:class:`StubResponse`, string body),
         supposedly the "response" of an http request
+
+    TODO: hopefully once all service requests are made by the cloud client,
+    this can be moved into the client's test module instead.
     """
     if not isinstance(stub_response, basestring):
         try:

--- a/otter/test/utils.py
+++ b/otter/test/utils.py
@@ -377,8 +377,8 @@ class StubResponse(object):
             self.headers == other.headers and
             self._data == other._data)
 
-    def __neq__(self, other):
-        return self != other
+    def __ne__(self, other):
+        return not self == other
 
 
 def stub_pure_response(body, code=200, response_headers=None):

--- a/otter/test/utils.py
+++ b/otter/test/utils.py
@@ -742,9 +742,6 @@ def get_fake_service_request_performer(stub_response):
     :param service_request: the :class:`ServiceRequest` to "perform"
     :param stub_response: a tuple of (:class:`StubResponse`, string body),
         supposedly the "response" of an http request
-
-    TODO: hopefully once all service requests are made by the cloud client,
-    this can be moved into the client's test module instead.
     """
     if not isinstance(stub_response, basestring):
         try:


### PR DESCRIPTION
As per discussion in #1189, have client calls that can include structured information.

This also encapsulates our knowledge about what errors can occur during particular calls.