### PR TITLE
Return ConvergeLater from convergence if there are building servers

### DIFF
--- a/autoscale_cloudroast/test_repo/autoscale/system/integration/test_system_integration_lbaas.py
+++ b/autoscale_cloudroast/test_repo/autoscale/system/integration/test_system_integration_lbaas.py
@@ -186,7 +186,7 @@ class AutoscaleLbaasFixture(AutoscaleFixture):
             active_servers_from_scale, self.load_balancer_1,
             self.load_balancer_2, self.load_balancer_3)
 
-    @tags(speed='slow', type='lbaas', convergence='error')
+    @tags(speed='slow', type='lbaas', convergence='yes')
     def test_update_existing_lbaas_in_launch_config(self):
         """
         Create a scaling group with a given load balancer and verify the
@@ -259,7 +259,7 @@ class AutoscaleLbaasFixture(AutoscaleFixture):
         lb_node_after_del = self._get_node_list_from_lb(load_balancer)
         self.assertEquals(len(lb_node_after_del), 0)
 
-    @tags(speed='slow', type='lbaas', convergence='error')
+    @tags(speed='slow', type='lbaas', convergence='yes')
     def test_existing_nodes_on_lb_unaffected_by_scaling(self):
         """
         Get load balancer node id list before anyscale operation, create a

--- a/otter/convergence/planning.py
+++ b/otter/convergence/planning.py
@@ -15,6 +15,7 @@ from otter.convergence.steps import (
     BulkAddToRCv3,
     BulkRemoveFromRCv3,
     ChangeCLBNode,
+    ConvergeLater,
     CreateServer,
     DeleteServer,
     RemoveNodesFromCLB,
@@ -246,12 +247,18 @@ def converge(desired_state, servers_with_cheese, load_balancer_contents, now,
             [node for node in load_balancer_contents if node.matches(server)])
         ]
 
+    # if there are any building servers left, also return a ConvergeLater step.
+    converge_later = []
+    if any((s not in servers_to_delete for s in waiting_for_build)):
+        converge_later = [ConvergeLater()]
+
     return pbag(create_steps +
                 scale_down_steps +
                 delete_error_steps +
                 cleanup_errored_and_deleted_steps +
                 delete_timeout_steps +
-                lb_converge_steps)
+                lb_converge_steps +
+                converge_later)
 
 
 _optimizers = {}

--- a/otter/convergence/planning.py
+++ b/otter/convergence/planning.py
@@ -131,9 +131,14 @@ def _drain_and_delete(server, timeout, current_lb_nodes, now):
     """
     If server is not already in draining state, put it into draining state.
     If the server is free of load balancers, just delete it.
+
+    If a server is in building, it can just be deleted, along with any
+    load balancer nodes associated with it, regardless of timeouts.
     """
     lb_draining_steps = _remove_from_lb_with_draining(
-        timeout, current_lb_nodes, now)
+        timeout if server.state != ServerState.BUILD else 0,
+        current_lb_nodes,
+        now)
 
     # if there are no load balancers that are waiting on draining timeouts or
     # connections, just delete the server too

--- a/otter/convergence/steps.py
+++ b/otter/convergence/steps.py
@@ -631,6 +631,7 @@ def _rcv3_check_bulk_delete(attempted_pairs, result):
 
 
 @implementer(IStep)
+@attributes([])
 class ConvergeLater(object):
     """
     Converge later in some time

--- a/otter/test/convergence/test_planning.py
+++ b/otter/test/convergence/test_planning.py
@@ -27,6 +27,7 @@ from otter.convergence.steps import (
     BulkAddToRCv3,
     BulkRemoveFromRCv3,
     ChangeCLBNode,
+    ConvergeLater,
     CreateServer,
     DeleteServer,
     RemoveNodesFromCLB,
@@ -782,7 +783,8 @@ class ConvergeTests(SynchronousTestCase):
     def test_count_building_as_meeting_capacity(self):
         """
         No servers are created if there are building servers that sum with
-        active servers to meet capacity.
+        active servers to meet capacity.  :class:`ConvergeLater` is returned
+        as a step if the building servers are not being deleted.
         """
         self.assertEqual(
             converge(
@@ -790,7 +792,7 @@ class ConvergeTests(SynchronousTestCase):
                 set([server('abc', ServerState.BUILD)]),
                 set(),
                 0),
-            pbag([]))
+            pbag([ConvergeLater()]))
 
     def test_delete_nodes_in_error_state(self):
         """
@@ -899,7 +901,9 @@ class ConvergeTests(SynchronousTestCase):
     def test_scale_down_building_first(self):
         """
         When scaling down, first we delete building servers, in preference
-        to older server.
+        to older server.  :class:`ConvergeLater` does not get returned, even
+        though there is a building server, because the building server gets
+        deleted.
         """
         self.assertEqual(
             converge(
@@ -914,7 +918,9 @@ class ConvergeTests(SynchronousTestCase):
     def test_timeout_building(self):
         """
         Servers that have been building for too long will be deleted and
-        replaced.
+        replaced. :class:`ConvergeLater` does not get returned, even
+        though there is a building server, because the building server gets
+        deleted.
         """
         self.assertEqual(
             converge(
@@ -930,7 +936,9 @@ class ConvergeTests(SynchronousTestCase):
     def test_timeout_replace_only_when_necessary(self):
         """
         If a server is timing out *and* we're over capacity, it will be
-        deleted without replacement.
+        deleted without replacement.  :class:`ConvergeLater` does not get
+        returned, even though there is a building server, because the building
+        server gets deleted.
         """
         self.assertEqual(
             converge(

--- a/otter/test/convergence/test_planning.py
+++ b/otter/test/convergence/test_planning.py
@@ -551,7 +551,6 @@ class DrainAndDeleteServerTests(SynchronousTestCase):
                 0),
             pbag([DeleteServer(server_id='abc')]))
 
-
     def test_active_server_can_be_deleted_if_all_lbs_can_be_removed(self):
         """
         If an active server to be scaled down can be removed from all the load


### PR DESCRIPTION
Hopefully this fixes #1235.

This returns ConvergeLater only if there are building servers that aren't being deleted.

Also fixed an issue where it's possible for building servers to be drained.