### PR TITLE
Stop using versions for dirty flags, switch to one dirty flag per request

### DIFF
--- a/otter/convergence/service.py
+++ b/otter/convergence/service.py
@@ -311,8 +311,13 @@ def get_my_divergent_groups(my_buckets, all_buckets):
     def got_children_with_stats(children_with_stats):
         dirty_info = map(structure_info, children_with_stats)
         # Uniquify by group
-        groups = {x['group_id']: x for x in dirty_info}
-        dirty_info = groups.values()
+        seen_groups = []
+        groups = []
+        for x in dirty_info:
+            if (x['tenant_id'], x['group_id']) not in seen_groups:
+                seen_groups.append((x['tenant_id'], x['group_id']))
+                groups.append(x)
+        dirty_info = groups
         num_buckets = len(all_buckets)
         converging = (
             info for info in dirty_info
@@ -418,7 +423,7 @@ class Converger(MultiService):
         :param buckets: collection of logical `buckets` which are shared
             between all Otter nodes running this service. Will be partitioned
             up between nodes to detirmine which nodes should work on which
-            groups.
+            groups. This *must* be a list of integers starting from 0.
         :param partitioner_factory: Callable of (log, callback) which should
             create an :obj:`Partitioner` to distribute the buckets.
         """

--- a/otter/convergence/service.py
+++ b/otter/convergence/service.py
@@ -423,7 +423,7 @@ class Converger(MultiService):
         :param buckets: collection of logical `buckets` which are shared
             between all Otter nodes running this service. Will be partitioned
             up between nodes to detirmine which nodes should work on which
-            groups. This *must* be a list of integers starting from 0.
+            groups. This *must* contain consecutive integers starting from 0.
         :param partitioner_factory: Callable of (log, callback) which should
             create an :obj:`Partitioner` to distribute the buckets.
         """

--- a/otter/test/test_effect_dispatcher.py
+++ b/otter/test/test_effect_dispatcher.py
@@ -18,7 +18,7 @@ from otter.models.cass import CQLQueryExecute
 from otter.models.intents import GetScalingGroupInfo
 from otter.util.pure_http import Request
 from otter.util.retry import Retry
-from otter.util.zk import CreateOrSet
+from otter.util.zk import Create
 
 
 def simple_intents():
@@ -41,7 +41,7 @@ def legacy_intents():
 
 def full_intents():
     return legacy_intents() + [
-        CreateOrSet(path='foo', content='bar'),
+        Create('foo'),
         GetScalingGroupInfo(tenant_id='foo', group_id='bar')
     ]
 

--- a/otter/util/zk.py
+++ b/otter/util/zk.py
@@ -5,96 +5,43 @@ from characteristic import attributes
 from effect import TypeDispatcher
 from effect.twisted import deferred_performer
 
-from kazoo.exceptions import NoNodeError, NodeExistsError
-
-from twisted.internet.defer import gatherResults
-
-from otter.util.deferredutils import catch_failure
-
-
-CREATE_OR_SET_LOOP_LIMIT = 50
-"""
-A limit on the number of times we'll jump between trying to create a node
-vs trying to set a node's contents in perform_create_or_set.
-"""
-
-
-@attributes(['path', 'content'])
-class CreateOrSet(object):
-    """
-    Create a node, or if the node already exists, set the content.
-
-    Handles the case where a node gets deleted in between our attempt and
-    creating and setting.
-    """
-
-
-class CreateOrSetLoopLimitReachedError(Exception):
-    """
-    Raised when the number of times trying to create a node in
-    :func:`perform_create_or_set` has gone over
-    :obj:`CREATE_OR_SET_LOOP_LIMIT`.
-    """
-
-
-@deferred_performer
-def perform_create_or_set(kz_client, dispatcher, create_or_set):
-    """
-    Performer for :obj:`CreateOrSet`. Must be partialed with ``kz_client``.
-    """
-    path = create_or_set.path
-    content = create_or_set.content
-
-    def create(count):
-        if count >= CREATE_OR_SET_LOOP_LIMIT:
-            raise CreateOrSetLoopLimitReachedError(path)
-        d = kz_client.create(path, content, makepath=True)
-        d.addErrback(catch_failure(NodeExistsError,
-                                   lambda f: set_content(count)))
-        return d
-
-    def set_content(count):
-        d = kz_client.set(path, content)
-        d.addErrback(catch_failure(NoNodeError,
-                                   lambda f: create(count + 1)))
-        return d.addCallback(lambda r: path)
-
-    return create(0)
-
 
 @attributes(['path'], apply_with_init=False)
-class GetChildrenWithStats(object):
-    """
-    List children along with their stat information.
-
-    Results in ``[(child_path, :obj:`ZnodeStat`)]``.
-    """
+class Create(object):
+    """Create a node."""
     def __init__(self, path):
         self.path = path
 
 
 @deferred_performer
-def perform_get_children_with_stats(kz_client, dispatcher, intent):
+def perform_create(kz_client, dispatcher, intent):
     """
-    Perform :obj:`GetChildrenWithStats`. Must be partialed with ``kz_client``.
+    Performer for :obj:`Create`. Must be partialed with ``kz_client``.
+
+    :param Create intent: the intent
+    """
+    path = intent.path
+    return kz_client.create(path, makepath=True)
+
+
+@attributes(['path'], apply_with_init=False)
+class GetChildren(object):
+    """List children."""
+    def __init__(self, path):
+        self.path = path
+
+
+@deferred_performer
+def perform_get_children(kz_client, dispatcher, intent):
+    """
+    Perform :obj:`GetChildren`. Must be partialed with ``kz_client``.
 
     :param kz_client: txKazoo client
     :param dispatcher: dispatcher, supplied by perform
-    :param GetChildrenWithStats intent: the intent
+    :param GetChildren intent: the intent
     """
     path = intent.path
-    children = kz_client.get_children(path)
-
-    def got_children(children):
-        ds = [
-            kz_client.exists(path + '/' + child).addCallback(
-                lambda r, child=child: (child, r) if r is not None else None)
-            for child in children
-        ]
-        return gatherResults(ds)
-    children.addCallback(got_children)
-    children.addCallback(partial(filter, None))
-    return children
+    return kz_client.get_children(path)
 
 
 @attributes(['path', 'version'])
@@ -116,10 +63,10 @@ def perform_delete_node(kz_client, dispatcher, intent):
 def get_zk_dispatcher(kz_client):
     """Get a dispatcher that can support all of the ZooKeeper intents."""
     return TypeDispatcher({
-        CreateOrSet:
-            partial(perform_create_or_set, kz_client),
+        Create:
+            partial(perform_create, kz_client),
         DeleteNode:
             partial(perform_delete_node, kz_client),
-        GetChildrenWithStats:
-            partial(perform_get_children_with_stats, kz_client),
+        GetChildren:
+            partial(perform_get_children, kz_client),
     })


### PR DESCRIPTION
The goal here is to allow us to use a ZooKeeper "child watch" to receive immediate notification when a convergence request is made. The current system of only having one dirty flag that has its version bumped every convergence request doesn't work, because ZK child watches don't get triggered when child versions get bumped. They only get triggered when children are created or deleted. Thus, this PR changes the dirty bookkeeping to create a new node for every ZK request, with a random suffix. This allows us to create a child watch on /groups/divergent and get all the events we need to immediately converge when necessary.

The downside to this is that we lose the optimization in the old version-based approach, which allowed us to only converge once even if multiple requests have been received. With this system there will always be one convergence per request, which is not the end of the world but also not as efficient as it could be.

If anyone has any better ideas on how to do this so that we can maintain that optimization, please let me know.

Note that this PR does not implement the ZK watcher just yet, it just changes the dirty flag formatting.