### PR TITLE
Speed up mimic tests

### DIFF
--- a/autoscale_cloudcafe/autoscale/behaviors.py
+++ b/autoscale_cloudcafe/autoscale/behaviors.py
@@ -482,13 +482,13 @@ class AutoscaleBehaviors(BaseBehavior):
 
         if time_scale:
             # scale time down if using mimic - no shorter than 1 second, though
-            time_scaling_factor = 0.1 if self.autoscale_config.mimic else 1
+            time_scaling_factor = 0.25 if self.autoscale_config.mimic else 1
             timeout, interval_time = [
                 max(val * time_scaling_factor, 1)
                 for val in (timeout, interval_time)
             ]
-            # max out mimic waiting to 15 seconds, no matter what the timeout
-            timeout = min(timeout, 15)
+            # max out mimic waiting to 60 seconds, no matter what the timeout
+            timeout = min(timeout, 60)
 
         # retry uses millseconds, not seconds
         @retry(wait_fixed=interval_time * 1000, stop_max_delay=timeout * 1000)

--- a/autoscale_cloudcafe/autoscale/config.py
+++ b/autoscale_cloudcafe/autoscale/config.py
@@ -162,14 +162,14 @@ class AutoscaleConfig(ConfigSectionInterface):
         """
         Interval time for polling group state table for active servers
         """
-        return self.get('interval_time')
+        return int(self.get('interval_time', 0))
 
     @property
     def timeout(self):
         """
         Timeout is the wait time for all servers on that group to be active
         """
-        return self.get('timeout')
+        return int(self.get('timeout', 0))
 
     @property
     def autoscale_endpoint_name(self):

--- a/autoscale_cloudroast/test_repo/autoscale/fixtures.py
+++ b/autoscale_cloudroast/test_repo/autoscale/fixtures.py
@@ -374,77 +374,74 @@ class AutoscaleFixture(BaseTestFixture):
         return [s for s in self.get_non_deleting_servers() if is_in_group(s)]
 
     def verify_server_count_using_server_metadata(self, group_id,
-                                                  expected_count):
+                                                  expected_count,
+                                                  time_scale=True):
         """
         Asserts the expected count is the number of servers with the groupid
         in the metadata. Fails if the count is not met in 60 seconds.
         """
-        end_time = time.time() + 60
-        while time.time() < end_time:
+        def verify(elapsed_time):
             actual_count = len(
                 self.get_group_servers_based_on_metadata(group_id)
             )
-            if actual_count is expected_count:
-                break
-            time.sleep(5)
-        else:
-            self.fail('Waited 60 seconds, expecting {0} servers with group id '
-                      ': {1} in the '
-                      'metadata but has {2} servers'.format(
-                          expected_count, group_id, actual_count))
+            if actual_count != expected_count:
+                self.fail(
+                    'Waited {0} seconds, expecting {1} servers with group id '
+                    ': {1} in the metadata but has {2} servers'.format(
+                        elapsed_time, expected_count, group_id, actual_count))
+
+        return self.autoscale_behaviors.retry(
+            verify, timeout=60, interval_time=5, time_scale=time_scale)
 
     def wait_for_expected_number_of_active_servers(self, group_id,
                                                    expected_servers,
                                                    interval_time=None,
                                                    timeout=None,
-                                                   api="Autoscale"):
+                                                   api="Autoscale",
+                                                   time_scale=True):
         """This thunks to its replacement in Behaviors.
         Please refer to Autoscale's behaviors.py for more details.
         """
         return (self.autoscale_behaviors
                 .wait_for_expected_number_of_active_servers(
                     group_id, expected_servers, interval_time, timeout,
-                    api=api, asserter=self))
+                    api=api, asserter=self, time_scale=time_scale))
 
     def wait_for_expected_group_state(self, group_id, expected_servers,
-                                      wait_time=180, interval=None):
+                                      wait_time=180, interval=None,
+                                      time_scale=True):
         """
         :summary: verify the group state reached the expected servers count.
         :param group_id: Group id
         :param expected_servers: Number of servers expected
         """
-        if interval is None:
-            interval = self.interval_time
-
-        end_time = time.time() + wait_time
-        while time.time() < end_time:
+        def check_state(elapsed_time):
             group_state = self.autoscale_client.list_status_entities_sgroups(
                 group_id).entity
-            if group_state.desiredCapacity == expected_servers:
-                return
-            time.sleep(interval)
-        else:
-            self.fail(
-                "wait_for_exepected_group_state ran for {0} seconds for group "
-                "{1} and did not observe the active server list achieving the "
-                "expected servers count: {2}.  Got {3} instead.".format(
-                    interval, group_id, expected_servers,
-                    group_state.desiredCapacity))
+            if group_state.desiredCapacity != expected_servers:
+                self.fail(
+                    "wait_for_exepected_group_state ran for {0} seconds for "
+                    "group {1} and did not observe the active server list "
+                    "achieving the expected servers count: {2}.  "
+                    "Got {3} instead.".format(
+                        elapsed_time, group_id, expected_servers,
+                        group_state.desiredCapacity))
+        return self.autoscale_behaviors.retry(
+            check_state, timeout=wait_time, interval_time=interval,
+            time_scale=time_scale)
 
     def check_for_expected_number_of_building_servers(
         self, group_id, expected_servers,
-            desired_capacity=None, server_name=None):
+            desired_capacity=None, server_name=None, time_scale=True):
         """
-        :summary: verify the desired capacity in group state is equal to expected servers
-         and verifies for the specified number of servers with the name specified in the
+        :summary: verify the desired capacity in group state is equal to
+            expected servers and verifies for the specified number of servers
+            with the name specified in the
          group's current launch config, exist on the tenant
         :param group_id: Group id
         :param expected_servers: Total active servers expected on the group
-        :param interval_time: Time to wait during polling group state
-        :param timeout: Time to wait before exiting this function
         :return: returns the list of active servers in the group
         """
-        end_time = time.time() + 120
         desired_capacity = desired_capacity or expected_servers
 
         def get_server_list():
@@ -455,61 +452,69 @@ class AutoscaleFixture(BaseTestFixture):
                 return self.get_servers_containing_given_name_on_tenant(
                     group_id=group_id)
 
-        while time.time() < end_time:
+        def check_servers(elapsed_time):
             group_state = self.autoscale_client.list_status_entities_sgroups(
                 group_id).entity
             if group_state.desiredCapacity == desired_capacity:
                 server_list = get_server_list()
                 if (len(server_list) == expected_servers):
                     return server_list
-            time.sleep(5)
-        else:
-            server_list = get_server_list()
+
             self.fail(
-                'Waited 2 mins for desired capacity/active server list to '
-                'reach the server count of {0}. Has desired capacity {1} on '
-                'the group {2} and {3} servers on the account. '
+                'Waited {0} secs for desired capacity/active server list to '
+                'reach the server count of {1}. Has desired capacity {2} on '
+                'the group {3} and {4} servers on the account. '
                 'Filtering by server_name={server_name}'.format(
+                    elapsed_time,
                     desired_capacity,
                     group_state.desiredCapacity, group_id,
                     len(server_list),
                     server_name=server_name))
 
-    def assert_servers_deleted_successfully(self, server_name, count=0):
+        return self.autoscale_behaviors.retry(
+            check_servers, timeout=120, interval_time=5, time_scale=time_scale)
+
+    def assert_servers_deleted_successfully(self, server_name, count=0,
+                                            time_scale=True):
         """
-        Given a partial server name, polls for 15 mins to assert that the tenant id
-        has only specified count of servers containing that name, and returns the list
-        of servers.
+        Given a partial server name, polls for 15 mins to assert that the
+        tenant id has only specified count of servers containing that name,
+        and returns the list of servers.
         """
-        endtime = time.time() + 900
-        while time.time() < endtime:
+        def check_deleted(elapsed_time):
             server_list = self.get_servers_containing_given_name_on_tenant(
                 server_name=server_name)
             if len(server_list) == count:
                 return server_list
-            time.sleep(self.interval_time)
-        else:
-            self.fail('Servers on the tenant with name {0} were not deleted even'
-                      ' after waiting 15 mins'.format(server_name))
+            self.fail('Servers on the tenant with name {0} were not deleted '
+                      'even after waiting {1} seconds'.format(
+                          server_name, elapsed_time))
+        return self.autoscale_behaviors.retry(
+            check_deleted,  timeout=900, time_scale=time_scale)
 
     def delete_nodes_in_loadbalancer(self, node_id_list, load_balancer):
         """
         Given the node id list and load balancer id, check for lb status
         'PENDING UPDATE' and delete node when lb is ACTIVE
         """
+        class _TimeoutError(Exception):
+            def __init__(elapsed):
+                self.elapsed = elapsed
+
         for each_node_id in node_id_list:
-            end_time = time.time() + 120
-            while time.time() < end_time:
+            def check_deleted(elapsed_time):
                 delete_response = self.lbaas_client.delete_node(
                     load_balancer,
                     each_node_id)
                 if 'PENDING_UPDATE' in delete_response.text:
-                    time.sleep(2)
-                else:
-                    break
-            else:
-                print('Tried deleting node for 2 mins but lb {0} remained '
-                      'in PENDING_UPDATE state'.format(load_balancer))
+                    raise _TimeoutError(elapsed_time)
+            try:
+                self.autoscale_behaviors.retry(
+                    check_deleted, timeout=120, interval_time=2)
+            except _TimeoutError as e:
+                print('Tried deleting node for {0} secs but lb {1} remained '
+                      'in PENDING_UPDATE state'.format(e.elapsed,
+                                                       load_balancer))
 
     def get_total_num_groups(self):
         """
@@ -555,15 +560,14 @@ class AutoscaleFixture(BaseTestFixture):
         Given the load balancer id, tries to delete the load balancer for 15
         minutes, until a 204 is received.
         """
-        endtime = time.time() + 900
-        while time.time() < endtime:
+        def del_lb(elapsed_time):
             del_lb = self.lbaas_client.delete_load_balancer(lb_id)
-            if del_lb.status_code == 202:
-                break
-            time.sleep(self.interval_time)
-        else:
-            self.fail('Deleting load balancer failed, as load balncer remained in building'
-                      ' after waiting 15 mins'.format(lb_id))
+            if del_lb.status_code != 202:
+                self.fail(
+                    'Deleting load balancer failed, as load balancer {0} '
+                    'remained in building after waiting {1} seconds'.format(
+                        lb_id, elapsed_time))
+        return self.autoscale_behaviors.retry(del_lb, timeout=900)
 
     @classmethod
     def tearDownClass(cls):

--- a/autoscale_cloudroast/test_repo/autoscale/system/group/test_group_servers.py
+++ b/autoscale_cloudroast/test_repo/autoscale/system/group/test_group_servers.py
@@ -33,18 +33,15 @@ class ServersTests(AutoscaleFixture):
         """
         Assert if given server is still in group
         """
-        tries = 10
-        interval = 15
-        while tries > 0:
+        def check_deleted(time_elapsed):
             servers = self.get_servers_containing_given_name_on_tenant(
                 group_id=self.groupid)
             if server_id in servers:
-                tries -= 1
-                time.sleep(interval)
-            else:
-                return
-        self.fail('Server {} in group {} not deleted'.format(server_id,
-                                                             self.groupid))
+                self.fail('Server {} in group {} not deleted after {} seconds'
+                          .format(server_id, self.groupid, time_elapsed))
+
+        return self.autoscale_behaviors.retry(check_deleted, timeout=150,
+                                              interval_time=15)
 
     @tags(speed='slow', convergence='error')
     # TODO: https://github.com/rackerlabs/otter/issues/1238

--- a/autoscale_cloudroast/test_repo/autoscale/system/group/test_group_servers.py
+++ b/autoscale_cloudroast/test_repo/autoscale/system/group/test_group_servers.py
@@ -1,8 +1,6 @@
 """
 Tests for `/groups/<groupId>/servers/` endpoint
 """
-import time
-
 from cafe.drivers.unittest.decorators import tags
 
 from test_repo.autoscale.fixtures import AutoscaleFixture

--- a/autoscale_cloudroast/test_repo/autoscale/system/integration/test_system_integration_lbaas.py
+++ b/autoscale_cloudroast/test_repo/autoscale/system/integration/test_system_integration_lbaas.py
@@ -440,17 +440,17 @@ class AutoscaleLbaasFixture(AutoscaleFixture):
         Waits for nodes in the ip_list to be deleted from the given load
         balancer
         """
-        end_time = time.time() + 600
-        while time.time() < end_time:
+        def verify(elapsed_time):
             lb_node_list = [each_node.address for each_node in
                             self._get_node_list_from_lb(lbaas_id)]
-            if set(lb_node_list).isdisjoint(ip_list):
-                break
-            time.sleep(10)
-        else:
-            self.fail("waited one minute for nodes {0} to be deleted from load"
-                      "balancer {1} but {2} exist".format(ip_list, lbaas_id,
-                                                          lb_node_list))
+            if not set(lb_node_list).isdisjoint(ip_list):
+                self.fail(
+                    "waited {0} seconds for nodes {1} to be deleted from load"
+                    "balancer {2} but {3} exist".format(
+                        elapsed_time, ip_list, lbaas_id, lb_node_list))
+
+        return self.autoscale_behaviors.retry(
+            verify, timeout=600, interval_time=10)
 
     def _update_launch_config(self, group, *lbaas_ids):
         """
@@ -516,20 +516,20 @@ class AutoscaleLbaasFixture(AutoscaleFixture):
         capacity, then waits for the desired capacity to be server_after_lb
         when a group with an invalid load balancer is created.
         """
-        end_time = time.time() + 600
         group_state = (self.autoscale_client.list_status_entities_sgroups(
             group_id)).entity
         if group_state.desiredCapacity is servers_before_lb:
-            while time.time() < end_time:
-                time.sleep(10)
+            def wait_for_servers(elapsed_time):
                 group_state = (
                     self.autoscale_client.list_status_entities_sgroups(
                         group_id)).entity
-                if group_state.desiredCapacity is server_after_lb:
-                    return
-            else:
-                self.fail('Servers not deleted from group even when group has '
-                          'invalid load balancers!')
+                if group_state.desiredCapacity != server_after_lb:
+                    self.fail(
+                        'Servers not deleted from group even when group has '
+                        'invalid load balancers!')
+
+            return self.autoscale_behaviors.retry(
+                wait_for_servers, timeout=600, interval_time=10)
         else:
             self.fail(
                 'Number of servers building on the group are not as expected')

--- a/autoscale_cloudroast/test_repo/autoscale/system/integration/test_system_integration_lbaas.py
+++ b/autoscale_cloudroast/test_repo/autoscale/system/integration/test_system_integration_lbaas.py
@@ -3,8 +3,6 @@ System Integration tests autoscaling with lbaas
 """
 
 import random
-import time
-
 
 from cafe.drivers.unittest.decorators import tags
 

--- a/autoscale_cloudroast/test_repo/autoscale/system/integration/test_system_integration_rcv3.py
+++ b/autoscale_cloudroast/test_repo/autoscale/system/integration/test_system_integration_rcv3.py
@@ -313,7 +313,7 @@ class AutoscaleRackConnectFixture(AutoscaleFixture):
         # Wait for rackconnect to reflect number of servers.  This is
         # intentionally not a polling loop since that would prevent overage
         # detection.
-        time.sleep(10 if self.autoscale_behaviors.mimic else 60)
+        time.sleep(10 if autoscale_config.mimic else 60)
 
         # Make sure that we have the correct number of cloud servers in our
         # possession.

--- a/autoscale_cloudroast/test_repo/autoscale/system/integration/test_system_integration_rcv3.py
+++ b/autoscale_cloudroast/test_repo/autoscale/system/integration/test_system_integration_rcv3.py
@@ -291,7 +291,7 @@ class AutoscaleRackConnectFixture(AutoscaleFixture):
         # This sleep is necessary because other tests have just completed, but
         # their resources haven't yet been completely freed up.  TODO(sfalvo):
         # See Github issue #855.
-        time.sleep(15 if self.autoscale_behaviors.mimic else 120)
+        time.sleep(15 if autoscale_config.mimic else 120)
 
         # Capture the initial number of cloud servers on the node.
         # This is our baseline number of servers.

--- a/autoscale_cloudroast/test_repo/autoscale/system/integration/test_system_integration_rcv3.py
+++ b/autoscale_cloudroast/test_repo/autoscale/system/integration/test_system_integration_rcv3.py
@@ -291,7 +291,7 @@ class AutoscaleRackConnectFixture(AutoscaleFixture):
         # This sleep is necessary because other tests have just completed, but
         # their resources haven't yet been completely freed up.  TODO(sfalvo):
         # See Github issue #855.
-        time.sleep(120)
+        time.sleep(15 if self.autoscale_behaviors.mimic else 120)
 
         # Capture the initial number of cloud servers on the node.
         # This is our baseline number of servers.
@@ -313,7 +313,7 @@ class AutoscaleRackConnectFixture(AutoscaleFixture):
         # Wait for rackconnect to reflect number of servers.  This is
         # intentionally not a polling loop since that would prevent overage
         # detection.
-        time.sleep(60)
+        time.sleep(10 if self.autoscale_behaviors.mimic else 60)
 
         # Make sure that we have the correct number of cloud servers in our
         # possession.

--- a/autoscale_cloudroast/test_repo/autoscale/system/schedule_policies/test_system_cron_style_scheduler.py
+++ b/autoscale_cloudroast/test_repo/autoscale/system/schedule_policies/test_system_cron_style_scheduler.py
@@ -104,9 +104,9 @@ class CronStyleSchedulerTests(AutoscaleFixture):
         self.wait_for_expected_group_state(
             self.group.id,
             self.group.groupConfiguration.minEntities + self.sp_change,
-            60 + self.scheduler_interval, 2)
+            60 + self.scheduler_interval, 2, time_scale=False)
         # Now wait for next execution
         self.wait_for_expected_group_state(
             self.group.id,
             self.group.groupConfiguration.minEntities + self.sp_change * 2,
-            60 + self.scheduler_interval, 2)
+            60 + self.scheduler_interval, 2, time_scale=False)

--- a/autoscale_cloudroast/test_repo/autoscale/system/schedule_policies/test_system_update_scheduler.py
+++ b/autoscale_cloudroast/test_repo/autoscale/system/schedule_policies/test_system_update_scheduler.py
@@ -120,13 +120,13 @@ class UpdateSchedulerTests(AutoscaleFixture):
             sp_cooldown=0)
         self.wait_for_expected_group_state(
             self.group.id, self.group.groupConfiguration.minEntities + 1,
-            60 + self.scheduler_interval, 2)
+            60 + self.scheduler_interval, 2, time_scale=False)
         self._update_policy(
             self.group.id, cron_style_policy, self.cron_policy_args,
             change_value=2)
         self.wait_for_expected_group_state(
             self.group.id, self.group.groupConfiguration.minEntities + 3,
-            60 + self.scheduler_interval)
+            60 + self.scheduler_interval, time_scale=False)
 
     @tags(speed='slow')
     def test_system_update_name_for_cron_style_scheduled_policy(self):

--- a/cafe_requirements.txt
+++ b/cafe_requirements.txt
@@ -2,3 +2,4 @@ git+https://github.com/stackforge/opencafe.git@b971070b28d07c0b19f8809e18950f2d6
 git+https://github.com/stackforge/cloudcafe.git@4dc2227b4b0140158ceab286dfa127384886f5b7#egg=cloudcafe
 IPy==0.82a
 unittest2==0.5.1
+retrying==1.3.3


### PR DESCRIPTION
Refactor the cloudcafe tests so that retries use the `retrying` library, and then scale down the interval and timeouts if we are using mimic, capping the max timeout for mimic at 60 seconds currently.

This should make the integration tests fail faster on mimic, so the non-gating convergence tests can actually maybe produce useful results (we can see if any new tests pass).

I will probably need to go through the scheduling tests, and set it not to scale down the timeouts for mimic, but right now all the worker non-schedule tests pass, the converger non-schedule gating tests pass, and the converger non-schedule failing tests all fail within 15:04 minutes.

Prior to this change, I gave up running the converger non-schedule failing tests after about 47 minutes.

The one issue is that if a test should take more than 1 minute with the converger, this can make it artificially fail, and we might not know.  :|