### PR TITLE
Use assertIsNotNone rather than assertNotIdentical, which doesn't exist.

### DIFF
--- a/autoscale_cloudroast/test_repo/autoscale/functional/scaling_group/test_create_scaling_group.py
+++ b/autoscale_cloudroast/test_repo/autoscale/functional/scaling_group/test_create_scaling_group.py
@@ -82,12 +82,12 @@ class CreateScalingGroupTest(AutoscaleFixture):
         """
         Verify the scaling group id and links exist in the response.
         """
-        self.assertNotIdentical(
-            self.scaling_group.id, None,
+        self.assertIsNotNone(
+            self.scaling_group.id,
             msg='Scaling Group id was not set in the response for group {0}'
             .format(self.scaling_group.id))
-        self.assertNotIdentical(
-            self.scaling_group.links, None,
+        self.assertIsNotNone(
+            self.scaling_group.links,
             msg='Scaling Group links not set in the response for group {0}'
             .format(self.scaling_group.id))
 


### PR DESCRIPTION
Should hopefully fix the integration tests.