### PR TITLE
view_manifest gets deleting groups

### DIFF
--- a/otter/json_schema/model_schemas.py
+++ b/otter/json_schema/model_schemas.py
@@ -74,6 +74,8 @@ policy_list = array_type(policy)
 
 
 # create group and view manifest returns a dictionary with keys being the ids
+m_pol_list = deepcopy(policy_list)
+m_pol_list['required'] = False
 manifest = {
     "type": "object",
     "description": "Schema returned by the interface for viewing a manifest",
@@ -82,7 +84,14 @@ manifest = {
         "state": {},
         "groupConfiguration": group_schemas.config,
         "launchConfiguration": group_schemas.launch_config,
-        "scalingPolicies": policy_list
+        "scalingPolicies": m_pol_list,
+        "status": {
+            "type": "string",
+            "required": False,
+            "decription": (
+                "Status of the group. One of 'ACTIVE', 'ERROR' or 'DELETING'"),
+            "pattern": "ACTIVE|ERROR|DELETING"
+        },
     },
     "additionalProperties": False
 }

--- a/otter/models/cass.py
+++ b/otter/models/cass.py
@@ -503,9 +503,7 @@ def verified_view(connection, view_query, del_query, data, consistency,
     `exception_if_empty` if group's status is DELETING
 
     :param bool get_deleting: Should it return deleting group?
-
-    TODO: Should there be seperate argument for view_consistency and
-    del_consistency.
+    :return: Deferred that fires with result of executing view query
     """
     def _check_resurrection(result):
         if len(result) == 0:

--- a/otter/models/cass.py
+++ b/otter/models/cass.py
@@ -648,8 +648,16 @@ class CassScalingGroup(object):
         return wrapper
 
     def _group_status(self, status, deleting):
-        return (ScalingGroupStatus.DELETING
-                if deleting else ScalingGroupStatus.lookupByName(status))
+        if deleting:
+            return ScalingGroupStatus.DELETING
+        else:
+            # TODO: #1304
+            if status is None:
+                return ScalingGroupStatus.ACTIVE
+            elif status == 'DISABLED':
+                return ScalingGroupStatus.ERROR
+            else:
+                return ScalingGroupStatus.lookupByName(status)
 
     def view_manifest(self, with_policies=True, with_webhooks=False,
                       get_deleting=False):

--- a/otter/models/cass.py
+++ b/otter/models/cass.py
@@ -514,7 +514,7 @@ def verified_view(connection, view_query, del_query, data, consistency,
             log.msg('Resurrected row', row=result[0], row_params=data)
             connection.execute(del_query, data, consistency)
             raise exception_if_empty
-        # Do not return group if group is deleting and we are told to do so
+        # Do not return group if group is deleting unless we are told to do so
         if not get_deleting and group.get('deleting', False):
             raise exception_if_empty
         return group

--- a/otter/models/intents.py
+++ b/otter/models/intents.py
@@ -39,7 +39,8 @@ def perform_get_scaling_group_info(log, store, dispatcher, intent):
     """
     group = store.get_scaling_group(log, intent.tenant_id, intent.group_id)
     manifest = yield group.view_manifest(with_policies=False,
-                                         with_webhooks=False)
+                                         with_webhooks=False,
+                                         with_status=True)
     returnValue((group, manifest))
 
 

--- a/otter/models/intents.py
+++ b/otter/models/intents.py
@@ -40,7 +40,7 @@ def perform_get_scaling_group_info(log, store, dispatcher, intent):
     group = store.get_scaling_group(log, intent.tenant_id, intent.group_id)
     manifest = yield group.view_manifest(with_policies=False,
                                          with_webhooks=False,
-                                         with_status=True)
+                                         get_deleting=True)
     returnValue((group, manifest))
 
 

--- a/otter/models/interface.py
+++ b/otter/models/interface.py
@@ -275,7 +275,7 @@ class IScalingGroup(Interface):
     tenant_id = Attribute("Rackspace Tenant ID of the owner of this group.")
 
     def view_manifest(with_policies=True, with_webhooks=False,
-                      with_status=False):
+                      get_deleting=False):
         """
         The manifest contains everything required to configure this scaling:
         the config, the launch config, and all the scaling policies.
@@ -283,7 +283,9 @@ class IScalingGroup(Interface):
         :param bool with_policies: Should policies information be included?
         :param bool with_webhooks: If policies are included, should webhooks
             information be included?
-        :param bool with_status: Should status be included?
+        :param bool get_deleting: Should group be returned if it is deleting?
+            If True, then returned manifest will contain "status" that will be
+            one of "ACTIVE", "ERROR" or "DELETING"
 
         :return: a dictionary corresponding to the JSON schema at
             :data:`otter.json_schema.model_schemas.manifest`

--- a/otter/models/interface.py
+++ b/otter/models/interface.py
@@ -274,7 +274,8 @@ class IScalingGroup(Interface):
     uuid = Attribute("UUID of the scaling group - immutable.")
     tenant_id = Attribute("Rackspace Tenant ID of the owner of this group.")
 
-    def view_manifest(with_policies=True, with_webhooks=False):
+    def view_manifest(with_policies=True, with_webhooks=False,
+                      with_status=False):
         """
         The manifest contains everything required to configure this scaling:
         the config, the launch config, and all the scaling policies.
@@ -282,6 +283,7 @@ class IScalingGroup(Interface):
         :param bool with_policies: Should policies information be included?
         :param bool with_webhooks: If policies are included, should webhooks
             information be included?
+        :param bool with_status: Should status be included?
 
         :return: a dictionary corresponding to the JSON schema at
             :data:`otter.json_schema.model_schemas.manifest`

--- a/otter/test/models/test_cass_models.py
+++ b/otter/test/models/test_cass_models.py
@@ -3319,6 +3319,11 @@ class CassScalingGroupsCollectionTestCase(IScalingGroupCollectionProviderMixin,
                                         policy_touched={},
                                         paused=False)])
 
+    def _extract_execute_query(self, call):
+        args, _ = call
+        query, params, c = args
+        return query
+
     def test_list_states_filters_deleting_groups(self):
         """
         Groups that are deleting based on "deleting" column to be true are not
@@ -3339,6 +3344,11 @@ class CassScalingGroupsCollectionTestCase(IScalingGroupCollectionProviderMixin,
                                         group_touched='0001-01-01T00:00:00Z',
                                         policy_touched={},
                                         paused=False)])
+        # No call to delete row was made
+        self.assertEqual(len(self.connection.execute.call_args_list), 1)
+        self.assertNotIn(
+            'DELETE', self._extract_execute_query(
+                self.connection.execute.call_args_list[0]))
 
     def test_get_scaling_group(self):
         """

--- a/otter/test/models/test_cass_models.py
+++ b/otter/test/models/test_cass_models.py
@@ -3138,14 +3138,15 @@ class CassScalingGroupsCollectionTestCase(IScalingGroupCollectionProviderMixin,
             'policyTouched': '{}',
             'paused': '\x00',
             'desired': 0,
-            'created_at': 23
+            'created_at': 23,
+            'deleting': False
         } for i in range(2)]]
 
         expectedData = {'tenantId': '123', 'limit': 100}
         expectedCql = (
             'SELECT "tenantId", "groupId", group_config, active, pending, '
-            '"groupTouched", "policyTouched", paused, desired, created_at '
-            'FROM scaling_group '
+            '"groupTouched", "policyTouched", paused, desired, created_at, '
+            'deleting FROM scaling_group '
             'WHERE "tenantId" = :tenantId LIMIT :limit;')
         r = self.validate_list_states_return_value(self.mock_log, '123')
         self.connection.execute.assert_called_once_with(
@@ -3175,7 +3176,8 @@ class CassScalingGroupsCollectionTestCase(IScalingGroupCollectionProviderMixin,
         expectedData = {'tenantId': '123', 'limit': 100}
         expectedCql = (
             'SELECT "tenantId", "groupId", group_config, active, pending, '
-            '"groupTouched", "policyTouched", paused, desired, created_at '
+            '"groupTouched", "policyTouched", paused, desired, '
+            'created_at, deleting '
             'FROM scaling_group WHERE "tenantId" = :tenantId LIMIT :limit;')
         r = self.validate_list_states_return_value(self.mock_log, '123')
         self.assertEqual(r, [])

--- a/otter/test/models/test_cass_models.py
+++ b/otter/test/models/test_cass_models.py
@@ -2168,7 +2168,7 @@ class ViewManifestTests(CassScalingGroupTestCase):
         self.verified_view.return_value = defer.succeed(self.vv_return)
 
         # Getting policies
-        policies = [group_examples.policy()[i] for i in range(3)]
+        policies = group_examples.policy()[:3]
         [policy.update({'id': str(i)}) for i, policy in enumerate(policies)]
         self.group._naive_list_policies = mock.Mock(
             return_value=defer.succeed(policies))

--- a/otter/test/models/test_cass_models.py
+++ b/otter/test/models/test_cass_models.py
@@ -2111,7 +2111,7 @@ class ViewManifestTests(CassScalingGroupTestCase):
             'pending': '{"P":"R"}',
             'groupTouched': '2014-01-01T00:00:05Z.1234',
             'policyTouched': '{"PT":"R"}',
-            'paused': '\x00',
+            'paused': False,
             'desired': 0,
             'created_at': 23
         }

--- a/otter/test/models/test_intents.py
+++ b/otter/test/models/test_intents.py
@@ -26,10 +26,10 @@ class GetScalingGroupInfoTests(SynchronousTestCase):
     """Tests for :obj:`GetScalingGroupInfo`."""
     def test_perform(self):
         """Performing returns the group, the state, and the launch config."""
-        def view_manifest(with_policies, with_webhooks, with_status):
+        def view_manifest(with_policies, with_webhooks, get_deleting):
             self.assertEqual(with_policies, False)
             self.assertEqual(with_webhooks, False)
-            self.assertEqual(with_status, True)
+            self.assertEqual(get_deleting, True)
             return succeed(manifest)
 
         def get_scaling_group(log, tenant_id, group_id):

--- a/otter/test/models/test_intents.py
+++ b/otter/test/models/test_intents.py
@@ -26,9 +26,10 @@ class GetScalingGroupInfoTests(SynchronousTestCase):
     """Tests for :obj:`GetScalingGroupInfo`."""
     def test_perform(self):
         """Performing returns the group, the state, and the launch config."""
-        def view_manifest(with_policies, with_webhooks):
+        def view_manifest(with_policies, with_webhooks, with_status):
             self.assertEqual(with_policies, False)
             self.assertEqual(with_webhooks, False)
+            self.assertEqual(with_status, True)
             return succeed(manifest)
 
         def get_scaling_group(log, tenant_id, group_id):


### PR DESCRIPTION
`view_manifest` supports getting DELETING groups by passing `get_deleting=True`. All group viewing methods return `NoSuchScalingGroupError` when trying to access DELETING group including listing groups. This way REST API's accessing deleting groups will get 404. 
- refactored cass tests
    - moved view_manifest tests to separate class
    - moved modify_state tests from test_interface to cass tests
- as a result of refactor, realized that returned manifest without policies was not conforming to model schema. Hence, made "scalingPolicies" optional in schema

Closes 2nd and 3rd task of #1179.