### PR TITLE
Converger deleting group

### DIFF
--- a/otter/convergence/service.py
+++ b/otter/convergence/service.py
@@ -140,7 +140,7 @@ def execute_convergence(tenant_id, group_id, log,
             worst_status=worst_status)
 
     if (worst_status == StepResult.SUCCESS and
-        group_status == ScalingGroupStatus.DELETING):
+            group_status == ScalingGroupStatus.DELETING):
             # servers have been deleted. Delete the group for real
         yield Effect(DeleteGroup(tenant_id=tenant_id, group_id=group_id))
 

--- a/otter/convergence/service.py
+++ b/otter/convergence/service.py
@@ -126,7 +126,8 @@ def execute_convergence(tenant_id, group_id, log,
     log.msg('execute-convergence',
             servers=servers, lb_nodes=lb_nodes, steps=steps, now=now,
             desired=desired_group_state, active=active)
-    yield _update_active(scaling_group, active)
+    if group_status != ScalingGroupStatus.DELETING:
+        yield _update_active(scaling_group, active)
     if len(steps) == 0:
         yield do_return(StepResult.SUCCESS)
     results = yield steps_to_effect(steps)

--- a/otter/models/intents.py
+++ b/otter/models/intents.py
@@ -39,7 +39,8 @@ def perform_get_scaling_group_info(log, store, dispatcher, intent):
     """
     group = store.get_scaling_group(log, intent.tenant_id, intent.group_id)
     manifest = yield group.view_manifest(with_policies=False,
-                                         with_webhooks=False)
+                                         with_webhooks=False,
+                                         get_deleting=True)
     returnValue((group, manifest))
 
 

--- a/otter/models/intents.py
+++ b/otter/models/intents.py
@@ -43,11 +43,27 @@ def perform_get_scaling_group_info(log, store, dispatcher, intent):
     returnValue((group, manifest))
 
 
+@attributes(['tenant_id', 'group_id'])
+class DeleteGroup(object):
+    """
+    Delete scaling group
+    """
+
+
+@deferred_performer
+def perform_delete_group(log, store, dispatcher, intent):
+    """
+    Perform `DeleteGroup`
+    """
+    group = store.get_scaling_group(log, intent.tenant_id, intent.group_id)
+    return group.delete_group()
+
+
 def get_model_dispatcher(log, store):
     """Get a dispatcher that can handle all the model-related intents."""
     return TypeDispatcher({
-        ModifyGroupState:
-            perform_modify_group_state,
+        ModifyGroupState: perform_modify_group_state,
         GetScalingGroupInfo:
-            partial(perform_get_scaling_group_info, log, store)
+            partial(perform_get_scaling_group_info, log, store),
+        DeleteGroup: partial(perform_delete_group, log, store)
     })

--- a/otter/test/convergence/test_service.py
+++ b/otter/test/convergence/test_service.py
@@ -726,8 +726,15 @@ class ExecuteConvergenceTests(SynchronousTestCase):
         self.manifest['status'] = 'DELETING'
         exp_intents = [(del_group, None),
                        (self.gsgi, (self.group, self.manifest))]
-
-        disp = self._get_dispatcher(exp_intents)
+        disp = ComposedDispatcher([
+            EQDispatcher(exp_intents),
+            TypeDispatcher({
+                ParallelEffects: perform_parallel_async,
+            }),
+            base_dispatcher,
+        ])
+        # This succeeded without `ModifyGroupState` dispatcher in it
+        # ensuring that it was not called
         self.assertEqual(sync_perform(disp, eff), StepResult.SUCCESS)
 
         # desired capacity was changed to 0

--- a/otter/test/convergence/test_service.py
+++ b/otter/test/convergence/test_service.py
@@ -562,6 +562,7 @@ class ExecuteConvergenceTests(SynchronousTestCase):
         self.manifest = {  # Many details elided!
             'state': self.state,
             'launchConfiguration': self.lc,
+            'status': 'ACTIVE'
         }
         gsgi_result = (self.group, self.manifest)
         self.expected_intents = [(gsgi, gsgi_result)]

--- a/otter/test/convergence/test_service.py
+++ b/otter/test/convergence/test_service.py
@@ -31,7 +31,10 @@ from otter.convergence.service import (
     non_concurrently)
 from otter.convergence.steps import ConvergeLater
 from otter.models.intents import (
-    GetScalingGroupInfo, ModifyGroupState, perform_modify_group_state)
+    DeleteGroup,
+    GetScalingGroupInfo,
+    ModifyGroupState,
+    perform_modify_group_state)
 from otter.models.interface import GroupState, NoSuchScalingGroupError
 from otter.test.convergence.test_planning import server
 from otter.test.util.test_zk import ZNodeStatStub
@@ -515,6 +518,7 @@ class ExecuteConvergenceTests(SynchronousTestCase):
         ]
         gsgi = GetScalingGroupInfo(tenant_id='tenant-id',
                                    group_id='group-id')
+        self.gsgi = gsgi
         self.manifest = {  # Many details elided!
             'state': self.state,
             'launchConfiguration': self.lc,
@@ -620,6 +624,46 @@ class ExecuteConvergenceTests(SynchronousTestCase):
         # And make sure that exception isn't wrapped in FirstError.
         e = self.assertRaises(RuntimeError, sync_perform, dispatcher, eff)
         self.assertEqual(str(e), 'foo')
+
+    def test_deleting_group(self):
+        """
+        If group's status is DELETING, plan will be generated to delete
+        all servers and group is deleted if the steps return SUCCESS. The
+        group is not deleted is the step do not succeed
+        """
+        log = mock_log()
+        gacd = self._get_gacd_func(self.group.uuid)
+
+        def _plan(dsg, *a):
+            self.dsg = dsg
+            return [TestStep(Effect(Constant((StepResult.SUCCESS, []))))]
+
+        eff = execute_convergence(self.tenant_id, self.group_id, log,
+                                  get_all_convergence_data=gacd, plan=_plan)
+
+        # setup intents for DeleteGroup and GetScalingGroupInfo
+        del_group = DeleteGroup(tenant_id=self.tenant_id,
+                                group_id=self.group_id)
+        self.manifest['status'] = 'DELETING'
+        exp_intents = [(del_group, None),
+                       (self.gsgi, (self.group, self.manifest))]
+
+        disp = self._get_dispatcher(exp_intents)
+        self.assertEqual(sync_perform(disp, eff), StepResult.SUCCESS)
+
+        # desired capacity was changed to 0
+        self.assertEqual(self.dsg.capacity, 0)
+
+        # Group is not deleted if step result was not successful
+        def fplan(*a):
+            return [TestStep(Effect(Constant((StepResult.RETRY, []))))]
+
+        eff = execute_convergence(self.tenant_id, self.group_id, log,
+                                  get_all_convergence_data=gacd, plan=fplan)
+        disp = self._get_dispatcher([(self.gsgi, (self.group, self.manifest))])
+        # This succeeded without DeleteGroup performer being there ensuring
+        # that it was not called
+        self.assertEqual(sync_perform(disp, eff), StepResult.RETRY)
 
     def test_returns_retry(self):
         """

--- a/otter/test/models/test_intents.py
+++ b/otter/test/models/test_intents.py
@@ -46,9 +46,10 @@ class ScalingGroupIntentsTests(SynchronousTestCase):
         Performing `GetScalingGroupInfo` returns the group,
         the state, and the launch config.
         """
-        def view_manifest(with_policies, with_webhooks):
+        def view_manifest(with_policies, with_webhooks, get_deleting):
             self.assertEqual(with_policies, False)
             self.assertEqual(with_webhooks, False)
+            self.assertEqual(get_deleting, True)
             return succeed(manifest)
 
         manifest = {}

--- a/otter/test/models/test_intents.py
+++ b/otter/test/models/test_intents.py
@@ -5,7 +5,7 @@ from twisted.internet.defer import succeed
 from twisted.trial.unittest import SynchronousTestCase
 
 from otter.models.intents import (
-    GetScalingGroupInfo, ModifyGroupState, get_model_dispatcher)
+    DeleteGroup, GetScalingGroupInfo, ModifyGroupState, get_model_dispatcher)
 from otter.models.interface import IScalingGroupCollection
 from otter.test.utils import iMock, mock_group, mock_log
 
@@ -22,27 +22,51 @@ class ModifyGroupStateTests(SynchronousTestCase):
         self.assertEqual(group.modify_state_values, ['new state'])
 
 
-class GetScalingGroupInfoTests(SynchronousTestCase):
-    """Tests for :obj:`GetScalingGroupInfo`."""
-    def test_perform(self):
-        """Performing returns the group, the state, and the launch config."""
+class ScalingGroupIntentsTests(SynchronousTestCase):
+    """
+    Tests for :obj:`GetScalingGroupInfo` and `DeleteGroup`
+    """
+
+    def setUp(self):
+        """
+        Sample group, collection and dispatcher
+        """
+        self.log = mock_log()
+        self.group = mock_group(None)
+        self.store = iMock(IScalingGroupCollection)
+        self.dispatcher = get_model_dispatcher(self.log, self.store)
+
+        def get_scaling_group(log, tenant_id, group_id):
+            return self.data[(log, tenant_id, group_id)]
+
+        self.store.get_scaling_group.side_effect = get_scaling_group
+
+    def test_get_scaling_group_info(self):
+        """
+        Performing `GetScalingGroupInfo` returns the group,
+        the state, and the launch config.
+        """
         def view_manifest(with_policies, with_webhooks):
             self.assertEqual(with_policies, False)
             self.assertEqual(with_webhooks, False)
             return succeed(manifest)
 
-        def get_scaling_group(log, tenant_id, group_id):
-            return data[(log, tenant_id, group_id)]
-
-        log = mock_log()
         manifest = {}
-        group = mock_group(None)
-        group.view_manifest.side_effect = view_manifest
-        data = {(log, '00', 'g1'): group}
-        store = iMock(IScalingGroupCollection)
-        store.get_scaling_group.side_effect = get_scaling_group
-        dispatcher = get_model_dispatcher(log, store)
+        self.group.view_manifest.side_effect = view_manifest
+        self.data = {(self.log, '00', 'g1'): self.group}
         info = sync_perform(
-            dispatcher,
+            self.dispatcher,
             Effect(GetScalingGroupInfo(tenant_id='00', group_id='g1')))
-        self.assertEqual(info, (group, manifest))
+        self.assertEqual(info, (self.group, manifest))
+
+    def test_delete_group(self):
+        """
+        Performing `DeleteGroup` calls group.delete_group
+        """
+        self.data = {(self.log, '00', 'g1'): self.group}
+        self.group.delete_group.return_value = succeed('del')
+        self.assertEqual(
+            sync_perform(
+                self.dispatcher,
+                Effect(DeleteGroup(tenant_id='00', group_id='g1'))),
+            'del')


### PR DESCRIPTION
Converger deletes all servers for DELETING groups and then deletes the group. 

4th task of #1179. Depends on #1268. The tests will pass after that PR is merged. 