### PR TITLE
Add some tests to make sure that draining servers without LBs are deleted right away

### DIFF
--- a/otter/test/convergence/test_planning.py
+++ b/otter/test/convergence/test_planning.py
@@ -551,6 +551,22 @@ class DrainAndDeleteServerTests(SynchronousTestCase):
                 0),
             pbag([DeleteServer(server_id='abc')]))
 
+    def test_draing_server_without_load_balancers_can_be_deleted(self):
+        """
+        If a draining server is not attached to any load balancers, even if
+        it should be, it can be deleted.  "Draining" is not re-set on its
+        metadata.
+        """
+        self.assertEqual(
+            converge(
+                DesiredGroupState(server_config={}, capacity=0,
+                                  draining_timeout=10.0),
+                set([server('abc', state=ServerState.DRAINING,
+                            desired_lbs=s(self.clb_desc, self.rcv3_desc))]),
+                set(),
+                0),
+            pbag([DeleteServer(server_id='abc')]))
+
     def test_active_server_can_be_deleted_if_all_lbs_can_be_removed(self):
         """
         If an active server to be scaled down can be removed from all the load
@@ -691,9 +707,10 @@ class DrainAndDeleteServerTests(SynchronousTestCase):
 
     def test_active_server_is_drained_even_if_all_already_in_draining(self):
         """
-        If an active server already has all of its load balancers in draining,
-        but it cannot be removed from all of them yet, it is set to draining
-        state even though no load balancer actions need to be performed.
+        If an active server is attached to load balancers, and all those load
+        balancer nodes are already in draining but it cannot be removed yet,
+        the server is set to draining state even though no load balancer
+        actions need to be performed.
 
         This can happen for instance if the server was supposed to be deleted
         in a previous convergence run, and the load balancers were set to
@@ -720,13 +737,15 @@ class DrainAndDeleteServerTests(SynchronousTestCase):
 
     def test_draining_server_has_all_enabled_lb_set_to_draining(self):
         """
-        If a draining server is enabled on any load balancers, it is set to
-        draining on those load balancers and it is not deleted.  The metadata
-        is not re-set to draining.
+        If a draining server is associated with any load balancers, those
+        load balancer nodes will be set to draining and the server is not
+        deleted.  The metadata on the server is not re-set to draining.
 
         This can happen for instance if the server was supposed to be deleted
         in a previous convergence run, and the server metadata was set but
         the load balancers update failed.
+
+        Or if the server is set to be manually deleted via the API.
         """
         self.assertEqual(
             converge(


### PR DESCRIPTION
Since the current strategy for deleting a server from a group involves just setting it to DRAINING for now (see #1238)