### PR TITLE
separate column for deleting status

### DIFF
--- a/otter/models/cass.py
+++ b/otter/models/cass.py
@@ -42,6 +42,7 @@ from otter.models.interface import (
     NoSuchWebhookError,
     PoliciesOverLimitError,
     ScalingGroupOverLimitError,
+    ScalingGroupStatus,
     UnrecognizedCapabilityError,
     WebhooksOverLimitError,
     next_cron_occurrence)
@@ -808,7 +809,24 @@ class CassScalingGroup(object):
                  'status': status.name},
                 DEFAULT_CONSISTENCY)
 
-        return self.view_config().addCallback(_do_update)
+        @self.with_timestamp
+        def set_deleting(ts, _):
+            return self.connection.execute(
+                _cql_update.format(cf=self.group_table,
+                                   column='deleting',
+                                   name=':deleting'),
+                {'tenantId': self.tenant_id,
+                 'groupId': self.uuid,
+                 'ts': ts,
+                 'deleting': True},
+                DEFAULT_CONSISTENCY)
+
+        d = self.view_config()
+        if status == ScalingGroupStatus.DELETING:
+            d.addCallback(set_deleting)
+        else:
+            d.addCallback(_do_update)
+        return d
 
     def update_config(self, data):
         """

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ jsonschema==2.4.0
 iso8601==0.1.8
 lxml==3.4.1
 treq==0.2.1
-silverberg==0.1.9
+silverberg==0.1.11
 pyOpenSSL==0.14
 jsonfig==0.1.1
 testtools==0.9.32

--- a/schema/migrations/control_51_add_deleting_column.cql
+++ b/schema/migrations/control_51_add_deleting_column.cql
@@ -1,0 +1,6 @@
+USE @@KEYSPACE@@;
+
+-- Add "deleting" column to scaling_groups table
+
+ALTER TABLE scaling_group
+ADD deleting boolean;

--- a/schema/setup/control_15_create_scaling_groups.cql
+++ b/schema/setup/control_15_create_scaling_groups.cql
@@ -51,6 +51,7 @@ CREATE COLUMNFAMILY scaling_group (
     paused boolean,
     created_at timestamp,
     status ascii,
+    deleting boolean,
     PRIMARY KEY("tenantId", "groupId")
 ) WITH compaction = {
     'class' : 'SizeTieredCompactionStrategy',


### PR DESCRIPTION
Based on https://github.com/rackerlabs/otter/pull/1261#discussion_r27331263 this adds another column for DELETING status. This way DELETING status does not interfere with ACTIVE or ERROR and always takes precedence. Please note that this PR does not contain code to _read_ status. That will be in separate PRs under `view_manifest` (most likely a fix to #1268)

This PR depends on supporting boolean types in silverberg that will be released in 0.1.11 version after merging https://github.com/rackerlabs/silverberg/pull/49. Hence, please review that too :)