### PR TITLE
Decorator that allows skipping of integration tests based on whether mimic is used or not

### DIFF
--- a/autoscale_cloudroast/test_repo/autoscale/fixtures.py
+++ b/autoscale_cloudroast/test_repo/autoscale/fixtures.py
@@ -135,13 +135,16 @@ _rcv3_cloud_network = autoscale_config.rcv3_cloud_network
 autoscale_client, server_client, lbaas_client, rcv3_client = _set_up_clients()
 
 
-def skip_if_mimic_is(boolean):
+def only_run_if_mimic_is(should_mimic_be_available):
     """
-    Decorator that skips a test if mimic is equal to the given boolean.
+    Decorator that only runs a test if mimic is equal to the given boolean
+    ``should_mimic_be_available``.  Otherwise the test is skipped.
     """
     def actual_decorator(f):
-        if autoscale_config.mimic == boolean:
-            return skip(f)
+        if autoscale_config.mimic != should_mimic_be_available:
+            msg = "Skipping because mimic is {0}".format(
+                "available" if autoscale_config.mimic else "not available")
+            return skip(msg)(f)
         return f
     return actual_decorator
 

--- a/autoscale_cloudroast/test_repo/autoscale/fixtures.py
+++ b/autoscale_cloudroast/test_repo/autoscale/fixtures.py
@@ -7,6 +7,7 @@ from __future__ import print_function
 import json
 import time
 from functools import partial
+from unittest import skip
 
 from cafe.drivers.unittest.fixtures import BaseTestFixture
 
@@ -132,6 +133,17 @@ except Exception:
 _rcv3_cloud_network = autoscale_config.rcv3_cloud_network
 
 autoscale_client, server_client, lbaas_client, rcv3_client = _set_up_clients()
+
+
+def skip_if_mimic_is(boolean):
+    """
+    Decorator that skips a test if mimic is equal to the given boolean.
+    """
+    def actual_decorator(f):
+        if autoscale_config.mimic == boolean:
+            return skip(f)
+        return f
+    return actual_decorator
 
 
 class AutoscaleFixture(BaseTestFixture):

--- a/autoscale_cloudroast/test_repo/autoscale/system/group/test_system_group_negative.py
+++ b/autoscale_cloudroast/test_repo/autoscale/system/group/test_system_group_negative.py
@@ -97,11 +97,16 @@ class NegativeGroupFixture(AutoscaleFixture):
             group_state.desiredCapacity, 0,
             msg='Desired capacity is not equal to expected number of servers')
 
-    @tags(speed='quick', convergence='error')
+    @tags(speed='quick', convergence='never')
     def test_user_delete_some_servers_out_of_band(self):
         """
         Create a group with 4 minentities and verify the group state when user
-        deletes one of the servers on the group
+        deletes one of the servers on the group.  When the server is deleted
+        out of band, while autoscale is waiting for the servers to finish
+        building, then autoscale will treat the deletion as an error during
+        the build, and decrease the desired capacity by 1 accordingly.
+
+        This should never be the case in convergence.
         """
         server_count = 4
         group_response = self.autoscale_behaviors.create_scaling_group_given(


### PR DESCRIPTION
Also, update the docstring on one of the tests that should never pass for convergence.

May help with #1228.