### PR TITLE
APIs needed for deleting one server in convergence

### DIFF
--- a/otter/cloud_client.py
+++ b/otter/cloud_client.py
@@ -409,10 +409,8 @@ def set_nova_metadata_item(server_id, key, value):
             if api_error.code == code:
                 message = try_json_with_keys(api_error.body, keys)
                 if message and (not pattern or pattern.match(message)):
-                    kwargs = {}
-                    if exc_class != NovaRateLimitError:
-                        kwargs = {'server_id': six.text_type(server_id)}
-                    raise exc_class(message, **kwargs)
+                    raise exc_class(message,
+                                    server_id=six.text_type(server_id))
 
         six.reraise(*exc_info)
 

--- a/otter/cloud_client.py
+++ b/otter/cloud_client.py
@@ -364,6 +364,7 @@ class ServerMetadataOverLimitError(Exception):
     """
 
 
+@attributes([])
 class NovaRateLimitError(Exception):
     """
     Exception to be raised when Nova has rate-limited requests.

--- a/otter/cloud_client.py
+++ b/otter/cloud_client.py
@@ -345,3 +345,82 @@ def _process_clb_api_error(exc_info, lb_id, extra_parsing):
 
     # No? Re-raise, then
     six.reraise(*exc_info)
+
+
+# ----- Nova requests and error parsing -----
+@attributes([Attribute('server_id', instance_of=six.text_type)])
+class NoSuchServerError(Exception):
+    """
+    Exception to be raised when there is no such server in Nova.
+    """
+
+@attributes([Attribute('server_id', instance_of=six.text_type)])
+class ServerMetadataOverLimitError(Exception):
+    """
+    Exception to be raised when there are too many metadata items on the
+    server already.
+    """
+
+class NovaRateLimitError(Exception):
+    """
+    Exception to be raised when Nova has rate-limited requests.
+    """
+
+
+_MAX_METADATA_PATTERN = re.compile('^Maximum number of metadata items .*$')
+
+
+def set_nova_metadata_item(server_id, key, value):
+    """
+    Set metadata key/value item on the given server.
+
+    :ivar str server_id: a Nova server ID.
+    :ivar str key: The metadata key to set (<=256 characters)
+    :ivar str value: The value to assign to the metadata key (<=256 characters)
+
+    Succeed on 200.
+
+    :raise: :class:`NoSuchServer`, :class:`MetadataOverLimit`,
+        :class:`APIError`
+    """
+    eff = service_request(
+        ServiceType.CLOUD_SERVERS,
+        'PUT',
+        append_segments('servers', server_id, 'metadata', key),
+        data={'meta': {key: value}},
+        reauth_codes=(401,),
+        success_pred=has_code(200))
+
+    def _parse_err(exc_info):
+        api_error = exc_info[1]
+        _check_nova_rate_limit(api_error)
+
+        matches = [
+            (404, ('itemNotFound', 'message'), None, NoSuchServerError),
+            (403, ('forbidden', 'message'), _MAX_METADATA_PATTERN,
+             ServerMetadataOverLimitError),
+        ]
+
+        for code, keys, pattern, exc_class in matches:
+            if api_error.code == code:
+                message = try_json_with_keys(api_error.body, keys)
+                if message and (not pattern or pattern.match(message)):
+                    kwargs = {}
+                    if exc_class != NovaRateLimitError:
+                        kwargs = {'server_id': six.text_type(server_id)}
+                    raise exc_class(message, **kwargs)
+
+        six.reraise(*exc_info)
+
+    return eff.on(error=catch(APIError, _parse_err))
+
+
+def _check_nova_rate_limit(api_error):
+    """
+    Check if the API error is a nova rate limiting error.
+    """
+    if api_error.code == 413:
+        message = try_json_with_keys(api_error.body, ('overLimit', 'message'))
+        if message:
+            raise NovaRateLimitError(message)
+

--- a/otter/cloud_client.py
+++ b/otter/cloud_client.py
@@ -348,11 +348,13 @@ def _process_clb_api_error(exc_info, lb_id, extra_parsing):
 
 
 # ----- Nova requests and error parsing -----
+
 @attributes([Attribute('server_id', instance_of=six.text_type)])
 class NoSuchServerError(Exception):
     """
     Exception to be raised when there is no such server in Nova.
     """
+
 
 @attributes([Attribute('server_id', instance_of=six.text_type)])
 class ServerMetadataOverLimitError(Exception):
@@ -360,6 +362,7 @@ class ServerMetadataOverLimitError(Exception):
     Exception to be raised when there are too many metadata items on the
     server already.
     """
+
 
 class NovaRateLimitError(Exception):
     """
@@ -423,4 +426,3 @@ def _check_nova_rate_limit(api_error):
         message = try_json_with_keys(api_error.body, ('overLimit', 'message'))
         if message:
             raise NovaRateLimitError(message)
-

--- a/otter/test/test_cloud_client.py
+++ b/otter/test/test_cloud_client.py
@@ -515,7 +515,7 @@ class NovaClientTests(SynchronousTestCase):
             service_request_eqf(
                 stub_pure_response(json.dumps(failure_body), 413)))])
 
-        with self.assertRaises(NoSuchServerError) as cm:
+        with self.assertRaises(NovaRateLimitError) as cm:
             sync_perform(dispatcher, real)
 
         self.assertEqual(cm.exception,

--- a/otter/test/test_cloud_client.py
+++ b/otter/test/test_cloud_client.py
@@ -503,11 +503,11 @@ class NovaClientTests(SynchronousTestCase):
         server_id, expected, real = self._setup_for_set_nova_metadata_item()
 
         failure_body = {
-            "overLimit" : {
-                "code" : 413,
-                "message" : "OverLimit Retry...",
-                "details" : "Error Details...",
-                "retryAfter" : "2015-02-27T23:42:27Z"
+            "overLimit": {
+                "code": 413,
+                "message": "OverLimit Retry...",
+                "details": "Error Details...",
+                "retryAfter": "2015-02-27T23:42:27Z"
             }
         }
         dispatcher = EQFDispatcher([(
@@ -518,4 +518,5 @@ class NovaClientTests(SynchronousTestCase):
         with self.assertRaises(NoSuchServerError) as cm:
             sync_perform(dispatcher, real)
 
-        self.assertEqual(cm.exception, NovaRateLimitError("OverLimit Retry..."))
+        self.assertEqual(cm.exception,
+                         NovaRateLimitError("OverLimit Retry..."))

--- a/otter/test/test_cloud_client.py
+++ b/otter/test/test_cloud_client.py
@@ -2,6 +2,7 @@
 
 import json
 from functools import partial
+from uuid import uuid4
 
 from effect import (
     ComposedDispatcher,
@@ -12,6 +13,8 @@ from effect import (
     sync_perform)
 from effect.testing import EQFDispatcher
 
+import six
+
 from twisted.trial.unittest import SynchronousTestCase
 
 from otter.auth import Authenticate, InvalidateToken
@@ -21,15 +24,20 @@ from otter.cloud_client import (
     CLBRateLimitError,
     NoSuchCLBError,
     NoSuchCLBNodeError,
+    NoSuchServerError,
+    NovaRateLimitError,
+    ServerMetadataOverLimitError,
     ServiceRequest,
     TenantScope,
     add_bind_service,
     change_clb_node,
     concretize_service_request,
     perform_tenant_scope,
-    service_request)
+    service_request,
+    set_nova_metadata_item)
 from otter.constants import ServiceType
 from otter.test.utils import (
+    StubResponse,
     resolve_effect,
     stub_pure_response)
 from otter.test.worker.test_launch_server_v1 import fake_service_catalog
@@ -405,3 +413,109 @@ class CLBClientTests(SynchronousTestCase):
 
         # all the common failures
         self.assert_parses_common_clb_errors(expected.intent, eff)
+
+
+class NovaClientTests(SynchronousTestCase):
+    """
+    Tests for Nova client functions, such as :obj:`set_nova_metadata_item`.
+    """
+    def _setup_for_set_nova_metadata_item(self):
+        """
+        Produce the data needed to test :obj:`set_nova_metadata_item`: a tuple
+        of (server_id, expected_effect, real_effect)
+        """
+        server_id = str(uuid4())
+        real = set_nova_metadata_item(server_id=server_id, key='k', value='v')
+        expected = service_request(
+            ServiceType.CLOUD_SERVERS,
+            'PUT',
+            'servers/{0}/metadata/k'.format(server_id),
+            data={'meta': {'k': 'v'}},
+            reauth_codes=(401,),
+            success_pred=has_code(200))
+        return (server_id, expected, real)
+
+    def test_set_nova_metadata_item_success(self):
+        """
+        Produce a request setting a metadata item on a Nova server, which
+        returns a successful result on 200.
+        """
+        server_id, expected, real = self._setup_for_set_nova_metadata_item()
+
+        success_body = {"meta": {"k": "v"}}
+        dispatcher = EQFDispatcher([(
+            expected.intent,
+            service_request_eqf(
+                stub_pure_response(json.dumps(success_body), 200)))])
+
+        self.assertEqual(sync_perform(dispatcher, real),
+                         (StubResponse(200, {}), success_body))
+
+    def test_set_nova_metadata_item_too_many_metadata_items(self):
+        """
+        Return a :class:`ServerMetadataOverLimitError` if there are too many
+        metadata items on a server.
+        """
+        server_id, expected, real = self._setup_for_set_nova_metadata_item()
+
+        message = "Maximum number of metadata items exceeds 40"
+        failure_body = {"forbidden": {"message": message, "code": 403}}
+
+        dispatcher = EQFDispatcher([(
+            expected.intent,
+            service_request_eqf(
+                stub_pure_response(json.dumps(failure_body), 403)))])
+
+        with self.assertRaises(ServerMetadataOverLimitError) as cm:
+            sync_perform(dispatcher, real)
+
+        self.assertEqual(
+            cm.exception,
+            ServerMetadataOverLimitError(message,
+                                         server_id=six.text_type(server_id)))
+
+    def test_set_nova_metadata_item_no_such_server(self):
+        """
+        Return a :class:`NoSuchServerError` if the server doesn't exist.
+        """
+        server_id, expected, real = self._setup_for_set_nova_metadata_item()
+
+        message = "Server does not exist"
+        failure_body = {"itemNotFound": {"message": message, "code": 404}}
+
+        dispatcher = EQFDispatcher([(
+            expected.intent,
+            service_request_eqf(
+                stub_pure_response(json.dumps(failure_body), 404)))])
+
+        with self.assertRaises(NoSuchServerError) as cm:
+            sync_perform(dispatcher, real)
+
+        self.assertEqual(
+            cm.exception,
+            NoSuchServerError(message, server_id=six.text_type(server_id)))
+
+    def test_set_nova_metadata_rate_limiting(self):
+        """
+        Return a :class:`NovaRateLimitError` if Nova starts rate-limiting
+        requests.
+        """
+        server_id, expected, real = self._setup_for_set_nova_metadata_item()
+
+        failure_body = {
+            "overLimit" : {
+                "code" : 413,
+                "message" : "OverLimit Retry...",
+                "details" : "Error Details...",
+                "retryAfter" : "2015-02-27T23:42:27Z"
+            }
+        }
+        dispatcher = EQFDispatcher([(
+            expected.intent,
+            service_request_eqf(
+                stub_pure_response(json.dumps(failure_body), 413)))])
+
+        with self.assertRaises(NoSuchServerError) as cm:
+            sync_perform(dispatcher, real)
+
+        self.assertEqual(cm.exception, NovaRateLimitError("OverLimit Retry..."))


### PR DESCRIPTION
This includes an API for setting a metadata item (which we need to set DRAINING) and for getting server details (to determine whether a server is a member of our group)

So that this can be called for the convergence codepath of #1238.

For more context, I plan on using the APIs here:  https://github.com/rackerlabs/otter/compare/delete_server_with_convergence