### PR TITLE
Parse server metadata to recognize "DRAINING" state

### DIFF
--- a/otter/convergence/model.py
+++ b/otter/convergence/model.py
@@ -80,7 +80,9 @@ class ServerState(Names):
 
     DRAINING = NamedConstant()
     """"
-    Autoscale is deleting the server.
+    Autoscale is deleting the server.  This state is meant to supercede Nova's
+    ``BUILD`` and ``ACTIVE`` states, because this state means that the server
+    is basically functional, but that Autoscale would like to delete it.
     """
 
     DELETED = NamedConstant()

--- a/otter/convergence/model.py
+++ b/otter/convergence/model.py
@@ -272,6 +272,9 @@ def generate_metadata(group_id, lb_descriptions):
     return metadata
 
 
+DRAINING_METADATA = ('rax:autoscale:server:state', 'draining')
+
+
 @attributes(['server_config', 'capacity',
              Attribute('desired_lbs', default_factory=pset, instance_of=PSet),
              Attribute('draining_timeout', default_value=0.0,

--- a/otter/convergence/planning.py
+++ b/otter/convergence/planning.py
@@ -8,8 +8,14 @@ from toolz.curried import filter, groupby
 from toolz.itertoolz import concat, concatv, mapcat
 
 from otter.convergence.model import (
-    CLBDescription, CLBNode, CLBNodeCondition, IDrainable,
-    RCv3Description, RCv3Node, ServerState)
+    CLBDescription,
+    CLBNode,
+    CLBNodeCondition,
+    DRAINING_METADATA,
+    IDrainable,
+    RCv3Description,
+    RCv3Node,
+    ServerState)
 from otter.convergence.steps import (
     AddNodesToCLB,
     BulkAddToRCv3,
@@ -153,8 +159,8 @@ def _drain_and_delete(server, timeout, current_lb_nodes, now):
     if server.state != ServerState.DRAINING:
         return lb_draining_steps + [
             SetMetadataItemOnServer(server_id=server.id,
-                                    key='rax:auto_scaling_draining',
-                                    value='draining')]
+                                    key=DRAINING_METADATA[0],
+                                    value=DRAINING_METADATA[1])]
 
     return lb_draining_steps
 

--- a/otter/test/convergence/test_model.py
+++ b/otter/test/convergence/test_model.py
@@ -16,6 +16,7 @@ from otter.convergence.model import (
     CLBNode,
     CLBNodeCondition,
     CLBNodeType,
+    DRAINING_METADATA,
     IDrainable,
     ILBDescription,
     ILBNode,
@@ -490,6 +491,64 @@ class ToNovaServerTests(SynchronousTestCase):
                        desired_lbs=pset(),
                        servicenet_address='',
                        links=freeze(self.links[0])))
+
+    def test_draining_from_metadata_trumps_active_build_nova_states(self):
+        """
+        If a draining key and value are in the metadata, the server is in
+        DRAINING state so long as the Nova vm state is either ACTIVE or BUILD.
+        """
+        self.servers[0]['metadata'] = dict([DRAINING_METADATA])
+
+        for status in ("ACTIVE", "BUILD"):
+            self.servers[0]['status'] = status
+            self.assertEqual(
+                NovaServer.from_server_details_json(self.servers[0]),
+                NovaServer(id='a',
+                           state=ServerState.DRAINING,
+                           image_id='valid_image',
+                           flavor_id='valid_flavor',
+                           created=self.createds[0][1],
+                           desired_lbs=pset(),
+                           servicenet_address='',
+                           links=freeze(self.links[0])))
+
+    def test_draining_state_invalid_values(self):
+        """
+        If a draining key is in the metadata, but the value is invalid, the
+        server is not recognized to be in DRAINING state and will just go
+        with the Nova vm state.
+        """
+        self.servers[0]['metadata'] = {DRAINING_METADATA[0]: "meh"}
+        self.assertEqual(
+            NovaServer.from_server_details_json(self.servers[0]),
+            NovaServer(id='a',
+                       state=ServerState.ACTIVE,
+                       image_id='valid_image',
+                       flavor_id='valid_flavor',
+                       created=self.createds[0][1],
+                       desired_lbs=pset(),
+                       servicenet_address='',
+                       links=freeze(self.links[0])))
+
+    def test_error_and_deleted_nova_state_trumps_draining_from_metadata(self):
+        """
+        If a draining key and value are in the metadata, but the Nova vm state
+        is DELETED, then the server is in DELETED state, not DRAINING state.
+        """
+        self.servers[0]['metadata'] = dict([DRAINING_METADATA])
+        for status, state in (("ERROR", ServerState.ERROR),
+                              ("DELETED", ServerState.DELETED)):
+            self.servers[0]['status'] = status
+            self.assertEqual(
+                NovaServer.from_server_details_json(self.servers[0]),
+                NovaServer(id='a',
+                           state=state,
+                           image_id='valid_image',
+                           flavor_id='valid_flavor',
+                           created=self.createds[0][1],
+                           desired_lbs=pset(),
+                           servicenet_address='',
+                           links=freeze(self.links[0])))
 
 
 class IPAddressTests(SynchronousTestCase):

--- a/otter/test/convergence/test_planning.py
+++ b/otter/test/convergence/test_planning.py
@@ -12,6 +12,7 @@ from otter.convergence.model import (
     CLBNodeCondition,
     CLBNodeType,
     DesiredGroupState,
+    DRAINING_METADATA,
     NovaServer,
     RCv3Description,
     RCv3Node,
@@ -699,8 +700,8 @@ class DrainAndDeleteServerTests(SynchronousTestCase):
                               condition=CLBNodeCondition.DRAINING,
                               type=CLBNodeType.PRIMARY),
                 SetMetadataItemOnServer(server_id='abc',
-                                        key='rax:auto_scaling_draining',
-                                        value='draining'),
+                                        key=DRAINING_METADATA[0],
+                                        value=DRAINING_METADATA[1]),
                 BulkRemoveFromRCv3(lb_node_pairs=s(
                     (self.rcv3_desc.lb_id, 'abc')))
             ]))
@@ -731,8 +732,8 @@ class DrainAndDeleteServerTests(SynchronousTestCase):
                 1),
             pbag([
                 SetMetadataItemOnServer(server_id='abc',
-                                        key='rax:auto_scaling_draining',
-                                        value='draining')
+                                        key=DRAINING_METADATA[0],
+                                        value=DRAINING_METADATA[1])
             ]))
 
     def test_draining_server_has_all_enabled_lb_set_to_draining(self):


### PR DESCRIPTION
In the convergence models, the server state should be DRAINING if the draining metadata is on the server.

However, DELETED and ERROR states should trump DRAINING, since "DRAINING" just means that the server is pretty much worker but Autoscale would like to delete it.

Part of #1238 