### PR TITLE
new bool unmarshalling in silverberg for GroupState.paused

### DIFF
--- a/otter/models/cass.py
+++ b/otter/models/cass.py
@@ -450,7 +450,7 @@ def _unmarshal_state(state_dict):
         _jsonloads_data(state_dict["pending"]),
         state_dict["groupTouched"],
         _jsonloads_data(state_dict["policyTouched"]),
-        bool(ord(state_dict["paused"])),
+        state_dict["paused"],
         desired=desired_capacity
     )
 

--- a/otter/test/models/test_cass_models.py
+++ b/otter/test/models/test_cass_models.py
@@ -512,7 +512,7 @@ class CassScalingGroupTests(CassScalingGroupTestCase):
              'pending': '{"P":"R"}',
              'groupTouched': '2014-01-01T00:00:05Z.1234',
              'policyTouched': '{"PT":"R"}',
-             'paused': '\x00',
+             'paused': False,
              'created_at': 23,
              'desired': 10}]
         self.returns = [cass_response]
@@ -550,7 +550,7 @@ class CassScalingGroupTests(CassScalingGroupTestCase):
              'pending': '{"P":"R"}',
              'groupTouched': '2014-01-01T00:00:05Z.1234',
              'policyTouched': '{"PT":"R"}',
-             'paused': '\x00',
+             'paused': False,
              'created_at': 23,
              'desired': None}]
         self.returns = [cass_response]
@@ -577,7 +577,7 @@ class CassScalingGroupTests(CassScalingGroupTestCase):
              'pending': '{"P":"R"}',
              'groupTouched': '2014-01-01T00:00:05Z.1234',
              'policyTouched': '{"PT":"R"}',
-             'paused': '\x00',
+             'paused': False,
              'desired': 0,
              'created_at': 23}]
         self.returns = [cass_response]
@@ -611,7 +611,7 @@ class CassScalingGroupTests(CassScalingGroupTestCase):
              'pending': '{"P":"R"}',
              'groupTouched': '2014-01-01T00:00:05Z.1234',
              'policyTouched': '{"PT":"R"}',
-             'paused': '\x00',
+             'paused': False,
              'desired': None,
              'created_at': None}]
         self.returns = [cass_response, None]
@@ -642,7 +642,7 @@ class CassScalingGroupTests(CassScalingGroupTestCase):
              'pending': '{"P":"R"}',
              'groupTouched': '2014-01-01T00:00:05Z.1234',
              'policyTouched': '{"PT":"R"}',
-             'paused': '\x01',
+             'paused': True,
              'desired': 0,
              'created_at': 3}])
 
@@ -1873,7 +1873,7 @@ class CassScalingGroupTests(CassScalingGroupTestCase):
             'pending': '{"P":"R"}',
             'groupTouched': '2014-01-01T00:00:05Z.1234',
             'policyTouched': '{"PT":"R"}',
-            'paused': '\x00',
+            'paused': False,
             'desired': 0,
             'created_at': 23
         })
@@ -1928,7 +1928,7 @@ class CassScalingGroupTests(CassScalingGroupTestCase):
             'pending': '{"P":"R"}',
             'groupTouched': '2014-01-01T00:00:05Z.1234',
             'policyTouched': '{"PT":"R"}',
-            'paused': '\x00',
+            'paused': False,
             'desired': 0,
             'created_at': 23
         })
@@ -1966,7 +1966,7 @@ class CassScalingGroupTests(CassScalingGroupTestCase):
             'pending': '{"P":"R"}',
             'groupTouched': '2014-01-01T00:00:05Z.1234',
             'policyTouched': '{"PT":"R"}',
-            'paused': '\x00',
+            'paused': False,
             'desired': 0,
             'created_at': 23
         })
@@ -2018,7 +2018,7 @@ class CassScalingGroupTests(CassScalingGroupTestCase):
             'pending': '{"P":"R"}',
             'groupTouched': '2014-01-01T00:00:05Z.1234',
             'policyTouched': '{"PT":"R"}',
-            'paused': '\x00',
+            'paused': False,
             'desired': 0,
             'created_at': 23
         })
@@ -3141,7 +3141,7 @@ class CassScalingGroupsCollectionTestCase(IScalingGroupCollectionProviderMixin,
             'pending': '{}',
             'groupTouched': None,
             'policyTouched': '{}',
-            'paused': '\x00',
+            'paused': False,
             'desired': 0,
             'created_at': 23
         } for i in range(2)]]
@@ -3235,7 +3235,7 @@ class CassScalingGroupsCollectionTestCase(IScalingGroupCollectionProviderMixin,
             'pending': '{}',
             'groupTouched': None,
             'policyTouched': '{}',
-            'paused': '\x00',
+            'paused': False,
             'desired': 0,
             'created_at': 23
         }, {
@@ -3246,7 +3246,7 @@ class CassScalingGroupsCollectionTestCase(IScalingGroupCollectionProviderMixin,
             'pending': '{}',
             'groupTouched': None,
             'policyTouched': '{}',
-            'paused': '\x00',
+            'paused': False,
             'desired': 0,
             'created_at': None
         }]
@@ -3288,7 +3288,7 @@ class CassScalingGroupsCollectionTestCase(IScalingGroupCollectionProviderMixin,
             'pending': '{}',
             'groupTouched': None,
             'policyTouched': '{}',
-            'paused': '\x00',
+            'paused': False,
             'desired': 0,
             'created_at': 23
         }, {
@@ -3299,7 +3299,7 @@ class CassScalingGroupsCollectionTestCase(IScalingGroupCollectionProviderMixin,
             'pending': '{}',
             'groupTouched': None,
             'policyTouched': '{}',
-            'paused': '\x00',
+            'paused': False,
             'desired': 0,
             'created_at': None
         }, {
@@ -3310,7 +3310,7 @@ class CassScalingGroupsCollectionTestCase(IScalingGroupCollectionProviderMixin,
             'pending': '{}',
             'groupTouched': None,
             'policyTouched': '{}',
-            'paused': '\x00',
+            'paused': False,
             'desired': 0,
             'created_at': None
         }]

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ jsonschema==2.4.0
 iso8601==0.1.8
 lxml==3.4.1
 treq==0.2.1
-silverberg==0.1.9
+silverberg==0.1.11
 pyOpenSSL==0.14
 jsonfig==0.1.1
 testtools==0.9.32


### PR DESCRIPTION
While implementing deleting column in #1277, I realized that GroupState.paused manually unmarshals boolean in code. Hence, changing that to use new boolean unmarshalling in https://github.com/rackerlabs/silverberg/pull/49. Kindly review silverberg PR first :)