### PR TITLE
update to txkazoo 0.0.6b2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ pyOpenSSL==0.14
 jsonfig==0.1.1
 testtools==0.9.32
 croniter==0.3.5
-txkazoo==0.0.6b1
+txkazoo==0.0.6b2
 effect==0.1a15
 characteristic==14.3.0
 toolz==0.7.1


### PR DESCRIPTION
this is because 0.0.6b1 pinned some dependencies to specific versions, but 0.0.6b2 is more relaxed in its dependencies, and we want newer versions. 