### PR TITLE
make the converger interval configurable as `converger.interval`

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -60,5 +60,8 @@
         "interval": 60
     },
     "cloudfeeds": {"service": "cloudFeeds", "tenant_id": "tenant",
-                   "url": "http://cfurl.net/"}
+                   "url": "http://cfurl.net/"},
+    "converger": {
+        "interval": 30
+    }
 }

--- a/otter/tap/api.py
+++ b/otter/tap/api.py
@@ -286,7 +286,8 @@ def makeService(config):
             starter = ConvergenceStarter(dispatcher)
             set_convergence_starter(starter)
 
-            setup_converger(s, kz_client, dispatcher)
+            setup_converger(s, kz_client, dispatcher,
+                            config_value('converger.interval') or 10)
 
         d.addCallback(on_client_ready)
         d.addErrback(log.err, 'Could not start TxKazooClient')
@@ -294,7 +295,7 @@ def makeService(config):
     return s
 
 
-def setup_converger(parent, kz_client, dispatcher):
+def setup_converger(parent, kz_client, dispatcher, interval):
     """
     Create a Converger service, which has a Partitioner as a child service, so
     that if the Converger is stopped, the partitioner is also stopped.
@@ -303,7 +304,7 @@ def setup_converger(parent, kz_client, dispatcher):
     partitioner_factory = partial(
         Partitioner,
         kz_client,
-        10,  # interval
+        interval,
         CONVERGENCE_PARTITIONER_PATH,
         converger_buckets,
         15,  # time boundary

--- a/otter/test/tap/test_api.py
+++ b/otter/test/tap/test_api.py
@@ -660,14 +660,17 @@ class ConvergerSetupTests(SynchronousTestCase):
         ms = MultiService()
         kz_client = object()
         dispatcher = object()
-        setup_converger(ms, kz_client, dispatcher)
+        interval = 50
+        setup_converger(ms, kz_client, dispatcher, interval)
         [converger] = ms.services
         self.assertIs(converger.__class__, Converger)
         self.assertEqual(converger._dispatcher, dispatcher)
         [partitioner] = converger.services
+        [timer] = partitioner.services
         self.assertIs(partitioner.__class__, Partitioner)
         self.assertIs(partitioner, converger.partitioner)
         self.assertIs(partitioner.kz_client, kz_client)
+        self.assertEqual(timer.step, interval)
 
 
 class SchedulerSetupTests(SynchronousTestCase):


### PR DESCRIPTION
Mostly to allow us to tweak this for integration test purposes, where we probably want to set it to something very low.