### PR TITLE
use ZK watches to trigger convergence faster

### DIFF
--- a/autoscale_cloudroast/test_repo/autoscale/system/group/test_force_delete_group.py
+++ b/autoscale_cloudroast/test_repo/autoscale/system/group/test_force_delete_group.py
@@ -17,7 +17,7 @@ class ForceDeleteGroupTest(AutoscaleFixture):
     invalid_params = [0, '', '$%^#', 'false', 'False', False, 'anything',
                       'truee']
 
-    @tags(speed='slow', convergence='yes')
+    @tags(speed='slow', convergence='error')
     def test_minentities_over_zero(self):
         """
         Force deleting a scaling group with active servers, updates the desired

--- a/otter/convergence/service.py
+++ b/otter/convergence/service.py
@@ -446,6 +446,7 @@ class Converger(MultiService):
             # TODO: don't use private stuff :(
             # TODO: only call buckets_acquired if we own some of the children
             # TODO: maybe don't do so much work?
+            # TODO: nagle?
             my_buckets = self.partitioner._get_current_buckets()
             self.buckets_acquired(my_buckets)
 

--- a/otter/convergence/service.py
+++ b/otter/convergence/service.py
@@ -440,6 +440,14 @@ class Converger(MultiService):
         # the return value is ignored, but we return this for testing
         return result
 
+    def divergent_changed(self, children):
+        self.log.msg('convergence-zk-watch')
+        if self.partitioner.partitioner.acquired:
+            # TODO: don't use private stuff :(
+            # TODO: only call buckets_acquired if we own some of the children
+            # TODO: maybe don't do so much work?
+            my_buckets = self.partitioner._get_current_buckets()
+            self.buckets_acquired(my_buckets)
 
 # We're using a global for now because it's difficult to thread a new parameter
 # all the way through the REST objects to the controller code, where this

--- a/otter/tap/api.py
+++ b/otter/tap/api.py
@@ -25,10 +25,14 @@ from twisted.web.server import Site
 
 from txkazoo import TxKazooClient
 from txkazoo.log import TxLogger
+from txkazoo.recipe.watchers import watch_children
 
 from otter.auth import generate_authenticator
 from otter.bobby import BobbyClient
-from otter.constants import CONVERGENCE_PARTITIONER_PATH, get_service_configs
+from otter.constants import (
+    CONVERGENCE_DIRTY_DIR,
+    CONVERGENCE_PARTITIONER_PATH,
+    get_service_configs)
 from otter.convergence.service import (
     ConvergenceStarter, Converger, set_convergence_starter)
 from otter.effect_dispatcher import get_full_dispatcher
@@ -310,6 +314,7 @@ def setup_converger(parent, kz_client, dispatcher):
     )
     cvg = Converger(log, dispatcher, converger_buckets, partitioner_factory)
     cvg.setServiceParent(parent)
+    watch_children(kz_client, CONVERGENCE_DIRTY_DIR, cvg.divergent_changed)
 
 
 def setup_scheduler(parent, store, kz_client):

--- a/otter/test/convergence/test_service.py
+++ b/otter/test/convergence/test_service.py
@@ -84,7 +84,6 @@ class ConvergerTests(SynchronousTestCase):
     """Tests for :obj:`Converger`."""
 
     def setUp(self):
-        self.dispatcher = _get_dispatcher()
         self.log = mock_log()
         self.buckets = range(10)
 

--- a/otter/test/convergence/test_service.py
+++ b/otter/test/convergence/test_service.py
@@ -8,6 +8,7 @@ from effect.ref import Reference, reference_dispatcher
 from effect.testing import EQDispatcher, EQFDispatcher, SequenceDispatcher
 
 from kazoo.exceptions import BadVersionError
+from kazoo.recipe.partitioner import PartitionState
 
 import mock
 
@@ -91,7 +92,7 @@ class ConvergerTests(SynchronousTestCase):
         if dispatcher is None:
             dispatcher = _get_dispatcher()
         return Converger(
-            self.log, self.dispatcher, self.buckets,
+            self.log, dispatcher, self.buckets,
             self._pfactory, converge_all_groups=converge_all_groups)
 
     def _pfactory(self, log, callable):
@@ -132,11 +133,43 @@ class ConvergerTests(SynchronousTestCase):
             CheckFailureValue(RuntimeError('foo')),
             'converge-all-groups-error', system='converger')
 
+    def test_divergent_changed_not_acquired(self):
+        """
+        When notified that divergent groups have changed and we have not
+        acquired our buckets, nothing is done.
+        """
+        dispatcher = SequenceDispatcher([])  # "nothing happens"
+        converger = self._converger(lambda *a, **kw: 1 / 0,
+                                    dispatcher=dispatcher)
+        converger.divergent_changed(['group1', 'group2'])
+
+    def test_divergent_changed_not_ours(self):
+        """
+        When notified that divergent groups have changed but they're not ours,
+        nothing is done.
+        """
+        dispatcher = SequenceDispatcher([])  # "nothing happens"
+        converger = self._converger(lambda *a, **kw: 1 / 0,
+                                    dispatcher=dispatcher)
+        self.fake_partitioner.current_state = PartitionState.ACQUIRED
+        converger.divergent_changed(['group1', 'group2'])
+
     def test_divergent_changed(self):
+        """
+        When notified that divergent groups have changed, and one of the groups
+        is associated with a bucket assigned to us, convergence is triggered.
+        """
         def converge_all_groups(log, group_locks, _my_buckets, all_buckets):
-            return Effect(Constant('foo'))
-        converger = self._converger(converge_all_groups)
-        converger.divergent_changed([], dispatcher=object())
+            return Effect('converge-all-groups')
+        dispatcher = SequenceDispatcher([
+            ('converge-all-groups', lambda i: None)
+        ])
+        converger = self._converger(converge_all_groups, dispatcher=dispatcher)
+        # sha1('group1') % 10 == 3
+        self.fake_partitioner.current_state = PartitionState.ACQUIRED
+        self.fake_partitioner.my_buckets = [3]
+        converger.divergent_changed(['group1', 'group2'])
+        self.assertEqual(dispatcher.sequence, [])  # All side-effects performed
 
 
 class ConvergeOneGroupTests(SynchronousTestCase):

--- a/otter/test/tap/test_api.py
+++ b/otter/test/tap/test_api.py
@@ -672,7 +672,6 @@ class ConvergerSetupTests(SynchronousTestCase):
         self.assertIs(partitioner.kz_client, kz_client)
         mock_watch_children.assert_called_once_with(
             kz_client, CONVERGENCE_DIRTY_DIR, converger.divergent_changed)
-        
 
 
 class SchedulerSetupTests(SynchronousTestCase):

--- a/otter/test/tap/test_api.py
+++ b/otter/test/tap/test_api.py
@@ -15,7 +15,8 @@ from twisted.internet.task import Clock
 from twisted.trial.unittest import SynchronousTestCase
 
 from otter.auth import CachingAuthenticator, SingleTenantAuthenticator
-from otter.constants import ServiceType, get_service_configs
+from otter.constants import (
+    CONVERGENCE_DIRTY_DIR, ServiceType, get_service_configs)
 from otter.convergence.service import Converger
 from otter.log.cloudfeeds import CloudFeedsObserver
 from otter.models.cass import CassScalingGroupCollection as OriginalStore
@@ -652,7 +653,8 @@ class APIMakeServiceTests(SynchronousTestCase):
 class ConvergerSetupTests(SynchronousTestCase):
     """Tests for :func:`setup_converger`."""
 
-    def test_setup_converger(self):
+    @mock.patch('otter.tap.api.watch_children')
+    def test_setup_converger(self, mock_watch_children):
         """
         Puts a :obj:`Converger` with a :obj:`Partitioner` in the given parent
         service.
@@ -668,6 +670,9 @@ class ConvergerSetupTests(SynchronousTestCase):
         self.assertIs(partitioner.__class__, Partitioner)
         self.assertIs(partitioner, converger.partitioner)
         self.assertIs(partitioner.kz_client, kz_client)
+        mock_watch_children.assert_called_once_with(
+            kz_client, CONVERGENCE_DIRTY_DIR, converger.divergent_changed)
+        
 
 
 class SchedulerSetupTests(SynchronousTestCase):

--- a/otter/test/util/test_zkpartitioner.py
+++ b/otter/test/util/test_zkpartitioner.py
@@ -2,6 +2,8 @@
 
 import mock
 
+from kazoo.recipe.partitioner import PartitionState
+
 from twisted.internet.task import Clock
 from twisted.trial.unittest import SynchronousTestCase
 
@@ -224,3 +226,17 @@ class PartitionerTests(SynchronousTestCase):
         self.assertEqual(
             self.successResultOf(self.partitioner.health_check()),
             (True, {'buckets': [2, 3]}))
+
+    def test_get_current_buckets(self):
+        """The current buckets can be retrieved."""
+        self.kz_partitioner.acquired = True
+        self.partitioner.startService()
+        self.kz_partitioner.__iter__.return_value = iter([2, 3])
+        self.assertEqual(self.partitioner.get_current_buckets(), [2, 3])
+
+    def test_get_current_state(self):
+        """The current state can be retrieved."""
+        self.kz_partitioner.state = PartitionState.ACQUIRED
+        self.partitioner.startService()
+        self.assertEqual(self.partitioner.get_current_state(),
+                         PartitionState.ACQUIRED)

--- a/otter/test/util/test_zkpartitioner.py
+++ b/otter/test/util/test_zkpartitioner.py
@@ -1,8 +1,8 @@
 """Tests for otter.util.zkpartitioner"""
 
-import mock
-
 from kazoo.recipe.partitioner import PartitionState
+
+import mock
 
 from twisted.internet.task import Clock
 from twisted.trial.unittest import SynchronousTestCase

--- a/otter/test/utils.py
+++ b/otter/test/utils.py
@@ -14,6 +14,8 @@ from effect.testing import (
     resolve_effect as eff_resolve_effect,
     resolve_stubs as eff_resolve_stubs)
 
+from kazoo.recipe.partitioner import PartitionState
+
 import mock
 
 from pyrsistent import freeze, pmap
@@ -702,16 +704,24 @@ def defaults_by_name(fn):
 
 class FakePartitioner(Service):
     """A fake version of a :obj:`Partitioner`."""
-    def __init__(self, log, callback):
+    def __init__(self, log, callback, current_state=PartitionState.ALLOCATING):
         self.log = log
         self.got_buckets = callback
-        self.health = (True, {'buckets': []})
+        self.my_buckets = []
+        self.health = (True, {'buckets': self.my_buckets})
+        self.current_state = current_state
+
+    def get_current_state(self):
+        return self.current_state
 
     def reset_path(self, new_path):
         return 'partitioner reset to {}'.format(new_path)
 
     def health_check(self):
         return defer.succeed(self.health)
+
+    def get_current_buckets(self):
+        return self.my_buckets
 
 
 def transform_eq(transformer, rhs):

--- a/otter/util/zkpartitioner.py
+++ b/otter/util/zkpartitioner.py
@@ -135,5 +135,10 @@ class Partitioner(MultiService):
         return succeed((True, {'buckets': self.get_current_buckets()}))
 
     def get_current_buckets(self):
-        """Retrieve the current buckets as a list."""
+        """
+        Retrieve the current buckets as a list.
+
+        This should only be relied on when the current partitioner state is
+        ``ACQUIRED``.
+        """
         return list(self.partitioner)

--- a/otter/util/zkpartitioner.py
+++ b/otter/util/zkpartitioner.py
@@ -47,6 +47,9 @@ class Partitioner(MultiService):
         ts.clock = clock
         self._old_buckets = []
 
+    def get_current_state(self):
+        return self.partitioner.state
+
     def _new_partitioner(self):
         return self.kz_client.SetPartitioner(
             self.partitioner_path,
@@ -97,13 +100,13 @@ class Partitioner(MultiService):
         if not self.partitioner.acquired:
             self.log.err(
                 'Unknown state {}. This cannot happen. Starting new'.format(
-                    self.partitioner.state),
+                    self.get_current_state()),
                 otter_msg_type='partition-invalid-state')
             self.partitioner.finish()
             self.partitioner = self._new_partitioner()
             return
 
-        buckets = self._get_current_buckets()
+        buckets = self.get_current_buckets()
         if buckets != self._old_buckets:
             self.log.msg('Got buckets {buckets}', buckets=buckets,
                          path=self.partitioner_path,
@@ -128,8 +131,8 @@ class Partitioner(MultiService):
             # during network issues.
             return succeed((False, {'reason': 'Not acquired'}))
 
-        return succeed((True, {'buckets': self._get_current_buckets()}))
+        return succeed((True, {'buckets': self.get_current_buckets()}))
 
-    def _get_current_buckets(self):
+    def get_current_buckets(self):
         """Retrieve the current buckets as a list."""
         return list(self.partitioner)

--- a/otter/util/zkpartitioner.py
+++ b/otter/util/zkpartitioner.py
@@ -48,6 +48,7 @@ class Partitioner(MultiService):
         self._old_buckets = []
 
     def get_current_state(self):
+        """Return the current partitioner state."""
         return self.partitioner.state
 
     def _new_partitioner(self):


### PR DESCRIPTION
Fixes #1236.

I had to modify ZKPartitioner to expose `get_current_state` and `get_current_buckets`, so we can make sure not to trigger convergence when we haven't acquired our buckets.

I also had to disable one test that was previously marked as `convergence='yes'`, because it was erroneously detecting a group that hadn't been converged yet as one that had been successfully force-deleted. This test relies on #1179 is fixed.

Other than that, this PR is pretty straightforward, and drastically speeds up the gating integration tests on my machine (~11m to ~5m).