### PR TITLE
DeleteServer returns RETRY instead of doing an additional gathering at the end of convergence

### DIFF
--- a/otter/convergence/service.py
+++ b/otter/convergence/service.py
@@ -132,15 +132,6 @@ def execute_convergence(tenant_id, group_id, log,
             results=zip(steps, results),
             worst_status=worst_status)
 
-    if worst_status == StepResult.SUCCESS:
-        # Do one last gathering + writing to `active` so we get updated
-        # based on any DELETEs or other stuff that happened.
-        (servers, lb_nodes) = yield gather_eff
-        active = determine_active(servers, lb_nodes)
-        yield _update_active(scaling_group, active)
-        # given that we're gathering in this case, wouldn't it make sense to
-        # also plan, and then to execute that plan if something is found...?
-
     yield do_return(worst_status)
 
 

--- a/otter/convergence/steps.py
+++ b/otter/convergence/steps.py
@@ -220,7 +220,7 @@ class DeleteServer(object):
             next_interval=exponential_backoff_interval(2))
 
         def report_success(result):
-            return StepResult.SUCCESS, []
+            return StepResult.RETRY, ['must re-gather after deletion']
 
         return eff.on(success=report_success)
 

--- a/otter/convergence/steps.py
+++ b/otter/convergence/steps.py
@@ -220,7 +220,9 @@ class DeleteServer(object):
             next_interval=exponential_backoff_interval(2))
 
         def report_success(result):
-            return StepResult.RETRY, ['must re-gather after deletion']
+            return StepResult.RETRY, [
+                'must re-gather after deletion in order to update the active '
+                'cache']
 
         return eff.on(success=report_success)
 

--- a/otter/test/convergence/test_service.py
+++ b/otter/test/convergence/test_service.py
@@ -5,7 +5,7 @@ from effect import (
     TypeDispatcher, base_dispatcher, sync_perform)
 from effect.async import perform_parallel_async
 from effect.ref import Reference, reference_dispatcher
-from effect.testing import EQDispatcher, EQFDispatcher, SequenceDispatcher
+from effect.testing import EQDispatcher, EQFDispatcher
 
 from kazoo.exceptions import BadVersionError
 
@@ -41,7 +41,6 @@ from otter.test.utils import (
     matches,
     mock_group, mock_log,
     raise_,
-    test_dispatcher,
     transform_eq)
 from otter.util.zk import CreateOrSet, DeleteNode, GetChildrenWithStats
 
@@ -664,72 +663,6 @@ class ExecuteConvergenceTests(SynchronousTestCase):
                                   get_all_convergence_data=gacd)
         dispatcher = self._get_dispatcher()
         self.assertEqual(sync_perform(dispatcher, eff), StepResult.FAILURE)
-
-    def _results_in_active(self, active):
-        """
-        Return a "transformer" that compares equal to a ``modifier`` function
-        as given to :obj:`ModifyGroupState` when modifying ``self.group`` and
-        ``self.state`` returns new state with the given ``active`` servers.
-        """
-        return transform_eq(
-            lambda modifier: modifier(self.group, self.state).active,
-            active)
-
-    def test_update_active_after_success(self):
-        """
-        When all steps are successful, one last gathering is performed and the
-        group's ``active`` servers are updated based on it, so that things like
-        successful server deletion get reflected in the active servers list.
-        """
-        log = mock_log()
-
-        def get_all_convergence_data(group_id):
-            return Effect(('get-all-data', group_id))
-
-        def plan(*args, **kwargs):
-            return pbag([TestStep(Effect('some-boring-step'))])
-
-        server1 = server('id1', ServerState.ACTIVE)
-        server2 = server('id2', ServerState.ACTIVE)
-
-        sequence = SequenceDispatcher([
-
-            # Look up group in Cass
-            (GetScalingGroupInfo(tenant_id='tenant-id', group_id='group-id'),
-             lambda i: (self.group, self.manifest)),
-
-            # gather convergence data
-            (('get-all-data', 'group-id'), lambda i: ([server1], [])),
-
-            # update active based on that data
-            (ModifyGroupState(
-                scaling_group=self.group,
-                modifier=self._results_in_active(
-                    {'id1': {'id': 'id1', 'links': []}})),
-             lambda i: None),
-
-            # run the steps
-            ('some-boring-step', lambda i: (StepResult.SUCCESS, [])),
-
-            # gather convergence data again, since everything was SUCCESS
-            (('get-all-data', 'group-id'), lambda i: ([server1, server2], [])),
-
-            # update active on the group with the new results
-            (ModifyGroupState(
-                scaling_group=self.group,
-                modifier=self._results_in_active(
-                    {'id1': {'id': 'id1', 'links': []},
-                     'id2': {'id': 'id2', 'links': []}})),
-             lambda i: None),
-        ])
-
-        dispatcher = ComposedDispatcher([test_dispatcher(), sequence])
-
-        eff = execute_convergence(
-            self.tenant_id, self.group_id, log,
-            plan=plan,
-            get_all_convergence_data=get_all_convergence_data)
-        self.assertEqual(sync_perform(dispatcher, eff), StepResult.SUCCESS)
 
 
 class DetermineActiveTests(SynchronousTestCase):

--- a/otter/test/convergence/test_steps.py
+++ b/otter/test/convergence/test_steps.py
@@ -326,7 +326,9 @@ class DeleteServerTests(SynchronousTestCase):
 
         self.assertEqual(
             resolve_effect(eff, (None, {})),
-            (StepResult.RETRY, ['must re-gather after deletion']))
+            (StepResult.RETRY, [
+                'must re-gather after deletion in order to update the active '
+                'cache']))
 
     def test_delete_and_verify_del_404(self):
         """

--- a/otter/test/convergence/test_steps.py
+++ b/otter/test/convergence/test_steps.py
@@ -326,7 +326,7 @@ class DeleteServerTests(SynchronousTestCase):
 
         self.assertEqual(
             resolve_effect(eff, (None, {})),
-            (StepResult.SUCCESS, []))
+            (StepResult.RETRY, ['must re-gather after deletion']))
 
     def test_delete_and_verify_del_404(self):
         """


### PR DESCRIPTION
It turns out I had a big brain-fart when fixing #1234. It's fine for DeleteServer to return RETRY to indicate that we should do another gathering after a successful deletion. And so we don't need to explicitly perform one last gathering after a successful convergence.