### PR TITLE
Convergence delete server

### DIFF
--- a/otter/controller.py
+++ b/otter/controller.py
@@ -20,13 +20,14 @@ Storage model for state information:
  * last touched information for group
  * last touched information for policy
 """
+import json
 from datetime import datetime
 from decimal import Decimal, ROUND_UP
-import iso8601
-import json
 
 from effect import Effect, parallel_all_errors
 from effect.do import do, do_return
+
+import iso8601
 
 from six import reraise
 
@@ -39,10 +40,10 @@ from otter.cloud_client import (
     get_server_details,
     set_nova_metadata_item)
 from otter.convergence.composition import tenant_is_enabled
+from otter.convergence.model import DRAINING_METADATA, group_id_from_metadata
 from otter.convergence.service import get_convergence_starter
 from otter.json_schema.group_schemas import MAX_ENTITIES
 from otter.log import audit
-from otter.convergence.model import DRAINING_METADATA, group_id_from_metadata
 from otter.models.intents import GetScalingGroupInfo
 from otter.supervisor import (
     CannotDeleteServerBelowMinError,

--- a/otter/controller.py
+++ b/otter/controller.py
@@ -44,6 +44,7 @@ from otter.convergence.model import DRAINING_METADATA, group_id_from_metadata
 from otter.convergence.service import get_convergence_starter
 from otter.json_schema.group_schemas import MAX_ENTITIES
 from otter.log import audit
+from otter.models.interface import GroupState
 from otter.models.intents import GetScalingGroupInfo
 from otter.supervisor import (
     CannotDeleteServerBelowMinError,
@@ -453,6 +454,9 @@ def convergence_remove_server_from_group(
     yield retry_effect(eff, retry_times(3), exponential_backoff_interval(2))
 
     if not replace:
-        state.desired -= 1
-
-    yield do_return(state)
+        yield do_return(GroupState(
+            state.tenant_id, state.group_id, state.group_name, state.active,
+            state.pending, state.group_touched, state.policy_touched,
+            state.paused, state.desired - 1, state.now))
+    else:
+        yield do_return(state)

--- a/otter/controller.py
+++ b/otter/controller.py
@@ -393,7 +393,7 @@ def _is_server_in_group(group, server_id):
 
 
 @do
-def _can_maybe_scale_down(group, server_id):
+def _can_scale_down(group, server_id):
     """
     Given a group and a server ID, determines if the group can be scaled down.
     If not, it raises a :class:`CannotDeleteServerBelowMinError`.
@@ -433,7 +433,7 @@ def convergence_remove_server_from_group(
     """
     effects = [_is_server_in_group(group, server_id)]
     if not replace:
-        effects.append(_can_maybe_scale_down(group, server_id))
+        effects.append(_can_scale_down(group, server_id))
 
     # the (possibly) two checks can happen in parallel, but we want
     # ServerNotFoundError to take precedence over

--- a/otter/controller.py
+++ b/otter/controller.py
@@ -44,7 +44,6 @@ from otter.convergence.model import DRAINING_METADATA, group_id_from_metadata
 from otter.convergence.service import get_convergence_starter
 from otter.json_schema.group_schemas import MAX_ENTITIES
 from otter.log import audit
-from otter.models.interface import GroupState
 from otter.models.intents import GetScalingGroupInfo
 from otter.supervisor import (
     CannotDeleteServerBelowMinError,
@@ -54,6 +53,7 @@ from otter.supervisor import (
     execute_launch_config)
 from otter.util.config import config_value
 from otter.util.deferredutils import unwrap_first_error
+from otter.util.fp import assoc_obj
 from otter.util.retry import (
     exponential_backoff_interval,
     retry_effect,
@@ -454,9 +454,6 @@ def convergence_remove_server_from_group(
     yield retry_effect(eff, retry_times(3), exponential_backoff_interval(2))
 
     if not replace:
-        yield do_return(GroupState(
-            state.tenant_id, state.group_id, state.group_name, state.active,
-            state.pending, state.group_touched, state.policy_touched,
-            state.paused, state.desired - 1, state.now))
+        yield do_return(assoc_obj(state, desired=state.desired - 1))
     else:
         yield do_return(state)

--- a/otter/controller.py
+++ b/otter/controller.py
@@ -411,7 +411,7 @@ def _can_scale_down(group, server_id):
 
 @do
 def convergence_remove_server_from_group(
-        group, state, server_id, replace, purge):
+        log, transaction_id, group, state, server_id, replace, purge):
     """
     Remove a specific server from the group, optionally decrementing the
     desired capacity.
@@ -419,6 +419,8 @@ def convergence_remove_server_from_group(
     The server may just be scheduled for deletion, or it may be evicted from
     the group by removing otter-specific metdata from the server.
 
+    :param log: A bound logger
+    :param bytes transaction_id: The transaction id for this operation.
     :param group: The scaling group to remove a server from.
     :type group: :class:`~otter.models.interface.IScalingGroup`
     :param bytes server_id: The id of the server to be removed.
@@ -449,7 +451,9 @@ def convergence_remove_server_from_group(
         eff = set_nova_metadata_item(server_id, *DRAINING_METADATA)
     else:
         eff = Effect(
-            EvictServerFromScalingGroup(scaling_group=group,
+            EvictServerFromScalingGroup(log=log,
+                                        transaction_id=transaction_id,
+                                        scaling_group=group,
                                         server_id=server_id))
     yield retry_effect(eff, retry_times(3), exponential_backoff_interval(2))
 

--- a/otter/convergence/service.py
+++ b/otter/convergence/service.py
@@ -223,13 +223,13 @@ class ConvergenceStarter(object):
     for that).
     """
     def __init__(self, dispatcher):
-        self._dispatcher = dispatcher
+        self.dispatcher = dispatcher
 
     def start_convergence(self, log, tenant_id, group_id, perform=perform):
         """Record that a group needs converged by creating a ZooKeeper node."""
         log = log.bind(tenant_id=tenant_id, group_id=group_id)
         eff = mark_divergent(tenant_id, group_id)
-        d = perform(self._dispatcher, eff)
+        d = perform(self.dispatcher, eff)
 
         def success(r):
             log.msg('mark-dirty-success')

--- a/otter/convergence/service.py
+++ b/otter/convergence/service.py
@@ -223,13 +223,13 @@ class ConvergenceStarter(object):
     for that).
     """
     def __init__(self, dispatcher):
-        self.dispatcher = dispatcher
+        self._dispatcher = dispatcher
 
     def start_convergence(self, log, tenant_id, group_id, perform=perform):
         """Record that a group needs converged by creating a ZooKeeper node."""
         log = log.bind(tenant_id=tenant_id, group_id=group_id)
         eff = mark_divergent(tenant_id, group_id)
-        d = perform(self.dispatcher, eff)
+        d = perform(self._dispatcher, eff)
 
         def success(r):
             log.msg('mark-dirty-success')

--- a/otter/supervisor.py
+++ b/otter/supervisor.py
@@ -698,10 +698,10 @@ class EvictServerFromScalingGroup(object):
 @deferred_performer
 def perform_evict_server(log, transaction_id, dispatcher, intent):
     """
-    Performs evicting a server from the group.
+    Perform evicting a server from the group.
     """
     supervisor = get_supervisor()
     return supervisor.scrub_otter_metadata(
-            log, transaction_id,
-            intent.scaling_group.tenant_id,
-            intent.server_id)
+        log, transaction_id,
+        intent.scaling_group.tenant_id,
+        intent.server_id)

--- a/otter/supervisor.py
+++ b/otter/supervisor.py
@@ -687,7 +687,7 @@ def remove_server_from_group(log, trans_id, server_id, replace, purge, group, st
     return d
 
 
-@attributes(['scaling_group', 'server_id'])
+@attributes(['log', 'transaction_id', 'scaling_group', 'server_id'])
 class EvictServerFromScalingGroup(object):
     """
     An Effect intent which indicates that a server should be evicted from a
@@ -696,12 +696,11 @@ class EvictServerFromScalingGroup(object):
 
 
 @deferred_performer
-def perform_evict_server(log, transaction_id, dispatcher, intent):
+def perform_evict_server(supervisor, dispatcher, intent):
     """
     Perform evicting a server from the group.
     """
-    supervisor = get_supervisor()
     return supervisor.scrub_otter_metadata(
-        log, transaction_id,
+        intent.log, intent.transaction_id,
         intent.scaling_group.tenant_id,
         intent.server_id)

--- a/otter/supervisor.py
+++ b/otter/supervisor.py
@@ -6,6 +6,8 @@ This code is specific to the launch_server_v1 worker.
 
 from characteristic import attributes
 
+from effect.twisted import deferred_performer
+
 from twisted.application.service import Service
 from twisted.internet import reactor
 from twisted.internet.defer import succeed
@@ -683,3 +685,22 @@ def remove_server_from_group(log, trans_id, server_id, replace, purge, group, st
 
     d.addCallback(remove_server_from_state)
     return d
+
+
+@attributes(['scaling_group', 'server_id'])
+class EvictServerFromScalingGroup(object):
+    """
+    An Effect intent which indicates that a server should be evicted from a
+    particular group.
+    """
+
+
+@deferred_performer
+def perform_evict_server(log, transaction_id, dispatcher, intent):
+    """
+    Performs evicting a server from the group.
+    """
+    supervisor = get_supervisor()
+    return supervisor.scrub_otter_metadata(
+            log, transaction_id, intent.scaling_group.tenant_id,
+            intent.server_id)

--- a/otter/supervisor.py
+++ b/otter/supervisor.py
@@ -702,5 +702,6 @@ def perform_evict_server(log, transaction_id, dispatcher, intent):
     """
     supervisor = get_supervisor()
     return supervisor.scrub_otter_metadata(
-            log, transaction_id, intent.scaling_group.tenant_id,
+            log, transaction_id,
+            intent.scaling_group.tenant_id,
             intent.server_id)

--- a/otter/test/test_controller.py
+++ b/otter/test/test_controller.py
@@ -1231,7 +1231,8 @@ class ConvergenceRemoveServerTests(SynchronousTestCase):
             dispatcher])
 
         eff = controller.convergence_remove_server_from_group(
-            self.group, self.state, 'server_id', replace, purge)
+            self.log, self.trans_id, self.group, self.state, 'server_id',
+            replace, purge)
         return sync_perform(full_dispatcher, eff)
 
     def test_no_such_server_replace_true(self):
@@ -1383,7 +1384,9 @@ class ConvergenceRemoveServerTests(SynchronousTestCase):
         dispatcher = SequenceDispatcher([
             (get_server_details('server_id').intent,
                 lambda _: self.server_details),
-            (EvictServerFromScalingGroup(scaling_group=self.group,
+            (EvictServerFromScalingGroup(log=self.log,
+                                         transaction_id=self.trans_id,
+                                         scaling_group=self.group,
                                          server_id='server_id'),
                 lambda _: None)
         ])
@@ -1404,7 +1407,9 @@ class ConvergenceRemoveServerTests(SynchronousTestCase):
                 lambda _: self.server_details),
             (GetScalingGroupInfo(tenant_id='tenant_id', group_id='group_id'),
                 lambda _: self.group_manifest_info),
-            (EvictServerFromScalingGroup(scaling_group=self.group,
+            (EvictServerFromScalingGroup(log=self.log,
+                                         transaction_id=self.trans_id,
+                                         scaling_group=self.group,
                                          server_id='server_id'),
                 lambda _: None)
         ])
@@ -1422,7 +1427,9 @@ class ConvergenceRemoveServerTests(SynchronousTestCase):
         dispatcher = SequenceDispatcher([
             (get_server_details('server_id').intent,
                 lambda _: self.server_details),
-            (EvictServerFromScalingGroup(scaling_group=self.group,
+            (EvictServerFromScalingGroup(log=self.log,
+                                         transaction_id=self.trans_id,
+                                         scaling_group=self.group,
                                          server_id='server_id'),
                 lambda _: raise_(ValueError('oops')))
         ])

--- a/otter/test/test_controller.py
+++ b/otter/test/test_controller.py
@@ -1,7 +1,7 @@
 """
 Tests for :mod:`otter.controller`
 """
-from datetime import timedelta, datetime
+from datetime import datetime, timedelta
 
 from effect import (
     ComposedDispatcher,
@@ -32,16 +32,16 @@ from otter.supervisor import (
     CannotDeleteServerBelowMinError,
     EvictServerFromScalingGroup,
     ServerNotFoundError)
-from otter.util.retry import (
-    Retry, ShouldDelayAndRetry, exponential_backoff_interval, retry_times)
-from otter.util.timestamp import MIN
 from otter.test.utils import (
     iMock,
     matches,
-    patch,
     mock_log,
+    patch,
     raise_,
     test_dispatcher)
+from otter.util.retry import (
+    Retry, ShouldDelayAndRetry, exponential_backoff_interval, retry_times)
+from otter.util.timestamp import MIN
 
 
 class CalculateDeltaTestCase(SynchronousTestCase):

--- a/otter/test/test_controller.py
+++ b/otter/test/test_controller.py
@@ -20,12 +20,18 @@ from twisted.trial.unittest import SynchronousTestCase
 from otter import controller
 from otter.cloud_client import (
     NoSuchServerError,
-    get_server_details)
+    get_server_details,
+    set_nova_metadata_item)
+from otter.convergence.model import DRAINING_METADATA
 from otter.convergence.service import (
     get_convergence_starter, set_convergence_starter)
+from otter.models.intents import GetScalingGroupInfo
 from otter.models.interface import (
     GroupState, IScalingGroup, NoSuchPolicyError)
-from otter.supervisor import ServerNotFoundError
+from otter.supervisor import (
+    CannotDeleteServerBelowMinError,
+    EvictServerFromScalingGroup,
+    ServerNotFoundError)
 from otter.util.retry import (
     Retry, ShouldDelayAndRetry, exponential_backoff_interval, retry_times)
 from otter.util.timestamp import MIN
@@ -1180,6 +1186,20 @@ class ConvergenceRemoveServerTests(SynchronousTestCase):
                                 desired=1)
         self.group = iMock(IScalingGroup, tenant_id='tenant_id',
                            uuid='group_id')
+        self.server_details = {
+            'server': {
+                'id': 'server_id',
+                'metadata': {
+                    'rax:autoscale:group:id': 'group_id',
+                    'rax:auto_scaling_group_id': 'group_id'
+                }
+            }
+        }
+        self.group_manifest_info = {
+            'groupConfiguration': {'minEntities': 0},
+            'launchConfiguration': {'this is not used': 'here'},
+            'state': self.state
+        }
 
     def _remove(self, replace, purge, dispatcher):
         # Retry intents can't really be compared if the effect inside
@@ -1206,46 +1226,194 @@ class ConvergenceRemoveServerTests(SynchronousTestCase):
     def test_no_such_server_replace_true(self):
         """
         If there is no such server at all in Nova, a
-        :class:`ServerNotFoundError` is returned.  No additional checking
+        :class:`ServerNotFoundError` is raised.  No additional checking
         for config is needed because replace is set True.
         """
         dispatcher = SequenceDispatcher([
             (get_server_details('server_id').intent,
-                lambda i: raise_(NoSuchServerError(server_id=u'server_id')))
+                lambda _: raise_(NoSuchServerError(server_id=u'server_id')))
         ])
         self.assertRaises(
             ServerNotFoundError, self._remove, True, False, dispatcher)
+        self.assertEqual(dispatcher.sequence, [])
 
     def test_server_not_autoscale_server_replace_true(self):
         """
         If there is such a server in Nova, but it does not have
         autoscale-specific metadata, then :class:`ServerNotFoundError` is
-        returned.  No additional checking for config is needed because
+        raised.  No additional checking for config is needed because
         replace is set True.
         """
+        self.server_details['server'].pop('metadata')
         dispatcher = SequenceDispatcher([
             (get_server_details('server_id').intent,
-                lambda i: {'server': {'id': 'server_id'}})
+                lambda _: self.server_details)
         ])
         self.assertRaises(
             ServerNotFoundError, self._remove, True, False, dispatcher)
+        self.assertEqual(dispatcher.sequence, [])
 
     def test_server_in_wrong_group_replace_true(self):
         """
         If there is such a server in Nova, but it belongs to a different group,
-        then :class:`ServerNotFoundError` is returned.  No additional checking
+        then :class:`ServerNotFoundError` is raised.  No additional checking
         for config is needed because replace is set True.
         """
-        server_json = {
-            'id': 'server_id',
-            'metadata': {
-                'rax:autoscale:group:id': 'other_group_id',
-                'rax:auto_scaling_group_id': 'other_group_id'
-            }
+        self.server_details['server']['metadata'] = {
+            'rax:autoscale:group:id': 'other_group_id',
+            'rax:auto_scaling_group_id': 'other_group_id'
         }
 
         dispatcher = SequenceDispatcher([
-            (get_server_details('server_id').intent, lambda i: server_json)
+            (get_server_details('server_id').intent,
+                lambda _: self.server_details)
         ])
         self.assertRaises(
             ServerNotFoundError, self._remove, True, False, dispatcher)
+        self.assertEqual(dispatcher.sequence, [])
+
+    def test_server_in_group_cannot_scale_down(self):
+        """
+        If ``replace=False`` a check is done to see if the group can be scaled
+        down by 1.  If not, then removing fails with a
+        :class:`CannotExecutePolicyError` even if the server is in the group.
+        """
+        self.state.desired = 1
+        self.group_manifest_info['groupConfiguration']['minEntities'] = 1
+        dispatcher = SequenceDispatcher([
+            (get_server_details('server_id').intent,
+                lambda _: self.server_details),
+            (GetScalingGroupInfo(tenant_id='tenant_id', group_id='group_id'),
+                lambda _: self.group_manifest_info)
+        ])
+        self.assertRaises(
+            CannotDeleteServerBelowMinError, self._remove, False, False,
+            dispatcher)
+        self.assertEqual(dispatcher.sequence, [])
+
+    def test_server_not_in_group_cannot_scale_down(self):
+        """
+        If both the server check and the scaling down check fail,
+        the exception that gets raised is :class:`ServerNotFoundError`.
+        """
+        self.server_details['server'].pop('metadata')
+        self.state.desired = 1
+        self.group_manifest_info['groupConfiguration']['minEntities'] = 1
+        dispatcher = SequenceDispatcher([
+            (get_server_details('server_id').intent,
+                lambda _: self.server_details),
+            (GetScalingGroupInfo(tenant_id='tenant_id', group_id='group_id'),
+                lambda _: self.group_manifest_info)
+        ])
+        self.assertRaises(
+            ServerNotFoundError, self._remove, False, False, dispatcher)
+        self.assertEqual(dispatcher.sequence, [])
+
+    def test_checks_pass_replace_true_purge_success(self):
+        """
+        If all the checks pass, and purge is true, then "DRAINING" is added
+        to the server's metadata.  If this is successful, then the whole
+        effect is a success, and returns same state the function was called
+        with.
+        """
+        dispatcher = SequenceDispatcher([
+            (get_server_details('server_id').intent,
+                lambda _: self.server_details),
+            (set_nova_metadata_item('server_id', *DRAINING_METADATA).intent,
+                lambda _: None)
+        ])
+        result = self._remove(True, True, dispatcher)
+        self.assertEqual(result, self.state)
+        self.assertEqual(dispatcher.sequence, [])
+
+    def test_checks_pass_replace_false_purge_success(self):
+        """
+        If all the checks pass, and purge is true and replace is false, then
+        "DRAINING" is added to the server's metadata.  If this is successful,
+        then the whole effect is a success, and returns the state the function
+        was called with, with the desired value decremented.
+        """
+        old_desired = self.state.desired = 2
+        dispatcher = SequenceDispatcher([
+            (get_server_details('server_id').intent,
+                lambda _: self.server_details),
+            (GetScalingGroupInfo(tenant_id='tenant_id', group_id='group_id'),
+                lambda _: self.group_manifest_info),
+            (set_nova_metadata_item('server_id', *DRAINING_METADATA).intent,
+                lambda _: None)
+        ])
+        result = self._remove(False, True, dispatcher)
+        self.assertEqual(result, self.state)
+        self.assertEqual(result.desired, old_desired - 1)
+        self.assertEqual(dispatcher.sequence, [])
+
+    def test_checks_pass_replace_true_purge_failure(self):
+        """
+        If all the checks pass, and purge is true, then "DRAINING" is added
+        to the server's metadata.  If this fails, then the failure is
+        propagated and the state is not returned.
+        """
+        dispatcher = SequenceDispatcher([
+            (get_server_details('server_id').intent,
+                lambda _: self.server_details),
+            (set_nova_metadata_item('server_id', *DRAINING_METADATA).intent,
+                lambda _: raise_(ValueError('oops!')))
+        ])
+        self.assertRaises(ValueError, self._remove, True, True, dispatcher)
+        self.assertEqual(dispatcher.sequence, [])
+
+    def test_checks_pass_replace_true_no_purge_success(self):
+        """
+        If all the checks pass, and purge is false, then autoscale-specific
+        metadata is removed from the server's metadata.  If this is successful,
+        then the whole effect is a success, and returns same state the function
+        was called with.
+        """
+        dispatcher = SequenceDispatcher([
+            (get_server_details('server_id').intent,
+                lambda _: self.server_details),
+            (EvictServerFromScalingGroup(scaling_group=self.group,
+                                         server_id='server_id'),
+                lambda _: None)
+        ])
+        result = self._remove(True, False, dispatcher)
+        self.assertEqual(result, self.state)
+        self.assertEqual(dispatcher.sequence, [])
+
+    def test_checks_pass_replace_false_no_purge_success(self):
+        """
+        If all the checks pass, and purge is true and replace is false, then
+        "DRAINING" is added to the server's metadata.  If this is successful,
+        then the whole effect is a success, and returns the state the function
+        was called with, with the desired value decremented.
+        """
+        old_desired = self.state.desired = 2
+        dispatcher = SequenceDispatcher([
+            (get_server_details('server_id').intent,
+                lambda _: self.server_details),
+            (GetScalingGroupInfo(tenant_id='tenant_id', group_id='group_id'),
+                lambda _: self.group_manifest_info),
+            (EvictServerFromScalingGroup(scaling_group=self.group,
+                                         server_id='server_id'),
+                lambda _: None)
+        ])
+        result = self._remove(False, False, dispatcher)
+        self.assertEqual(result, self.state)
+        self.assertEqual(result.desired, old_desired - 1)
+        self.assertEqual(dispatcher.sequence, [])
+
+    def test_checks_pass_replace_true_no_purge_failure(self):
+        """
+        If all the checks pass, and purge is true, then "DRAINING" is added
+        to the server's metadata.  If this fails, then the failure is
+        propagated and the state is not returned.
+        """
+        dispatcher = SequenceDispatcher([
+            (get_server_details('server_id').intent,
+                lambda _: self.server_details),
+            (EvictServerFromScalingGroup(scaling_group=self.group,
+                                         server_id='server_id'),
+                lambda _: raise_(ValueError('oops')))
+        ])
+        self.assertRaises(ValueError, self._remove, True, False, dispatcher)
+        self.assertEqual(dispatcher.sequence, [])

--- a/otter/test/test_controller.py
+++ b/otter/test/test_controller.py
@@ -1201,6 +1201,17 @@ class ConvergenceRemoveServerTests(SynchronousTestCase):
             'state': self.state
         }
 
+    def assert_states_equivalent_except_desired(self, state1, state2):
+        """
+        Compare the given states and check that all the attributes except
+        ``desired`` are equivalent.
+        """
+        for attribute in ("tenant_id", "group_id", "group_name", "active",
+                          "pending", "group_touched", "policy_touched",
+                          "paused"):
+            self.assertEqual(getattr(state1, attribute),
+                             getattr(state2, attribute))
+
     def _remove(self, replace, purge, dispatcher):
         # Retry intents can't really be compared if the effect inside
         # has callbacks, so just unpack and assert something about the retry
@@ -1343,7 +1354,7 @@ class ConvergenceRemoveServerTests(SynchronousTestCase):
                 lambda _: None)
         ])
         result = self._remove(False, True, dispatcher)
-        self.assertEqual(result, self.state)
+        self.assert_states_equivalent_except_desired(result, self.state)
         self.assertEqual(result.desired, old_desired - 1)
         self.assertEqual(dispatcher.sequence, [])
 
@@ -1398,7 +1409,7 @@ class ConvergenceRemoveServerTests(SynchronousTestCase):
                 lambda _: None)
         ])
         result = self._remove(False, False, dispatcher)
-        self.assertEqual(result, self.state)
+        self.assert_states_equivalent_except_desired(result, self.state)
         self.assertEqual(result.desired, old_desired - 1)
         self.assertEqual(dispatcher.sequence, [])
 

--- a/otter/test/test_supervisor.py
+++ b/otter/test/test_supervisor.py
@@ -1263,7 +1263,7 @@ class PerformEvictionTests(SynchronousTestCase):
     """
     def test_perform_eviction(self):
         """
-        Calls supervisor's scrub metadata function.
+        Call supervisor's scrub metadata function.
         """
         supervisor = FakeSupervisor()
         set_supervisor(supervisor)
@@ -1271,12 +1271,14 @@ class PerformEvictionTests(SynchronousTestCase):
 
         log, group = (object(), mock_group(None))
         intent = EvictServerFromScalingGroup(
+            log=log, transaction_id='transaction_id',
             scaling_group=group, server_id='server_id')
 
         r = sync_perform(
             TypeDispatcher({
                 EvictServerFromScalingGroup: partial(
-                    perform_evict_server, log, "transaction_id")}),
+                    perform_evict_server, supervisor)
+            }),
             Effect(intent))
 
         self.assertIsNone(r)

--- a/otter/test/test_supervisor.py
+++ b/otter/test/test_supervisor.py
@@ -1,10 +1,15 @@
 """
 Tests for the worker supervisor.
 """
+from functools import partial
 
 from effect import Constant, Effect
 
 import mock
+
+from effect import Effect, TypeDispatcher, sync_perform
+from effect.testing import resolve_effect
+
 
 from testtools.matchers import ContainsDict, Equals, IsInstance
 
@@ -21,8 +26,14 @@ from otter.constants import ServiceType
 from otter.models.interface import (
     GroupState, IScalingGroup, NoSuchScalingGroupError)
 from otter.supervisor import (
-    CannotDeleteServerBelowMinError, ISupervisor, ServerNotFoundError,
-    SupervisorService, execute_launch_config, remove_server_from_group,
+    CannotDeleteServerBelowMinError,
+    EvictServerFromScalingGroup,
+    ISupervisor,
+    ServerNotFoundError,
+    SupervisorService,
+    execute_launch_config,
+    perform_evict_server,
+    remove_server_from_group,
     set_supervisor)
 from otter.test.utils import (
     CheckFailure, DummyException, FakeSupervisor, IsBoundWith, iMock, matches,
@@ -1248,3 +1259,31 @@ class RemoveServerTests(SynchronousTestCase):
         self._assert_create_scheduled(state)
         self._assert_metadata_scrubbing_scheduled()
         self.assertEqual(state.desired, 1)
+
+
+class PerformEvictionTests(SynchronousTestCase):
+    """
+    Tests for :func:`perform_evict_server` function
+    """
+    def test_perform_eviction(self):
+        """
+        Calls supervisor's scrub metadata function.
+        """
+        supervisor = FakeSupervisor()
+        set_supervisor(supervisor)
+        self.addCleanup(set_supervisor, None)
+
+        log, group = (object(), mock_group(None))
+        intent = EvictServerFromScalingGroup(
+            scaling_group=group, server_id='server_id')
+
+        r = sync_perform(
+            TypeDispatcher({
+                EvictServerFromScalingGroup: partial(
+                    perform_evict_server, log, "transaction_id")}),
+            Effect(intent))
+
+        self.assertIsNone(r)
+        self.assertEqual(
+            supervisor.scrub_calls,
+            [(log, "transaction_id", group.tenant_id, 'server_id')])

--- a/otter/test/test_supervisor.py
+++ b/otter/test/test_supervisor.py
@@ -3,13 +3,9 @@ Tests for the worker supervisor.
 """
 from functools import partial
 
-from effect import Constant, Effect
+from effect import Constant, Effect, TypeDispatcher, sync_perform
 
 import mock
-
-from effect import Effect, TypeDispatcher, sync_perform
-from effect.testing import resolve_effect
-
 
 from testtools.matchers import ContainsDict, Equals, IsInstance
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ jsonfig==0.1.1
 testtools==0.9.32
 croniter==0.3.5
 txkazoo==0.0.6b2
-effect==0.1a15
+effect==0.1a16
 characteristic==14.3.0
 toolz==0.7.1
 pyrsistent==0.7.0


### PR DESCRIPTION
Part of fixing #1238.

This provides a convergence-specific implementation for removing a server from the scaling group - we can't just check the DB for the server, because that is a cache of servers.  Nova is the source of truth.

And we just have to set the server metadata to DRAINING and kick off a convergence cycle (which will be done in the next PR, which will have a `remove_server_from_scaling_group` function that dispatches to either the supervisor function or this one which.

The branch I'm working towards for the next PR (it still has bits of code from this PR) is:  https://github.com/rackerlabs/otter/compare/delete_server_with_convergence

Review questions:
- Should this live in the controller?  I didn't know where else to put it - maybe it should be in a different file instead
- Wondering about whether it's worthwhile to do the check in parallel
- I just randomly picked a retry value - not sure if we should do 3 times with exponential backoff, since we probably want to block the delete request until all these checks and metadata setting are finished.