### PR TITLE
only `stat` dirty nodes that we really need to 

### DIFF
--- a/otter/test/convergence/test_service.py
+++ b/otter/test/convergence/test_service.py
@@ -1,10 +1,8 @@
-from functools import partial
-
 from effect import (
     ComposedDispatcher, Constant, Effect, Error, Func, ParallelEffects,
     TypeDispatcher, base_dispatcher, sync_perform)
 from effect.async import perform_parallel_async
-from effect.ref import Reference, reference_dispatcher
+from effect.ref import ReadReference, ModifyReference, Reference, reference_dispatcher
 from effect.testing import EQDispatcher, EQFDispatcher, SequenceDispatcher
 
 from kazoo.exceptions import BadVersionError
@@ -28,7 +26,6 @@ from otter.convergence.service import (
     converge_all_groups,
     converge_one_group,
     determine_active, execute_convergence, get_my_divergent_groups,
-    make_lock_set,
     non_concurrently)
 from otter.convergence.steps import ConvergeLater
 from otter.models.intents import (
@@ -42,8 +39,9 @@ from otter.test.utils import (
     matches,
     mock_group, mock_log,
     raise_,
+    test_dispatcher,
     transform_eq)
-from otter.util.zk import CreateOrSet, DeleteNode, GetChildrenWithStats
+from otter.util.zk import CreateOrSet, DeleteNode, GetChildren, GetStat
 
 
 class ConvergenceStarterTests(SynchronousTestCase):
@@ -102,9 +100,11 @@ class ConvergerTests(SynchronousTestCase):
         When buckets are allocated, the result of converge_all_groups is
         performed.
         """
-        def converge_all_groups(log, group_locks, _my_buckets, all_buckets):
-            self.assertEqual(log, matches(IsBoundWith(system='converger')))
-            self.assertIs(group_locks, converger.group_locks)
+        def converge_all_groups(log, currently_converging, _my_buckets,
+                                all_buckets):
+            self.assertEqual(log,
+                             matches(IsBoundWith(otter_service='converger')))
+            self.assertIs(currently_converging, converger.currently_converging)
             self.assertEqual(_my_buckets, my_buckets)
             self.assertEqual(all_buckets, self.buckets)
             return Effect(Constant('foo'))
@@ -120,7 +120,8 @@ class ConvergerTests(SynchronousTestCase):
         Errors raised from performing the converge_all_groups effect are
         logged, and None is the ultimate result.
         """
-        def converge_all_groups(log, group_locks, _my_buckets, all_buckets):
+        def converge_all_groups(log, currently_converging, _my_buckets,
+                                all_buckets):
             return Effect(Error(RuntimeError('foo')))
 
         self._converger(converge_all_groups)
@@ -129,7 +130,7 @@ class ConvergerTests(SynchronousTestCase):
         self.assertEqual(self.successResultOf(result), None)
         self.log.err.assert_called_once_with(
             CheckFailureValue(RuntimeError('foo')),
-            'converge-all-groups-error', system='converger')
+            'converge-all-groups-error', otter_service='converger')
 
     def test_divergent_changed_not_acquired(self):
         """
@@ -157,7 +158,8 @@ class ConvergerTests(SynchronousTestCase):
         When notified that divergent groups have changed, and one of the groups
         is associated with a bucket assigned to us, convergence is triggered.
         """
-        def converge_all_groups(log, group_locks, _my_buckets, all_buckets):
+        def converge_all_groups(log, currently_converging, _my_buckets,
+                                all_buckets):
             return Effect('converge-all-groups')
         dispatcher = SequenceDispatcher([
             ('converge-all-groups', lambda i: None)
@@ -201,7 +203,7 @@ class ConvergeOneGroupTests(SynchronousTestCase):
             return Effect(Func(p))
 
         eff = converge_one_group(
-            self.log, make_lock_set(), self.tenant_id, self.group_id,
+            self.log, Reference(pset()), self.tenant_id, self.group_id,
             self.version,
             execute_convergence=execute_convergence)
         result = sync_perform(self.dispatcher, eff)
@@ -226,9 +228,9 @@ class ConvergeOneGroupTests(SynchronousTestCase):
         def execute_convergence(tenant_id, group_id, log):
             return Effect(Func(lambda: calls.append('should not be run')))
 
-        lock_set = partial(non_concurrently, Reference(pset([self.group_id])))
+        currently_converging = Reference(pset([self.group_id]))
         eff = converge_one_group(
-            self.log, lock_set, self.tenant_id,
+            self.log, currently_converging, self.tenant_id,
             self.group_id, self.version,
             execute_convergence=execute_convergence)
         result = sync_perform(self.dispatcher, eff)
@@ -246,7 +248,7 @@ class ConvergeOneGroupTests(SynchronousTestCase):
             return Effect(Error(NoSuchScalingGroupError(tenant_id, group_id)))
 
         eff = converge_one_group(
-            self.log, make_lock_set(), self.tenant_id, self.group_id,
+            self.log, Reference(pset()), self.tenant_id, self.group_id,
             self.version,
             execute_convergence=execute_convergence)
         result = sync_perform(self.dispatcher, eff)
@@ -271,7 +273,7 @@ class ConvergeOneGroupTests(SynchronousTestCase):
             return Effect(Error(RuntimeError('uh oh!')))
 
         eff = converge_one_group(
-            self.log, make_lock_set(), self.tenant_id, self.group_id,
+            self.log, Reference(pset()), self.tenant_id, self.group_id,
             self.version,
             execute_convergence=execute_convergence)
         result = sync_perform(self.dispatcher, eff)
@@ -301,7 +303,7 @@ class ConvergeOneGroupTests(SynchronousTestCase):
             return Effect(Constant(StepResult.SUCCESS))
 
         eff = converge_one_group(
-            self.log, make_lock_set(), self.tenant_id, self.group_id,
+            self.log, Reference(pset()), self.tenant_id, self.group_id,
             self.version,
             execute_convergence=execute_convergence)
         result = sync_perform(dispatcher, eff)
@@ -309,7 +311,9 @@ class ConvergeOneGroupTests(SynchronousTestCase):
         self.log.err.assert_any_call(
             CheckFailureValue(BadVersionError()),
             'mark-clean-failure',
-            tenant_id=self.tenant_id, group_id=self.group_id)
+            tenant_id=self.tenant_id, group_id=self.group_id,
+            dirty_version=5,
+            path='/groups/divergent/tenant-id_g1')
 
     def test_retry(self):
         """
@@ -319,7 +323,7 @@ class ConvergeOneGroupTests(SynchronousTestCase):
         def execute_convergence(tenant_id, group_id, log):
             return Effect(Constant(StepResult.RETRY))
         eff = converge_one_group(
-            self.log, make_lock_set(), self.tenant_id, self.group_id,
+            self.log, Reference(pset()), self.tenant_id, self.group_id,
             self.version,
             execute_convergence=execute_convergence)
         result = sync_perform(self.dispatcher, eff)
@@ -334,7 +338,7 @@ class ConvergeOneGroupTests(SynchronousTestCase):
         def execute_convergence(tenant_id, group_id, log):
             return Effect(Constant(StepResult.FAILURE))
         eff = converge_one_group(
-            self.log, make_lock_set(), self.tenant_id, self.group_id,
+            self.log, Reference(pset()), self.tenant_id, self.group_id,
             self.version,
             execute_convergence=execute_convergence)
         result = sync_perform(self.dispatcher, eff)
@@ -350,39 +354,51 @@ class ConvergeAllGroupsTests(SynchronousTestCase):
         Fetches divergent groups and runs converge_one_group for each one
         needing convergence.
         """
+        group_infos = [
+            {'tenant_id': '00', 'group_id': 'g1',
+             'dirty-flag': '/groups/divergent/00_g1'},
+            {'tenant_id': '01', 'group_id': 'g2',
+             'dirty-flag': '/groups/divergent/01_g2'}
+        ]
         def get_my_divergent_groups(_my_buckets, _all_buckets):
             self.assertEqual(_my_buckets, my_buckets)
             self.assertEqual(_all_buckets, all_buckets)
-            return Effect(Constant([
-                {'tenant_id': '00', 'group_id': 'g1', 'version': 1},
-                {'tenant_id': '01', 'group_id': 'g2', 'version': 5}
-            ]))
+            return Effect(Constant(group_infos))
 
-        def converge_one_group(log, lock_set, tenant_id, group_id, version):
-            return Effect(Constant(
-                (tenant_id, group_id, version, 'converge!')))
+        def converge_one_group(log, currently_converging, tenant_id, group_id,
+                               version):
+            return Effect((tenant_id, group_id, version, 'converge!'))
 
         log = mock_log()
-        lock_set = make_lock_set()
+        currently_converging = Reference(pset())
         my_buckets = [0, 5]
         all_buckets = range(10)
         eff = converge_all_groups(
-            log, lock_set, my_buckets, all_buckets,
+            log, currently_converging, my_buckets, all_buckets,
             get_my_divergent_groups=get_my_divergent_groups,
             converge_one_group=converge_one_group)
 
-        expected_tscope_1 = TenantScope(
-            Effect(Constant(('00', 'g1', 1, 'converge!'))),
-            '00')
-        expected_tscope_2 = TenantScope(
-            Effect(Constant(('01', 'g2', 5, 'converge!'))),
-            '01')
-        dispatcher = ComposedDispatcher([
-            EQFDispatcher([
-                (expected_tscope_1, lambda tscope: tscope.effect),
-                (expected_tscope_2, lambda tscope: tscope.effect),
-            ]),
-            _get_dispatcher()])
+        sequence = SequenceDispatcher([
+            (ReadReference(ref=currently_converging),
+             lambda i: pset()),
+            (GetStat(path='/groups/divergent/00_g1'),
+             lambda i: ZNodeStatStub(version=1)),
+            (TenantScope(
+                Effect(('00', 'g1', 1, 'converge!')),
+                '00'),
+             lambda tscope: tscope.effect),
+            (('00', 'g1', 1, 'converge!'),
+             lambda i: i),
+            (GetStat(path='/groups/divergent/01_g2'),
+             lambda i: ZNodeStatStub(version=5)),
+            (TenantScope(
+                Effect(('01', 'g2', 5, 'converge!')),
+                '01'),
+             lambda tscope: tscope.effect),
+            (('01', 'g2', 5, 'converge!'),
+             lambda i: i),
+        ])
+        dispatcher = ComposedDispatcher([sequence, test_dispatcher()])
 
         self.assertEqual(
             sync_perform(dispatcher, eff),
@@ -390,23 +406,25 @@ class ConvergeAllGroupsTests(SynchronousTestCase):
              ('01', 'g2', 5, 'converge!')])
         log.msg.assert_called_once_with(
             'converge-all-groups',
-            group_infos=[{'tenant_id': '00', 'group_id': 'g1', 'version': 1},
-                         {'tenant_id': '01', 'group_id': 'g2', 'version': 5}])
+            group_infos=group_infos,
+            currently_converging=[])
+        self.assertEqual(sequence.sequence, [])  # All side-effects performed
 
     def test_no_log_on_no_groups(self):
         """When there's no work, no log message is emitted."""
         def get_my_divergent_groups(_my_buckets, _all_buckets):
             return Effect(Constant([]))
 
-        def converge_one_group(log, lock_set, tenant_id, group_id, version):
+        def converge_one_group(log, currently_converging, tenant_id, group_id,
+                               version):
             1 / 0
 
         log = mock_log()
-        lock_set = make_lock_set()
+        currently_converging = Reference(pset())
         my_buckets = [0, 5]
         all_buckets = range(10)
         result = converge_all_groups(
-            log, lock_set, my_buckets, all_buckets,
+            log, currently_converging, my_buckets, all_buckets,
             get_my_divergent_groups=get_my_divergent_groups,
             converge_one_group=converge_one_group)
         self.assertEqual(sync_perform(_get_dispatcher(), result), None)
@@ -423,10 +441,10 @@ class GetMyDivergentGroupsTests(SynchronousTestCase):
         # sha1('00') % 10 is 6, sha1('01') % 10 is 1.
         dispatcher = ComposedDispatcher([
             EQDispatcher([
-                (GetChildrenWithStats(CONVERGENCE_DIRTY_DIR),
-                 [('00_gr1', ZNodeStatStub(version=0)),
-                  ('00_gr2', ZNodeStatStub(version=3)),
-                  ('01_gr3', ZNodeStatStub(version=5))]),
+                (GetChildren(CONVERGENCE_DIRTY_DIR),
+                 ['00_gr1',
+                  '00_gr2',
+                  '01_gr3'])
             ]),
             _get_dispatcher()
         ])
@@ -434,8 +452,10 @@ class GetMyDivergentGroupsTests(SynchronousTestCase):
             dispatcher, get_my_divergent_groups([6], range(10)))
         self.assertEqual(
             result,
-            [{'tenant_id': '00', 'group_id': 'gr1', 'version': 0},
-             {'tenant_id': '00', 'group_id': 'gr2', 'version': 3}])
+            [{'tenant_id': '00', 'group_id': 'gr1',
+              'dirty-flag': '/groups/divergent/00_gr1'},
+             {'tenant_id': '00', 'group_id': 'gr2',
+              'dirty-flag': '/groups/divergent/00_gr2'}])
 
 
 def _get_dispatcher():
@@ -446,22 +466,6 @@ def _get_dispatcher():
         reference_dispatcher,
         base_dispatcher,
     ])
-
-
-class MakeLockSetTests(SynchronousTestCase):
-    """Tests for :func:`make_lock_set`."""
-
-    def test_make_lock_set(self):
-        """
-        Returns a :obj:`Reference` to an empty :obj:`PSet` partially applied to
-        :func:`non_concurrently`.
-        """
-        lock_set = make_lock_set()
-        self.assertIs(lock_set.func, non_concurrently)
-        self.assertEqual(lock_set.keywords, None)
-        (ref,) = lock_set.args
-        self.assertEqual(sync_perform(_get_dispatcher(), ref.read()),
-                         pset())
 
 
 class NonConcurrentlyTests(SynchronousTestCase):


### PR DESCRIPTION
Fixes #1288
Fixes: #1216 

`master` currently uses `GetChildrenWithStats` to find the dirty groups, which causes a bunch of `stat` calls that we don't need. These fall into two categories:

1. stats on dirty nodes that aren't allocated to us according to the bucket set partitioner
2. stats on dirty nodes that ARE allocated to us, but which we're already converging on.

So now we just `GetChildren` instead of `GetChildrenWithStats`, and only `Stat` it after filtering out groups that aren't ours and aren't already converging.

To do the second part, I needed to de-encapsulate the "currently converging" set from the group_locks object. Now the Converger service has an attribute `self.currently_converging = Reference(pset())` instead of a `self.group_locks = make_lock_set()`. This *also* allows us to log the currently converging set easily, so I went ahead and did that, fixing #1216.

There's one more useful optimization to make that I haven't done yet: #1296.