### PR TITLE
First convergence-specific test I'm aware of.

### DIFF
--- a/otter/integration/lib/autoscale.py
+++ b/otter/integration/lib/autoscale.py
@@ -23,6 +23,53 @@ class BreakLoopException(Exception):
     """This serves to break out of a `retry_and_timeout` loop."""
 
 
+def create_scaling_group_dict(
+    image_ref=None, flavor_ref=None, min_entities=0, name=None
+):
+    """This function returns a dictionary containing a scaling group's JSON
+    payload.  Note: this function does NOT create a scaling group.
+
+    :param str image_ref: An OpenStack image reference ID (typically a UUID).
+        If not provided, the content of the AS_IMAGE_REF environment variable
+        will be taken as default.  If that doesn't exist, "" will be used.
+    :param str flavor_ref: As with image_ref above, but for the launch config's
+        flavor setting.
+    :param int min_entities: The minimum number of servers to bring up when
+        the scaling group is eventually created or operating.  If not
+        specified, 0 is assumed.
+    :param str name: The scaling group name.  If not provided, a default is
+        chosen.
+    :return: A dictionary containing a scaling group JSON descriptor.  Inside,
+        it will contain a default launch config with the provided (or assumed)
+        flavor and image IDs.
+    """
+
+    if not image_ref:
+        image_ref = os.environ['AS_IMAGE_REF']
+    if not flavor_ref:
+        flavor_ref = os.environ['AS_FLAVOR_REF']
+    if not name:
+        name = "automatically-generated-test-configuration"
+
+    return {
+        "launchConfiguration": {
+            "type": "launch_server",
+            "args": {
+                "server": {
+                    "flavorRef": flavor_ref,
+                    "imageRef": image_ref,
+                }
+            }
+        },
+        "groupConfiguration": {
+            "name": name,
+            "cooldown": 0,
+            "minEntities": min_entities,
+        },
+        "scalingPolicies": [],
+    }
+
+
 @attributes([
     Attribute('group_config', instance_of=dict),
     Attribute('pool', default_value=None),

--- a/otter/integration/lib/autoscale.py
+++ b/otter/integration/lib/autoscale.py
@@ -3,6 +3,7 @@
 from __future__ import print_function
 
 import json
+import os
 
 from characteristic import Attribute, attributes
 

--- a/otter/integration/lib/identity.py
+++ b/otter/integration/lib/identity.py
@@ -51,13 +51,9 @@ class IdentityV2(object):
             dictionary representation of the Identity authentication results.
         """
 
-        def record_result(r):
-            rcs.access = freeze(r)
-            return rcs
-
         return self.auth.authenticate_user(
             self.endpoint, self.username, self.password, pool=self.pool
-        ).addCallback(record_result)
+        ).addCallback(rcs.init_from_access)
 
 
 def find_endpoint(catalog, service_type, region):

--- a/otter/integration/lib/identity.py
+++ b/otter/integration/lib/identity.py
@@ -2,8 +2,6 @@
 
 from characteristic import Attribute, attributes
 
-from pyrsistent import freeze
-
 
 @attributes([
     Attribute('auth'),

--- a/otter/integration/lib/resources.py
+++ b/otter/integration/lib/resources.py
@@ -4,6 +4,12 @@ integration tests.
 
 from characteristic import Attribute, attributes
 
+from pyrsistent import freeze
+
+from twisted.internet.defer import Deferred
+
+from otter import auth
+
 
 @attributes([
     Attribute('access', default_value=None),
@@ -18,3 +24,53 @@ class TestResources(object):
     useful scratchpad for passing test resource availability amongst Twisted
     callbacks.
     """
+
+    def init_from_access(self, acc):
+        """After authenticating from Identity API, this function takes the
+        resulting JSON "access" structure, and extracts from it important
+        information to enable invoking API calls later.
+
+        :param dict acc: The parsed JSON "access" response from authenticating
+            with Identity API.
+
+        :return: Self, as it's intended to be used as a Deferred callback.
+        """
+
+        self.access = freeze(acc)
+        self.tenant = self.access["access"]["token"]["tenant"]["id"]
+        self.token = self.access["access"]["token"]["id"]
+        self.sc = self.access["access"]["serviceCatalog"]
+        return self
+
+    def find_end_point(self, _, key, service_type, region, default_url=None):
+        """Initialize the instance with the endpoint required for later test
+        execution.
+
+        :param str key: The dictionary key to store the resulting endpoint URL
+            under.  Supported keys are listed above.
+        :param str service_type: The kind of service to look for in the service
+            catalog.  For example, "cloudServersOpenStack" or "autoscale".
+        :param str region: The region under which to look for the endpoint.
+        :param str default_url: If provided, a template that can be used to
+            compute a well-known endpoint.  For example, if you're developing
+            an implementation of a new service and using a set of mocks,
+            you'll want to hide any mock version of your service, and use the
+            endpoint your daemon provides in lieu of any mock.  For example,
+            "http://localhost:9000/v1.0/{0}.  Note that {0} expands to the
+            OpenStack tenant ID.
+
+        :return: self.
+        """
+
+        try:
+            self.endpoints[key] = auth.public_endpoint_url(
+                self.sc, service_type, region
+            )
+        except auth.NoSuchEndpoint:
+            if not default_url:
+                raise
+            self.endpoints[key] = default_url.format(self.tenant)
+
+        d = Deferred()
+        d.callback(self)  # really wish this didn't return None.
+        return d

--- a/otter/integration/tests/test_convergence.py
+++ b/otter/integration/tests/test_convergence.py
@@ -18,6 +18,7 @@ from otter.integration.lib.autoscale import (
     BreakLoopException,
     ScalingGroup,
     ScalingPolicy,
+    create_scaling_group_dict,
 )
 from otter.integration.lib.identity import IdentityV2
 from otter.integration.lib.resources import TestResources
@@ -77,23 +78,10 @@ class TestConvergence(unittest.TestCase):
 
         rcs = TestResources()
 
-        scaling_group_body = {
-            "launchConfiguration": {
-                "type": "launch_server",
-                "args": {
-                    "server": {
-                        "flavorRef": flavor_ref,
-                        "imageRef": image_ref,
-                    }
-                }
-            },
-            "groupConfiguration": {
-                "name": "converger-test-configuration",
-                "cooldown": 0,
-                "minEntities": N_SERVERS,
-            },
-            "scalingPolicies": [],
-        }
+        scaling_group_body = create_scaling_group_dict(
+            image_ref=image_ref, flavor_ref=flavor_ref,
+            min_entities=N_SERVERS
+        )
 
         self.scaling_group = ScalingGroup(
             group_config=scaling_group_body,

--- a/otter/integration/tests/test_convergence.py
+++ b/otter/integration/tests/test_convergence.py
@@ -53,9 +53,6 @@ def find_end_points(rcs):
         rcs.endpoints["otter"] = 'http://localhost:9000/v1.0/{0}'.format(
             rcs.access['access']['token']['tenant']['id'])
 
-    rcs.endpoints["loadbalancers"] = auth.public_endpoint_url(
-        sc, "cloudLoadBalancers", region
-    )
     rcs.endpoints["nova"] = auth.public_endpoint_url(
         sc, "cloudServersOpenStack", region
     )
@@ -181,8 +178,8 @@ class TestConvergence(unittest.TestCase):
         situation and reflect it in the scaling group state accordingly.
         """
 
-        def check(state):
-            if state[0] != 200:
+        def check((code, response)):
+            if code != 200:
                 raise BreakLoopException(
                     "Scaling group appears to have disappeared"
                 )
@@ -192,7 +189,7 @@ class TestConvergence(unittest.TestCase):
             # the remaining servers plus 1.
 
             n_remaining = self.n_servers - self.n_killed + 1
-            if len(state[1]["group"]["active"]) == n_remaining:
+            if len(response["group"]["active"]) == n_remaining:
                 return rcs
 
             raise TransientRetryError()

--- a/otter/integration/tests/test_convergence.py
+++ b/otter/integration/tests/test_convergence.py
@@ -188,7 +188,7 @@ class TestConvergence(unittest.TestCase):
                 .addCallback(lambda _: rcs)
             )
 
-        deferreds = map(lambda i: delete_server_by_id(i), ids)
+        deferreds = map(delete_server_by_id, ids)
         # If no error occurs while deleting, all the results will be the
         # same.  So just return the 1st, which is just our rcs value.
         return gatherResults(deferreds).addCallback(lambda rslts: rslts[0])

--- a/otter/integration/tests/test_convergence.py
+++ b/otter/integration/tests/test_convergence.py
@@ -1,0 +1,168 @@
+"""Tests covering foreseen or known edge cases for the Convergence subsystem.
+Tests covering self-healing should be placed in a separate test file.
+"""
+
+from __future__ import print_function
+
+import json
+import os
+
+import treq
+
+from twisted.internet import reactor
+from twisted.internet.defer import gatherResults
+from twisted.internet.task import deferLater
+from twisted.internet.tcp import Client
+from twisted.trial import unittest
+from twisted.web.client import HTTPConnectionPool
+
+from otter import auth
+from otter.integration.lib import autoscale
+from otter.integration.lib.identity import IdentityV2
+from otter.integration.lib.resources import TestResources
+
+from otter.util.http import check_success, headers
+
+
+username = os.environ['AS_USERNAME']
+password = os.environ['AS_PASSWORD']
+endpoint = os.environ['AS_IDENTITY']
+flavor_ref = os.environ['AS_FLAVOR_REF']
+image_ref = os.environ['AS_IMAGE_REF']
+region = os.environ['AS_REGION']
+
+
+def find_end_points(rcs):
+    """Locates the endpoints we need to conduct convergence tests."""
+
+    rcs.token = rcs.access["access"]["token"]["id"]
+    sc = rcs.access["access"]["serviceCatalog"]
+    try:
+        rcs.endpoints["otter"] = auth.public_endpoint_url(sc,
+                                                          "autoscale",
+                                                          region)
+    except auth.NoSuchEndpoint:
+        # If the autoscale endpoint is not defined, use local otter
+        rcs.endpoints["otter"] = 'http://localhost:9000/v1.0/{0}'.format(
+            rcs.access['access']['token']['tenant']['id'])
+
+    rcs.endpoints["loadbalancers"] = auth.public_endpoint_url(
+        sc, "cloudLoadBalancers", region
+    )
+    rcs.endpoints["nova"] = auth.public_endpoint_url(
+        sc, "cloudServersOpenStack", region
+    )
+    return rcs
+
+
+def dbg(x, msg):
+    print(msg)
+    return x
+
+
+class TestConvergence(unittest.TestCase):
+    """This class contains test cases aimed at the Otter Converger."""
+
+    def setUp(self):
+        """Establish an HTTP connection pool and commonly used resources for
+        each test.  The HTTP connection pool is important for maintaining a
+        clean Twisted reactor.
+        """
+
+        self.pool = HTTPConnectionPool(reactor, False)
+        self.identity = IdentityV2(
+            auth=auth, username=username, password=password,
+            endpoint=endpoint, pool=self.pool
+        )
+
+    def tearDown(self):
+        """Destroy the HTTP connection pool, so that we close the reactor
+        cleanly.
+        """
+
+        def _check_fds(_):
+            fds = set(reactor.getReaders() + reactor.getReaders())
+            if not [fd for fd in fds if isinstance(fd, Client)]:
+                return
+            return deferLater(reactor, 0, _check_fds, None)
+        return self.pool.closeCachedConnections().addBoth(_check_fds)
+
+    def test_reaction_to_oob_server_deletion(self):
+        """Exercise out-of-band server deletion.  The goal is to spin up, say,
+        eight servers, then use Nova to delete four of them.  We should be able
+        to see, over time, more servers coming into existence to replace those
+        deleted.
+        """
+
+        N_SERVERS = 2
+
+        rcs = TestResources()
+
+        def choose_half_the_servers(t):
+            if t[0] != 200:
+                raise Exception("Got 404; where'd the scaling group go?")
+            ids = map(lambda obj: obj['id'], t[1]['group']['active'])
+            return ids[:(len(ids) / 2)]
+
+        def delete_server_by_id(i):
+            print("{}/servers/{}".format(str(rcs.endpoints["nova"]), i))
+            return (
+                treq.delete(
+                    "{}/servers/{}".format(str(rcs.endpoints["nova"]), i),
+                    headers=headers(str(rcs.token)),
+                    pool=self.pool
+                ).addCallback(check_success, [204])
+                .addCallback(lambda _: rcs)
+            )
+
+        def delete_those_servers(ids):
+            deferreds = map(lambda i: delete_server_by_id(i), ids)
+            # If no error occurs while deleting, all the results will be the
+            # same.  So just return the 1st, which is just our rcs value.
+            return gatherResults(deferreds).addCallback(lambda rslts: rslts[0])
+
+        scaling_group_body = {
+            "launchConfiguration": {
+                "type": "launch_server",
+                "args": {
+                    "server": {
+                        "flavorRef": flavor_ref,
+                        "imageRef": image_ref,
+                    }
+                }
+            },
+            "groupConfiguration": {
+                "name": "converger-test-configuration",
+                "cooldown": 0,
+                "minEntities": N_SERVERS,
+            },
+            "scalingPolicies": [],
+        }
+
+        self.scaling_group = autoscale.ScalingGroup(
+            group_config=scaling_group_body,
+            pool=self.pool
+        )
+
+        d = (
+            self.identity.authenticate_user(rcs)
+            .addCallback(dbg, "find_end_points")
+            .addCallback(find_end_points)
+            .addCallback(dbg, "scaling_group.start")
+            .addCallback(self.scaling_group.start, self)
+            .addCallback(dbg, "wait for N_SERVERS")
+            .addCallback(
+                self.scaling_group.wait_for_N_servers, N_SERVERS, timeout=1800
+            ).addCallback(self.scaling_group.get_scaling_group_state)
+            .addCallback(dbg, "choose_half_the_servers")
+            .addCallback(choose_half_the_servers)
+            .addCallback(dbg, "delete_those_servers")
+            .addCallback(delete_those_servers)
+            .addCallback(dbg, "get_scaling_group_state")
+            .addCallback(self.scaling_group.get_scaling_group_state)
+            .addCallback(dbg, "print")
+            .addCallback(lambda x: print(json.dumps(x, indent=4)))
+            .addCallback(dbg, "done")
+        )
+        return d
+    test_reaction_to_oob_server_deletion.timeout = 600

--- a/otter/integration/tests/test_convergence.py
+++ b/otter/integration/tests/test_convergence.py
@@ -80,7 +80,7 @@ class TestConvergence(unittest.TestCase):
         """
 
         def _check_fds(_):
-            fds = set(reactor.getReaders() + reactor.getReaders())
+            fds = set(reactor.getReaders() + reactor.getWriters())
             if not [fd for fd in fds if isinstance(fd, Client)]:
                 return
             return deferLater(reactor, 0, _check_fds, None)

--- a/otter/integration/tests/test_convergence.py
+++ b/otter/integration/tests/test_convergence.py
@@ -127,16 +127,16 @@ class TestConvergence(unittest.TestCase):
         )
     test_reaction_to_oob_server_deletion.timeout = 600
 
-    def _choose_half_the_servers(self, t):
+    def _choose_half_the_servers(self, (code, response)):
         """Select the first half of the servers returned by the
         ``get_scaling_group_state`` function.  Record the number of servers
         received in ``n_servers`` attribute, and the number killed (which
         should be roughly half) in ``n_killed``.
         """
 
-        if t[0] != 200:
+        if code != 200:
             raise Exception("Got 404; where'd the scaling group go?")
-        ids = map(lambda obj: obj['id'], t[1]['group']['active'])
+        ids = map(lambda obj: obj['id'], response['group']['active'])
         self.n_servers = len(ids)
         self.n_killed = self.n_servers / 2
         return ids[:self.n_killed]

--- a/otter/integration/tests/test_scaling.py
+++ b/otter/integration/tests/test_scaling.py
@@ -78,25 +78,10 @@ class TestScaling(unittest.TestCase):
         return self.pool.closeCachedConnections().addBoth(_check_fds)
 
     def test_scaling_up(self):
-        group_configuration = {
-            "name": "my-group-configuration",
-            "cooldown": 0,
-            "minEntities": 0,
-        }
-        launch_configuration = {
-            "type": "launch_server",
-            "args": {
-                "server": {
-                    "flavorRef": flavor_ref,
-                    "imageRef": image_ref,
-                }
-            }
-        }
-        scaling_group_body = {
-            "launchConfiguration": launch_configuration,
-            "groupConfiguration": group_configuration,
-            "scalingPolicies": [],
-        }
+        scaling_group_body = autoscale.create_scaling_group_dict(
+            image_ref=image_ref, flavor_ref=flavor_ref,
+            name="my-group-configuration"
+        )
 
         self.scaling_group = autoscale.ScalingGroup(
             group_config=scaling_group_body,
@@ -130,25 +115,11 @@ class TestScaling(unittest.TestCase):
         """
         Verify that a basic scale down operation completes as expected.
         """
-        group_configuration = {
-            "name": "tr-scaledown-conf",
-            "cooldown": 0,
-            "minEntities": 0,
-        }
-        launch_configuration = {
-            "type": "launch_server",
-            "args": {
-                "server": {
-                    "flavorRef": flavor_ref,
-                    "imageRef": image_ref,
-                }
-            }
-        }
-        scaling_group_body = {
-            "launchConfiguration": launch_configuration,
-            "groupConfiguration": group_configuration,
-            "scalingPolicies": [],
-        }
+        scaling_group_body = autoscale.create_scaling_group_dict(
+            image_ref=image_ref, flavor_ref=flavor_ref,
+            name="tr-scaledown-conf",
+        )
+
         self.scaling_group = autoscale.ScalingGroup(
             group_config=scaling_group_body,
             pool=self.pool


### PR DESCRIPTION
This test aims to exercise the case where a user deletes a Nova server
from a scaling group out-of-band.

It's not finished yet, but it runs through to completion and doesn't
mess anything up.

It works by creating a scaling group with N_SERVERS (constant in the
source code).  It then deletes half of those servers through Nova's API.
What comes next is a subject for a future PR.

This is relevant to #1203.