### PR TITLE
mock_group tests refactor

### DIFF
--- a/otter/test/models/test_intents.py
+++ b/otter/test/models/test_intents.py
@@ -18,7 +18,7 @@ class ModifyGroupStateTests(SynchronousTestCase):
                                modifier=lambda g, o: 'new state')
         dispatcher = get_model_dispatcher(mock_log(), None)
         result = sync_perform(dispatcher, Effect(mgs))
-        self.assertEqual(result, 'new state')
+        self.assertIsNone(result)
         self.assertEqual(group.modify_state_values, ['new state'])
 
 

--- a/otter/test/test_supervisor.py
+++ b/otter/test/test_supervisor.py
@@ -889,9 +889,8 @@ class PrivateJobHelperTestCase(SynchronousTestCase):
         self.job.start('launch')
         self.completion_deferred.callback({'id': 'active'})
 
-        self.assertIs(self.successResultOf(self.completion_deferred),
-                      self.state)
-
+        self.assertIsNone(self.successResultOf(self.completion_deferred))
+        self.assertEqual(self.group.modify_state_values, [self.state])
         self.assertEqual(self.state.pending, {})
         self.assertEqual(
             self.state.active,
@@ -927,8 +926,8 @@ class PrivateJobHelperTestCase(SynchronousTestCase):
         self.job.start('launch')
         self.completion_deferred.callback({'id': 'active'})
 
-        self.assertIs(self.successResultOf(self.completion_deferred),
-                      self.state)
+        self.assertIsNone(self.successResultOf(self.completion_deferred))
+        self.assertEqual(self.group.modify_state_values, [self.state])
 
         self.assertEqual(self.state.pending, {})
         self.assertEqual(self.state.active, {})
@@ -969,8 +968,8 @@ class PrivateJobHelperTestCase(SynchronousTestCase):
         self.job.start(self.mock_launch)
         self.completion_deferred.errback(DummyException('e'))
 
-        self.assertIs(self.successResultOf(self.completion_deferred),
-                      self.state)
+        self.assertIsNone(self.successResultOf(self.completion_deferred))
+        self.assertEqual(self.group.modify_state_values, [self.state])
 
         self.assertEqual(self.state.pending, {})
         self.assertEqual(self.state.active, {})
@@ -990,8 +989,8 @@ class PrivateJobHelperTestCase(SynchronousTestCase):
         self.job.start(self.mock_launch)
         self.completion_deferred.errback(DummyException('e'))
 
-        self.assertIs(self.successResultOf(self.completion_deferred),
-                      self.state)
+        self.assertIsNone(self.successResultOf(self.completion_deferred))
+        self.assertEqual(self.group.modify_state_values, [self.state])
 
         self.assertEqual(self.state.pending, {})
         self.assertEqual(self.state.active, {})

--- a/otter/test/utils.py
+++ b/otter/test/utils.py
@@ -622,7 +622,7 @@ def mock_group(state, tenant_id='tenant', group_id='group'):
 
     def fake_modify_state(f, *args, **kwargs):
         d = maybeDeferred(f, group, state, *args, **kwargs)
-        d.addCallback(lambda r: group.modify_state_values.append(r) or r)
+        d.addCallback(lambda r: group.modify_state_values.append(r))
         if group.pause_modify_state:
             group.modify_state_pause_d = Deferred()
             return group.modify_state_pause_d.addCallback(lambda _: d)


### PR DESCRIPTION
As per `group.modify_state` docs it is supposed to return None. So, changing the mock `modify_state` to return None instead of new state. Changed affected tests