### PR TITLE
scale down fix for mimic

### DIFF
--- a/autoscale_cloudcafe/autoscale/behaviors.py
+++ b/autoscale_cloudcafe/autoscale/behaviors.py
@@ -480,13 +480,11 @@ class AutoscaleBehaviors(BaseBehavior):
         if interval_time is None:
             interval_time = self.autoscale_config.interval_time
 
-        if time_scale:
+        if time_scale and self.autoscale_config.mimic:
             # scale time down if using mimic - no shorter than 1 second, though
-            time_scaling_factor = 0.25 if self.autoscale_config.mimic else 1
-            timeout, interval_time = [
-                max(val * time_scaling_factor, 1)
-                for val in (timeout, interval_time)
-            ]
+            scale_down_factor = 0.25
+            timeout = timeout * scale_down_factor
+            interval_time = interval_time * scale_down_factor
             # max out mimic waiting to 60 seconds, no matter what the timeout
             timeout = min(timeout, 60)
 

--- a/autoscale_cloudcafe/autoscale/behaviors.py
+++ b/autoscale_cloudcafe/autoscale/behaviors.py
@@ -483,7 +483,7 @@ class AutoscaleBehaviors(BaseBehavior):
         if time_scale and self.autoscale_config.mimic:
             # scale time down if using mimic - no shorter than 1 second, though
             scale_down_factor = 0.25
-            timeout = timeout * scale_down_factor
+            timeout = max(timeout * scale_down_factor, 1)
             interval_time = interval_time * scale_down_factor
             # max out mimic waiting to 60 seconds, no matter what the timeout
             timeout = min(timeout, 60)

--- a/autoscale_cloudcafe/autoscale/config.py
+++ b/autoscale_cloudcafe/autoscale/config.py
@@ -356,4 +356,4 @@ class AutoscaleConfig(ConfigSectionInterface):
         """
         Specify whether this configuration is against a mimic instance.
         """
-        return bool(self.get('mimic'))
+        return self.get('mimic', 'false').lower() == 'true'


### PR DESCRIPTION
The boolean mimic config was incorrectly read as true everytime causing smaller timeout and interval in retry. Also, it looked like timeout was fixed to 60 seconds independent of mimic config. So, fixed reading
config and simpler code for scaling down timeout, interval.