### PR TITLE
error when capacity tries to go outside min/max

### DIFF
--- a/autoscale_cloudroast/test_repo/autoscale/system/group/test_system_group.py
+++ b/autoscale_cloudroast/test_repo/autoscale/system/group/test_system_group.py
@@ -190,7 +190,7 @@ class GroupFixture(AutoscaleFixture):
             'change'] + group.groupConfiguration.minEntities + policy['change']
         self.verify_group_state(group.id, total_servers)
 
-    @tags(speed='quick', convergence='error')
+    @tags(speed='quick', convergence='yes')
     def test_execute_policy_beyond_maxentities(self):
         """
         Scaling policy is executed when change + minentities > maxentities,
@@ -227,7 +227,7 @@ class GroupFixture(AutoscaleFixture):
         total_servers = maxentities + policy['change']
         self.verify_group_state(group.id, total_servers)
 
-    @tags(speed='quick', convergence='error')
+    @tags(speed='quick', convergence='yes')
     def test_execute_policy_beyond_maxentities_when_min_equals_max(self):
         """
         Scaling group with minentities = maxentities cannot execute scale up

--- a/otter/controller.py
+++ b/otter/controller.py
@@ -148,24 +148,24 @@ def converge(log, transaction_id, config, scaling_group, state, launch_config,
         are to be made to the group, None will synchronously be returned.
     """
     if tenant_is_enabled(scaling_group.tenant_id, config_value):
-        # Note that convergence must be run whether or not delta is 0, because
-        # delta will be zero when a group is initially created with a non-zero
-        # min-entities (desired=min entities, so there is technically no
-        # change).
-
-        # For non-convergence tenants, the value used for desired-capacity is
-        # the sum of active+pending, which is 0, so the delta ends up being
-        # the min entities due to constraint calculation.
-
-        apply_delta(log, state.desired, state, config, policy)
+        # For convergence tenants, find delta based on group's desired
+        # capacity
+        delta = apply_delta(log, state.desired, state, config, policy)
+        # Delta could be 0, however we may still want to trigger convergence
         d = get_convergence_starter().start_convergence(
             log, scaling_group.tenant_id, scaling_group.uuid)
+        if delta == 0:
+            # No change in servers. Return None synchronously
+            return None
+        else:
+            # We honor start_convergence's deferred here so that we can
+            # communicate back a strong acknowledgement that convergence
+            # has been triggered on the group
+            return d.addCallback(lambda _: state)
 
-        # We honor start_convergence's deferred here so that we can communicate
-        # back a strong acknowledgement that a group has been marked dirty for
-        # convergence.
-        return d.addCallback(lambda _: state)
-
+    # For non-convergence tenants, the value used for desired-capacity is
+    # the sum of active+pending, which is 0, so the delta ends up being
+    # the min entities due to constraint calculation.
     delta = calculate_delta(log, state, config, policy)
     execute_log = log.bind(server_delta=delta)
 

--- a/otter/test/test_controller.py
+++ b/otter/test/test_controller.py
@@ -1092,9 +1092,8 @@ class ConvergeTestCase(SynchronousTestCase):
 
     def test_real_convergence_nonzero_delta(self):
         """
-        When a tenant is configured to for convergence, if the delta is
-        non-zero, the Convergence service's ``converge`` method is invoked and
-        a Deferred that fires with `None` is returned.
+        When a tenant is configured for convergence, convergence is triggered
+        and state is returned after convergence triggering is successful
         """
         log = mock_log()
         state = GroupState('tenant', 'group', "test", [], [], None, {},
@@ -1119,7 +1118,7 @@ class ConvergeTestCase(SynchronousTestCase):
         """
         When a tenant is configured for convergence, if the delta is zero, the
         ConvergenceStarter service's ``start_convergence`` method is still
-        invoked.
+        invoked. However, None is returned synchronously
         """
         log = mock_log()
         state = GroupState('tenant', 'group-id', "test", [], [], None, {},
@@ -1134,7 +1133,7 @@ class ConvergeTestCase(SynchronousTestCase):
         result = controller.converge(log, 'txn-id', group_config, self.group,
                                      state, 'launch', policy,
                                      config_value=config_data.get)
-        self.assertIs(self.successResultOf(result), state)
+        self.assertIsNone(result)
         start_convergence.assert_called_once_with(log, 'tenant', 'group')
 
         # And execute_launch_config is _not_ called


### PR DESCRIPTION
When executing policy on convergence tenants, error is raised if no change in servers is detected. This allows 2 more tests to pass.