### PR TITLE
Scale up by 3, delete 1 OOB, then scale up by 2.

### DIFF
--- a/otter/integration/lib/autoscale.py
+++ b/otter/integration/lib/autoscale.py
@@ -24,6 +24,16 @@ class BreakLoopException(Exception):
     """This serves to break out of a `retry_and_timeout` loop."""
 
 
+def extract_active_ids(group_status):
+    """Extracts all server IDs from a scaling group's status report.
+
+    :param dict group_status: The successful result from
+        ``get_scaling_group_state``.
+    :result: A list of server IDs known to the scaling group.
+    """
+    return [obj['id'] for obj in group_status['group']['active']]
+
+
 def create_scaling_group_dict(
     image_ref=None, flavor_ref=None, min_entities=0, name=None
 ):
@@ -292,7 +302,7 @@ class ScalingGroup(object):
         else:
             report = (
                 "Scaling group failed to reflect {} servers removed."
-                .format(len(ids_deleted))
+                .format(len(removed_ids))
             )
 
         return retry_and_timeout(

--- a/otter/integration/lib/autoscale.py
+++ b/otter/integration/lib/autoscale.py
@@ -195,7 +195,7 @@ class ScalingGroup(object):
         """
 
         def check((code, response)):
-            if code != 200:
+            if code == 404:
                 raise BreakLoopException("Scaling group not found.")
             servers_active = len(response["group"]["active"])
             if servers_active == servers_desired:

--- a/otter/integration/lib/autoscale.py
+++ b/otter/integration/lib/autoscale.py
@@ -194,10 +194,10 @@ class ScalingGroup(object):
             Otherwise, an exception is raised.
         """
 
-        def check(state):
-            if state[0] != 200:
+        def check((code, response)):
+            if code != 200:
                 raise BreakLoopException("Scaling group not found.")
-            servers_active = len(state[1]["group"]["active"])
+            servers_active = len(response["group"]["active"])
             if servers_active == servers_desired:
                 return rcs
 

--- a/otter/integration/lib/autoscale.py
+++ b/otter/integration/lib/autoscale.py
@@ -204,7 +204,8 @@ class ScalingGroup(object):
             Otherwise, an exception is raised.
         """
 
-        def check((code, response)):
+        def check(state):
+            code, response = state
             if code == 404:
                 raise BreakLoopException("Scaling group not found.")
             servers_active = len(response["group"]["active"])
@@ -278,7 +279,8 @@ class ScalingGroup(object):
             will be raised otherwise, including timeout.
         """
 
-        def check((code, response)):
+        def check(state):
+            code, response = state
             if code == 404:
                 raise BreakLoopException(
                     "Scaling group appears to have disappeared"

--- a/otter/integration/tests/test_convergence.py
+++ b/otter/integration/tests/test_convergence.py
@@ -62,7 +62,7 @@ class TestConvergence(unittest.TestCase):
             return deferLater(reactor, 0, _check_fds, None)
         return self.pool.closeCachedConnections().addBoth(_check_fds)
 
-    def test_reaction_to_oob_deletion_after_scale_up(self):
+    def test_reaction_to_oob_deletion_then_scale_up(self):
         """Exercise out-of-band server deletion, but then scale up afterwards.
         The goal is to spin up, say, three servers, then use Nova to delete
         one of them directly, without Autoscale's knowledge.  Then we scale up
@@ -114,7 +114,7 @@ class TestConvergence(unittest.TestCase):
                 self.scaling_group.wait_for_N_servers, 5, timeout=1800
             )
         )
-    test_reaction_to_oob_deletion_after_scale_up.timeout = 1800
+    test_reaction_to_oob_deletion_then_scale_up.timeout = 1800
 
     def test_reaction_to_oob_server_deletion(self):
         """Exercise out-of-band server deletion.  The goal is to spin up, say,

--- a/otter/integration/tests/test_convergence.py
+++ b/otter/integration/tests/test_convergence.py
@@ -20,6 +20,7 @@ from otter.integration.lib.autoscale import (
     ScalingGroup,
     ScalingPolicy,
     create_scaling_group_dict,
+    extract_active_ids,
 )
 from otter.integration.lib.identity import IdentityV2
 from otter.integration.lib.resources import TestResources
@@ -39,15 +40,6 @@ endpoint = os.environ['AS_IDENTITY']
 flavor_ref = os.environ['AS_FLAVOR_REF']
 image_ref = os.environ['AS_IMAGE_REF']
 region = os.environ['AS_REGION']
-
-
-def extract_active_ids(group_status):
-    """Extracts all server IDs from a scaling group's status report.
-    :param dict group_status: The successful result from
-        ``get_scaling_group_state``.
-    :result: A list of server IDs known to the scaling group.
-    """
-    return [obj['id'] for obj in group_status['group']['active']]
 
 
 class TestConvergence(unittest.TestCase):

--- a/otter/integration/tests/test_convergence.py
+++ b/otter/integration/tests/test_convergence.py
@@ -16,7 +16,6 @@ from twisted.web.client import HTTPConnectionPool
 
 from otter import auth
 from otter.integration.lib.autoscale import (
-    BreakLoopException,
     ScalingGroup,
     ScalingPolicy,
     create_scaling_group_dict,
@@ -25,13 +24,7 @@ from otter.integration.lib.autoscale import (
 from otter.integration.lib.identity import IdentityV2
 from otter.integration.lib.resources import TestResources
 
-from otter.util.deferredutils import retry_and_timeout
 from otter.util.http import check_success, headers
-from otter.util.retry import (
-    TransientRetryError,
-    repeating_interval,
-    transient_errors_except,
-)
 
 
 username = os.environ['AS_USERNAME']

--- a/otter/integration/tests/test_convergence.py
+++ b/otter/integration/tests/test_convergence.py
@@ -104,14 +104,14 @@ class TestConvergence(unittest.TestCase):
                 "nova", "cloudServersOpenStack", region
             ).addCallback(self.scaling_group.start, self)
             .addCallback(
-                self.scaling_group.wait_for_N_servers, 3, timeout=60
+                self.scaling_group.wait_for_N_servers, 3, timeout=1800
             ).addCallback(self.scaling_group.get_scaling_group_state)
             .addCallback(self._choose_random_servers, 1)
             .addCallback(self._delete_those_servers, rcs)
             .addCallback(self.scaling_policy.start, self)
             .addCallback(self.scaling_policy.execute)
             .addCallback(
-                self.scaling_group.wait_for_N_servers, 4, timeout=60
+                self.scaling_group.wait_for_N_servers, 4, timeout=1800
             )
         )
     test_reaction_to_oob_deletion_after_scale_up.timeout = 1800

--- a/otter/integration/tests/test_convergence.py
+++ b/otter/integration/tests/test_convergence.py
@@ -176,7 +176,7 @@ class TestConvergence(unittest.TestCase):
         should be roughly half) in ``n_killed``.
         """
 
-        if code != 200:
+        if code == 404:
             raise Exception("Got 404; where'd the scaling group go?")
         ids = extract_active_ids(response)
         self.n_servers = len(ids)
@@ -188,7 +188,7 @@ class TestConvergence(unittest.TestCase):
         ``get_scaling_group_state`` function.
         """
 
-        if code != 200:
+        if code == 404:
             raise Exception("Got 404; dude, where's my scaling group?")
         ids = extract_active_ids(response)
         self.n_servers = len(ids)

--- a/otter/integration/tests/test_convergence.py
+++ b/otter/integration/tests/test_convergence.py
@@ -119,7 +119,12 @@ class TestConvergence(unittest.TestCase):
             .addCallback(self._delete_those_servers, rcs)
             .addCallback(self.scaling_policy.start, self)
             .addCallback(self.scaling_policy.execute)
-            .addCallback(self._wait_for_autoscale_to_catch_up, rcs)
+            .addCallback(lambda _: self.removed_ids)
+            .addCallback(
+                self.scaling_group.wait_for_deleted_id_removal,
+                rcs,
+                total_servers=3,
+            )
             .addCallback(
                 self.scaling_group.wait_for_N_servers, 5, timeout=1800
             )
@@ -214,7 +219,7 @@ class TestConvergence(unittest.TestCase):
             )
 
         deferreds = map(delete_server_by_id, ids)
-        self.ids_deleted = ids
+        self.removed_ids = ids
         # If no error occurs while deleting, all the results will be the
         # same.  So just return the 1st, which is just our rcs value.
         return gatherResults(deferreds).addCallback(lambda rslts: rslts[0])


### PR DESCRIPTION
We expect 4 servers after this sequence of operations.

Fixes #1314 

Also replaces some legacy code in autoscale.py with easier-to-read, but semantically identical, code.