### PR TITLE
Convergence tests: Scale to clb max after oob delete

### DIFF
--- a/otter/integration/lib/autoscale.py
+++ b/otter/integration/lib/autoscale.py
@@ -25,7 +25,8 @@ class BreakLoopException(Exception):
 
 
 def create_scaling_group_dict(
-    image_ref=None, flavor_ref=None, min_entities=0, name=None
+    image_ref=None, flavor_ref=None, min_entities=0, name=None,
+    use_lbs=None
 ):
     """This function returns a dictionary containing a scaling group's JSON
     payload.  Note: this function does NOT create a scaling group.
@@ -40,6 +41,11 @@ def create_scaling_group_dict(
         specified, 0 is assumed.
     :param str name: The scaling group name.  If not provided, a default is
         chosen.
+    :param list use_lbs: Specifies a list of one or more cloud or RackConnect
+        load balancer JSON *dictionary* objects.  These are *not* instances of
+        ``otter.lib.CloudLoadBalancer``.  However, you can get the dicts by
+        invoking the o.l.CLB.scaling_group_spec() method on such objects.  If
+        not given, no load balancers will be used.
     :return: A dictionary containing a scaling group JSON descriptor.  Inside,
         it will contain a default launch config with the provided (or assumed)
         flavor and image IDs.
@@ -52,7 +58,7 @@ def create_scaling_group_dict(
     if not name:
         name = "automatically-generated-test-configuration"
 
-    return {
+    obj = {
         "launchConfiguration": {
             "type": "launch_server",
             "args": {
@@ -69,6 +75,11 @@ def create_scaling_group_dict(
         },
         "scalingPolicies": [],
     }
+
+    if use_lbs:
+        obj["launchConfiguration"]["args"]["loadBalancers"] = use_lbs
+
+    return obj
 
 
 @attributes([

--- a/otter/integration/lib/autoscale.py
+++ b/otter/integration/lib/autoscale.py
@@ -2,9 +2,9 @@
 
 from __future__ import print_function
 
+import datetime
 import json
 import os
-import datetime
 
 from characteristic import Attribute, attributes
 

--- a/otter/integration/lib/cloud_load_balancer.py
+++ b/otter/integration/lib/cloud_load_balancer.py
@@ -43,6 +43,17 @@ class CloudLoadBalancer(object):
             }
         }
 
+    def scaling_group_spec(self):
+        """Computes the necessary CLB specification to use when creating a
+        scaling group.  See also the lib.autoscale.create_scaling_group_dict
+        function for more details.
+        """
+
+        return {
+            "port": 80,
+            "loadBalancerId": self.clb_id,
+        }
+
     def get_state(self, rcs):
         """Returns the current state of the cloud load balancer.
 

--- a/otter/integration/tests/test_convergence.py
+++ b/otter/integration/tests/test_convergence.py
@@ -174,10 +174,12 @@ class TestConvergence(unittest.TestCase):
                 .addCallback(self._choose_random_servers, 2)
                 .addCallback(self._delete_those_servers, rcs)
                 .addCallback(self.second_scaling_policy.execute)
+                .addCallback(lambda _: self.removed_ids)
                 .addCallback(
-                    self._wait_for_autoscale_to_catch_up, rcs, delta=-1
-                )
-                .addCallback(self.third_scaling_policy.execute)
+                    self.scaling_group.wait_for_deleted_id_removal,
+                    rcs,
+                    total_servers=24,
+                ).addCallback(self.third_scaling_policy.execute)
                 .addCallback(
                     self.scaling_group.wait_for_N_servers, 25, timeout=1800
                 )
@@ -232,8 +234,7 @@ class TestConvergence(unittest.TestCase):
                 self.scaling_group.wait_for_deleted_id_removal,
                 rcs,
                 total_servers=3,
-            )
-            .addCallback(
+            ).addCallback(
                 self.scaling_group.wait_for_N_servers, 5, timeout=1800
             )
         )

--- a/otter/integration/tests/test_convergence.py
+++ b/otter/integration/tests/test_convergence.py
@@ -3,6 +3,7 @@ Tests covering self-healing should be placed in a separate test file.
 """
 
 import os
+import random
 
 import treq
 
@@ -20,6 +21,7 @@ from otter.integration.lib.autoscale import (
     ScalingPolicy,
     create_scaling_group_dict,
 )
+from otter.integration.lib.cloud_load_balancer import CloudLoadBalancer
 from otter.integration.lib.identity import IdentityV2
 from otter.integration.lib.resources import TestResources
 
@@ -66,6 +68,106 @@ class TestConvergence(unittest.TestCase):
                 return
             return deferLater(reactor, 0, _check_fds, None)
         return self.pool.closeCachedConnections().addBoth(_check_fds)
+
+    def test_scaling_to_clb_max_after_oob_delete_type1(self):
+        """This test starts with a scaling group with no servers.  We scale up
+        to 24 servers, but after that's done, we delete 2 directly through
+        Nova.  After that, we scale up once more by 1 server, thus max'ing out
+        the CLB's ports.  We expect that the group will return to 25 servers,
+        and does not overshoot in the process.
+
+        Further, we want to make sure the deleted servers are removed from the
+        CLB.
+        """
+
+        rcs = TestResources()
+
+        def create_clb_first():
+            self.clb = CloudLoadBalancer(pool=self.pool)
+            return (
+                self.identity.authenticate_user(rcs)
+                .addCallback(
+                    rcs.find_end_point,
+                    "otter", "autoscale", region,
+                    default_url='http://localhost:9000/v1.0/{0}'
+                ).addCallback(
+                    rcs.find_end_point,
+                    "nova", "cloudServersOpenStack", region
+                ).addCallback(
+                    rcs.find_end_point,
+                    "loadbalancers", "cloudLoadBalancers", region
+                ).addCallback(self.clb.start, self)
+                .addCallback(self.clb.wait_for_state, "ACTIVE", 600)
+            )
+
+        def then_test(_):
+            scaling_group_body = create_scaling_group_dict(
+                image_ref=image_ref, flavor_ref=flavor_ref,
+                use_lbs=[self.clb.scaling_group_spec()],
+            )
+
+            self.scaling_group = ScalingGroup(
+                group_config=scaling_group_body,
+                pool=self.pool
+            )
+
+            self.first_scaling_policy = ScalingPolicy(
+                scale_by=24,
+                scaling_group=self.scaling_group
+            )
+
+            # If we didn't have this policy, then this test would always pass
+            # on an Otter deployment w/out Convergence enabled.  Reason: we
+            # start off with 24 servers.  We OOB-delete 2 of them, leaving 22
+            # actually running; however, Otter will still think 24 exist.  We
+            # scale up by one, and:
+            #
+            # - If Otter doesn't converge, then it'll just spin up another
+            # server, and will meet the test criteria, OR,
+            #
+            # - If Otter converges, it's entirely possible for it to notice
+            # that two servers are gone, for it to attempt to provision
+            # replacements, and then provision the third and final server, all
+            # before we get a response back from
+            # scaling_group.get_scaling_group_state.
+            #
+            # So, we need an intermediate step that *guarantees* our test the
+            # ability to inspect Otter's behavior.  This is that step.
+            self.second_scaling_policy = ScalingPolicy(
+                scale_by=-1,
+                scaling_group=self.scaling_group
+            )
+
+            # We scale up by 2 here instead of 1, to make up for the -1 in the
+            # previous scaling policy.
+            self.third_scaling_policy = ScalingPolicy(
+                scale_by=2,
+                scaling_group=self.scaling_group
+            )
+
+            return (
+                self.scaling_group.start(rcs, self)
+                .addCallback(self.first_scaling_policy.start, self)
+                .addCallback(self.second_scaling_policy.start, self)
+                .addCallback(self.third_scaling_policy.start, self)
+                .addCallback(self.first_scaling_policy.execute)
+                .addCallback(
+                    self.scaling_group.wait_for_N_servers, 24, timeout=1800
+                ).addCallback(self.scaling_group.get_scaling_group_state)
+                .addCallback(self._choose_random_servers, 2)
+                .addCallback(self._delete_those_servers, rcs)
+                .addCallback(self.second_scaling_policy.execute)
+                .addCallback(
+                    self._wait_for_autoscale_to_catch_up, rcs, delta=-1
+                )
+                .addCallback(self.third_scaling_policy.execute)
+                .addCallback(
+                    self.scaling_group.wait_for_N_servers, 25, timeout=1800
+                )
+            )
+
+        return create_clb_first().addCallback(then_test)
+    test_scaling_to_clb_max_after_oob_delete_type1.timeout = 1800
 
     def test_reaction_to_oob_server_deletion(self):
         """Exercise out-of-band server deletion.  The goal is to spin up, say,
@@ -129,6 +231,18 @@ class TestConvergence(unittest.TestCase):
         self.n_killed = self.n_servers / 2
         return ids[:self.n_killed]
 
+    def _choose_random_servers(self, (code, response), n):
+        """Selects ``n`` randomly selected servers from those returned by the
+        ``get_scaling_group_state`` function.
+        """
+
+        if code != 200:
+            raise Exception("Got 404; dude, where's my scaling group?")
+        ids = map(lambda obj: obj['id'], response['group']['active'])
+        self.n_servers = len(ids)
+        self.n_killed = n
+        return random.sample(ids, n)
+
     def _delete_those_servers(self, ids, rcs):
         """Delete each of the servers selected."""
 
@@ -147,9 +261,16 @@ class TestConvergence(unittest.TestCase):
         # same.  So just return the 1st, which is just our rcs value.
         return gatherResults(deferreds).addCallback(lambda rslts: rslts[0])
 
-    def _wait_for_autoscale_to_catch_up(self, _, rcs, timeout=60, period=1):
+    def _wait_for_autoscale_to_catch_up(
+        self, _, rcs, timeout=60, period=1, delta=1
+    ):
         """Wait for the converger to recognize the reality of this tenant's
         situation and reflect it in the scaling group state accordingly.
+
+        Most tests are organized to execute a scale-up policy with a +1 delta.
+        For this reason, if you don't specify a ``delta`` kwArg, it defaults to
+        1.  For those tests which have a different scale-up policy, you'll need
+        to specify the delta you use explicitly.
         """
 
         def check((code, response)):
@@ -158,11 +279,7 @@ class TestConvergence(unittest.TestCase):
                     "Scaling group appears to have disappeared"
                 )
 
-            # Our scaling policy (see above) is configured to scale up by 1
-            # server.  Thus, we check to see if our server quantity equals
-            # the remaining servers plus 1.
-
-            n_remaining = self.n_servers - self.n_killed + 1
+            n_remaining = self.n_servers - self.n_killed + delta
             if len(response["group"]["active"]) == n_remaining:
                 return rcs
 


### PR DESCRIPTION
This exercises two variants of the core test logic:

1) When SG's max_entities == CLB's max
2) When SG's max_entities > CLB's max
