### PR TITLE
missing webhook keys mitigation - Issue #1223

### DIFF
--- a/otter/effect_dispatcher.py
+++ b/otter/effect_dispatcher.py
@@ -16,7 +16,6 @@ from .auth import (
     perform_invalidate_token,
 )
 from .cloud_client import TenantScope, perform_tenant_scope
-from .models.cass import CQLQueryExecute, perform_cql_query
 from .models.intents import get_model_dispatcher
 from .util.pure_http import Request, perform_request
 from .util.retry import Retry, perform_retry
@@ -68,19 +67,4 @@ def get_legacy_dispatcher(reactor, authenticator, log, service_configs):
             TenantScope: partial(perform_tenant_scope, authenticator, log,
                                  service_configs)}),
         get_simple_dispatcher(reactor),
-    ])
-
-
-def get_cql_dispatcher(reactor, connection):
-    """
-    Get dispatcher with `CQLQueryExecute`'s performer in it
-
-    :param reactor: Twisted reactor
-    :param connection: Silverberg connection
-    """
-    return ComposedDispatcher([
-        get_simple_dispatcher(reactor),
-        TypeDispatcher({
-            CQLQueryExecute: partial(perform_cql_query, connection)
-        })
     ])

--- a/otter/test/models/test_cass_models.py
+++ b/otter/test/models/test_cass_models.py
@@ -9,7 +9,7 @@ from datetime import datetime
 from functools import partial
 
 from effect import Effect, ParallelEffects, TypeDispatcher, sync_perform
-from effect.testing import resolve_effect
+from effect.testing import SequenceDispatcher, resolve_effect
 
 from jsonschema import ValidationError
 
@@ -41,7 +41,8 @@ from otter.models.cass import (
     assemble_webhooks_in_policies,
     perform_cql_query,
     serialize_json_data,
-    verified_view
+    verified_view,
+    webhook_by_hash_effect
 )
 from otter.models.interface import (
     GroupNotEmptyError,
@@ -65,7 +66,8 @@ from otter.test.utils import (
     LockMixin,
     matches,
     mock_log,
-    patch)
+    patch,
+    raise_)
 from otter.util.config import set_config_data
 from otter.util.timestamp import from_timestamp
 
@@ -2756,6 +2758,87 @@ class ScalingGroupWebhookMigrateTests(SynchronousTestCase):
                             consistency_level=ConsistencyLevel.ONE))
 
 
+class WebhookHashEffectTests(SynchronousTestCase):
+    """
+    Tests for :func:`webhook_by_hash_effect`
+    """
+    def setUp(self):
+        self.log = mock_log()
+        self.ch = 'h' * 64
+
+    def _get_intent(self, query):
+        return CQLQueryExecute(
+            query=query, params={'webhookKey': self.ch},
+            consistency_level=ConsistencyLevel.ONE)
+
+    def test_not_64_len(self):
+        """
+        Raises error if cap_hash is not 64 chars
+        """
+        self.assertRaises(
+            UnrecognizedCapabilityError, webhook_by_hash_effect,
+            self.log, 'hash', 'wk', 'pw')
+        self.assertRaises(
+            UnrecognizedCapabilityError, webhook_by_hash_effect,
+            self.log, 'ha' * 65, 'wk', 'pw')
+
+    def test_from_keys_table(self):
+        """
+        Returns info from keys table if found and does not check webhooks table
+        Does not log err
+        """
+        eff = webhook_by_hash_effect(self.log, self.ch, 'wk', 'pw')
+        disp = SequenceDispatcher(
+            [(self._get_intent(
+                'SELECT "tenantId", "groupId", "policyId" FROM wk '
+                'WHERE "webhookKey" = :webhookKey;'),
+              lambda i: [
+                  {'tenantId': 't1', 'groupId': 'g1', 'policyId': 'p1'}])])
+        self.assertEqual(sync_perform(disp, eff), ('t1', 'g1', 'p1'))
+        self.assertFalse(self.log.err.called)
+
+    def test_from_webhooks_table(self):
+        """
+        If info is not found in keys table, finds info in webhooks table
+        and logs error
+        """
+        eff = webhook_by_hash_effect(self.log, self.ch, 'wk', 'pw')
+        disp = SequenceDispatcher(
+            [(self._get_intent(
+                'SELECT "tenantId", "groupId", "policyId" FROM wk '
+                'WHERE "webhookKey" = :webhookKey;'),
+              lambda i: raise_(UnrecognizedCapabilityError(self.ch, 1))),
+             (self._get_intent(
+                'SELECT "tenantId", "groupId", "policyId" FROM pw '
+                'WHERE "webhookKey" = :webhookKey;'),
+              lambda i: [
+                  {'tenantId': 't1', 'groupId': 'g1', 'policyId': 'p1'}])])
+        self.assertEqual(sync_perform(disp, eff), ('t1', 'g1', 'p1'))
+        self.log.err.assert_called_once_with(
+            None,
+            ('Webhook hash not in webhook_keys table but in '
+             'policy_webhooks table'))
+
+    def test_not_found(self):
+        """
+        It tries the keys table and if not found tries the webhooks table
+        and if not found raises error
+        """
+        eff = webhook_by_hash_effect(self.log, self.ch, 'wk', 'pw')
+        disp = SequenceDispatcher(
+            [(self._get_intent(
+                'SELECT "tenantId", "groupId", "policyId" FROM wk '
+                'WHERE "webhookKey" = :webhookKey;'),
+              lambda i: raise_(UnrecognizedCapabilityError(self.ch, 1))),
+             (self._get_intent(
+                'SELECT "tenantId", "groupId", "policyId" FROM pw '
+                'WHERE "webhookKey" = :webhookKey;'),
+              lambda i: raise_(UnrecognizedCapabilityError(self.ch, 1)))])
+        self.assertRaises(
+            UnrecognizedCapabilityError, sync_perform, disp, eff)
+        self.assertFalse(self.log.err.called)
+
+
 class CassScalingScheduleCollectionTestCase(
         IScalingScheduleCollectionProviderMixin, SynchronousTestCase):
     """
@@ -3420,37 +3503,23 @@ class CassScalingGroupsCollectionTestCase(IScalingGroupCollectionProviderMixin,
         self.assertEqual(g.tenant_id, '123')
         self.assertIs(g.local_locks, self.collection.local_locks)
 
-    def test_webhook_info_by_hash(self):
+    @mock.patch('otter.models.cass.perform')
+    @mock.patch('otter.models.cass.get_cql_dispatcher')
+    @mock.patch('otter.models.cass.webhook_by_hash_effect')
+    def test_webhook_info_by_hash(self, mock_wbhe, mock_gqd, mock_p):
         """
-        `webhook_info_by_hash` gets the info from webhook_keys table
+        `webhook_info_by_hash` gets effect from `webhook_by_hash_effect`
+        and performs it
         """
-        self.returns = [_cassandrify_data([
-            {'tenantId': '123', 'groupId': 'group1', 'policyId': 'pol1'}]),
-            _cassandrify_data([{'data': '{}'}])
-        ]
-        expectedData = {'webhookKey': 'x'}
-        expectedCql = ('SELECT "tenantId", "groupId", "policyId" '
-                       'FROM webhook_keys '
-                       'WHERE "webhookKey" = :webhookKey;')
+        # NOTE: This is gnarly
         d = self.collection.webhook_info_by_hash(self.mock_log, 'x')
-        r = self.successResultOf(d)
-        self.assertEqual(r, ('123', 'group1', 'pol1'))
-        self.connection.execute.assert_called_once_with(
-            expectedCql, expectedData, ConsistencyLevel.ONE)
-
-    def test_webhook_bad(self):
-        """
-        Test that a bad webhook will fail with UnrecognizedCapabilityError
-        """
-        self.returns = [[]]
-        expectedData = {'webhookKey': 'x'}
-        expectedCql = ('SELECT "tenantId", "groupId", "policyId" '
-                       'FROM webhook_keys '
-                       'WHERE "webhookKey" = :webhookKey;')
-        d = self.collection.webhook_info_by_hash(self.mock_log, 'x')
-        self.failureResultOf(d, UnrecognizedCapabilityError)
-        self.connection.execute.assert_called_once_with(
-            expectedCql, expectedData, ConsistencyLevel.ONE)
+        self.assertEqual(d, mock_p.return_value)
+        mock_wbhe.assert_called_once_with(
+            self.mock_log, 'x', 'webhook_keys', 'policy_webhooks')
+        mock_gqd.assert_called_once_with(
+            self.collection.reactor, self.collection.connection)
+        mock_p.assert_called_once_with(
+            mock_gqd.return_value, mock_wbhe.return_value)
 
     def test_get_counts(self):
         """

--- a/otter/test/models/test_cass_models.py
+++ b/otter/test/models/test_cass_models.py
@@ -10,6 +10,7 @@ from functools import partial
 
 from effect import Effect, ParallelEffects, TypeDispatcher, sync_perform
 from effect.testing import SequenceDispatcher, resolve_effect
+from effect.twisted import deferred_performer
 
 from jsonschema import ValidationError
 
@@ -30,6 +31,7 @@ from twisted.internet import defer
 from twisted.internet.task import Clock
 from twisted.trial.unittest import SynchronousTestCase
 
+from otter.effect_dispatcher import get_simple_dispatcher
 from otter.json_schema import group_examples
 from otter.models.cass import (
     CQLQueryExecute,
@@ -39,6 +41,7 @@ from otter.models.cass import (
     WeakLocks,
     _assemble_webhook_from_row,
     assemble_webhooks_in_policies,
+    get_cql_dispatcher,
     perform_cql_query,
     serialize_json_data,
     verified_view,
@@ -61,6 +64,7 @@ from otter.test.models.test_interface import (
     IScalingGroupProviderMixin,
     IScalingScheduleCollectionProviderMixin
 )
+from otter.test.test_effect_dispatcher import simple_intents
 from otter.test.utils import (
     DummyException,
     LockMixin,
@@ -138,6 +142,31 @@ class PerformTests(SynchronousTestCase):
         self.assertEqual(r, 'ret')
         conn.execute.assert_called_once_with(
             'query', {'w': 2}, ConsistencyLevel.ONE)
+
+
+class CQLDispatcherTests(SynchronousTestCase):
+    """Tests for :func:`get_cql_dispatcher`."""
+
+    def test_intent_support(self):
+        """Basic intents are supported by the dispatcher."""
+        dispatcher = get_simple_dispatcher(None)
+        for intent in simple_intents():
+            self.assertIsNot(dispatcher(intent), None)
+
+    @mock.patch('otter.models.cass.perform_cql_query')
+    def test_cql_disp(self, mock_pcq):
+        """The :obj:`CQLQueryExecute` performer is called."""
+
+        @deferred_performer
+        def performer(c, d, i):
+            return defer.succeed('p' + c)
+
+        mock_pcq.side_effect = performer
+
+        dispatcher = get_cql_dispatcher(object(), 'conn')
+        intent = CQLQueryExecute(query='q', params='p', consistency_level=1)
+        eff = Effect(intent)
+        self.assertEqual(sync_perform(dispatcher, eff), 'pconn')
 
 
 class SerialJsonDataTestCase(SynchronousTestCase):

--- a/scripts/load_cql.py
+++ b/scripts/load_cql.py
@@ -20,8 +20,7 @@ from silverberg.client import CQLClient
 from twisted.internet import task
 from twisted.internet.endpoints import clientFromString
 
-from otter.effect_dispatcher import get_cql_dispatcher
-from otter.models.cass import CassScalingGroupCollection
+from otter.models.cass import CassScalingGroupCollection, get_cql_dispatcher
 from otter.test.resources import CQLGenerator
 
 


### PR DESCRIPTION
Mitigating #1223. Getting webhook key from policy_webhooks if it is not found in webhook_keys table. This is done temporarily until the root cause is known. It also logs error when such a situation arises. Did some refactoring:
   - implemented getting using effect. the main function only performs it 
   - moved `get_cql_dispatcher` to cass.py itself as their was cyclic import issues