### PR TITLE
Move performer and intent from supervisor to worker_intents

### DIFF
--- a/otter/controller.py
+++ b/otter/controller.py
@@ -47,7 +47,6 @@ from otter.log import audit
 from otter.models.intents import GetScalingGroupInfo
 from otter.supervisor import (
     CannotDeleteServerBelowMinError,
-    EvictServerFromScalingGroup,
     ServerNotFoundError,
     exec_scale_down,
     execute_launch_config)
@@ -59,6 +58,7 @@ from otter.util.retry import (
     retry_effect,
     retry_times)
 from otter.util.timestamp import from_timestamp
+from otter.worker_intents import EvictServerFromScalingGroup
 
 
 class CannotExecutePolicyError(Exception):

--- a/otter/supervisor.py
+++ b/otter/supervisor.py
@@ -6,8 +6,6 @@ This code is specific to the launch_server_v1 worker.
 
 from characteristic import attributes
 
-from effect.twisted import deferred_performer
-
 from twisted.application.service import Service
 from twisted.internet import reactor
 from twisted.internet.defer import succeed
@@ -685,22 +683,3 @@ def remove_server_from_group(log, trans_id, server_id, replace, purge, group, st
 
     d.addCallback(remove_server_from_state)
     return d
-
-
-@attributes(['log', 'transaction_id', 'scaling_group', 'server_id'])
-class EvictServerFromScalingGroup(object):
-    """
-    An Effect intent which indicates that a server should be evicted from a
-    particular group.
-    """
-
-
-@deferred_performer
-def perform_evict_server(supervisor, dispatcher, intent):
-    """
-    Perform evicting a server from the group.
-    """
-    return supervisor.scrub_otter_metadata(
-        intent.log, intent.transaction_id,
-        intent.scaling_group.tenant_id,
-        intent.server_id)

--- a/otter/test/test_controller.py
+++ b/otter/test/test_controller.py
@@ -30,7 +30,6 @@ from otter.models.interface import (
     GroupState, IScalingGroup, NoSuchPolicyError)
 from otter.supervisor import (
     CannotDeleteServerBelowMinError,
-    EvictServerFromScalingGroup,
     ServerNotFoundError)
 from otter.test.utils import (
     iMock,
@@ -42,6 +41,7 @@ from otter.test.utils import (
 from otter.util.retry import (
     Retry, ShouldDelayAndRetry, exponential_backoff_interval, retry_times)
 from otter.util.timestamp import MIN
+from otter.worker_intents import EvictServerFromScalingGroup
 
 
 class CalculateDeltaTestCase(SynchronousTestCase):

--- a/otter/test/test_supervisor.py
+++ b/otter/test/test_supervisor.py
@@ -1,9 +1,7 @@
 """
 Tests for the worker supervisor.
 """
-from functools import partial
-
-from effect import Constant, Effect, TypeDispatcher, sync_perform
+from effect import Constant, Effect
 
 import mock
 
@@ -23,12 +21,10 @@ from otter.models.interface import (
     GroupState, IScalingGroup, NoSuchScalingGroupError)
 from otter.supervisor import (
     CannotDeleteServerBelowMinError,
-    EvictServerFromScalingGroup,
     ISupervisor,
     ServerNotFoundError,
     SupervisorService,
     execute_launch_config,
-    perform_evict_server,
     remove_server_from_group,
     set_supervisor)
 from otter.test.utils import (
@@ -1254,33 +1250,3 @@ class RemoveServerTests(SynchronousTestCase):
         self._assert_create_scheduled(state)
         self._assert_metadata_scrubbing_scheduled()
         self.assertEqual(state.desired, 1)
-
-
-class PerformEvictionTests(SynchronousTestCase):
-    """
-    Tests for :func:`perform_evict_server` function
-    """
-    def test_perform_eviction(self):
-        """
-        Call supervisor's scrub metadata function.
-        """
-        supervisor = FakeSupervisor()
-        set_supervisor(supervisor)
-        self.addCleanup(set_supervisor, None)
-
-        log, group = (object(), mock_group(None))
-        intent = EvictServerFromScalingGroup(
-            log=log, transaction_id='transaction_id',
-            scaling_group=group, server_id='server_id')
-
-        r = sync_perform(
-            TypeDispatcher({
-                EvictServerFromScalingGroup: partial(
-                    perform_evict_server, supervisor)
-            }),
-            Effect(intent))
-
-        self.assertIsNone(r)
-        self.assertEqual(
-            supervisor.scrub_calls,
-            [(log, "transaction_id", group.tenant_id, 'server_id')])

--- a/otter/test/test_worker_intents.py
+++ b/otter/test/test_worker_intents.py
@@ -1,0 +1,45 @@
+"""
+Tests for :mod:`otter.worker_intents`
+"""
+
+from functools import partial
+
+from effect import Effect, TypeDispatcher
+from effect import sync_perform
+
+from twisted.trial.unittest import SynchronousTestCase
+
+from otter.supervisor import set_supervisor
+from otter.worker_intents import (
+    EvictServerFromScalingGroup, perform_evict_server)
+from otter.test.utils import FakeSupervisor, mock_group
+
+
+class PerformEvictionTests(SynchronousTestCase):
+    """
+    Tests for :func:`perform_evict_server` function
+    """
+    def test_perform_eviction(self):
+        """
+        Call supervisor's scrub metadata function.
+        """
+        supervisor = FakeSupervisor()
+        set_supervisor(supervisor)
+        self.addCleanup(set_supervisor, None)
+
+        log, group = (object(), mock_group(None))
+        intent = EvictServerFromScalingGroup(
+            log=log, transaction_id='transaction_id',
+            scaling_group=group, server_id='server_id')
+
+        r = sync_perform(
+            TypeDispatcher({
+                EvictServerFromScalingGroup: partial(
+                    perform_evict_server, supervisor)
+            }),
+            Effect(intent))
+
+        self.assertIsNone(r)
+        self.assertEqual(
+            supervisor.scrub_calls,
+            [(log, "transaction_id", group.tenant_id, 'server_id')])

--- a/otter/test/test_worker_intents.py
+++ b/otter/test/test_worker_intents.py
@@ -10,9 +10,9 @@ from effect import sync_perform
 from twisted.trial.unittest import SynchronousTestCase
 
 from otter.supervisor import set_supervisor
+from otter.test.utils import FakeSupervisor, mock_group
 from otter.worker_intents import (
     EvictServerFromScalingGroup, perform_evict_server)
-from otter.test.utils import FakeSupervisor, mock_group
 
 
 class PerformEvictionTests(SynchronousTestCase):

--- a/otter/worker_intents.py
+++ b/otter/worker_intents.py
@@ -1,0 +1,27 @@
+"""
+Intents for worker code including the controller, supervisor, and launch server
+worker.
+"""
+
+from characteristic import attributes
+
+from effect.twisted import deferred_performer
+
+
+@attributes(['log', 'transaction_id', 'scaling_group', 'server_id'])
+class EvictServerFromScalingGroup(object):
+    """
+    An Effect intent which indicates that a server should be evicted from a
+    particular group.
+    """
+
+
+@deferred_performer
+def perform_evict_server(supervisor, dispatcher, intent):
+    """
+    Perform evicting a server from the group.
+    """
+    return supervisor.scrub_otter_metadata(
+        intent.log, intent.transaction_id,
+        intent.scaling_group.tenant_id,
+        intent.server_id)


### PR DESCRIPTION
As suggested by @radix to avoid circular imports when making a dispatcher that handles `EvictServerFromScalingGroup`

This is just a move - no code changes except for imports from the controller.