### PR TITLE
More retries in steps

### DIFF
--- a/otter/convergence/steps.py
+++ b/otter/convergence/steps.py
@@ -331,7 +331,9 @@ class AddNodesToCLB(object):
                 _check_clb_422(_CLB_DUPLICATE_NODES_PATTERN)))
 
         def report_success(result):
-            return StepResult.SUCCESS, []
+            return StepResult.RETRY, [
+                'must re-gather after adding to CLB in order to update the '
+                'active cache']
 
         def report_api_failure(result):
             """
@@ -384,8 +386,9 @@ class RemoveNodesFromCLB(object):
                                _CLB_DELETED_PATTERN)))
         # 400 means that there are some nodes that are no longer on the
         # load balancer.  Parse them out and try again.
-        return eff.on(partial(
+        eff = eff.on(partial(
             _clb_check_bulk_delete, self.lb_id, self.node_ids))
+        return eff.on(lambda r: (StepResult.SUCCESS, []))
 
 
 def _clb_check_bulk_delete(lb_id, attempted_nodes, result):
@@ -575,7 +578,9 @@ def _rcv3_check_bulk_add(attempted_pairs, result):
         next_step = BulkAddToRCv3(lb_node_pairs=to_retry)
         return next_step.as_effect()
     else:
-        return StepResult.SUCCESS, []
+        return StepResult.RETRY, [
+            'must re-gather after adding to LB in order to update the active '
+            'cache']
 
 
 @implementer(IStep)

--- a/otter/convergence/steps.py
+++ b/otter/convergence/steps.py
@@ -553,7 +553,9 @@ def _rcv3_check_bulk_add(attempted_pairs, result):
     response, body = result
 
     if response.code == 201:  # All done!
-        return StepResult.SUCCESS, []
+        return StepResult.RETRY, [
+            'must re-gather after adding to LB in order to update the active '
+            'cache']
 
     failure_reasons = []
     to_retry = pset(attempted_pairs)
@@ -578,9 +580,9 @@ def _rcv3_check_bulk_add(attempted_pairs, result):
         next_step = BulkAddToRCv3(lb_node_pairs=to_retry)
         return next_step.as_effect()
     else:
-        return StepResult.RETRY, [
-            'must re-gather after adding to LB in order to update the active '
-            'cache']
+        # It's unclear when this condition is reached. Should we really be
+        # returning SUCCESS?
+        return StepResult.SUCCESS, []
 
 
 @implementer(IStep)

--- a/otter/test/convergence/test_service.py
+++ b/otter/test/convergence/test_service.py
@@ -1,3 +1,5 @@
+import time
+
 from effect import (
     ComposedDispatcher, Constant, Effect, Error, Func, ParallelEffects,
     TypeDispatcher, base_dispatcher, sync_perform)
@@ -17,8 +19,10 @@ from twisted.trial.unittest import SynchronousTestCase
 
 from otter.cloud_client import TenantScope, service_request
 from otter.constants import CONVERGENCE_DIRTY_DIR, ServiceType
+from otter.convergence.composition import get_desired_group_state
 from otter.convergence.model import (
-    CLBDescription, CLBNode, NovaServer, ServerState, StepResult)
+    CLBDescription, CLBNode, DesiredGroupState, NovaServer, ServerState,
+    StepResult)
 from otter.convergence.service import (
     ConcurrentError,
     ConvergenceStarter,
@@ -640,38 +644,38 @@ class ExecuteConvergenceTests(SynchronousTestCase):
 
     def test_success(self):
         """
-        Executes optimized steps if state of world does not match desired and
-        returns the result of all the steps.
+        Executes the plan and returns SUCCESS when that's the most severe
+        result.
         """
-        # The scenario: We have two servers but they're not in the LBs
-        # yet. convergence should add them to the LBs.
         log = mock_log()
         gacd = self._get_gacd_func(self.group.uuid)
+        def plan(dgs, servers, lb_nodes, now):
+            return [
+                TestStep(
+                    Effect(
+                        {'dgs': dgs,
+                         'servers': servers,
+                         'lb_nodes': lb_nodes,
+                         'now': now})
+                    .on(lambda _: (StepResult.SUCCESS, [])))]
+
         eff = execute_convergence(self.tenant_id, self.group_id, log,
-                                  get_all_convergence_data=gacd)
-        expected_req = service_request(
-            ServiceType.CLOUD_LOAD_BALANCERS,
-            'POST',
-            'loadbalancers/23/nodes',
-            data=transform_eq(
-                freeze,
-                pmap({
-                    'nodes': transform_eq(
-                        lambda nodes: set(freeze(nodes)),
-                        set([pmap({'weight': 1, 'type': 'PRIMARY',
-                                   'port': 80,
-                                   'condition': 'ENABLED',
-                                   'address': '10.0.0.2'}),
-                             pmap({'weight': 1, 'type': 'PRIMARY',
-                                   'port': 80,
-                                   'condition': 'ENABLED',
-                                   'address': '10.0.0.1'})]))})),
-            success_pred=mock.ANY)
-        expected_intents = self.expected_intents + [
-            (expected_req.intent, 'successful response')]
-        result = sync_perform(self._get_dispatcher(expected_intents), eff)
+                                  get_all_convergence_data=gacd,
+                                  plan=plan)
+
+        sequence = SequenceDispatcher([
+            (Func(time.time), lambda i: 500),
+            ({'dgs': get_desired_group_state(self.group_id, self.lc, 2),
+              'servers': tuple(self.servers),
+              'lb_nodes': (),
+              'now': 500},
+             lambda i: None)
+        ])
+        dispatcher = ComposedDispatcher([sequence, self._get_dispatcher()])
+        result = sync_perform(dispatcher, eff)
         self.assertEqual(self.group.modify_state_values[-1].active, {})
         self.assertEqual(result, StepResult.SUCCESS)
+        self.assertEqual(sequence.sequence, [])
 
     def test_first_error_extraction(self):
         """

--- a/otter/test/convergence/test_service.py
+++ b/otter/test/convergence/test_service.py
@@ -10,19 +10,16 @@ from effect.testing import EQDispatcher, EQFDispatcher, SequenceDispatcher
 from kazoo.exceptions import BadVersionError
 from kazoo.recipe.partitioner import PartitionState
 
-import mock
-
 from pyrsistent import freeze, pbag, pmap, pset, s
 
 from twisted.internet.defer import fail, succeed
 from twisted.trial.unittest import SynchronousTestCase
 
-from otter.cloud_client import TenantScope, service_request
-from otter.constants import CONVERGENCE_DIRTY_DIR, ServiceType
+from otter.cloud_client import TenantScope
+from otter.constants import CONVERGENCE_DIRTY_DIR
 from otter.convergence.composition import get_desired_group_state
 from otter.convergence.model import (
-    CLBDescription, CLBNode, DesiredGroupState, NovaServer, ServerState,
-    StepResult)
+    CLBDescription, CLBNode, NovaServer, ServerState, StepResult)
 from otter.convergence.service import (
     ConcurrentError,
     ConvergenceStarter,
@@ -649,6 +646,7 @@ class ExecuteConvergenceTests(SynchronousTestCase):
         """
         log = mock_log()
         gacd = self._get_gacd_func(self.group.uuid)
+
         def plan(dgs, servers, lb_nodes, now):
             return [
                 TestStep(

--- a/otter/test/convergence/test_steps.py
+++ b/otter/test/convergence/test_steps.py
@@ -536,8 +536,11 @@ class StepAsEffectTests(SynchronousTestCase):
                 }),
                 request)
 
-        self.assertEqual(get_result(StubResponse(202, {}), ''),
-                         (StepResult.SUCCESS, []))
+        self.assertEqual(
+            get_result(StubResponse(202, {}), ''),
+            (StepResult.RETRY,
+             ['must re-gather after adding to CLB in order to update the '
+              'active cache']))
 
         self.assertEqual(
             get_result(
@@ -548,7 +551,9 @@ class StepAsEffectTests(SynchronousTestCase):
                                "balancer.",
                     "code": 422
                 }),
-            (StepResult.SUCCESS, []))
+            (StepResult.RETRY,
+             ['must re-gather after adding to CLB in order to update the '
+              'active cache']))
 
     def test_add_nodes_to_clb_failure_response_codes(self):
         """
@@ -929,7 +934,9 @@ class RCv3CheckBulkAddTests(SynchronousTestCase):
     """
     def test_good_response(self):
         """
-        If the response code indicates success, the response was successful.
+        If the response code indicates success, the step returns a RETRY so
+        that another convergence cycle can be done to update the active server
+        list.
         """
         node_a_id = '825b8c72-9951-4aff-9cd8-fa3ca5551c90'
         lb_a_id = '2b0e17b6-0429-4056-b86c-e670ad5de853'
@@ -944,7 +951,11 @@ class RCv3CheckBulkAddTests(SynchronousTestCase):
                  "load_balancer_pool": {"id": lb_id}}
                 for (lb_id, node_id) in pairs]
         res = _rcv3_check_bulk_add(pairs, (resp, body))
-        self.assertEqual(res, (StepResult.SUCCESS, []))
+        self.assertEqual(
+            res,
+            (StepResult.RETRY,
+             ['must re-gather after adding to LB in order to update the '
+              'active cache']))
 
     def test_try_again(self):
         """


### PR DESCRIPTION
- AddNodesToCLB now returns RETRY on success, so that cached active servers can be updated
- ditto adding nodes to RCv3. There's still one case that I'm not sure about (see comment)
- make RemoveNodesFromCLB return step results at all (it hadn't been updated to the new step result API). It returns SUCCESS just because a remove from LB should always immediately be followed by a remove from server (or if not, the server isn't ours anyway?) This fixes #1171.

The fact that pretty much all SUCCESSes are gradually becoming RETRY does make me wonder if we should move this "retry to update active cache" *back* to service.py. but there are a few cases where we don't need to? more analysis necessary, but I think for now we should make this change so that stuff works.