### PR TITLE
Pass params through during request concretization

### DIFF
--- a/otter/cloud_client.py
+++ b/otter/cloud_client.py
@@ -190,6 +190,7 @@ def concretize_service_request(
             service_request.url,
             headers=service_request.headers,
             data=service_request.data,
+            params=service_request.params,
             log=log)
     return auth_eff.on(got_auth)
 

--- a/otter/test/test_cloud_client.py
+++ b/otter/test/test_cloud_client.py
@@ -247,6 +247,14 @@ class PerformServiceRequestTests(SynchronousTestCase):
 
         self.assertEqual(cm.exception.body, "THIS IS A FAILURE")
 
+    def test_params(self):
+        """Params are passed through."""
+        svcreq = service_request(ServiceType.CLOUD_SERVERS, "GET", "servers",
+                                 params={"foo": ["bar"]}).intent
+        eff = self._concrete(svcreq)
+        pure_request_eff = resolve_authenticate(eff)
+        self.assertEqual(pure_request_eff.intent.params, {"foo": ["bar"]})
+
 
 class PerformTenantScopeTests(SynchronousTestCase):
     """Tests for :func:`perform_tenant_scope`."""


### PR DESCRIPTION
`concretize_service_request` was not passing params through to the underlying `pure_http.Request`. The CLB bulk delete step is relying on this.