### PR TITLE
a bunch of miscellaneous logging improvements

### DIFF
--- a/otter/convergence/service.py
+++ b/otter/convergence/service.py
@@ -119,7 +119,7 @@ def execute_convergence(tenant_id, group_id, log,
     steps = plan(desired_group_state, servers, lb_nodes, now)
     active = determine_active(servers, lb_nodes)
     log.msg('execute-convergence',
-            servers=servers, lb_nodes=lb_nodes, steps=steps, now=now,
+            servers=servers, lb_nodes=lb_nodes, steps=list(steps), now=now,
             desired=desired_group_state, active=active)
     yield _update_active(scaling_group, active)
     if len(steps) == 0:
@@ -132,7 +132,7 @@ def execute_convergence(tenant_id, group_id, log,
     worst_status = priority[0][0]
     log.msg('execute-convergence-results',
             results=zip(steps, results),
-            worst_status=worst_status)
+            worst_status=worst_status.name)
 
     yield do_return(worst_status)
 
@@ -228,7 +228,7 @@ class ConvergenceStarter(object):
 
     def start_convergence(self, log, tenant_id, group_id, perform=perform):
         """Record that a group needs converged by creating a ZooKeeper node."""
-        log = log.bind(tenant_id=tenant_id, group_id=group_id)
+        log = log.bind(tenant_id=tenant_id, scaling_group_id=group_id)
         eff = mark_divergent(tenant_id, group_id)
         d = perform(self._dispatcher, eff)
 
@@ -306,7 +306,7 @@ def converge_one_group(log, currently_converging, tenant_id, group_id, version,
     :param Reference currently_converging: pset of currently converging groups
     :param version: version number of ZNode of the group's dirty flag
     """
-    log = log.bind(tenant_id=tenant_id, group_id=group_id)
+    log = log.bind(tenant_id=tenant_id, scaling_group_id=group_id)
     eff = execute_convergence(tenant_id, group_id, log)
     try:
         result = yield non_concurrently(currently_converging, group_id, eff)

--- a/otter/test/convergence/test_service.py
+++ b/otter/test/convergence/test_service.py
@@ -62,7 +62,7 @@ class ConvergenceStarterTests(SynchronousTestCase):
              Effect(CreateOrSet(path='/groups/divergent/tenant_group',
                                 content='dirty'))))
         log.msg.assert_called_once_with(
-            'mark-dirty-success', tenant_id='tenant', group_id='group')
+            'mark-dirty-success', tenant_id='tenant', scaling_group_id='group')
 
     def test_error_marking_dirty(self):
         """An error is logged when marking dirty fails."""
@@ -75,7 +75,7 @@ class ConvergenceStarterTests(SynchronousTestCase):
         self.assertEqual(self.successResultOf(d), None)
         log.err.assert_called_once_with(
             CheckFailureValue(RuntimeError('oh no')),
-            'mark-dirty-failure', tenant_id='tenant', group_id='group')
+            'mark-dirty-failure', tenant_id='tenant', scaling_group_id='group')
 
 
 class ConvergerTests(SynchronousTestCase):
@@ -232,11 +232,11 @@ class ConvergeOneGroupTests(SynchronousTestCase):
             calls,
             [(self.tenant_id, self.group_id,
               matches(IsBoundWith(tenant_id=self.tenant_id,
-                                  group_id=self.group_id)))])
+                                  scaling_group_id=self.group_id)))])
         self.assertEqual(self.deletions, [True])
         self.log.msg.assert_any_call(
             'mark-clean-success',
-            tenant_id=self.tenant_id, group_id=self.group_id)
+            tenant_id=self.tenant_id, scaling_group_id=self.group_id)
 
     def test_non_concurrent(self):
         """
@@ -277,12 +277,12 @@ class ConvergeOneGroupTests(SynchronousTestCase):
         self.log.err.assert_any_call(
             None,
             'converge-fatal-error',
-            tenant_id=self.tenant_id, group_id=self.group_id)
+            tenant_id=self.tenant_id, scaling_group_id=self.group_id)
 
         self.assertEqual(self.deletions, [True])
         self.log.msg.assert_any_call(
             'mark-clean-success',
-            tenant_id=self.tenant_id, group_id=self.group_id)
+            tenant_id=self.tenant_id, scaling_group_id=self.group_id)
 
     def test_unexpected_errors(self):
         """
@@ -301,7 +301,7 @@ class ConvergeOneGroupTests(SynchronousTestCase):
         self.log.err.assert_any_call(
             None,
             'converge-non-fatal-error',
-            tenant_id=self.tenant_id, group_id=self.group_id)
+            tenant_id=self.tenant_id, scaling_group_id=self.group_id)
         self.assertEqual(self.deletions, [])
 
     def test_delete_node_version_mismatch(self):
@@ -331,7 +331,7 @@ class ConvergeOneGroupTests(SynchronousTestCase):
         self.log.err.assert_any_call(
             CheckFailureValue(BadVersionError()),
             'mark-clean-failure',
-            tenant_id=self.tenant_id, group_id=self.group_id,
+            tenant_id=self.tenant_id, scaling_group_id=self.group_id,
             dirty_version=5,
             path='/groups/divergent/tenant-id_g1')
 

--- a/otter/test/test_logging_treq.py
+++ b/otter/test/test_logging_treq.py
@@ -28,7 +28,8 @@ class LoggingTreqTest(SynchronousTestCase):
 
         configuration = {}
 
-        for method in ('request', 'head', 'get', 'put', 'patch', 'post', 'delete'):
+        for method in ('request', 'head', 'get', 'put', 'patch', 'post',
+                       'delete'):
             configuration['{0}.__name__'.format(method)] = method
             configuration['{0}.return_value'.format(method)] = Deferred()
 
@@ -46,11 +47,12 @@ class LoggingTreqTest(SynchronousTestCase):
         """
         self.assertEqual(self.log.msg.mock_calls, [
             mock.call(mock.ANY, url=self.url, system="treq.request",
-                      method=method, treq_request_id=mock.ANY, url_params=None),
+                      method=method, treq_request_id=mock.ANY,
+                      url_params=None),
             mock.call(
                 mock.ANY, url=self.url, status_code=status, headers={'1': '2'},
-                system="treq.request", request_time=request_time, method=method,
-                treq_request_id=mock.ANY, url_params=None)
+                system="treq.request", request_time=request_time,
+                method=method, treq_request_id=mock.ANY, url_params=None)
         ])
 
     def _assert_failure_logging(self, method, exception_type, request_time):
@@ -59,11 +61,12 @@ class LoggingTreqTest(SynchronousTestCase):
         """
         self.assertEqual(self.log.msg.mock_calls, [
             mock.call(mock.ANY, url=self.url, system="treq.request",
-                      method=method, treq_request_id=mock.ANY, url_params=None),
+                      method=method, treq_request_id=mock.ANY,
+                      url_params=None),
             mock.call(
                 mock.ANY, url=self.url, reason=CheckFailure(exception_type),
-                system="treq.request", request_time=request_time, method=method,
-                treq_request_id=mock.ANY, url_params=None)
+                system="treq.request", request_time=request_time,
+                method=method, treq_request_id=mock.ANY, url_params=None)
         ])
 
     def test_request(self):

--- a/otter/test/test_logging_treq.py
+++ b/otter/test/test_logging_treq.py
@@ -41,18 +41,19 @@ class LoggingTreqTest(SynchronousTestCase):
 
         self.url = 'myurl'
 
-    def _assert_success_logging(self, method, status, request_time):
+    def _assert_success_logging(self, method, status, request_time,
+                                url_params=None):
         """
         msg expected to be made on a successful request are logged
         """
         self.assertEqual(self.log.msg.mock_calls, [
             mock.call(mock.ANY, url=self.url, system="treq.request",
                       method=method, treq_request_id=mock.ANY,
-                      url_params=None),
+                      url_params=url_params),
             mock.call(
                 mock.ANY, url=self.url, status_code=status, headers={'1': '2'},
                 system="treq.request", request_time=request_time,
-                method=method, treq_request_id=mock.ANY, url_params=None)
+                method=method, treq_request_id=mock.ANY, url_params=url_params)
         ])
 
     def _assert_failure_logging(self, method, exception_type, request_time):
@@ -84,6 +85,18 @@ class LoggingTreqTest(SynchronousTestCase):
 
         self.assertIs(self.successResultOf(d), self.response)
         self._assert_success_logging('patch', 204, 5)
+
+    def test_url_params(self):
+        """`params` is logged as `url_params`."""
+        params = {'key': 'val'}
+        d = logging_treq.request('get', self.url, headers={}, data='',
+                                 log=self.log, params=params, clock=self.clock)
+        self.clock.advance(5)
+        self.treq.request.return_value.callback(self.response)
+        self.treq.request.assert_called_once_with(
+            method='get', url=self.url, headers={}, data='', params=params)
+        self.assertIs(self.successResultOf(d), self.response)
+        self._assert_success_logging('get', 204, 5, url_params=params)
 
     def test_request_failure(self):
         """

--- a/otter/test/test_logging_treq.py
+++ b/otter/test/test_logging_treq.py
@@ -46,11 +46,11 @@ class LoggingTreqTest(SynchronousTestCase):
         """
         self.assertEqual(self.log.msg.mock_calls, [
             mock.call(mock.ANY, url=self.url, system="treq.request",
-                      method=method, treq_request_id=mock.ANY),
+                      method=method, treq_request_id=mock.ANY, url_params=None),
             mock.call(
                 mock.ANY, url=self.url, status_code=status, headers={'1': '2'},
                 system="treq.request", request_time=request_time, method=method,
-                treq_request_id=mock.ANY)
+                treq_request_id=mock.ANY, url_params=None)
         ])
 
     def _assert_failure_logging(self, method, exception_type, request_time):
@@ -59,11 +59,11 @@ class LoggingTreqTest(SynchronousTestCase):
         """
         self.assertEqual(self.log.msg.mock_calls, [
             mock.call(mock.ANY, url=self.url, system="treq.request",
-                      method=method, treq_request_id=mock.ANY),
+                      method=method, treq_request_id=mock.ANY, url_params=None),
             mock.call(
                 mock.ANY, url=self.url, reason=CheckFailure(exception_type),
                 system="treq.request", request_time=request_time, method=method,
-                treq_request_id=mock.ANY)
+                treq_request_id=mock.ANY, url_params=None)
         ])
 
     def test_request(self):

--- a/otter/util/logging_treq.py
+++ b/otter/util/logging_treq.py
@@ -30,6 +30,7 @@ def _log_request(treq_call, url, **kwargs):
 
     treq_transaction = str(uuid4())
     log = log.bind(system='treq.request', url=url, method=method,
+                   url_params=kwargs.get('params'),
                    treq_request_id=treq_transaction)
     start_time = clock.seconds()
 


### PR DESCRIPTION
- make convergence bind `scaling_group_id` instead of `group_id` to be consistent with the rest of otter
- convert steps to list so they're a bit more structured
- log worst_status.name instead of worst_status repr
- log url_params in logging_treq