### PR TITLE
Add tenant override for convergence.

### DIFF
--- a/otter/integration/lib/identity.py
+++ b/otter/integration/lib/identity.py
@@ -9,6 +9,7 @@ from characteristic import Attribute, attributes
     Attribute('password', instance_of=str),
     Attribute('endpoint', instance_of=str),
     Attribute('pool', default_value=None),
+    Attribute('convergence_tenant_override', default_value=None),
 ])
 class IdentityV2(object):
     """This class provides a way to configure commonly used parameters
@@ -50,7 +51,8 @@ class IdentityV2(object):
         """
 
         return self.auth.authenticate_user(
-            self.endpoint, self.username, self.password, pool=self.pool
+            self.endpoint, self.username, self.password, pool=self.pool,
+            tenant_id=self.convergence_tenant_override,
         ).addCallback(rcs.init_from_access)
 
 

--- a/otter/integration/lib/test_identity.py
+++ b/otter/integration/lib/test_identity.py
@@ -86,7 +86,9 @@ class IdentityV2Tests(SynchronousTestCase):
             def __init__(self):
                 self.pool = None
 
-            def authenticate_user(self, endpt, user, passwd, pool=None):
+            def authenticate_user(
+                self, endpt, user, passwd, pool=None, tenant_id=None
+            ):
                 self.pool = pool
                 return defer.succeed(_test_catalog)
 

--- a/otter/integration/tests/test_convergence.py
+++ b/otter/integration/tests/test_convergence.py
@@ -38,6 +38,7 @@ region = os.environ['AS_REGION']
 # not throw an exception.  None is a valid value for convergence_tenant.
 convergence_tenant = os.environ.get('AS_CONVERGENCE_TENANT')
 
+
 class TestConvergence(unittest.TestCase):
     """This class contains test cases aimed at the Otter Converger."""
 

--- a/otter/integration/tests/test_convergence.py
+++ b/otter/integration/tests/test_convergence.py
@@ -34,7 +34,9 @@ endpoint = os.environ['AS_IDENTITY']
 flavor_ref = os.environ['AS_FLAVOR_REF']
 image_ref = os.environ['AS_IMAGE_REF']
 region = os.environ['AS_REGION']
-
+# Get vs dict lookup because it will return None if not found,
+# not throw an exception.  None is a valid value for convergence_tenant.
+convergence_tenant = os.environ.get('AS_CONVERGENCE_TENANT')
 
 class TestConvergence(unittest.TestCase):
     """This class contains test cases aimed at the Otter Converger."""
@@ -48,7 +50,8 @@ class TestConvergence(unittest.TestCase):
         self.pool = HTTPConnectionPool(reactor, False)
         self.identity = IdentityV2(
             auth=auth, username=username, password=password,
-            endpoint=endpoint, pool=self.pool
+            endpoint=endpoint, pool=self.pool,
+            convergence_tenant_override=convergence_tenant,
         )
 
     def tearDown(self):


### PR DESCRIPTION
To use:

$ trial test.foo.bar  --  without Convergence
$ AS_CONVERGENCE_TENANT=000000 trial test.foo.bar  --  with convergence