### PR TITLE
Deleting column and index in query

### DIFF
--- a/otter/models/cass.py
+++ b/otter/models/cass.py
@@ -1594,6 +1594,9 @@ class CassScalingGroupCollection:
         return r[0]['count']
 
     def get_groups_count(self, log, tenant_id):
+        """
+        Return number of valid (non-deleting) groups of the tenant
+        """
         d = self.connection.execute(
             _cql_count_for_tenant.format(cf='scaling_group',
                                          deleting='AND deleting=false'),

--- a/otter/models/cass.py
+++ b/otter/models/cass.py
@@ -1179,7 +1179,11 @@ class CassScalingGroup(object):
             d.addCallback(_assemble_webhook)
             return d
 
-        return self.get_policy(policy_id).addCallback(fetch_webhook)
+        # Ensure group is there since it can be deleting group and its
+        # corresponding policy and webhook entries will remain.
+        # We need not check if policy exists since corresponding
+        # webhook row will not be there if policy is not there
+        return self.view_config().addCallback(fetch_webhook)
 
     def update_webhook(self, policy_id, webhook_id, data):
         """

--- a/otter/models/cass.py
+++ b/otter/models/cass.py
@@ -92,9 +92,9 @@ def serialize_json_data(data, ver):
 # Otherwise it won't.
 #
 # Thus, selects have a semicolon, everything else doesn't.
-_cql_view = ('SELECT {column}, created_at, deleting FROM {cf} '
-             'WHERE "tenantId" = :tenantId AND '
-             '"groupId" = :groupId;')
+_cql_view = ('SELECT {column}, created_at FROM {cf} '
+             'WHERE "tenantId" = :tenantId AND "groupId" = :groupId '
+             'AND deleting=false;')
 _cql_view_policy = (
     'SELECT data, version FROM {cf} '
     'WHERE "tenantId" = :tenantId AND "groupId" = :groupId '
@@ -107,10 +107,10 @@ _cql_view_webhook = (
 _cql_create_group = (
     'INSERT INTO {cf}("tenantId", "groupId", group_config, '
     'launch_config, active, pending, "policyTouched", paused, '
-    'desired, created_at) '
+    'desired, created_at, deleting) '
     'VALUES (:tenantId, :groupId, :group_config, '
     ':launch_config, :active, :pending, :policyTouched, '
-    ':paused, :desired, :created_at) '
+    ':paused, :desired, :created_at, false) '
     'USING TIMESTAMP :ts')
 _cql_view_manifest = (
     'SELECT "tenantId", "groupId", group_config, '
@@ -129,8 +129,9 @@ _cql_insert_group_state = (
     'USING TIMESTAMP :ts')
 _cql_view_group_state = (
     'SELECT "tenantId", "groupId", group_config, active, pending, '
-    '"groupTouched", "policyTouched", paused, desired, created_at, deleting '
-    'FROM {cf} WHERE "tenantId" = :tenantId AND "groupId" = :groupId;')
+    '"groupTouched", "policyTouched", paused, desired, created_at '
+    'FROM {cf} '
+    'WHERE "tenantId"=:tenantId AND "groupId"=:groupId AND deleting=false;')
 
 # --- Event related queries
 _cql_insert_group_event = (
@@ -183,7 +184,7 @@ _cql_delete_one_webhook = (
     '"webhookId" = :webhookId')
 _cql_list_states = (
     'SELECT "tenantId", "groupId", group_config, active, pending, '
-    '"groupTouched", "policyTouched", paused, desired, created_at, deleting '
+    '"groupTouched", "policyTouched", paused, desired, created_at '
     'FROM {cf} WHERE "tenantId"=:tenantId AND deleting=false;')
 _cql_list_policy = (
     'SELECT "policyId", data FROM {cf} WHERE '
@@ -206,7 +207,7 @@ _cql_del_on_key = 'DELETE FROM {cf} WHERE "webhookKey"=:{name}webhookKey'
 
 _cql_count_for_tenant = (
     'SELECT COUNT(*) FROM {cf} '
-    'WHERE "tenantId" = :tenantId;')
+    'WHERE "tenantId"=:tenantId AND deleting=false;')
 _cql_count_for_policy = (
     'SELECT COUNT(*) FROM {cf} '
     'WHERE "tenantId" = :tenantId AND "groupId" = :groupId '
@@ -498,14 +499,13 @@ def assemble_webhooks_in_policies(policies, webhooks):
 
 
 def verified_view(connection, view_query, del_query, data, consistency,
-                  exception_if_empty, log, get_deleting=False):
+                  exception_if_empty, log):
     """
     Ensures the view query on the group does not get resurrected row,
     i.e. one that does not have "created_at" in it.  Any resurrected entry is
     deleted and `exception_if_empty` is raised. Also raises
     `exception_if_empty` if group's status is DELETING
 
-    :param bool get_deleting: Should it return deleting group?
     :return: Deferred that fires with result of executing view query
     """
     def _check_resurrection(result):
@@ -516,9 +516,6 @@ def verified_view(connection, view_query, del_query, data, consistency,
             # resurrected row, trigger its deletion and raise empty exception
             log.msg('Resurrected row', row=result[0], row_params=data)
             connection.execute(del_query, data, consistency)
-            raise exception_if_empty
-        # Do not return group if group is deleting unless we are told to do so
-        if not get_deleting and group.get('deleting', False):
             raise exception_if_empty
         return group
 
@@ -699,6 +696,11 @@ class CassScalingGroup(object):
                 m['status'] = status.name
             return m
 
+        def check_deleting(group):
+            if not get_deleting and group['deleting']:
+                raise NoSuchScalingGroupError(self.tenant_id, self.uuid)
+            return group
+
         view_query = _cql_view_manifest.format(
             cf=self.group_table)
         del_query = _cql_delete_all_in_group.format(
@@ -708,7 +710,8 @@ class CassScalingGroup(object):
                            "groupId": self.uuid},
                           DEFAULT_CONSISTENCY,
                           NoSuchScalingGroupError(self.tenant_id, self.uuid),
-                          self.log, get_deleting=get_deleting)
+                          self.log)
+        d.addCallback(check_deleting)
         d.addCallback(_generate_manifest_group_part)
 
         if with_policies:
@@ -940,19 +943,22 @@ class CassScalingGroup(object):
         """
         see :meth:`otter.models.interface.IScalingGroup.get_policy`
         """
-        query = _cql_view_policy.format(cf=self.policies_table)
-        d = self.connection.execute(query,
-                                    {"tenantId": self.tenant_id,
-                                     "groupId": self.uuid,
-                                     "policyId": policy_id},
-                                    DEFAULT_CONSISTENCY)
+        def fetch_policy(_):
+            query = _cql_view_policy.format(cf=self.policies_table)
+            d = self.connection.execute(query,
+                                        {"tenantId": self.tenant_id,
+                                        "groupId": self.uuid,
+                                        "policyId": policy_id},
+                                        DEFAULT_CONSISTENCY)
+            return d.addCallback(_extract_policy)
 
         def _extract_policy(rows):
             if len(rows) == 0 or version and rows[0]['version'] != version:
                 raise NoSuchPolicyError(self.tenant_id, self.uuid, policy_id)
             return _jsonloads_data(rows[0]['data'])
 
-        return d.addCallback(_extract_policy)
+        d = self.view_config()  # Ensure group exists
+        return d.addCallback(fetch_policy)
 
     def create_policies(self, data):
         """
@@ -1163,15 +1169,18 @@ class CassScalingGroup(object):
                                          webhook_id)
             return _assemble_webhook_from_row(cass_data[0])
 
-        query = _cql_view_webhook.format(cf=self.webhooks_table)
-        d = self.connection.execute(query,
-                                    {"tenantId": self.tenant_id,
-                                     "groupId": self.uuid,
-                                     "policyId": policy_id,
-                                     "webhookId": webhook_id},
-                                    DEFAULT_CONSISTENCY)
-        d.addCallback(_assemble_webhook)
-        return d
+        def fetch_webhook(_):
+            query = _cql_view_webhook.format(cf=self.webhooks_table)
+            d = self.connection.execute(query,
+                                        {"tenantId": self.tenant_id,
+                                        "groupId": self.uuid,
+                                        "policyId": policy_id,
+                                        "webhookId": webhook_id},
+                                        DEFAULT_CONSISTENCY)
+            d.addCallback(_assemble_webhook)
+            return d
+
+        return self.get_policy(policy_id).addCallback(fetch_webhook)
 
     def update_webhook(self, policy_id, webhook_id, data):
         """
@@ -1463,7 +1472,6 @@ class CassScalingGroupCollection:
         d = self.connection.execute(cql.format(cf=self.group_table), params,
                                     DEFAULT_CONSISTENCY)
         d.addCallback(_filter_resurrected)
-        d.addCallback(filter(lambda g: not g['deleting']))
         d.addCallback(_build_states)
         return d
 

--- a/otter/models/cass.py
+++ b/otter/models/cass.py
@@ -184,7 +184,7 @@ _cql_delete_one_webhook = (
 _cql_list_states = (
     'SELECT "tenantId", "groupId", group_config, active, pending, '
     '"groupTouched", "policyTouched", paused, desired, created_at, deleting '
-    'FROM {cf} WHERE "tenantId" = :tenantId;')
+    'FROM {cf} WHERE "tenantId"=:tenantId AND deleting=false;')
 _cql_list_policy = (
     'SELECT "policyId", data FROM {cf} WHERE '
     '"tenantId" = :tenantId AND "groupId" = :groupId;')

--- a/otter/tap/api.py
+++ b/otter/tap/api.py
@@ -196,7 +196,8 @@ def makeService(config):
             config_value('cassandra.timeout') or 30),
         log.bind(system='otter.silverberg'))
 
-    store = CassScalingGroupCollection(cassandra_cluster, reactor)
+    store = CassScalingGroupCollection(
+        cassandra_cluster, reactor, config_value('limits.absolute.maxGroups'))
     admin_store = CassAdmin(cassandra_cluster)
 
     bobby_url = config_value('bobby_url')

--- a/otter/test/models/test_cass_models.py
+++ b/otter/test/models/test_cass_models.py
@@ -253,13 +253,13 @@ class VerifiedViewTests(SynchronousTestCase):
         self.connection = mock.Mock(spec=CQLClient)
         self.log = mock_log()
 
-    def _verified_view(self, get_deleting=False):
+    def _verified_view(self):
         """
         Returns a verified view, with some test arguments.
         """
         return verified_view(
             self.connection, 'vq', 'dq', {'d': 2}, ConsistencyLevel.TWO,
-            ValueError, self.log, get_deleting=get_deleting)
+            ValueError, self.log)
 
     def test_valid_view(self):
         """
@@ -269,32 +269,6 @@ class VerifiedViewTests(SynchronousTestCase):
             [{'c1': 2, 'created_at': 23}])
         r = self._verified_view()
         self.assertEqual(self.successResultOf(r), {'c1': 2, 'created_at': 23})
-        self.connection.execute.assert_called_once_with(
-            'vq', {'d': 2}, ConsistencyLevel.TWO)
-        self.assertFalse(self.log.msg.called)
-
-    def test_get_deleting_group(self):
-        """
-        Get DELETING group when get_deleting=True
-        """
-        self.connection.execute.return_value = defer.succeed(
-            [{'c1': 2, 'created_at': 23, 'deleting': True}])
-        r = self._verified_view(get_deleting=True)
-        self.assertEqual(
-            self.successResultOf(r),
-            {'c1': 2, 'created_at': 23, 'deleting': True})
-        self.connection.execute.assert_called_once_with(
-            'vq', {'d': 2}, ConsistencyLevel.TWO)
-        self.assertFalse(self.log.msg.called)
-
-    def test_false_get_deleting_group(self):
-        """
-        Raises empty exception when get_deleting=False and group is deleting
-        """
-        self.connection.execute.return_value = defer.succeed(
-            [{'c1': 2, 'created_at': 23, 'deleting': True}])
-        r = self._verified_view(get_deleting=False)
-        self.failureResultOf(r, ValueError)
         self.connection.execute.assert_called_once_with(
             'vq', {'d': 2}, ConsistencyLevel.TWO)
         self.assertFalse(self.log.msg.called)
@@ -497,10 +471,10 @@ class CassScalingGroupTests(CassScalingGroupTestCase):
         self.returns = [[{'group_config': '{}', 'created_at': 24}]]
         d = self.group.view_config()
         r = self.successResultOf(d)
-        expectedCql = ('SELECT group_config, created_at, deleting '
+        expectedCql = ('SELECT group_config, created_at '
                        'FROM scaling_group '
                        'WHERE "tenantId" = :tenantId '
-                       'AND "groupId" = :groupId;')
+                       'AND "groupId" = :groupId AND deleting=false;')
         expectedData = {"tenantId": "11111", "groupId": "12345678g"}
         self.connection.execute.assert_called_once_with(
             expectedCql, expectedData, ConsistencyLevel.QUORUM)
@@ -515,9 +489,10 @@ class CassScalingGroupTests(CassScalingGroupTestCase):
         self.returns = [[{'group_config': '{}', 'created_at': None}], None]
         r = self.group.view_config()
         self.failureResultOf(r, NoSuchScalingGroupError)
-        view_cql = ('SELECT group_config, created_at, deleting '
+        view_cql = ('SELECT group_config, created_at '
                     'FROM scaling_group '
-                    'WHERE "tenantId" = :tenantId AND "groupId" = :groupId;')
+                    'WHERE "tenantId" = :tenantId AND "groupId" = :groupId '
+                    'AND deleting=false;')
         del_cql = ('DELETE FROM scaling_group WHERE '
                    '"tenantId" = :tenantId AND "groupId" = :groupId')
         expectedData = {"tenantId": "11111", "groupId": "12345678g"}
@@ -545,9 +520,10 @@ class CassScalingGroupTests(CassScalingGroupTestCase):
         r = self.successResultOf(d)
         expectedCql = (
             'SELECT "tenantId", "groupId", group_config, active, pending, '
-            '"groupTouched", "policyTouched", paused, desired, created_at, '
-            'deleting FROM scaling_group '
-            'WHERE "tenantId" = :tenantId AND "groupId" = :groupId;')
+            '"groupTouched", "policyTouched", paused, desired, created_at '
+            'FROM scaling_group '
+            'WHERE "tenantId"=:tenantId AND "groupId"=:groupId '
+            'AND deleting=false;')
         expectedData = {"tenantId": self.tenant_id, "groupId": self.group_id}
         self.connection.execute.assert_called_once_with(
             expectedCql, expectedData, ConsistencyLevel.QUORUM)
@@ -644,9 +620,10 @@ class CassScalingGroupTests(CassScalingGroupTestCase):
         self.failureResultOf(d, NoSuchScalingGroupError)
         viewCql = (
             'SELECT "tenantId", "groupId", group_config, active, pending, '
-            '"groupTouched", "policyTouched", paused, desired, created_at, '
-            'deleting FROM scaling_group '
-            'WHERE "tenantId" = :tenantId AND "groupId" = :groupId;')
+            '"groupTouched", "policyTouched", paused, desired, created_at '
+            'FROM scaling_group '
+            'WHERE "tenantId"=:tenantId AND "groupId"=:groupId '
+            'AND deleting=false;')
         delCql = ('DELETE FROM scaling_group '
                   'WHERE "tenantId" = :tenantId AND "groupId" = :groupId')
         expectedData = {"tenantId": self.tenant_id, "groupId": self.group_id}
@@ -971,8 +948,9 @@ class CassScalingGroupTests(CassScalingGroupTestCase):
         d = self.group.view_config()
         self.failureResultOf(d, NoSuchScalingGroupError)
         expectedCql = (
-            'SELECT group_config, created_at, deleting FROM scaling_group '
-            'WHERE "tenantId" = :tenantId AND "groupId" = :groupId;')
+            'SELECT group_config, created_at FROM scaling_group '
+            'WHERE "tenantId" = :tenantId AND "groupId" = :groupId '
+            'AND deleting=false;')
         expectedData = {"tenantId": "11111", "groupId": "12345678g"}
         self.connection.execute.assert_called_once_with(
             expectedCql, expectedData, ConsistencyLevel.QUORUM)
@@ -1000,8 +978,9 @@ class CassScalingGroupTests(CassScalingGroupTestCase):
         d = self.group.view_launch_config()
         r = self.successResultOf(d)
         expectedCql = (
-            'SELECT launch_config, created_at, deleting FROM scaling_group '
-            'WHERE "tenantId" = :tenantId AND "groupId" = :groupId;')
+            'SELECT launch_config, created_at FROM scaling_group '
+            'WHERE "tenantId" = :tenantId AND "groupId" = :groupId '
+            'AND deleting=false;')
         expectedData = {"tenantId": "11111", "groupId": "12345678g"}
         self.connection.execute.assert_called_once_with(
             expectedCql, expectedData, ConsistencyLevel.QUORUM)
@@ -1017,9 +996,9 @@ class CassScalingGroupTests(CassScalingGroupTestCase):
         d = self.group.view_launch_config()
         self.failureResultOf(d, NoSuchScalingGroupError)
         expectedCql = (
-            'SELECT launch_config, created_at, deleting FROM scaling_group '
-            'WHERE "tenantId" = :tenantId '
-            'AND "groupId" = :groupId;')
+            'SELECT launch_config, created_at FROM scaling_group '
+            'WHERE "tenantId" = :tenantId AND "groupId" = :groupId '
+            'AND deleting=false;')
         expectedData = {"tenantId": "11111", "groupId": "12345678g"}
         self.connection.execute.assert_called_once_with(
             expectedCql, expectedData, ConsistencyLevel.QUORUM)
@@ -1047,9 +1026,10 @@ class CassScalingGroupTests(CassScalingGroupTestCase):
             NoSuchScalingGroupError('a', 'b'))
         d = self.group.view_launch_config()
         self.failureResultOf(d, NoSuchScalingGroupError)
-        viewCql = ('SELECT launch_config, created_at, deleting '
+        viewCql = ('SELECT launch_config, created_at '
                    'FROM scaling_group WHERE '
-                   '"tenantId" = :tenantId AND "groupId" = :groupId;')
+                   '"tenantId" = :tenantId AND "groupId" = :groupId '
+                   'AND deleting=false;')
         delCql = ('DELETE FROM scaling_group WHERE '
                   '"tenantId" = :tenantId AND "groupId" = :groupId')
         expectedData = {"tenantId": "11111", "groupId": "12345678g"}
@@ -1120,80 +1100,6 @@ class CassScalingGroupTests(CassScalingGroupTestCase):
             self.assertEqual(view_config.call_count, i + 1)
             # but extra executes, to update, are not called
             self.assertFalse(self.connection.execute.called)
-
-    def test_view_policy(self):
-        """
-        Test that you can call view and receive a valid parsed response
-        """
-        cass_response = [{'data': '{}'}]
-        self.returns = [cass_response]
-        d = self.group.get_policy("3444")
-        r = self.successResultOf(d)
-        expectedCql = (
-            'SELECT data, version FROM scaling_policies '
-            'WHERE "tenantId" = :tenantId '
-            'AND "groupId" = :groupId '
-            'AND "policyId" = :policyId;')
-        expectedData = {"tenantId": "11111",
-                        "groupId": "12345678g",
-                        "policyId": "3444"}
-        self.connection.execute.assert_called_once_with(
-            expectedCql, expectedData, ConsistencyLevel.QUORUM)
-
-        self.assertEqual(r, {})
-
-    def test_view_policy_no_such_policy(self):
-        """
-        Tests what happens if you try to view a policy that doesn't exist.
-        """
-        cass_response = []
-        self.returns = [cass_response]
-        d = self.group.get_policy('3444')
-        self.failureResultOf(d, NoSuchPolicyError)
-        expectedCql = (
-            'SELECT data, version '
-            'FROM scaling_policies '
-            'WHERE "tenantId" = :tenantId '
-            'AND "groupId" = :groupId '
-            'AND "policyId" = :policyId;')
-        expectedData = {"tenantId": "11111",
-                        "groupId": "12345678g",
-                        "policyId": "3444"}
-        self.connection.execute.assert_called_once_with(
-            expectedCql, expectedData, ConsistencyLevel.QUORUM)
-
-        self.flushLoggedErrors(NoSuchPolicyError)
-
-    def test_view_policy_no_version(self):
-        """
-        When viewing the policy, any version information is removed from the
-        final output
-        """
-        cass_response = [{'data': '{"_ver": 5}'}]
-        self.returns = [cass_response]
-        d = self.group.get_policy("3444")
-        r = self.successResultOf(d)
-        self.assertEqual(r, {})
-
-    def test_view_policy_with_version_success(self):
-        """
-        Calling `get_policy` with version succeeds if version matches
-        """
-        cass_response = [{'data': '{"_ver": 5}', 'version': 'v1'}]
-        self.returns = [cass_response]
-        d = self.group.get_policy("3444", version='v1')
-        r = self.successResultOf(d)
-        self.assertEqual(r, {})
-
-    def test_view_policy_with_version_fails(self):
-        """
-        Calling `get_policy` with version fails if version does not match
-        """
-        cass_response = [{'data': '{"_ver": 5}', 'version': 'v1'}]
-        self.returns = [cass_response]
-        d = self.group.get_policy("3444", version='v2')
-        self.failureResultOf(d, NoSuchPolicyError)
-        self.flushLoggedErrors(NoSuchPolicyError)
 
     def test_naive_list_policies_with_policies(self):
         """
@@ -1394,20 +1300,15 @@ class CassScalingGroupTests(CassScalingGroupTestCase):
         self.assertFalse(self.connection.execute.called)
         self.flushLoggedErrors(NoSuchPolicyError)
 
-    def test_update_config_bad(self):
+    @mock.patch('otter.models.cass.CassScalingGroup.view_config',
+                return_value=defer.fail(NoSuchScalingGroupError('t', 'g')))
+    def test_update_config_bad(self, mock_vc):
         """
-        Tests that you can't just create a scaling group by sending
-        an update to a nonexistant group
+        Tests that you can't update non-existent scaling group
         """
-        self.returns = [[], None]
+        self.returns = []
         d = self.group.update_config({"b": "lah"})
         self.failureResultOf(d, NoSuchScalingGroupError)
-        expectedCql = (
-            'SELECT group_config, created_at, deleting FROM scaling_group '
-            'WHERE "tenantId" = :tenantId AND "groupId" = :groupId;')
-        expectedData = {"tenantId": "11111", "groupId": "12345678g"}
-        self.connection.execute.assert_called_once_with(
-            expectedCql, expectedData, ConsistencyLevel.QUORUM)
 
     def test_update_policy_calls_view_first(self):
         """
@@ -1547,7 +1448,7 @@ class CassScalingGroupTests(CassScalingGroupTestCase):
         """
         Can't add webhooks to an invalid policy.
         """
-        self.returns = [[]]
+        self.returns = [[{'group_config': '{}', 'created_at': 24}], []]
         d = self.group.create_webhooks('23456789', [{}, {'metadata': 'who'}])
         self.failureResultOf(d, NoSuchPolicyError)
 
@@ -1781,7 +1682,9 @@ class CassScalingGroupTests(CassScalingGroupTestCase):
 
         mock_naive.assert_called_once_with('1234', limit=5, marker='blah')
 
-    def test_view_webhook(self):
+    @mock.patch('otter.models.cass.CassScalingGroup.get_policy',
+                return_value=defer.succeed('watever'))
+    def test_view_webhook(self, mock_gp):
         """
         Test that you can call view and receive a valid parsed response
         """
@@ -1789,6 +1692,7 @@ class CassScalingGroupTests(CassScalingGroupTestCase):
             [{'data': '{"name": "pokey"}', 'capability': '{"1": "h"}'}])]
         d = self.group.get_webhook("3444", "4555")
         r = self.successResultOf(d)
+        mock_gp.assert_called_once_with('3444')
         expectedCql = ('SELECT data, capability FROM policy_webhooks WHERE '
                        '"tenantId" = :tenantId AND "groupId" = :groupId AND '
                        '"policyId" = :policyId AND "webhookId" = :webhookId;')
@@ -1800,24 +1704,17 @@ class CassScalingGroupTests(CassScalingGroupTestCase):
         self.assertEqual(
             r, {'name': 'pokey', 'capability': {"version": "1", "hash": "h"}})
 
-    def test_view_webhook_no_such_webhook(self):
+    @mock.patch('otter.models.cass.CassScalingGroup.get_policy',
+                return_value=defer.succeed({}))
+    def test_view_webhook_no_such_webhook(self, mock_gp):
         """
         Tests what happens if you try to view a policy that doesn't exist.
         """
         self.returns = [[]]
         d = self.group.get_webhook('3444', '4555')
+        mock_gp.assert_called_once_with('3444')
         self.failureResultOf(d, NoSuchWebhookError)
         self.flushLoggedErrors(NoSuchPolicyError)
-
-    def test_view_webhook_no_version(self):
-        """
-        When viewing the policy, any version information is removed from the
-        final output
-        """
-        self.returns = [_cassandrify_data([{'data': '{"_ver": 5}'}])]
-        d = self.group.get_policy("3444")
-        r = self.successResultOf(d)
-        self.assertEqual(r, {})
 
     @mock.patch('otter.models.cass.CassScalingGroup.get_webhook')
     def test_update_webhook(self, mock_get_webhook):
@@ -1884,17 +1781,19 @@ class CassScalingGroupTests(CassScalingGroupTestCase):
         self.assertEqual(len(self.connection.execute.mock_calls), 0)
         self.flushLoggedErrors(NoSuchWebhookError)
 
-    def test_delete_webhook(self):
+    @mock.patch('otter.models.cass.CassScalingGroup.get_webhook')
+    def test_delete_webhook(self, mock_gw):
         """
         Tests that you can delete a scaling policy webhook, and if successful
         return value is None
         """
-        # return values for get webhook and then delete
-        self.returns = [
-            _cassandrify_data([{'data': '{}', 'capability': '{"1": "h"}'}]),
-            None]
+        # return value for delete
+        self.returns = [None]
+        mock_gw.return_value = defer.succeed(
+            {'data': '{}', 'capability': {"version": "1", "hash": "h"}})
         d = self.group.delete_webhook('3444', '4555')
         self.assertIsNone(self.successResultOf(d))  # delete returns None
+        mock_gw.assert_called_once_with('3444', '4555')
         expectedCql = ('BEGIN BATCH '
 
                        'DELETE FROM policy_webhooks WHERE '
@@ -1911,22 +1810,20 @@ class CassScalingGroupTests(CassScalingGroupTestCase):
                         "webhookId": "4555",
                         'webhookKey': 'h'}
 
-        self.assertEqual(len(self.connection.execute.mock_calls),
-                         2)  # view, delete
-        self.connection.execute.assert_called_with(expectedCql,
-                                                   expectedData,
-                                                   ConsistencyLevel.QUORUM)
+        self.connection.execute.assert_called_once_with(
+            expectedCql, expectedData, ConsistencyLevel.QUORUM)
 
-    def test_delete_non_existant_webhooks(self):
+    @mock.patch('otter.models.cass.CassScalingGroup.get_webhook',
+                return_value=defer.fail(NoSuchWebhookError(*range(4))))
+    def test_delete_non_existant_webhooks(self, mock_gw):
         """
         If you try to delete a scaling policy webhook that doesn't exist,
         :class:`NoSuchWebhookError` is raised
         """
-        self.returns = [[], None]
+        self.returns = []
         d = self.group.delete_webhook('3444', '4555')
         self.failureResultOf(d, NoSuchWebhookError)
-        self.assertEqual(len(self.connection.execute.mock_calls),
-                         1)  # only view
+        mock_gw.assert_called_once_with('3444', '4555')
         self.flushLoggedErrors(NoSuchWebhookError)
 
     @mock.patch('otter.models.cass.CassScalingGroup.view_state')
@@ -2113,6 +2010,93 @@ class CassScalingGroupTests(CassScalingGroupTestCase):
             otter_msg_type="ignore-delete-lock-error")
 
 
+class GetPolicyTests(CassScalingGroupTestCase):
+    """
+    Tests for :func:`CassScalingGroup.get_policy`
+    """
+
+    def setUp(self):
+        """ Mock view_config """
+        super(GetPolicyTests, self).setUp()
+        self.mock_vc = patch(
+            self, 'otter.models.cass.CassScalingGroup.view_config',
+            return_value=defer.succeed({}))
+
+    def test_view_policy(self):
+        """
+        Test that you can call view and receive a valid parsed response
+        """
+        cass_response = [{'data': '{}'}]
+        self.returns = [cass_response]
+        d = self.group.get_policy("3444")
+        r = self.successResultOf(d)
+        expectedCql = (
+            'SELECT data, version FROM scaling_policies '
+            'WHERE "tenantId" = :tenantId '
+            'AND "groupId" = :groupId '
+            'AND "policyId" = :policyId;')
+        expectedData = {"tenantId": "11111",
+                        "groupId": "12345678g",
+                        "policyId": "3444"}
+        self.connection.execute.assert_called_once_with(
+            expectedCql, expectedData, ConsistencyLevel.QUORUM)
+
+        self.assertEqual(r, {})
+
+    def test_view_policy_no_such_policy(self):
+        """
+        Tests what happens if you try to view a policy that doesn't exist.
+        """
+        cass_response = []
+        self.returns = [cass_response]
+        d = self.group.get_policy('3444')
+        self.failureResultOf(d, NoSuchPolicyError)
+        expectedCql = (
+            'SELECT data, version '
+            'FROM scaling_policies '
+            'WHERE "tenantId" = :tenantId '
+            'AND "groupId" = :groupId '
+            'AND "policyId" = :policyId;')
+        expectedData = {"tenantId": "11111",
+                        "groupId": "12345678g",
+                        "policyId": "3444"}
+        self.connection.execute.assert_called_once_with(
+            expectedCql, expectedData, ConsistencyLevel.QUORUM)
+
+        self.flushLoggedErrors(NoSuchPolicyError)
+
+    def test_view_policy_no_version(self):
+        """
+        When viewing the policy, any version information is removed from the
+        final output
+        """
+        cass_response = [{'data': '{"_ver": 5}'}]
+        self.returns = [cass_response]
+        d = self.group.get_policy("3444")
+        r = self.successResultOf(d)
+        self.assertEqual(r, {})
+
+    def test_view_policy_with_version_success(self):
+        """
+        Calling `get_policy` with version succeeds if version matches
+        """
+        cass_response = [{'data': '{"_ver": 5}', 'version': 'v1'}]
+        self.returns = [cass_response]
+        d = self.group.get_policy("3444", version='v1')
+        r = self.successResultOf(d)
+        self.assertEqual(r, {})
+
+    def test_view_policy_with_version_fails(self):
+        """
+        Calling `get_policy` with version fails if version does not match
+        """
+        cass_response = [{'data': '{"_ver": 5}', 'version': 'v1'}]
+        self.returns = [cass_response]
+        d = self.group.get_policy("3444", version='v2')
+        self.failureResultOf(d, NoSuchPolicyError)
+        self.flushLoggedErrors(NoSuchPolicyError)
+
+
 class ViewManifestTests(CassScalingGroupTestCase):
     """
     Tests for :func:`view_manifest`
@@ -2136,7 +2120,8 @@ class ViewManifestTests(CassScalingGroupTestCase):
             'policyTouched': '{"PT":"R"}',
             'paused': False,
             'desired': 0,
-            'created_at': 23
+            'created_at': 23,
+            'deleting': False
         }
         self.manifest = {
             'groupConfiguration': self.config,
@@ -2180,7 +2165,7 @@ class ViewManifestTests(CassScalingGroupTestCase):
             self.connection, view_cql, del_cql,
             exp_data, ConsistencyLevel.QUORUM,
             matches(IsInstance(NoSuchScalingGroupError)),
-            self.mock_log, get_deleting=False)
+            self.mock_log)
 
     def test_with_webhooks(self):
         """
@@ -2236,7 +2221,7 @@ class ViewManifestTests(CassScalingGroupTestCase):
         self.assertFalse(self.group._naive_list_policies.called)
         self.assertFalse(self.group._naive_list_all_webhooks.called)
 
-    def test_with_deleting(self):
+    def test_get_deleting_gets_deleting_group(self):
         """
         Viewing manifest ``get_deleting=True`` returns a manifest view with
         group status in it even if the group is deleting
@@ -2251,22 +2236,16 @@ class ViewManifestTests(CassScalingGroupTestCase):
         self.manifest['status'] = 'DELETING'
         self.assertEqual(resp, self.manifest)
 
-        # verified_view called with `get_deleting=True`
-        view_cql = (
-            'SELECT "tenantId", "groupId", group_config, launch_config, '
-            'active, pending, "groupTouched", "policyTouched", paused, '
-            'desired, created_at, status, deleting '
-            'FROM scaling_group '
-            'WHERE "tenantId" = :tenantId '
-            'AND "groupId" = :groupId')
-        del_cql = ('DELETE FROM scaling_group '
-                   'WHERE "tenantId" = :tenantId AND "groupId" = :groupId')
-        exp_data = {'tenantId': self.tenant_id, 'groupId': self.group_id}
-        self.verified_view.assert_called_once_with(
-            self.connection, view_cql, del_cql,
-            exp_data, ConsistencyLevel.QUORUM,
-            matches(IsInstance(NoSuchScalingGroupError)),
-            self.mock_log, get_deleting=True)
+    def test_nogrouperror_on_deleting_group(self):
+        """
+        Viewing manifest with `get_deleting=False` on a deleting group
+        raises NoSuchScalingGroupError
+        """
+        self.vv_return['status'] = 'ERROR'
+        self.vv_return['deleting'] = True
+        self.verified_view.return_value = defer.succeed(self.vv_return)
+        d = self.group.view_manifest(with_policies=False, get_deleting=False)
+        self.failureResultOf(d, NoSuchScalingGroupError)
 
     def _check_with_deleting(self, status):
         self.verified_view.return_value = defer.succeed(self.vv_return)
@@ -2281,7 +2260,6 @@ class ViewManifestTests(CassScalingGroupTestCase):
         including status when group is not deleting
         """
         self.vv_return['status'] = 'ACTIVE'
-        self.vv_return['deleting'] = None
         self._check_with_deleting('ACTIVE')
 
     def test_with_deleting_none_status(self):
@@ -2290,7 +2268,6 @@ class ViewManifestTests(CassScalingGroupTestCase):
         including ACTIVE status when group is not deleting and status is None
         """
         self.vv_return['status'] = None
-        self.vv_return['deleting'] = None
         self._check_with_deleting('ACTIVE')
 
     def test_with_deleting_disabled_status(self):
@@ -2300,7 +2277,6 @@ class ViewManifestTests(CassScalingGroupTestCase):
         DISABLED
         """
         self.vv_return['status'] = 'DISABLED'
-        self.vv_return['deleting'] = None
         self._check_with_deleting('ERROR')
 
     def test_with_deleting_error_status(self):
@@ -2310,7 +2286,6 @@ class ViewManifestTests(CassScalingGroupTestCase):
         ERROR
         """
         self.vv_return['status'] = 'ERROR'
-        self.vv_return['deleting'] = None
         self._check_with_deleting('ERROR')
 
     def test_no_such_group(self):
@@ -2702,7 +2677,7 @@ class ScalingGroupWebhookMigrateTests(SynchronousTestCase):
         """
         Sample CassScalingGroup object
         """
-        self.store = CassScalingGroupCollection(None, None)
+        self.store = CassScalingGroupCollection(None, None, 1)
 
     def test_webhook_index_only(self):
         """
@@ -2781,7 +2756,7 @@ class CassScalingScheduleCollectionTestCase(
 
         self.clock = Clock()
         self.collection = CassScalingGroupCollection(
-            self.connection, self.clock)
+            self.connection, self.clock, 1)
 
         self.uuid = patch(self, 'otter.models.cass.uuid')
         self.uuid.uuid1.return_value = 'timeuuid'
@@ -2931,7 +2906,7 @@ class CassScalingGroupsCollectionTestCase(IScalingGroupCollectionProviderMixin,
         self.clock = Clock()
 
         self.collection = CassScalingGroupCollection(self.connection,
-                                                     self.clock)
+                                                     self.clock, 100)
 
         self.tenant_id = 'goo1234'
         self.config = _de_identify({
@@ -2971,7 +2946,7 @@ class CassScalingGroupsCollectionTestCase(IScalingGroupCollectionProviderMixin,
         """
         `CassScalingGroupCollection` keeps new WeakLocks object
         """
-        collection = CassScalingGroupCollection(self.connection, self.clock)
+        collection = CassScalingGroupCollection(self.connection, self.clock, 1)
         mock_wl.assert_called_once_with()
         self.assertEqual(collection.local_locks, 2)
 
@@ -2997,10 +2972,10 @@ class CassScalingGroupsCollectionTestCase(IScalingGroupCollectionProviderMixin,
 
             'INSERT INTO scaling_group("tenantId", "groupId", group_config, '
             'launch_config, active, pending, "policyTouched", '
-            'paused, desired, created_at) '
+            'paused, desired, created_at, deleting) '
             'VALUES (:tenantId, :groupId, :group_config, :launch_config, '
             ':active, :pending, :policyTouched, :paused, :desired, '
-            ':created_at) '
+            ':created_at, false) '
             'USING TIMESTAMP :ts '
 
             'APPLY BATCH;')
@@ -3052,10 +3027,10 @@ class CassScalingGroupsCollectionTestCase(IScalingGroupCollectionProviderMixin,
 
             'INSERT INTO scaling_group("tenantId", "groupId", group_config, '
             'launch_config, active, pending, "policyTouched", paused, '
-            'desired, created_at) '
+            'desired, created_at, deleting) '
             'VALUES (:tenantId, :groupId, :group_config, :launch_config, '
             ':active, :pending, :policyTouched, :paused, :desired, '
-            ':created_at) '
+            ':created_at, false) '
             'USING TIMESTAMP :ts '
 
             'INSERT INTO scaling_policies("tenantId", "groupId", "policyId", '
@@ -3115,10 +3090,10 @@ class CassScalingGroupsCollectionTestCase(IScalingGroupCollectionProviderMixin,
 
             'INSERT INTO scaling_group("tenantId", "groupId", group_config, '
             'launch_config, active, pending, "policyTouched", paused, '
-            'desired, created_at) '
+            'desired, created_at, deleting) '
             'VALUES (:tenantId, :groupId, :group_config, :launch_config, '
             ':active, :pending, :policyTouched, :paused, :desired, '
-            ':created_at) '
+            ':created_at, false) '
             'USING TIMESTAMP :ts '
 
             'INSERT INTO scaling_policies("tenantId", "groupId", "policyId", '
@@ -3168,7 +3143,7 @@ class CassScalingGroupsCollectionTestCase(IScalingGroupCollectionProviderMixin,
 
         expectedData = {'tenantId': '1234'}
         expectedCQL = ('SELECT COUNT(*) FROM scaling_group '
-                       'WHERE "tenantId" = :tenantId;')
+                       'WHERE "tenantId"=:tenantId AND deleting=false;')
 
         d = self.collection.create_scaling_group(
             mock.Mock(), '1234', self.config, self.launch)
@@ -3177,24 +3152,24 @@ class CassScalingGroupsCollectionTestCase(IScalingGroupCollectionProviderMixin,
         self.assertEqual(len(self.connection.execute.mock_calls), 2)
         self.assertEqual(
             self.connection.execute.mock_calls[0],
-            mock.call(expectedCQL, expectedData, ConsistencyLevel.QUORUM))
+            mock.call(expectedCQL, expectedData, ConsistencyLevel.ONE))
 
     def test_max_groups_overlimit(self):
         """
         test scaling group creation when at maxGroups limit
         """
-        set_config_data({'limits': {'absolute': {'maxGroups': 1}}})
+        self.collection.max_groups = 1
         self.returns = [[{'count': 1}]]
 
         expectedData = {'tenantId': '1234'}
         expectedCQL = (
             'SELECT COUNT(*) FROM scaling_group '
-            'WHERE "tenantId" = :tenantId;')
+            'WHERE "tenantId"=:tenantId AND deleting=false;')
 
         d = self.collection.create_scaling_group(
             mock.Mock(), '1234', self.config, self.launch)
         self.connection.execute.assert_called_once_with(
-            expectedCQL, expectedData, ConsistencyLevel.QUORUM)
+            expectedCQL, expectedData, ConsistencyLevel.ONE)
 
         self.failureResultOf(d, ScalingGroupOverLimitError)
 
@@ -3209,9 +3184,9 @@ class CassScalingGroupsCollectionTestCase(IScalingGroupCollectionProviderMixin,
         expectedData = {'tenantId': '123', 'limit': 100}
         expectedCql = (
             'SELECT "tenantId", "groupId", group_config, active, pending, '
-            '"groupTouched", "policyTouched", paused, desired, created_at, '
-            'deleting FROM scaling_group '
-            'WHERE "tenantId" = :tenantId LIMIT :limit;')
+            '"groupTouched", "policyTouched", paused, desired, created_at '
+            'FROM scaling_group '
+            'WHERE "tenantId"=:tenantId AND deleting=false LIMIT :limit;')
         r = self.validate_list_states_return_value(self.mock_log, '123')
         self.connection.execute.assert_called_once_with(
             expectedCql, expectedData, ConsistencyLevel.QUORUM)
@@ -3241,8 +3216,8 @@ class CassScalingGroupsCollectionTestCase(IScalingGroupCollectionProviderMixin,
         expectedCql = (
             'SELECT "tenantId", "groupId", group_config, active, pending, '
             '"groupTouched", "policyTouched", paused, desired, '
-            'created_at, deleting '
-            'FROM scaling_group WHERE "tenantId" = :tenantId LIMIT :limit;')
+            'created_at FROM scaling_group '
+            'WHERE "tenantId"=:tenantId AND deleting=false LIMIT :limit;')
         r = self.validate_list_states_return_value(self.mock_log, '123')
         self.assertEqual(r, [])
         self.connection.execute.assert_called_once_with(
@@ -3257,9 +3232,9 @@ class CassScalingGroupsCollectionTestCase(IScalingGroupCollectionProviderMixin,
         expectedData = {'tenantId': '123', 'limit': 5}
         expectedCql = (
             'SELECT "tenantId", "groupId", group_config, active, pending, '
-            '"groupTouched", "policyTouched", paused, desired, created_at, '
-            'deleting FROM scaling_group '
-            'WHERE "tenantId" = :tenantId '
+            '"groupTouched", "policyTouched", paused, desired, created_at '
+            'FROM scaling_group '
+            'WHERE "tenantId"=:tenantId AND deleting=false '
             'LIMIT :limit;')
         self.collection.list_scaling_group_states(
             self.mock_log, '123', limit=5)
@@ -3274,10 +3249,10 @@ class CassScalingGroupsCollectionTestCase(IScalingGroupCollectionProviderMixin,
         expectedData = {'tenantId': '123', 'limit': 100, 'marker': '345'}
         expectedCql = (
             'SELECT "tenantId", "groupId", group_config, active, pending, '
-            '"groupTouched", "policyTouched", paused, desired, created_at, '
-            'deleting FROM scaling_group '
-            'WHERE "tenantId" = :tenantId '
-            'AND "groupId" > :marker LIMIT :limit;')
+            '"groupTouched", "policyTouched", paused, desired, created_at '
+            'FROM scaling_group '
+            'WHERE "tenantId"=:tenantId AND deleting=false AND '
+            '"groupId" > :marker LIMIT :limit;')
         self.collection.list_scaling_group_states(self.mock_log, '123',
                                                   marker='345')
         self.connection.execute.assert_called_once_with(
@@ -3299,9 +3274,9 @@ class CassScalingGroupsCollectionTestCase(IScalingGroupCollectionProviderMixin,
         expectedData = {'tenantId': '123', 'limit': 100}
         expectedCql = (
             'SELECT "tenantId", "groupId", group_config, active, pending, '
-            '"groupTouched", "policyTouched", paused, desired, created_at, '
-            'deleting FROM scaling_group '
-            'WHERE "tenantId" = :tenantId LIMIT :limit;')
+            '"groupTouched", "policyTouched", paused, desired, created_at '
+            'FROM scaling_group '
+            'WHERE "tenantId"=:tenantId AND deleting=false LIMIT :limit;')
         r = self.validate_list_states_return_value(self.mock_log, '123')
         self.assertEqual(
             self.connection.execute.call_args_list[0],
@@ -3383,32 +3358,6 @@ class CassScalingGroupsCollectionTestCase(IScalingGroupCollectionProviderMixin,
         query, params, c = args
         return query
 
-    def test_list_states_filters_deleting_groups(self):
-        """
-        Groups that are deleting based on "deleting" column to be true are not
-        returned
-        """
-        g1 = self.group.copy()
-        g1['groupId'] = 'group123'
-        g2 = self.group.copy()
-        g2['groupId'] = 'group124'
-        g2['deleting'] = True
-        self.returns = [[g1, g2], None]
-        r = self.validate_list_states_return_value(self.mock_log, '123')
-        self.assertEqual(r, [GroupState(tenant_id='123',
-                                        group_id='group123',
-                                        group_name='test',
-                                        active={},
-                                        pending={},
-                                        group_touched='0001-01-01T00:00:00Z',
-                                        policy_touched={},
-                                        paused=False)])
-        # No call to delete row was made
-        self.assertEqual(len(self.connection.execute.call_args_list), 1)
-        self.assertNotIn(
-            'DELETE', self._extract_execute_query(
-                self.connection.execute.call_args_list[0]))
-
     def test_get_scaling_group(self):
         """
         Tests that you can get a scaling group
@@ -3458,9 +3407,9 @@ class CassScalingGroupsCollectionTestCase(IScalingGroupCollectionProviderMixin,
         Check get_count returns dictionary in proper format
         """
         self.returns = [
-            [{'count': 100}],
             [{'count': 101}],
             [{'count': 102}],
+            [{'count': 100}],
         ]
 
         expectedData = {'tenantId': '123'}
@@ -3470,16 +3419,16 @@ class CassScalingGroupsCollectionTestCase(IScalingGroupCollectionProviderMixin,
             "webhooks": 102
         }
         config_query = ('SELECT COUNT(*) FROM scaling_group '
-                        'WHERE "tenantId" = :tenantId;')
+                        'WHERE "tenantId"=:tenantId AND deleting=false;')
         policy_query = ('SELECT COUNT(*) FROM scaling_policies '
-                        'WHERE "tenantId" = :tenantId;')
+                        'WHERE "tenantId"=:tenantId ;')
         webhook_query = ('SELECT COUNT(*) FROM policy_webhooks '
-                         'WHERE "tenantId" = :tenantId;')
+                         'WHERE "tenantId"=:tenantId ;')
 
         calls = [
-            mock.call(config_query, expectedData, ConsistencyLevel.ONE),
             mock.call(policy_query, expectedData, ConsistencyLevel.ONE),
-            mock.call(webhook_query, expectedData, ConsistencyLevel.ONE)]
+            mock.call(webhook_query, expectedData, ConsistencyLevel.ONE),
+            mock.call(config_query, expectedData, ConsistencyLevel.ONE)]
 
         d = self.collection.get_counts(self.mock_log, '123')
         result = self.successResultOf(d)
@@ -3500,7 +3449,7 @@ class CassScalingGroupsCollectionHealthCheckTestCase(
         self.connection.execute.return_value = defer.succeed([])
         self.clock = Clock()
         self.collection = CassScalingGroupCollection(self.connection,
-                                                     self.clock)
+                                                     self.clock, 1)
         self.collection.kz_client = mock.MagicMock(connected=True,
                                                    state=KazooState.CONNECTED)
         self.lock = self.mock_lock()

--- a/otter/test/models/test_cass_models.py
+++ b/otter/test/models/test_cass_models.py
@@ -1682,9 +1682,9 @@ class CassScalingGroupTests(CassScalingGroupTestCase):
 
         mock_naive.assert_called_once_with('1234', limit=5, marker='blah')
 
-    @mock.patch('otter.models.cass.CassScalingGroup.get_policy',
+    @mock.patch('otter.models.cass.CassScalingGroup.view_config',
                 return_value=defer.succeed('watever'))
-    def test_view_webhook(self, mock_gp):
+    def test_view_webhook(self, mock_vc):
         """
         Test that you can call view and receive a valid parsed response
         """
@@ -1692,7 +1692,7 @@ class CassScalingGroupTests(CassScalingGroupTestCase):
             [{'data': '{"name": "pokey"}', 'capability': '{"1": "h"}'}])]
         d = self.group.get_webhook("3444", "4555")
         r = self.successResultOf(d)
-        mock_gp.assert_called_once_with('3444')
+        mock_vc.assert_called_once_with()
         expectedCql = ('SELECT data, capability FROM policy_webhooks WHERE '
                        '"tenantId" = :tenantId AND "groupId" = :groupId AND '
                        '"policyId" = :policyId AND "webhookId" = :webhookId;')
@@ -1704,15 +1704,15 @@ class CassScalingGroupTests(CassScalingGroupTestCase):
         self.assertEqual(
             r, {'name': 'pokey', 'capability': {"version": "1", "hash": "h"}})
 
-    @mock.patch('otter.models.cass.CassScalingGroup.get_policy',
+    @mock.patch('otter.models.cass.CassScalingGroup.view_config',
                 return_value=defer.succeed({}))
-    def test_view_webhook_no_such_webhook(self, mock_gp):
+    def test_view_webhook_no_such_webhook(self, mock_vc):
         """
         Tests what happens if you try to view a policy that doesn't exist.
         """
         self.returns = [[]]
         d = self.group.get_webhook('3444', '4555')
-        mock_gp.assert_called_once_with('3444')
+        mock_vc.assert_called_once_with()
         self.failureResultOf(d, NoSuchWebhookError)
         self.flushLoggedErrors(NoSuchPolicyError)
 

--- a/otter/test/tap/test_api.py
+++ b/otter/test/tap/test_api.py
@@ -51,7 +51,8 @@ test_config = {
     'cloudLoadBalancers': 'cloudLoadBalancers',
     'rackconnect': 'rackconnect',
     'metrics': {'service': 'cloudMetricsIngest',
-                'region': 'IAD'}
+                'region': 'IAD'},
+    'limits': {'absolute': {'maxGroups': 100}}
 }
 
 
@@ -423,6 +424,14 @@ class APIMakeServiceTests(SynchronousTestCase):
         self.Otter.assert_called_once_with(self.store, 'ord',
                                            self.health_checker.health_check,
                                            es_host=None)
+
+    def test_max_groups(self):
+        """
+        CassScalingGroupCollection is created with max groups taken from
+        config
+        """
+        makeService(test_config)
+        self.assertEqual(self.store.max_groups, 100)
 
     @mock.patch('otter.tap.api.reactor')
     @mock.patch('otter.tap.api.generate_authenticator')

--- a/schema/setup/control_15_create_scaling_groups.cql
+++ b/schema/setup/control_15_create_scaling_groups.cql
@@ -57,3 +57,5 @@ CREATE COLUMNFAMILY scaling_group (
     'class' : 'SizeTieredCompactionStrategy',
     'min_threshold' : '2'
 } AND gc_grace_seconds = 3600;
+
+CREATE INDEX group_by_deleting ON scaling_group(deleting);


### PR DESCRIPTION
3rd task of #1363.

Certain refactorings:
- Taking groups limit as argument to constructor instead of reading from config in `CassScalingGroupCollection` and simplified checking limits in `create_group`
- Moved `CassScalingGroup.get_policy` tests to a separate class
- Removed unwanted and changed some cass tests (Cannot help refactoring these tests every time I modify it) 

NOTE: This code must be deployed AFTER creating index in prod, otherwise all queries involving `deleting` column will fail.