### PR TITLE
Integration test cleanup

### DIFF
--- a/otter/integration/lib/cloud_load_balancer.py
+++ b/otter/integration/lib/cloud_load_balancer.py
@@ -140,7 +140,6 @@ class CloudLoadBalancer(object):
         test.addCleanup(self.stop, rcs)
 
         def record_results(resp):
-            print(resp)
             rcs.clbs.append(resp)
             self.clb_id = str(resp["loadBalancer"]["id"])
             return rcs


### PR DESCRIPTION
This PR removes an extra policy execution from two of the integration tests.  Fixes #1359.