### PR TITLE
get_scaling_groups option to get null desired groups

### DIFF
--- a/otter/test/test_metrics.py
+++ b/otter/test/test_metrics.py
@@ -103,6 +103,22 @@ class GetScalingGroupsTests(SynchronousTestCase):
         d = get_scaling_groups(self.client, batch_size=5)
         self.assertEqual(list(self.successResultOf(d)), groups[-1:])
 
+    def test_does_not_filter_on_desired(self):
+        """
+        If `with_null_desired=True` then groups with null desired are returned
+        """
+        groups = [{'tenantId': 1, 'groupId': 2,
+                   'desired': 3, 'created_at': None},
+                  {'tenantId': 1, 'groupId': 3,
+                   'desired': None, 'created_at': 'c'},
+                  {'tenantId': 1, 'groupId': 5,
+                   'desired': 3, 'created_at': 'c'}]
+        self._add_exec_args(
+            self.select + ' LIMIT :limit;', {'limit': 5}, groups)
+        d = get_scaling_groups(self.client, batch_size=5,
+                               with_null_desired=True)
+        self.assertEqual(list(self.successResultOf(d)), groups[1:])
+
     def test_filters_on_group_pred_arg(self):
         """
         If group_pred arg is given then returns groups for which

--- a/scripts/load_cql.py
+++ b/scripts/load_cql.py
@@ -176,7 +176,7 @@ def insert_deleting_false(reactor, conn):
     """
     Insert false to all group's deleting column
     """
-    groups = yield get_scaling_groups(conn)
+    groups = yield get_scaling_groups(conn, with_null_desired=True)
     query = (
         'INSERT INTO scaling_group ("tenantId", "groupId", deleting) '
         'VALUES (:tenantId{i}, :groupId{i}, false);')


### PR DESCRIPTION
This is needed to do first task of #1363 since currently the migration script using `get_scaling_group` does not insert `false` on groups that has no `desired`. 