### PR TITLE
Convergence delete server fixes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ jsonfig==0.1.1
 testtools==0.9.32
 croniter==0.3.5
 txkazoo==0.0.6b2
-effect==0.1a16
+effect==0.1a17
 characteristic==14.3.0
 toolz==0.7.1
 pyrsistent==0.7.0


### PR DESCRIPTION
Ran into an issue when I was trying to delete servers in convergence - I forgot to wrap stuff up in TenantScope and forgot that ServiceRequest results were (response, body).

Really not sure how to test TenantScope, because I can't use it in the SequenceDispatcher, because the service request calls have callbacks, which makes the effects difficult to test for equivalence.  :|