### PR TITLE
otter start buckets error fix

### DIFF
--- a/otter/convergence/service.py
+++ b/otter/convergence/service.py
@@ -449,12 +449,13 @@ class Converger(MultiService):
         tenants associated with this service's buckets, a convergence will be
         triggered.
         """
+        if self.partitioner.get_current_state() != PartitionState.ACQUIRED:
+            return
         my_buckets = self.partitioner.get_current_buckets()
         changed_buckets = set(
             bucket_of_tenant(parse_dirty_flag(child)[0], len(self._buckets))
             for child in children)
-        if (self.partitioner.get_current_state() == PartitionState.ACQUIRED and
-                set(my_buckets).intersection(changed_buckets)):
+        if set(my_buckets).intersection(changed_buckets):
             # the return value is ignored, but we return this for testing
             eff = self._converge_all(my_buckets, children)
             return perform(self._dispatcher, eff)

--- a/otter/test/convergence/test_service.py
+++ b/otter/test/convergence/test_service.py
@@ -160,6 +160,8 @@ class ConvergerTests(SynchronousTestCase):
         dispatcher = SequenceDispatcher([])  # "nothing happens"
         converger = self._converger(lambda *a, **kw: 1 / 0,
                                     dispatcher=dispatcher)
+        # Doesn't try to get buckets
+        self.fake_partitioner.get_current_buckets = lambda s: 1 / 0
         converger.divergent_changed(['group1', 'group2'])
 
     def test_divergent_changed_not_ours(self):


### PR DESCRIPTION
When starting otter, `divergent_changed` was called before the buckets were allocated causing error when it called `get_current_buckets`. Now, the function does not do anything if the buckets are not acquired.