### PR TITLE
Use nova's pagination API

### DIFF
--- a/otter/convergence/gathering.py
+++ b/otter/convergence/gathering.py
@@ -72,7 +72,7 @@ def get_all_server_details(changes_since=None, batch_size=100):
                     "When gathering server details, got the same 'next' link "
                     "twice from Nova: {0}".format(last_link[-1]))
 
-            last_link.append(continuation[0])
+            last_link[:] = [continuation[0]]
             more_eff = get_server_details(continuation[0])
             return more_eff.on(lambda more_servers: servers + more_servers)
         return servers

--- a/otter/test/convergence/test_gathering.py
+++ b/otter/test/convergence/test_gathering.py
@@ -91,10 +91,11 @@ class GetAllServerDetailsTests(SynchronousTestCase):
                     'servers/detail?limit=10')
         self.servers = [{'id': i} for i in range(9)]
 
-    def test_get_all_less_batch_size(self):
+    def test_get_all_without_link_to_next_page(self):
         """
-        `get_all_server_details` will not fetch again if first get returns
-        results with size < batch_size
+        `get_all_server_details` will not fetch again if first does not have
+        a link to the next page (either pagination is not supported, or there
+        are no more pages)
         """
         fake_response = object()
         body = {'servers': self.servers}
@@ -103,23 +104,47 @@ class GetAllServerDetailsTests(SynchronousTestCase):
         result = resolve_svcreq(svcreq, (fake_response, body), *self.req)
         self.assertEqual(result, self.servers)
 
-    def test_get_all_above_batch_size(self):
+    def test_get_all_ignores_non_next_links(self):
         """
-        `get_all_server_details` will fetch again until batch returned has
-        size < batch_size
+        `get_all_server_details` will ignore links that do not have
+        "rel" = "next".
         """
-        servers = [{'id': i} for i in range(19)]
-        req2 = (ServiceType.CLOUD_SERVERS, 'GET',
-                'servers/detail?limit=10&marker=9')
+        fake_response = object()
+        body = {'servers': self.servers,
+                'server_links': [{'href': 'meh', 'rel': 'prev'}]}
+        eff = get_all_server_details(batch_size=10)
+        svcreq = resolve_retry_stubs(eff)
+        result = resolve_svcreq(svcreq, (fake_response, body), *self.req)
+        self.assertEqual(result, self.servers)
+
+    def test_get_all_with_link_to_next_page(self):
+        """
+        `get_all_server_details` will fetch again and again until there is
+        no more next page.
+        """
+        servers = [{'id': i} for i in range(20)]
+        # first request
         svcreq = resolve_retry_stubs(get_all_server_details(batch_size=10))
         fake_response = object()
-        body = {'servers': servers[:10]}
+        body = {'servers': servers[:10],
+                'servers_links': [{'href': 'nexturl1', 'rel': 'next'}]}
+        result = resolve_svcreq(svcreq, (fake_response, body), *self.req)
+        self.assertIsInstance(result, Effect)
 
-        next_retry = resolve_svcreq(svcreq, (fake_response, body),
-                                    *self.req)
-        next_req = resolve_retry_stubs(next_retry)
-        body = {'servers': servers[10:]}
-        result = resolve_svcreq(next_req, (fake_response, body), *req2)
+        # next request, because previous had a next link
+        next_req = resolve_retry_stubs(result)
+        body = {'servers': servers[10:],
+                'servers_links': [{'href': 'nexturl2', 'rel': 'next'}]}
+        result = resolve_svcreq(next_req, (fake_response, body),
+                                ServiceType.CLOUD_SERVERS, 'GET', 'nexturl1')
+        self.assertIsInstance(result, Effect)
+
+        # third request, because previous had a next link
+        next_req = resolve_retry_stubs(result)
+        body = {'servers': []}
+        result = resolve_svcreq(next_req, (fake_response, body),
+                                ServiceType.CLOUD_SERVERS, 'GET', 'nexturl2')
+
         self.assertEqual(result, servers)
 
     def test_with_changes_since(self):


### PR DESCRIPTION
If we get a list of servers, and it has a `servers_link` object in the body, we use that link instead of constructing our own batch URL.

If that link is not there, either the service doesn't support pagination, or there are no more pages.

Also introduced a check to make sure Nova doesn't return the same link twice, because that would be broken (since Nova depends upon limits and markers to differentiate pages).