### PR TITLE
Switch some convergence='error' tests to convergence='never', with explanations

### DIFF
--- a/autoscale_cloudcafe/autoscale/behaviors.py
+++ b/autoscale_cloudcafe/autoscale/behaviors.py
@@ -547,7 +547,8 @@ class AutoscaleBehaviors(BaseBehavior):
                     'servers'.format(group_id, expected_servers,
                                      group_state.desiredCapacity))
 
-                if len(active_list) == expected_servers:
+                num_servers = len(active_list)
+                if num_servers == expected_servers:
                     return [server.id for server in active_list]
             else:
                 # We're looking at the RackConnect API for our server list
@@ -556,14 +557,16 @@ class AutoscaleBehaviors(BaseBehavior):
                 server_list = [n for n in nodes.nodes
                                if (safe_hasattr(n, "cloud_server"))
                                and (n.status == "ACTIVE")]
-                if len(server_list) == expected_servers:
+                num_servers = len(server_list)
+                if num_servers == expected_servers:
                     return [n.id for n in server_list]
 
             asserter.fail(
                 "wait_for_active_list_in_group_state ran for {0} seconds "
                 "for group/pool ID {1} and did not observe the active "
-                "server list achieving the expected servers count: {2}."
-                .format(time_elapsed, group_id, expected_servers)
+                "server list achieving the expected servers count: {2}, "
+                "found: {3}."
+                .format(time_elapsed, group_id, expected_servers, num_servers)
             )
 
         return self.retry(do_polling, timeout, interval_time, time_scale)

--- a/autoscale_cloudcafe/autoscale/behaviors.py
+++ b/autoscale_cloudcafe/autoscale/behaviors.py
@@ -555,8 +555,8 @@ class AutoscaleBehaviors(BaseBehavior):
                 # here.
                 nodes = self.rcv3_client.get_nodes_on_pool(group_id).entity
                 server_list = [n for n in nodes.nodes
-                               if (safe_hasattr(n, "cloud_server"))
-                               and (n.status == "ACTIVE")]
+                               if (safe_hasattr(n, "cloud_server")) and
+                               (n.status == "ACTIVE")]
                 num_servers = len(server_list)
                 if num_servers == expected_servers:
                     return [n.id for n in server_list]

--- a/autoscale_cloudroast/test_repo/autoscale/system/integration/test_system_integration_lbaas.py
+++ b/autoscale_cloudroast/test_repo/autoscale/system/integration/test_system_integration_lbaas.py
@@ -43,7 +43,13 @@ class AutoscaleLbaasFixture(AutoscaleFixture):
                           cls.lbaas_client.delete_load_balancer)
         cls.lb_other_region = 0000
 
-    @tags(speed='slow', type='lbaas', convergence='error')
+    @tags(speed='slow', type='lbaas', convergence='never')
+    # Convergence: This doesn't work because Convergence just puts the group
+    # into ERROR, because when the load balancer is deleted, it notices the LB
+    # nodes are gone, and then tries to recreate the LB node for all active
+    # servers. This is done simultaneously with deleting one server during the
+    # scale-down in this test, but that doesn't matter much, because the failed
+    # "add node" operation causes the entire convergence to fail.
     def test_delete_server_if_deleted_load_balancer_during_scale_down(self):
         """
         Create a load balancer and provide it in the launch config during
@@ -78,7 +84,10 @@ class AutoscaleLbaasFixture(AutoscaleFixture):
             group.launchConfiguration.server.name, 1)
         self.assertEquals(actual_remaining_servers, remaining_servers)
 
-    @tags(speed='slow', type='lbaas', convergence='error')
+    @tags(speed='slow', type='lbaas', convergence='never')
+    # Convergence: Convergence does not delete servers when they can't be added
+    # to the LB: it just puts the group into ERROR and it's up to the user to
+    # recreate the LB.
     def test_delete_server_if_deleted_load_balancer_during_scale_up(self):
         """
         Create a load balancer and provide it in the launch config during
@@ -345,7 +354,10 @@ class AutoscaleLbaasFixture(AutoscaleFixture):
         self.assertTrue(all([server_ip not in node_list_on_lb for server_ip
                              in server_ip_list]))
 
-    @tags(speed='slow', type='lbaas', convergence='error')
+    @tags(speed='slow', type='lbaas', convergence='never')
+    # Convergence: Convergence does not delete servers when they can't be added
+    # to the LB: it just puts the group into ERROR and it's up to the user to
+    # recreate the LB.
     def test_negative_create_group_with_invalid_load_balancer(self):
         """
         Create group with a random number/lb from a differnt region as the load
@@ -400,7 +412,10 @@ class AutoscaleLbaasFixture(AutoscaleFixture):
             group.launchConfiguration.server.name,
             self.gc_min_entities_alt)
 
-    @tags(speed='slow', type='lbaas', convergence='error')
+    @tags(speed='slow', type='lbaas', convergence='never')
+    # Convergence: Convergence does not delete servers when they can't be added
+    # to the LB: it just puts the group into ERROR and it's up to the user to
+    # recreate the LB.
     def test_group_with_invalid_load_balancer_among_multiple_load_balancers(
             self):
         """


### PR DESCRIPTION
All of these tests fail because they rely on the old worker behavior of deleting servers that couldn't be added to a LB. Now convergence just fails.

The explanations have some, uh, forward-looking statements about the group moving to ERROR state.

Also improved some error reporting in an integration test assertion method.