### PR TITLE
Move step-transforming functions to `transforming.py`

### DIFF
--- a/otter/convergence/planning.py
+++ b/otter/convergence/planning.py
@@ -1,11 +1,9 @@
 """Code related to creating a plan for convergence."""
 
-from functools import partial
+from pyrsistent import pbag, pset
 
-from pyrsistent import pbag, pmap, pset
-
-from toolz.curried import filter, groupby
-from toolz.itertoolz import concat, concatv, mapcat
+from toolz.curried import filter
+from toolz.itertoolz import mapcat
 
 from otter.convergence.model import (
     CLBDescription,
@@ -27,6 +25,7 @@ from otter.convergence.steps import (
     RemoveNodesFromCLB,
     SetMetadataItemOnServer,
 )
+from otter.convergence.transforming import limit_steps_by_count, optimize_steps
 from otter.util.fp import partition_bool, partition_groups
 
 
@@ -267,101 +266,6 @@ def converge(desired_state, servers_with_cheese, load_balancer_contents, now,
                 converge_later)
 
 
-_optimizers = {}
-
-
-def _optimizer(step_type):
-    """
-    A decorator for a type-specific optimizer.
-
-    Usage::
-
-        @_optimizer(StepTypeToOptimize)
-        def optimizing_function(steps_of_that_type):
-           return iterable_of_optimized_steps
-    """
-    def _add_to_optimizers(optimizer):
-        _optimizers[step_type] = optimizer
-        return optimizer
-    return _add_to_optimizers
-
-
-def _register_bulk_clb_optimizer(step_class, attr_name):
-    """
-    Merge together multiple CLB bulk steps per load balancer.  This function
-    is for generating and registering the :obj:`AddNodesToCLB` and
-    :obj:`RemoveNodesFromCLB` optimizers.
-
-    :param step_class: One of :obj:`AddNodesToCLB` or :obj:`RemoveNodesFromCLB`
-    :param attr_name: The attribute name on the class that is the iterable that
-        needs to be concatenated together to make an optimized step.
-
-    :return: Nothing, because this just registers the optimizers with the
-        module.
-    """
-    def optimize_steps(clb_steps):
-        steps_by_lb = groupby(lambda s: s.lb_id, clb_steps)
-        return [
-            step_class(**{
-                'lb_id': lb_id,
-                attr_name: pset(concat(getattr(s, attr_name) for s in steps))})
-            for lb_id, steps in steps_by_lb.iteritems()
-        ]
-
-    _optimizer(step_class)(optimize_steps)
-
-_register_bulk_clb_optimizer(AddNodesToCLB, 'address_configs')
-_register_bulk_clb_optimizer(RemoveNodesFromCLB, 'node_ids')
-
-
-def optimize_steps(steps):
-    """
-    Optimize steps.
-
-    Currently only optimizes per step type. See the :func:`_optimizer`
-    decorator for more information on how to register an optimizer.
-
-    :param pbag steps: Collection of steps.
-    :return: a pbag of steps.
-    """
-    def grouping_fn(step):
-        step_type = type(step)
-        if step_type in _optimizers:
-            return step_type
-        else:
-            return "unoptimizable"
-
-    steps_by_type = groupby(grouping_fn, steps)
-    unoptimizable = steps_by_type.pop("unoptimizable", [])
-    omg_optimized = concat(_optimizers[step_type](steps)
-                           for step_type, steps in steps_by_type.iteritems())
-    return pbag(concatv(omg_optimized, unoptimizable))
-
-
-_DEFAULT_STEP_LIMITS = pmap({
-    CreateServer: 3
-})
-
-
-def _limit_step_count(steps, step_limits):
-    """
-    Limits step count by type.
-
-    :param steps: An iterable of steps.
-    :param step_limits: A dict mapping step classes to their maximum allowable
-        count. Classes not present in this dict have no limit.
-    :return: The input steps
-    :rtype: pset
-    """
-    return pbag(concat(typed_steps[:step_limits.get(cls)]
-                       for (cls, typed_steps)
-                       in groupby(type, steps).iteritems()))
-
-
-_default_limit_step_count = partial(
-    _limit_step_count, step_limits=_DEFAULT_STEP_LIMITS)
-
-
 def plan(desired_group_state, servers, lb_nodes, now):
     """
     Get an optimized convergence plan.
@@ -369,7 +273,7 @@ def plan(desired_group_state, servers, lb_nodes, now):
     Takes the same arguments as :func:`converge`.
     """
     steps = converge(desired_group_state, servers, lb_nodes, now)
-    steps = _default_limit_step_count(steps)
+    steps = limit_steps_by_count(steps)
     return optimize_steps(steps)
 
 

--- a/otter/convergence/transforming.py
+++ b/otter/convergence/transforming.py
@@ -5,7 +5,7 @@ There are a few classes of transformations here:
 
 - optimizing (converting multiple steps into one for the purposes of reducing
   API roundtrips)
-- throttling (by truncating the number of steps we take)
+- limiting (by truncating the number of steps we take)
 - throttling (by wrapping multiple steps with one that gradually executes them)
 """
 

--- a/otter/convergence/transforming.py
+++ b/otter/convergence/transforming.py
@@ -1,12 +1,9 @@
 """
 Functions for transforming collections of steps.
 
-There are a few classes of transformations here:
-
 - optimizing (converting multiple steps into one for the purposes of reducing
   API roundtrips)
 - limiting (by truncating the number of steps we take)
-- throttling (by wrapping multiple steps with one that gradually executes them)
 """
 
 from functools import partial

--- a/otter/convergence/transforming.py
+++ b/otter/convergence/transforming.py
@@ -1,0 +1,117 @@
+"""
+Functions for transforming collections of steps.
+
+There are a few classes of transformations here:
+
+- optimizing (converting multiple steps into one for the purposes of reducing
+  API roundtrips)
+- throttling (by truncating the number of steps we take)
+- throttling (by wrapping multiple steps with one that gradually executes them)
+"""
+
+from functools import partial
+
+from pyrsistent import pbag, pmap, pset
+
+from toolz.curried import groupby
+from toolz.itertoolz import concat, concatv
+
+from otter.convergence.steps import (
+    AddNodesToCLB,
+    CreateServer,
+    RemoveNodesFromCLB)
+
+
+_optimizers = {}
+
+
+def _optimizer(step_type):
+    """
+    A decorator for a type-specific optimizer.
+
+    Usage::
+
+        @_optimizer(StepTypeToOptimize)
+        def optimizing_function(steps_of_that_type):
+           return iterable_of_optimized_steps
+    """
+    def _add_to_optimizers(optimizer):
+        _optimizers[step_type] = optimizer
+        return optimizer
+    return _add_to_optimizers
+
+
+def _register_bulk_clb_optimizer(step_class, attr_name):
+    """
+    Merge together multiple CLB bulk steps per load balancer.  This function
+    is for generating and registering the :obj:`AddNodesToCLB` and
+    :obj:`RemoveNodesFromCLB` optimizers.
+
+    :param step_class: One of :obj:`AddNodesToCLB` or :obj:`RemoveNodesFromCLB`
+    :param attr_name: The attribute name on the class that is the iterable that
+        needs to be concatenated together to make an optimized step.
+
+    :return: Nothing, because this just registers the optimizers with the
+        module.
+    """
+    def optimize_steps(clb_steps):
+        steps_by_lb = groupby(lambda s: s.lb_id, clb_steps)
+        return [
+            step_class(**{
+                'lb_id': lb_id,
+                attr_name: pset(concat(getattr(s, attr_name) for s in steps))})
+            for lb_id, steps in steps_by_lb.iteritems()
+        ]
+
+    _optimizer(step_class)(optimize_steps)
+
+_register_bulk_clb_optimizer(AddNodesToCLB, 'address_configs')
+_register_bulk_clb_optimizer(RemoveNodesFromCLB, 'node_ids')
+
+
+def optimize_steps(steps):
+    """
+    Optimize steps.
+
+    Currently only optimizes per step type. See the :func:`_optimizer`
+    decorator for more information on how to register an optimizer.
+
+    :param pbag steps: Collection of steps.
+    :return: a pbag of steps.
+    """
+    def grouping_fn(step):
+        step_type = type(step)
+        if step_type in _optimizers:
+            return step_type
+        else:
+            return "unoptimizable"
+
+    steps_by_type = groupby(grouping_fn, steps)
+    unoptimizable = steps_by_type.pop("unoptimizable", [])
+    omg_optimized = concat(_optimizers[step_type](steps)
+                           for step_type, steps in steps_by_type.iteritems())
+    return pbag(concatv(omg_optimized, unoptimizable))
+
+
+_DEFAULT_STEP_LIMITS = pmap({
+    CreateServer: 3
+})
+
+
+def _limit_step_count(steps, step_limits):
+    """
+    Limits step count by type.
+
+    :param steps: An iterable of steps.
+    :param step_limits: A dict mapping step classes to their maximum allowable
+        count. Classes not present in this dict have no limit.
+    :return: The input steps
+    :rtype: pset
+    """
+    return pbag(concat(typed_steps[:step_limits.get(cls)]
+                       for (cls, typed_steps)
+                       in groupby(type, steps).iteritems()))
+
+
+limit_steps_by_count = partial(
+    _limit_step_count, step_limits=_DEFAULT_STEP_LIMITS)

--- a/otter/test/convergence/test_planning.py
+++ b/otter/test/convergence/test_planning.py
@@ -18,9 +18,8 @@ from otter.convergence.model import (
     RCv3Node,
     ServerState)
 from otter.convergence.planning import (
-    _default_limit_step_count,
-    _limit_step_count,
     converge,
+    limit_steps_by_count,
     optimize_steps,
     plan)
 from otter.convergence.steps import (
@@ -33,6 +32,7 @@ from otter.convergence.steps import (
     DeleteServer,
     RemoveNodesFromCLB,
     SetMetadataItemOnServer)
+from otter.convergence.transforming import _limit_step_count
 
 
 def copy_clb_desc(clb_desc, condition=CLBNodeCondition.ENABLED, weight=1):
@@ -1258,7 +1258,7 @@ class LimitStepCount(SynchronousTestCase):
         """
         The default limit limits server creation to up to 3 steps.
         """
-        limits = _default_limit_step_count.keywords["step_limits"]
+        limits = limit_steps_by_count.keywords["step_limits"]
         self.assertEqual(limits, pmap({CreateServer: 3}))
 
 

--- a/otter/test/convergence/test_planning.py
+++ b/otter/test/convergence/test_planning.py
@@ -2,8 +2,6 @@
 
 from pyrsistent import b, pbag, pmap, pset, s
 
-from toolz import groupby
-
 from twisted.trial.unittest import SynchronousTestCase
 
 from otter.convergence.model import (
@@ -11,17 +9,13 @@ from otter.convergence.model import (
     CLBNode,
     CLBNodeCondition,
     CLBNodeType,
-    DesiredGroupState,
     DRAINING_METADATA,
+    DesiredGroupState,
     NovaServer,
     RCv3Description,
     RCv3Node,
     ServerState)
-from otter.convergence.planning import (
-    converge,
-    limit_steps_by_count,
-    optimize_steps,
-    plan)
+from otter.convergence.planning import converge, plan
 from otter.convergence.steps import (
     AddNodesToCLB,
     BulkAddToRCv3,
@@ -32,7 +26,6 @@ from otter.convergence.steps import (
     DeleteServer,
     RemoveNodesFromCLB,
     SetMetadataItemOnServer)
-from otter.convergence.transforming import _limit_step_count
 
 
 def copy_clb_desc(clb_desc, condition=CLBNodeCondition.ENABLED, weight=1):
@@ -994,272 +987,6 @@ class ConvergeTests(SynchronousTestCase):
                     lb_id='5',
                     address_configs=s(('2.2.2.2', desc)))
             ]))
-
-
-class OptimizerTests(SynchronousTestCase):
-    """Tests for :func:`optimize_steps`."""
-
-    def test_optimize_clb_adds(self):
-        """
-        Multiple :class:`AddNodesToCLB` steps for the same LB
-        are merged into one.
-        """
-        steps = pbag([
-            AddNodesToCLB(
-                lb_id='5',
-                address_configs=s(('1.1.1.1',
-                                   CLBDescription(lb_id='5', port=80)))),
-            AddNodesToCLB(
-                lb_id='5',
-                address_configs=s(('1.2.3.4',
-                                   CLBDescription(lb_id='5', port=80))))])
-        self.assertEqual(
-            optimize_steps(steps),
-            pbag([
-                AddNodesToCLB(
-                    lb_id='5',
-                    address_configs=s(
-                        ('1.1.1.1', CLBDescription(lb_id='5', port=80)),
-                        ('1.2.3.4', CLBDescription(lb_id='5', port=80)))
-                )]))
-
-    def test_optimize_clb_adds_maintain_unique_ports(self):
-        """
-        Multiple ports can be specified for the same address and LB ID when
-        adding to a CLB.
-        """
-        steps = pbag([
-            AddNodesToCLB(
-                lb_id='5',
-                address_configs=s(('1.1.1.1',
-                                   CLBDescription(lb_id='5', port=80)))),
-            AddNodesToCLB(
-                lb_id='5',
-                address_configs=s(('1.1.1.1',
-                                   CLBDescription(lb_id='5', port=8080))))])
-
-        self.assertEqual(
-            optimize_steps(steps),
-            pbag([
-                AddNodesToCLB(
-                    lb_id='5',
-                    address_configs=s(
-                        ('1.1.1.1',
-                         CLBDescription(lb_id='5', port=80)),
-                        ('1.1.1.1',
-                         CLBDescription(lb_id='5', port=8080))))]))
-
-    def test_clb_adds_multiple_load_balancers(self):
-        """
-        Aggregation is done on a per-load-balancer basis when adding to a CLB.
-        """
-        steps = pbag([
-            AddNodesToCLB(
-                lb_id='5',
-                address_configs=s(('1.1.1.1',
-                                   CLBDescription(lb_id='5', port=80)))),
-            AddNodesToCLB(
-                lb_id='5',
-                address_configs=s(('1.1.1.2',
-                                   CLBDescription(lb_id='5', port=80)))),
-            AddNodesToCLB(
-                lb_id='6',
-                address_configs=s(('1.1.1.1',
-                                   CLBDescription(lb_id='6', port=80)))),
-            AddNodesToCLB(
-                lb_id='6',
-                address_configs=s(('1.1.1.2',
-                                   CLBDescription(lb_id='6', port=80)))),
-        ])
-        self.assertEqual(
-            optimize_steps(steps),
-            pbag([
-                AddNodesToCLB(
-                    lb_id='5',
-                    address_configs=s(
-                        ('1.1.1.1', CLBDescription(lb_id='5', port=80)),
-                        ('1.1.1.2', CLBDescription(lb_id='5', port=80)))),
-                AddNodesToCLB(
-                    lb_id='6',
-                    address_configs=s(
-                        ('1.1.1.1', CLBDescription(lb_id='6', port=80)),
-                        ('1.1.1.2', CLBDescription(lb_id='6', port=80)))),
-            ]))
-
-    def test_optimize_clb_removes(self):
-        """
-        Aggregation is done on a per-load-balancer basis when remove nodes from
-        a CLB.
-        """
-        steps = pbag([
-            RemoveNodesFromCLB(lb_id='5', node_ids=s('1')),
-            RemoveNodesFromCLB(lb_id='5', node_ids=s('2')),
-            RemoveNodesFromCLB(lb_id='5', node_ids=s('3')),
-            RemoveNodesFromCLB(lb_id='5', node_ids=s('4'))])
-
-        self.assertEqual(
-            optimize_steps(steps),
-            pbag([
-                RemoveNodesFromCLB(lb_id='5', node_ids=s('1', '2', '3', '4'))
-            ]))
-
-    def test_clb_remove_multiple_load_balancers(self):
-        """
-        Multiple :class:`RemoveNodesFromCLB` steps for the same LB
-        are merged into one.
-        """
-        steps = pbag([
-            RemoveNodesFromCLB(lb_id='5', node_ids=s('1')),
-            RemoveNodesFromCLB(lb_id='5', node_ids=s('2')),
-            RemoveNodesFromCLB(lb_id='6', node_ids=s('3')),
-            RemoveNodesFromCLB(lb_id='6', node_ids=s('4'))])
-
-        self.assertEqual(
-            optimize_steps(steps),
-            pbag([
-                RemoveNodesFromCLB(lb_id='5', node_ids=s('1', '2')),
-                RemoveNodesFromCLB(lb_id='6', node_ids=s('3', '4'))
-            ]))
-
-    def test_optimize_leaves_other_steps(self):
-        """
-        Unoptimizable steps pass the optimizer unchanged.
-        """
-        steps = pbag([
-            AddNodesToCLB(
-                lb_id='5',
-                address_configs=s(('1.1.1.1',
-                                   CLBDescription(lb_id='5', port=80)))),
-            RemoveNodesFromCLB(lb_id='5', node_ids=s('1')),
-            CreateServer(server_config=pmap({})),
-            BulkRemoveFromRCv3(lb_node_pairs=pset([("lb-1", "node-a")])),
-            BulkAddToRCv3(lb_node_pairs=pset([("lb-2", "node-b")]))
-            # Note that the add & remove pair should not be the same;
-            # the optimizer might reasonably optimize opposite
-            # operations away in the future.
-        ])
-        self.assertEqual(
-            optimize_steps(steps),
-            steps)
-
-    def test_mixed_optimization(self):
-        """
-        Mixes of optimizable and unoptimizable steps still get optimized
-        correctly.
-        """
-        steps = pbag([
-            # CLB adds
-            AddNodesToCLB(
-                lb_id='5',
-                address_configs=s(('1.1.1.1',
-                                   CLBDescription(lb_id='5', port=80)))),
-            AddNodesToCLB(
-                lb_id='5',
-                address_configs=s(('1.1.1.2',
-                                   CLBDescription(lb_id='5', port=80)))),
-            AddNodesToCLB(
-                lb_id='6',
-                address_configs=s(('1.1.1.1',
-                                   CLBDescription(lb_id='6', port=80)))),
-            AddNodesToCLB(
-                lb_id='6',
-                address_configs=s(('1.1.1.2',
-                                   CLBDescription(lb_id='6', port=80)))),
-            RemoveNodesFromCLB(lb_id='5', node_ids=s('1')),
-            RemoveNodesFromCLB(lb_id='5', node_ids=s('2')),
-            RemoveNodesFromCLB(lb_id='6', node_ids=s('3')),
-            RemoveNodesFromCLB(lb_id='6', node_ids=s('4')),
-
-            # Unoptimizable steps
-            CreateServer(server_config=pmap({})),
-        ])
-
-        self.assertEqual(
-            optimize_steps(steps),
-            pbag([
-                # Optimized CLB adds
-                AddNodesToCLB(
-                    lb_id='5',
-                    address_configs=s(('1.1.1.1',
-                                       CLBDescription(lb_id='5', port=80)),
-                                      ('1.1.1.2',
-                                       CLBDescription(lb_id='5', port=80)))),
-                AddNodesToCLB(
-                    lb_id='6',
-                    address_configs=s(('1.1.1.1',
-                                       CLBDescription(lb_id='6', port=80)),
-                                      ('1.1.1.2',
-                                       CLBDescription(lb_id='6', port=80)))),
-                RemoveNodesFromCLB(lb_id='5', node_ids=s('1', '2')),
-                RemoveNodesFromCLB(lb_id='6', node_ids=s('3', '4')),
-
-                # Unoptimizable steps
-                CreateServer(server_config=pmap({}))
-            ]))
-
-
-class LimitStepCount(SynchronousTestCase):
-    """
-    Tests for limiting step counts.
-    """
-
-    def _create_some_steps(self, counts={}):
-        """
-        Creates some steps for testing.
-
-        :param counts: A mapping of supported step classes to the number of
-            those steps to create. If unspecified, assumed to be zero.
-        :return: A pbag of steps.
-        """
-        create_servers = [CreateServer(server_config=pmap({"sentinel": i}))
-                          for i in xrange(counts.get(CreateServer, 0))]
-        delete_servers = [DeleteServer(server_id='abc-' + str(i))
-                          for i in xrange(counts.get(DeleteServer, 0))]
-        remove_from_clbs = [RemoveNodesFromCLB(lb_id='1', node_ids=(str(i),))
-                            for i in xrange(counts.get(RemoveNodesFromCLB, 0))]
-
-        return pbag(create_servers + delete_servers + remove_from_clbs)
-
-    def _test_limit_step_count(self, in_step_counts, step_limits):
-        """
-        Create some steps, limit them, assert they were limited.
-        """
-        in_steps = self._create_some_steps(in_step_counts)
-        out_steps = _limit_step_count(in_steps, step_limits)
-        expected_step_counts = {
-            cls: step_limits.get(cls, in_step_count)
-            for (cls, in_step_count)
-            in in_step_counts.iteritems()
-        }
-        actual_step_counts = {
-            cls: len(steps_of_this_type)
-            for (cls, steps_of_this_type)
-            in groupby(type, out_steps).iteritems()
-        }
-        self.assertEqual(expected_step_counts, actual_step_counts)
-
-    def test_limit_step_count(self):
-        """
-        The steps are limited so that there are at most as many of each
-        type as specified,. If no limit is specified for a type, any
-        number of them are allowed.
-        """
-        in_step_counts = {
-            CreateServer: 10,
-            DeleteServer: 10
-        }
-        step_limits = {
-            CreateServer: 3,
-            DeleteServer: 10
-        }
-        self._test_limit_step_count(in_step_counts, step_limits)
-
-    def test_default_step_limit(self):
-        """
-        The default limit limits server creation to up to 3 steps.
-        """
-        limits = limit_steps_by_count.keywords["step_limits"]
-        self.assertEqual(limits, pmap({CreateServer: 3}))
 
 
 class PlanTests(SynchronousTestCase):

--- a/otter/test/convergence/test_transforming.py
+++ b/otter/test/convergence/test_transforming.py
@@ -1,3 +1,5 @@
+"""Tests for otter.convergence.transforming."""
+
 from pyrsistent import pbag, pmap, pset, s
 
 from toolz import groupby

--- a/otter/test/convergence/test_transforming.py
+++ b/otter/test/convergence/test_transforming.py
@@ -1,0 +1,285 @@
+from pyrsistent import pbag, pmap, pset, s
+
+from toolz import groupby
+
+from twisted.trial.unittest import SynchronousTestCase
+
+from otter.convergence.model import CLBDescription
+from otter.convergence.steps import (
+    AddNodesToCLB,
+    BulkAddToRCv3,
+    BulkRemoveFromRCv3,
+    CreateServer,
+    DeleteServer,
+    RemoveNodesFromCLB,
+    )
+from otter.convergence.transforming import (
+    _limit_step_count,
+    limit_steps_by_count,
+    optimize_steps)
+
+
+class LimitStepCount(SynchronousTestCase):
+    """
+    Tests for limiting step counts.
+    """
+
+    def _create_some_steps(self, counts={}):
+        """
+        Creates some steps for testing.
+
+        :param counts: A mapping of supported step classes to the number of
+            those steps to create. If unspecified, assumed to be zero.
+        :return: A pbag of steps.
+        """
+        create_servers = [CreateServer(server_config=pmap({"sentinel": i}))
+                          for i in xrange(counts.get(CreateServer, 0))]
+        delete_servers = [DeleteServer(server_id='abc-' + str(i))
+                          for i in xrange(counts.get(DeleteServer, 0))]
+        remove_from_clbs = [RemoveNodesFromCLB(lb_id='1', node_ids=(str(i),))
+                            for i in xrange(counts.get(RemoveNodesFromCLB, 0))]
+
+        return pbag(create_servers + delete_servers + remove_from_clbs)
+
+    def _test_limit_step_count(self, in_step_counts, step_limits):
+        """
+        Create some steps, limit them, assert they were limited.
+        """
+        in_steps = self._create_some_steps(in_step_counts)
+        out_steps = _limit_step_count(in_steps, step_limits)
+        expected_step_counts = {
+            cls: step_limits.get(cls, in_step_count)
+            for (cls, in_step_count)
+            in in_step_counts.iteritems()
+        }
+        actual_step_counts = {
+            cls: len(steps_of_this_type)
+            for (cls, steps_of_this_type)
+            in groupby(type, out_steps).iteritems()
+        }
+        self.assertEqual(expected_step_counts, actual_step_counts)
+
+    def test_limit_step_count(self):
+        """
+        The steps are limited so that there are at most as many of each
+        type as specified,. If no limit is specified for a type, any
+        number of them are allowed.
+        """
+        in_step_counts = {
+            CreateServer: 10,
+            DeleteServer: 10
+        }
+        step_limits = {
+            CreateServer: 3,
+            DeleteServer: 10
+        }
+        self._test_limit_step_count(in_step_counts, step_limits)
+
+    def test_default_step_limit(self):
+        """
+        The default limit limits server creation to up to 3 steps.
+        """
+        limits = limit_steps_by_count.keywords["step_limits"]
+        self.assertEqual(limits, pmap({CreateServer: 3}))
+
+
+class OptimizerTests(SynchronousTestCase):
+    """Tests for :func:`optimize_steps`."""
+
+    def test_optimize_clb_adds(self):
+        """
+        Multiple :class:`AddNodesToCLB` steps for the same LB
+        are merged into one.
+        """
+        steps = pbag([
+            AddNodesToCLB(
+                lb_id='5',
+                address_configs=s(('1.1.1.1',
+                                   CLBDescription(lb_id='5', port=80)))),
+            AddNodesToCLB(
+                lb_id='5',
+                address_configs=s(('1.2.3.4',
+                                   CLBDescription(lb_id='5', port=80))))])
+        self.assertEqual(
+            optimize_steps(steps),
+            pbag([
+                AddNodesToCLB(
+                    lb_id='5',
+                    address_configs=s(
+                        ('1.1.1.1', CLBDescription(lb_id='5', port=80)),
+                        ('1.2.3.4', CLBDescription(lb_id='5', port=80)))
+                )]))
+
+    def test_optimize_clb_adds_maintain_unique_ports(self):
+        """
+        Multiple ports can be specified for the same address and LB ID when
+        adding to a CLB.
+        """
+        steps = pbag([
+            AddNodesToCLB(
+                lb_id='5',
+                address_configs=s(('1.1.1.1',
+                                   CLBDescription(lb_id='5', port=80)))),
+            AddNodesToCLB(
+                lb_id='5',
+                address_configs=s(('1.1.1.1',
+                                   CLBDescription(lb_id='5', port=8080))))])
+
+        self.assertEqual(
+            optimize_steps(steps),
+            pbag([
+                AddNodesToCLB(
+                    lb_id='5',
+                    address_configs=s(
+                        ('1.1.1.1',
+                         CLBDescription(lb_id='5', port=80)),
+                        ('1.1.1.1',
+                         CLBDescription(lb_id='5', port=8080))))]))
+
+    def test_clb_adds_multiple_load_balancers(self):
+        """
+        Aggregation is done on a per-load-balancer basis when adding to a CLB.
+        """
+        steps = pbag([
+            AddNodesToCLB(
+                lb_id='5',
+                address_configs=s(('1.1.1.1',
+                                   CLBDescription(lb_id='5', port=80)))),
+            AddNodesToCLB(
+                lb_id='5',
+                address_configs=s(('1.1.1.2',
+                                   CLBDescription(lb_id='5', port=80)))),
+            AddNodesToCLB(
+                lb_id='6',
+                address_configs=s(('1.1.1.1',
+                                   CLBDescription(lb_id='6', port=80)))),
+            AddNodesToCLB(
+                lb_id='6',
+                address_configs=s(('1.1.1.2',
+                                   CLBDescription(lb_id='6', port=80)))),
+        ])
+        self.assertEqual(
+            optimize_steps(steps),
+            pbag([
+                AddNodesToCLB(
+                    lb_id='5',
+                    address_configs=s(
+                        ('1.1.1.1', CLBDescription(lb_id='5', port=80)),
+                        ('1.1.1.2', CLBDescription(lb_id='5', port=80)))),
+                AddNodesToCLB(
+                    lb_id='6',
+                    address_configs=s(
+                        ('1.1.1.1', CLBDescription(lb_id='6', port=80)),
+                        ('1.1.1.2', CLBDescription(lb_id='6', port=80)))),
+            ]))
+
+    def test_optimize_clb_removes(self):
+        """
+        Aggregation is done on a per-load-balancer basis when remove nodes from
+        a CLB.
+        """
+        steps = pbag([
+            RemoveNodesFromCLB(lb_id='5', node_ids=s('1')),
+            RemoveNodesFromCLB(lb_id='5', node_ids=s('2')),
+            RemoveNodesFromCLB(lb_id='5', node_ids=s('3')),
+            RemoveNodesFromCLB(lb_id='5', node_ids=s('4'))])
+
+        self.assertEqual(
+            optimize_steps(steps),
+            pbag([
+                RemoveNodesFromCLB(lb_id='5', node_ids=s('1', '2', '3', '4'))
+            ]))
+
+    def test_clb_remove_multiple_load_balancers(self):
+        """
+        Multiple :class:`RemoveNodesFromCLB` steps for the same LB
+        are merged into one.
+        """
+        steps = pbag([
+            RemoveNodesFromCLB(lb_id='5', node_ids=s('1')),
+            RemoveNodesFromCLB(lb_id='5', node_ids=s('2')),
+            RemoveNodesFromCLB(lb_id='6', node_ids=s('3')),
+            RemoveNodesFromCLB(lb_id='6', node_ids=s('4'))])
+
+        self.assertEqual(
+            optimize_steps(steps),
+            pbag([
+                RemoveNodesFromCLB(lb_id='5', node_ids=s('1', '2')),
+                RemoveNodesFromCLB(lb_id='6', node_ids=s('3', '4'))
+            ]))
+
+    def test_optimize_leaves_other_steps(self):
+        """
+        Unoptimizable steps pass the optimizer unchanged.
+        """
+        steps = pbag([
+            AddNodesToCLB(
+                lb_id='5',
+                address_configs=s(('1.1.1.1',
+                                   CLBDescription(lb_id='5', port=80)))),
+            RemoveNodesFromCLB(lb_id='5', node_ids=s('1')),
+            CreateServer(server_config=pmap({})),
+            BulkRemoveFromRCv3(lb_node_pairs=pset([("lb-1", "node-a")])),
+            BulkAddToRCv3(lb_node_pairs=pset([("lb-2", "node-b")]))
+            # Note that the add & remove pair should not be the same;
+            # the optimizer might reasonably optimize opposite
+            # operations away in the future.
+        ])
+        self.assertEqual(
+            optimize_steps(steps),
+            steps)
+
+    def test_mixed_optimization(self):
+        """
+        Mixes of optimizable and unoptimizable steps still get optimized
+        correctly.
+        """
+        steps = pbag([
+            # CLB adds
+            AddNodesToCLB(
+                lb_id='5',
+                address_configs=s(('1.1.1.1',
+                                   CLBDescription(lb_id='5', port=80)))),
+            AddNodesToCLB(
+                lb_id='5',
+                address_configs=s(('1.1.1.2',
+                                   CLBDescription(lb_id='5', port=80)))),
+            AddNodesToCLB(
+                lb_id='6',
+                address_configs=s(('1.1.1.1',
+                                   CLBDescription(lb_id='6', port=80)))),
+            AddNodesToCLB(
+                lb_id='6',
+                address_configs=s(('1.1.1.2',
+                                   CLBDescription(lb_id='6', port=80)))),
+            RemoveNodesFromCLB(lb_id='5', node_ids=s('1')),
+            RemoveNodesFromCLB(lb_id='5', node_ids=s('2')),
+            RemoveNodesFromCLB(lb_id='6', node_ids=s('3')),
+            RemoveNodesFromCLB(lb_id='6', node_ids=s('4')),
+
+            # Unoptimizable steps
+            CreateServer(server_config=pmap({})),
+        ])
+
+        self.assertEqual(
+            optimize_steps(steps),
+            pbag([
+                # Optimized CLB adds
+                AddNodesToCLB(
+                    lb_id='5',
+                    address_configs=s(('1.1.1.1',
+                                       CLBDescription(lb_id='5', port=80)),
+                                      ('1.1.1.2',
+                                       CLBDescription(lb_id='5', port=80)))),
+                AddNodesToCLB(
+                    lb_id='6',
+                    address_configs=s(('1.1.1.1',
+                                       CLBDescription(lb_id='6', port=80)),
+                                      ('1.1.1.2',
+                                       CLBDescription(lb_id='6', port=80)))),
+                RemoveNodesFromCLB(lb_id='5', node_ids=s('1', '2')),
+                RemoveNodesFromCLB(lb_id='6', node_ids=s('3', '4')),
+
+                # Unoptimizable steps
+                CreateServer(server_config=pmap({}))
+            ]))


### PR DESCRIPTION
Move the optimizers and step-limiting code to otter.convergence.transforming. 

The TBD throttling code will go in this new module too.