### PR TITLE
Enable cafe policies tests in 4 modules

### DIFF
--- a/autoscale_cloudroast/test_repo/autoscale/system/policies/test_system_execute_webhook_scaledown.py
+++ b/autoscale_cloudroast/test_repo/autoscale/system/policies/test_system_execute_webhook_scaledown.py
@@ -30,8 +30,11 @@ class ScalingDownExecuteWebhookTest(AutoscaleFixture):
         self.servers_before_scaledown = (self.gc_min_entities_alt +
                                          self.policy_up['change'])
         self.resources.add(self.group, self.empty_scaling_group)
+        self.check_for_expected_number_of_building_servers(
+            self.group.id,
+            self.servers_before_scaledown)
 
-    @tags(speed='slow')
+    @tags(speed='slow', convergence='yes')
     def test_system_execute_webhook_scale_down_change(self):
         """
         Execute a scale down webhook with change as the number
@@ -46,14 +49,14 @@ class ScalingDownExecuteWebhookTest(AutoscaleFixture):
                 execute_webhook=True)
         self.assertEquals(execute_scale_down_webhook[
                           'execute_response'], 202)
-        self.wait_for_expected_group_state(
+        self.check_for_expected_number_of_building_servers(
             self.group.id,
             self.group.groupConfiguration.minEntities)
         self.assert_servers_deleted_successfully(
             self.group.launchConfiguration.server.name,
             self.group.groupConfiguration.minEntities)
 
-    @tags(speed='slow')
+    @tags(speed='slow', convergence='yes')
     def test_system_execute_webhook_scale_down_change_percent(self):
         """
         Execute a webhook with scale down with change percentage 60
@@ -70,13 +73,13 @@ class ScalingDownExecuteWebhookTest(AutoscaleFixture):
             current=self.group.groupConfiguration.minEntities +
             self.policy_up['change'],
             percentage=policy_down['change_percent'])
-        self.wait_for_expected_group_state(self.group.id,
-                                           servers_from_scale_down)
+        self.check_for_expected_number_of_building_servers(
+            self.group.id, servers_from_scale_down)
         self.assert_servers_deleted_successfully(
             self.group.launchConfiguration.server.name,
             servers_from_scale_down)
 
-    @tags(speed='slow')
+    @tags(speed='slow', convergence='yes')
     def test_system_execute_webhook_scale_down_desired_capacity(self):
         """
         Execute a webhook with scale down with desired capacity as the
@@ -91,8 +94,8 @@ class ScalingDownExecuteWebhookTest(AutoscaleFixture):
                 execute_webhook=True)
         self.assertEquals(execute_webhook_desired_capacity[
                           'execute_response'], 202)
-        self.wait_for_expected_group_state(self.group.id,
-                                           policy_down['desired_capacity'])
+        self.check_for_expected_number_of_building_servers(
+            self.group.id, policy_down['desired_capacity'])
         self.assert_servers_deleted_successfully(
             self.group.launchConfiguration.server.name,
             policy_down['desired_capacity'])

--- a/autoscale_cloudroast/test_repo/autoscale/system/policies/test_system_execute_webhook_scaleup.py
+++ b/autoscale_cloudroast/test_repo/autoscale/system/policies/test_system_execute_webhook_scaleup.py
@@ -23,7 +23,7 @@ class ScalingUpExecuteWebhookTest(AutoscaleFixture):
         self.group = self.create_group_response.entity
         self.resources.add(self.group, self.empty_scaling_group)
 
-    @tags(speed='quick')
+    @tags(speed='quick', convergence='yes')
     def test_system_execute_webhook_scale_up_change(self):
         """
         Create a scale up policy with change and execute its webhook
@@ -41,7 +41,7 @@ class ScalingUpExecuteWebhookTest(AutoscaleFixture):
             expected_servers=policy_up['change'] +
             self.group.groupConfiguration.minEntities)
 
-    @tags(speed='quick')
+    @tags(speed='quick', convergence='yes')
     def test_system_execute_webhook_scale_up_change_percent(self):
         """
         Execute a webhook for scale up policy with change percent.
@@ -61,7 +61,7 @@ class ScalingUpExecuteWebhookTest(AutoscaleFixture):
             group_id=self.group.id,
             expected_servers=servers_from_scale_up)
 
-    @tags(speed='quick')
+    @tags(speed='quick', convergence='yes')
     def test_system_execute_webhook_scale_up_desired_capacity(self):
         """
         Execute a webhook for scale up policy with desired capacity.

--- a/autoscale_cloudroast/test_repo/autoscale/system/policies/test_system_policies_negative.py
+++ b/autoscale_cloudroast/test_repo/autoscale/system/policies/test_system_policies_negative.py
@@ -34,7 +34,7 @@ class ScalingPoliciesNegativeFixture(AutoscaleFixture):
             execute_policy=False)
         self.resources.add(self.group, self.empty_scaling_group)
 
-    @tags(speed='quick')
+    @tags(speed='quick', convergence='yes')
     def test_execute_policy_when_maxentities_equals_minentities(self):
         """
         Update minentities=maxentities and execution of a scale up policy
@@ -52,7 +52,7 @@ class ScalingPoliciesNegativeFixture(AutoscaleFixture):
             'for group {1}'.format(
                 execute_policy_up.status_code, self.group.id))
 
-    @tags(speed='quick')
+    @tags(speed='quick', convergence='yes')
     def test_execute_scale_down_on_newly_created_group_with_minentities(self):
         """
         Update minentities=maxentities and execution of a scale down policy
@@ -70,7 +70,7 @@ class ScalingPoliciesNegativeFixture(AutoscaleFixture):
             ' on the group {0} with response code {1}'
             .format(self.group.id, execute_policy_down.status_code))
 
-    @tags(speed='quick')
+    @tags(speed='quick', convergence='yes')
     def test_delete_policy_during_execution(self):
         """
         Policy execution is not affected/paused when the policy is deleted
@@ -98,7 +98,7 @@ class ScalingPoliciesNegativeFixture(AutoscaleFixture):
             expected_servers=self.group.groupConfiguration.minEntities +
             self.policy_up_data['change'])
 
-    @tags(speed='quick')
+    @tags(speed='quick', convergence='yes')
     def test_execute_scale_up_after_maxentities_met(self):
         """
         Update max entities of the scaling group to be 3 and execute scale up
@@ -129,7 +129,7 @@ class ScalingPoliciesNegativeFixture(AutoscaleFixture):
             ' has maxentities, response code: {1}'
             .format(self.group.id, reexecute_scale_up.status_code))
 
-    @tags(speed='slow')
+    @tags(speed='slow', convergence='yes')
     def test_scaleup_update_min_max_0_delete_group(self):
         """
         Create a scaling group and update min and max entities to be 0 and
@@ -149,7 +149,7 @@ class ScalingPoliciesNegativeFixture(AutoscaleFixture):
             .format(self.group.id, delete_group.status_code))
         self.assert_servers_deleted_successfully(server_name)
 
-    @tags(speed='quick')
+    @tags(speed='quick', convergence='yes')
     def test_scaleup_update_min_scale_down(self):
         """
         Create a scaling group and execute a scale up policy, update min =
@@ -177,7 +177,7 @@ class ScalingPoliciesNegativeFixture(AutoscaleFixture):
             ' on the group {0} with response code {1}'
             .format(self.group.id, execute_policy_down.status_code))
 
-    @tags(speed='quick')
+    @tags(speed='quick', convergence='yes')
     def test_update_webhook_policy_to_at_style_scheduler(self):
         """
         Policy update fails when a webhook type policy is updated to be of type
@@ -196,7 +196,7 @@ class ScalingPoliciesNegativeFixture(AutoscaleFixture):
                           ' on the group {0} with response code {1}'.format(
                               self.group.id, upd_policy_response.status_code))
 
-    @tags(speed='quick')
+    @tags(speed='quick', convergence='yes')
     def test_update_webhook_policy_to_cron_style_scheduler(self):
         """
         Policy update fails when a webhook type policy is updated to be of type

--- a/autoscale_cloudroast/test_repo/autoscale/system/policies/test_system_policies_negative.py
+++ b/autoscale_cloudroast/test_repo/autoscale/system/policies/test_system_policies_negative.py
@@ -137,6 +137,10 @@ class ScalingPoliciesNegativeFixture(AutoscaleFixture):
         building).  The user will be able to delete the group and autoscaling
         will delete the servers on the group (AUTO-339)
         """
+        # wait for them to be building or done first
+        self.check_for_expected_number_of_building_servers(
+            group_id=self.group.id,
+            expected_servers=self.group.groupConfiguration.minEntities)
         server_name = self.group.launchConfiguration.server.name
         self._update_group_min_max_entities(group=self.group,
                                             maxentities=0, minentities=0)

--- a/autoscale_cloudroast/test_repo/autoscale/system/policies/test_system_update_policy_execute_webhook.py
+++ b/autoscale_cloudroast/test_repo/autoscale/system/policies/test_system_update_policy_execute_webhook.py
@@ -34,7 +34,7 @@ class UpdatePoliciesExecuteWebhookTest(AutoscaleFixture):
         sleep(10)  # time for the webhook to execute
         self.resources.add(self.group, self.empty_scaling_group)
 
-    @tags(speed='quick')
+    @tags(speed='quick', convergence="yes")
     def test_scale_up_execute_webhook(self):
         """
         Update a scale up policy and verify execution of such a policy using
@@ -55,7 +55,7 @@ class UpdatePoliciesExecuteWebhookTest(AutoscaleFixture):
             expected_servers=self.group.groupConfiguration.minEntities +
             self.policy_up['change'] + change)
 
-    @tags(speed='slow')
+    @tags(speed='slow', convergence="yes")
     def test_scale_up_to_scale_down_execute_webhook(self):
         """
         Update a scale up policy to scale down by the same change value and
@@ -80,7 +80,7 @@ class UpdatePoliciesExecuteWebhookTest(AutoscaleFixture):
             self.group.launchConfiguration.server.name,
             self.group.groupConfiguration.minEntities)
 
-    @tags(speed='slow')
+    @tags(speed='slow', convergence="yes")
     def test_from_change_to_change_percent_scale_down_execute_webhook(self):
         """
         Update the existing scale up policy from change to change percent,such


### PR DESCRIPTION
Enable 4 cafe system policy test modules for convergence.