### PR TITLE
Don't format kazoo errors in logging

### DIFF
--- a/otter/log/formatters.py
+++ b/otter/log/formatters.py
@@ -27,6 +27,8 @@ THROTTLED_MESSAGES = [
 
 THROTTLE_COUNT = 50
 
+NON_PEP3101_SYSTEMS = ('kazoo',)
+
 
 class LoggingEncoder(json.JSONEncoder):
     """
@@ -127,13 +129,14 @@ def PEP3101FormattingWrapper(observer):
     :rtype: :class:`ILogObserver`
     """
     def PEP3101FormattingObserver(eventDict):
-        if eventDict.get('why'):
+        if (eventDict.get('why') and
+                eventDict.get('system') not in NON_PEP3101_SYSTEMS):
             eventDict['why'] = eventDict['why'].format(**eventDict)
 
         if 'message' in eventDict:
             message = ' '.join(eventDict['message'])
 
-            if message:
+            if message and eventDict.get('system') not in NON_PEP3101_SYSTEMS:
                 try:
                     eventDict['message'] = (message.format(**eventDict),)
                 except:

--- a/otter/log/formatters.py
+++ b/otter/log/formatters.py
@@ -139,7 +139,7 @@ def PEP3101FormattingWrapper(observer):
             if message and eventDict.get('system') not in NON_PEP3101_SYSTEMS:
                 try:
                     eventDict['message'] = (message.format(**eventDict),)
-                except:
+                except Exception:
                     failure = Failure()
                     eventDict['message_formatting_error'] = str(failure)
                     eventDict['message'] = message

--- a/otter/test/log/test_log.py
+++ b/otter/test/log/test_log.py
@@ -298,6 +298,17 @@ class PEP3101FormattingWrapperTests(SynchronousTestCase):
         self.observer.assert_called_once_with({'why': 'Hello World',
                                                'name': 'World'})
 
+    def test_no_format_why_if_system_is_ignored(self):
+        """
+        PEP3101FormattingWrapper does not format the why argument to log.err
+        if the system is an ignored system.
+        """
+        self.wrapper({'why': 'Hello {name}', 'name': 'World',
+                      'system': 'kazoo'})
+        self.observer.assert_called_once_with({'why': 'Hello {name}',
+                                               'name': 'World',
+                                               'system': 'kazoo'})
+
     def test_format_message(self):
         """
         PEP3101FormattingWrapper formats the message.
@@ -306,6 +317,16 @@ class PEP3101FormattingWrapperTests(SynchronousTestCase):
         self.observer.assert_called_once_with(
             {'message': ('foo bar',), 'bar': 'bar'})
 
+    def test_no_format_message_if_system_is_ignored(self):
+        """
+        PEP3101FormattingWrapper does not format the message if the system is
+        an ignored system.
+        """
+        self.wrapper({'message': ('foo {bar}',), 'bar': 'bar',
+                      'system': 'kazoo'})
+        self.observer.assert_called_once_with(
+            {'message': ('foo {bar}',), 'bar': 'bar', 'system': 'kazoo'})
+
     def test_format_message_tuple(self):
         """
         PEP3101FormattingWrapper joins the message tuple before formatting.
@@ -313,6 +334,18 @@ class PEP3101FormattingWrapperTests(SynchronousTestCase):
         self.wrapper({'message': ('foo', 'bar', 'baz', '{bax}'), 'bax': 'bax'})
         self.observer.assert_called_once_with(
             {'message': ('foo bar baz bax',), 'bax': 'bax'})
+
+    def test_no_joins_no_format_message_tuple(self):
+        """
+        PEP3101FormattingWrapper neither joins nor formats the message tuple
+        if the system is an ignored system.
+        """
+        self.wrapper({'message': ('foo', 'bar', 'baz', '{bax}'),
+                      'bax': 'bax',
+                      'system': 'kazoo'})
+        self.observer.assert_called_once_with(
+            {'message': ('foo', 'bar', 'baz', '{bax}',), 'bax': 'bax',
+             'system': 'kazoo'})
 
     def test_formatting_failure(self):
         """


### PR DESCRIPTION
So we stop getting message formatting errors for kazoo.