### PR TITLE
increase CreateServer limit from 3 to 10

### DIFF
--- a/otter/convergence/transforming.py
+++ b/otter/convergence/transforming.py
@@ -91,7 +91,7 @@ def optimize_steps(steps):
 
 
 _DEFAULT_STEP_LIMITS = pmap({
-    CreateServer: 3
+    CreateServer: 10
 })
 
 

--- a/otter/test/convergence/test_planning.py
+++ b/otter/test/convergence/test_planning.py
@@ -997,7 +997,7 @@ class PlanTests(SynchronousTestCase):
         desc = CLBDescription(lb_id='5', port=80)
         desired_lbs = s(desc)
         desired_group_state = DesiredGroupState(
-            server_config={}, capacity=8, desired_lbs=desired_lbs)
+            server_config={}, capacity=20, desired_lbs=desired_lbs)
 
         result = plan(
             desired_group_state,
@@ -1016,4 +1016,4 @@ class PlanTests(SynchronousTestCase):
                 AddNodesToCLB(
                     lb_id='5',
                     address_configs=s(('1.1.1.1', desc), ('1.2.3.4', desc))
-                )] + [CreateServer(server_config=pmap({}))] * 3))
+                )] + [CreateServer(server_config=pmap({}))] * 10))

--- a/otter/test/convergence/test_transforming.py
+++ b/otter/test/convergence/test_transforming.py
@@ -79,10 +79,10 @@ class LimitStepCount(SynchronousTestCase):
 
     def test_default_step_limit(self):
         """
-        The default limit limits server creation to up to 3 steps.
+        The default limit limits server creation to up to 10 steps.
         """
         limits = limit_steps_by_count.keywords["step_limits"]
-        self.assertEqual(limits, pmap({CreateServer: 3}))
+        self.assertEqual(limits, pmap({CreateServer: 10}))
 
 
 class OptimizerTests(SynchronousTestCase):


### PR DESCRIPTION
- once we have throttling, 3 is really unnecessarily low
- this should allow some tests to go faster

I know that this should probably be configurable, but this is a quick thing to allow our tests to go faster (and probably a good default too)