### PR TITLE
enabling convergence on scheduler tests

### DIFF
--- a/autoscale_cloudroast/test_repo/autoscale/system/schedule_policies/test_system_at_style_scheduler.py
+++ b/autoscale_cloudroast/test_repo/autoscale/system/schedule_policies/test_system_at_style_scheduler.py
@@ -2,9 +2,11 @@
 Test at style scheduler policies are executed via change,
 change percent and desired caapacity
 """
-from test_repo.autoscale.fixtures import AutoscaleFixture
 from time import sleep
+
 from cafe.drivers.unittest.decorators import tags
+
+from test_repo.autoscale.fixtures import AutoscaleFixture
 
 
 class AtStyleSchedulerTests(AutoscaleFixture):
@@ -18,19 +20,19 @@ class AtStyleSchedulerTests(AutoscaleFixture):
         Create a scaling group with minentities=0 and cooldown=0
         """
         super(AtStyleSchedulerTests, self).setUp()
-        create_group_response = self.autoscale_behaviors.create_scaling_group_given(
+        response = self.autoscale_behaviors.create_scaling_group_given(
             lc_name='at_style_scheduled',
             gc_cooldown=0)
-        self.group = create_group_response.entity
+        self.group = response.entity
         self.resources.add(self.group, self.empty_scaling_group)
 
     @tags(speed='slow', convergence='yes')
     def test_system_at_style_change_policy_up_down(self):
         """
-        Create an at style schedule policy via change to scale up by 2, followed by an
-        at style schedule policy to scale down by -2, each policy with 0 cooldown.
-        The total servers after execution of both policies is the minentities with
-        which the group was created.
+        Create an at style schedule policy via change to scale up by 2,
+        followed by an at style schedule policy to scale down by -2,
+        each policy with 0 cooldown. The total servers after execution
+        of both policies is the minentities with which the group was created.
         """
         self.create_default_at_style_policy_wait_for_execution(
             self.group.id, 10)
@@ -44,10 +46,10 @@ class AtStyleSchedulerTests(AutoscaleFixture):
     @tags(speed='slow', convergence='yes')
     def test_system_at_style_desired_capacity_policy_up_down(self):
         """
-        Create an at style schedule policy via desired capacity to scale up by 1,
-        followed by an at style schedule policy to scale down to 0,
-        each policy with 0 cooldown. The total servers after execution of both
-        is 0.
+        Create an at style schedule policy via desired capacity to
+        scale up by 1, followed by an at style schedule policy to
+        scale down to 0, each policy with 0 cooldown. The total servers
+        after execution of both is 0.
         """
         self.autoscale_behaviors.create_schedule_policy_given(
             group_id=self.group.id,
@@ -67,11 +69,11 @@ class AtStyleSchedulerTests(AutoscaleFixture):
     @tags(speed='slow', convergence='yes')
     def test_system_at_style_execute_before_cooldown(self):
         """
-        Create an at style scheduler policy via change to scale up with cooldown>0,
-        and wait for it to execute. Re-execute the policy manually before the
-        cooldown results in 403
+        Create an at style scheduler policy via change to scale up
+        with cooldown>0, and wait for it to execute. Re-execute the policy
+        manually before the cooldown results in 403
         """
-        at_style_policy = self.autoscale_behaviors.create_schedule_policy_given(
+        at_policy = self.autoscale_behaviors.create_schedule_policy_given(
             group_id=self.group.id,
             sp_cooldown=600,
             sp_change=self.sp_change,
@@ -80,19 +82,20 @@ class AtStyleSchedulerTests(AutoscaleFixture):
         self.verify_group_state(self.group.id, self.sp_change)
         execute_scheduled_policy = self.autoscale_client.execute_policy(
             group_id=self.group.id,
-            policy_id=at_style_policy['id'])
+            policy_id=at_policy['id'])
         self.assertEquals(execute_scheduled_policy.status_code, 403)
         self.verify_group_state(self.group.id, self.sp_change)
 
     @tags(speed='slow', convergence='yes')
     def test_system_at_style_execute_after_cooldown(self):
         """
-        Create an at style scheduler policy via change to scale up with cooldown>0,
-        and wait for it to execute. Re-executing the policy manually after the
-        cooldown period, results in total active servers on the group to be 2 times
-        the change value specifies in scale up policy
+        Create an at style scheduler policy via change to scale up with
+        cooldown>0, and wait for it to execute. Re-executing the policy
+        manually after the cooldown period, results in total active
+        servers on the group to be 2 times the change value specifies
+        in scale up policy
         """
-        at_style_policy = self.autoscale_behaviors.create_schedule_policy_given(
+        at_policy = self.autoscale_behaviors.create_schedule_policy_given(
             group_id=self.group.id,
             sp_cooldown=10,
             sp_change=self.sp_change,
@@ -101,6 +104,6 @@ class AtStyleSchedulerTests(AutoscaleFixture):
         self.verify_group_state(self.group.id, self.sp_change)
         execute_scheduled_policy = self.autoscale_client.execute_policy(
             group_id=self.group.id,
-            policy_id=at_style_policy['id'])
+            policy_id=at_policy['id'])
         self.assertEquals(execute_scheduled_policy.status_code, 202)
         self.verify_group_state(self.group.id, self.sp_change * 2)

--- a/autoscale_cloudroast/test_repo/autoscale/system/schedule_policies/test_system_at_style_scheduler.py
+++ b/autoscale_cloudroast/test_repo/autoscale/system/schedule_policies/test_system_at_style_scheduler.py
@@ -24,7 +24,7 @@ class AtStyleSchedulerTests(AutoscaleFixture):
         self.group = create_group_response.entity
         self.resources.add(self.group, self.empty_scaling_group)
 
-    @tags(speed='slow')
+    @tags(speed='slow', convergence='yes')
     def test_system_at_style_change_policy_up_down(self):
         """
         Create an at style schedule policy via change to scale up by 2, followed by an
@@ -41,7 +41,7 @@ class AtStyleSchedulerTests(AutoscaleFixture):
         self.verify_group_state(
             self.group.id, self.group.groupConfiguration.minEntities)
 
-    @tags(speed='slow')
+    @tags(speed='slow', convergence='yes')
     def test_system_at_style_desired_capacity_policy_up_down(self):
         """
         Create an at style schedule policy via desired capacity to scale up by 1,
@@ -64,7 +64,7 @@ class AtStyleSchedulerTests(AutoscaleFixture):
         sleep(20 + self.scheduler_interval)
         self.verify_group_state(self.group.id, 0)
 
-    @tags(speed='slow')
+    @tags(speed='slow', convergence='yes')
     def test_system_at_style_execute_before_cooldown(self):
         """
         Create an at style scheduler policy via change to scale up with cooldown>0,
@@ -84,7 +84,7 @@ class AtStyleSchedulerTests(AutoscaleFixture):
         self.assertEquals(execute_scheduled_policy.status_code, 403)
         self.verify_group_state(self.group.id, self.sp_change)
 
-    @tags(speed='slow')
+    @tags(speed='slow', convergence='yes')
     def test_system_at_style_execute_after_cooldown(self):
         """
         Create an at style scheduler policy via change to scale up with cooldown>0,

--- a/autoscale_cloudroast/test_repo/autoscale/system/schedule_policies/test_system_cron_style_scheduler.py
+++ b/autoscale_cloudroast/test_repo/autoscale/system/schedule_policies/test_system_cron_style_scheduler.py
@@ -25,7 +25,7 @@ class CronStyleSchedulerTests(AutoscaleFixture):
         self.group = create_group_response.entity
         self.resources.add(self.group, self.empty_scaling_group)
 
-    @tags(speed='slow')
+    @tags(speed='slow', convergence='yes')
     def test_system_cron_style_change_policy_up_down(self):
         """
         Create a cron style schedule policy via change to scale up by 2, followed by
@@ -48,7 +48,7 @@ class CronStyleSchedulerTests(AutoscaleFixture):
         sleep(60 + self.scheduler_interval)
         self.verify_group_state(self.group.id, self.group.groupConfiguration.minEntities)
 
-    @tags(speed='slow')
+    @tags(speed='slow', convergence='yes')
     def test_system_cron_style_desired_capacity_policy_up_down(self):
         """
         Create a cron style schedule policy via desired capacity to scale up by 1,
@@ -71,7 +71,7 @@ class CronStyleSchedulerTests(AutoscaleFixture):
         sleep(60 + self.scheduler_interval)
         self.verify_group_state(self.group.id, self.group.groupConfiguration.minEntities)
 
-    @tags(speed='slow')
+    @tags(speed='slow', convergence='yes')
     def test_system_cron_style_policy_cooldown(self):
         """
         Create a cron style scheduler policy via change to scale up with cooldown>0,
@@ -90,7 +90,7 @@ class CronStyleSchedulerTests(AutoscaleFixture):
             policy_id=cron_style_policy['id'])
         self.assertEquals(execute_scheduled_policy.status_code, 403)
 
-    @tags(speed='slow')
+    @tags(speed='slow', convergence='yes')
     def test_system_cron_style_policy_executes_again(self):
         """
         1-minute Cron-style policy executes in a minute and then again after 1 minute

--- a/autoscale_cloudroast/test_repo/autoscale/system/schedule_policies/test_system_cron_style_scheduler.py
+++ b/autoscale_cloudroast/test_repo/autoscale/system/schedule_policies/test_system_cron_style_scheduler.py
@@ -2,9 +2,11 @@
 Test cron scheduler policies are executed via change, change percent
 and desired caapacity
 """
-from test_repo.autoscale.fixtures import AutoscaleFixture
 from time import sleep
+
 from cafe.drivers.unittest.decorators import tags
+
+from test_repo.autoscale.fixtures import AutoscaleFixture
 
 
 class CronStyleSchedulerTests(AutoscaleFixture):
@@ -19,19 +21,19 @@ class CronStyleSchedulerTests(AutoscaleFixture):
         Create a scaling group with minentities=0 and cooldown=0
         """
         super(CronStyleSchedulerTests, self).setUp()
-        create_group_response = self.autoscale_behaviors.create_scaling_group_given(
+        response = self.autoscale_behaviors.create_scaling_group_given(
             lc_name='cron_style_scheduled',
             gc_cooldown=0)
-        self.group = create_group_response.entity
+        self.group = response.entity
         self.resources.add(self.group, self.empty_scaling_group)
 
     @tags(speed='slow', convergence='yes')
     def test_system_cron_style_change_policy_up_down(self):
         """
-        Create a cron style schedule policy via change to scale up by 2, followed by
-        a cron style schedule policy to scale down by -2, each policy with 0 cooldown.
-        The total servers after execution of both policies is the minentities with
-        which the group was created.
+        Create a cron style schedule policy via change to scale up by 2,
+        followed by a cron style schedule policy to scale down by -2,
+        each policy with 0 cooldown. The total servers after execution of both
+        policies is the minentities with which the group was created.
         """
         self.autoscale_behaviors.create_schedule_policy_given(
             group_id=self.group.id,
@@ -46,13 +48,14 @@ class CronStyleSchedulerTests(AutoscaleFixture):
             sp_change=-self.sp_change,
             schedule_cron='* * * * *')
         sleep(60 + self.scheduler_interval)
-        self.verify_group_state(self.group.id, self.group.groupConfiguration.minEntities)
+        self.verify_group_state(
+            self.group.id, self.group.groupConfiguration.minEntities)
 
     @tags(speed='slow', convergence='yes')
     def test_system_cron_style_desired_capacity_policy_up_down(self):
         """
-        Create a cron style schedule policy via desired capacity to scale up by 1,
-        followed by a cron style schedule policy to scale down to 0,
+        Create a cron style schedule policy via desired capacity to scale
+        up by 1, followed by a cron style schedule policy to scale down to 0,
         each policy with 0 cooldown. The total servers after execution of both
         policies is 0.
         """
@@ -69,16 +72,17 @@ class CronStyleSchedulerTests(AutoscaleFixture):
             sp_desired_capacity=self.group.groupConfiguration.minEntities,
             schedule_cron='* * * * *')
         sleep(60 + self.scheduler_interval)
-        self.verify_group_state(self.group.id, self.group.groupConfiguration.minEntities)
+        self.verify_group_state(
+            self.group.id, self.group.groupConfiguration.minEntities)
 
     @tags(speed='slow', convergence='yes')
     def test_system_cron_style_policy_cooldown(self):
         """
-        Create a cron style scheduler policy via change to scale up with cooldown>0,
-        wait for it to execute. Re-execute the policy manually before the
-        cooldown results in 403.
+        Create a cron style scheduler policy via change to scale up
+        with cooldown>0, wait for it to execute. Re-execute the policy
+        manually before the cooldown results in 403.
         """
-        cron_style_policy = self.autoscale_behaviors.create_schedule_policy_given(
+        cron_policy = self.autoscale_behaviors.create_schedule_policy_given(
             group_id=self.group.id,
             sp_cooldown=75,
             sp_change=self.sp_change,
@@ -87,13 +91,14 @@ class CronStyleSchedulerTests(AutoscaleFixture):
         self.verify_group_state(self.group.id, self.sp_change)
         execute_scheduled_policy = self.autoscale_client.execute_policy(
             group_id=self.group.id,
-            policy_id=cron_style_policy['id'])
+            policy_id=cron_policy['id'])
         self.assertEquals(execute_scheduled_policy.status_code, 403)
 
     @tags(speed='slow', convergence='yes')
     def test_system_cron_style_policy_executes_again(self):
         """
-        1-minute Cron-style policy executes in a minute and then again after 1 minute
+        1-minute Cron-style policy executes in a minute and then again
+        after 1 minute
         """
         self.autoscale_behaviors.create_schedule_policy_given(
             group_id=self.group.id,

--- a/autoscale_cloudroast/test_repo/autoscale/system/schedule_policies/test_system_execute_scheduler_negative.py
+++ b/autoscale_cloudroast/test_repo/autoscale/system/schedule_policies/test_system_execute_scheduler_negative.py
@@ -16,7 +16,7 @@ class ExecuteNegativeSchedulerPolicy(AutoscaleFixture):
     Verify update scheduler policy
     """
 
-    @tags(speed='slow')
+    @tags(speed='slow', convergence='yes')
     def test_system_execute_at_style_scale_up_when_min_maxentities_are_met(self):
         """
         When min and max entities are already met on a scaling group, an at style
@@ -30,7 +30,7 @@ class ExecuteNegativeSchedulerPolicy(AutoscaleFixture):
             group.id, scale_down=True)
         self.verify_group_state(group.id, group.groupConfiguration.maxEntities)
 
-    @tags(speed='slow')
+    @tags(speed='slow', convergence='yes')
     def test_system_execute_cron_style_scale_up_when_min_maxentities_are_met(self):
         """
         When min and max entities are already met on a scaling group, a cron style
@@ -54,7 +54,7 @@ class ExecuteNegativeSchedulerPolicy(AutoscaleFixture):
         self.verify_group_state(group.id, self.gc_min_entities)
 
     @unittest.skip("Skipping until CRON timing test issues are addressed")
-    @tags(speed='slow')
+    @tags(speed='slow', convergence='yes')
     def test_system_cron_style_when_policy_cooldown_over_trigger_period(self):
         """
         When policy cooldown is set to be greater than a minute by few seconds for a
@@ -75,7 +75,7 @@ class ExecuteNegativeSchedulerPolicy(AutoscaleFixture):
         self.verify_group_state(group.id, self.sp_change * 2)
 
     @unittest.skip("Skipping until CRON timing test issues are addressed")
-    @tags(speed='slow')
+    @tags(speed='slow', convergence='yes')
     def test_system_cron_style_when_group_cooldown_over_trigger_period(self):
         """
         When group cooldown is set to be greater than a minute by few seconds for a
@@ -95,7 +95,7 @@ class ExecuteNegativeSchedulerPolicy(AutoscaleFixture):
         sleep(70 + self.scheduler_interval)
         self.verify_group_state(group.id, self.sp_change * 2)
 
-    @tags(speed='slow')
+    @tags(speed='slow', convergence='yes')
     def test_system_at_cron_style_execution_after_delete(self):
         """
         Create an at style and cron scheduler policy and delete them.
@@ -127,7 +127,7 @@ class ExecuteNegativeSchedulerPolicy(AutoscaleFixture):
         """
         pass
 
-    @tags(speed='quick')
+    @tags(speed='quick', convergence='yes')
     def test_system_scheduler_batch(self):
         """
         Create more number of policies than specified in scheduler batch size and verify all
@@ -154,7 +154,7 @@ class ExecuteNegativeSchedulerPolicy(AutoscaleFixture):
         self.check_for_expected_number_of_building_servers(group.id, self.scheduler_batch * size)
         self.verify_group_state(group.id, self.scheduler_batch * size)
 
-    @tags(speed='slow')
+    @tags(speed='slow', convergence='yes')
     def test_create_multiple_scheduler_policies_to_execute_simaltaneously(self):
         """
         Create multiple scheduler policies within the same group such that all of them are
@@ -178,7 +178,7 @@ class ExecuteNegativeSchedulerPolicy(AutoscaleFixture):
         sleep(5 + self.scheduler_interval)
         self.verify_group_state(group.id, 1 + 2 + 3)
 
-    @tags(speed='quick')
+    @tags(speed='quick', convergence='yes')
     def test_system_update_at_and_cron_style_scheduler_policy_to_webhook_type(self):
         """
         Policy updation fails when a cron style scheduler /at style scheduler is updated to

--- a/autoscale_cloudroast/test_repo/autoscale/system/schedule_policies/test_system_execute_scheduler_negative.py
+++ b/autoscale_cloudroast/test_repo/autoscale/system/schedule_policies/test_system_execute_scheduler_negative.py
@@ -2,28 +2,30 @@
 Test negative scenarios for execution of at style and
 cron style scheduler policies
 """
+import unittest
+from time import sleep
+
+from cafe.drivers.unittest.decorators import tags
+
+from cloudcafe.common.tools.datagen import rand_name
 
 from test_repo.autoscale.fixtures import AutoscaleFixture
-from time import sleep
-from cafe.drivers.unittest.decorators import tags
-from cloudcafe.common.tools.datagen import rand_name
-import unittest
 
 
 class ExecuteNegativeSchedulerPolicy(AutoscaleFixture):
-
     """
     Verify update scheduler policy
     """
 
     @tags(speed='slow', convergence='yes')
-    def test_system_execute_at_style_scale_up_when_min_maxentities_are_met(self):
+    def test_execute_at_style_scale_up_when_min_maxentities_are_met(self):
         """
-        When min and max entities are already met on a scaling group, an at style
-        scheduler policy to scale up or scale down will not be triggered.
+        When min and max entities are already met on a scaling group, an at
+        style scheduler policy to scale up or scale down will not be triggered.
         """
         group = self._create_group(minentities=self.gc_min_entities,
-                                   maxentities=self.gc_min_entities, cooldown=0)
+                                   maxentities=self.gc_min_entities,
+                                   cooldown=0)
         self.create_default_at_style_policy_wait_for_execution(group.id)
         self.verify_group_state(group.id, group.groupConfiguration.minEntities)
         self.create_default_at_style_policy_wait_for_execution(
@@ -31,10 +33,10 @@ class ExecuteNegativeSchedulerPolicy(AutoscaleFixture):
         self.verify_group_state(group.id, group.groupConfiguration.maxEntities)
 
     @tags(speed='slow', convergence='yes')
-    def test_system_execute_cron_style_scale_up_when_min_maxentities_are_met(self):
+    def test_execute_cron_style_scale_up_when_min_maxentities_are_met(self):
         """
-        When min and max entities are already met on a scaling group, a cron style
-        scheduler policy to scale up or scale down will not be triggered.
+        When min and max entities are already met on a scaling group, a cron
+        style scheduler policy to scale up or scale down will not be triggered.
         """
         group = self._create_group(
             0, self.gc_min_entities, self.gc_min_entities)
@@ -55,11 +57,11 @@ class ExecuteNegativeSchedulerPolicy(AutoscaleFixture):
 
     @unittest.skip("Skipping until CRON timing test issues are addressed")
     @tags(speed='slow', convergence='yes')
-    def test_system_cron_style_when_policy_cooldown_over_trigger_period(self):
+    def test_cron_style_when_policy_cooldown_over_trigger_period(self):
         """
-        When policy cooldown is set to be greater than a minute by few seconds for a
-        cron style policy that is set to trigger every minute, that policy is
-        executed every other time.
+        When policy cooldown is set to be greater than a minute by few seconds
+        for a cron style policy that is set to trigger every minute, that
+        policy is executed every other time.
         """
         group = self._create_group(cooldown=0)
         self.autoscale_behaviors.create_schedule_policy_given(
@@ -76,11 +78,11 @@ class ExecuteNegativeSchedulerPolicy(AutoscaleFixture):
 
     @unittest.skip("Skipping until CRON timing test issues are addressed")
     @tags(speed='slow', convergence='yes')
-    def test_system_cron_style_when_group_cooldown_over_trigger_period(self):
+    def test_cron_style_when_group_cooldown_over_trigger_period(self):
         """
-        When group cooldown is set to be greater than a minute by few seconds for a
-        cron style policy that is set to trigger every minute, that policy is
-        executed every other time.
+        When group cooldown is set to be greater than a minute by few seconds
+        for a cron style policy that is set to trigger every minute, that
+        policy is executed every other time.
         """
         group = self._create_group(cooldown=65)
         self.autoscale_behaviors.create_schedule_policy_given(
@@ -96,42 +98,42 @@ class ExecuteNegativeSchedulerPolicy(AutoscaleFixture):
         self.verify_group_state(group.id, self.sp_change * 2)
 
     @tags(speed='slow', convergence='yes')
-    def test_system_at_cron_style_execution_after_delete(self):
+    def test_at_cron_style_execution_after_delete(self):
         """
         Create an at style and cron scheduler policy and delete them.
         Verify they do not trigger after they have been deleted.
         """
         group = self._create_group()
-        at_style_policy = self.autoscale_behaviors.create_schedule_policy_given(
+        at_policy = self.autoscale_behaviors.create_schedule_policy_given(
             group_id=group.id,
             sp_cooldown=0,
             sp_change=self.sp_change,
             schedule_at=self.autoscale_behaviors.get_time_in_utc(10))
-        cron_style_policy = self.autoscale_behaviors.create_schedule_policy_given(
+        cron_policy = self.autoscale_behaviors.create_schedule_policy_given(
             group_id=group.id,
             sp_cooldown=0,
             sp_change=self.sp_change,
             schedule_cron='* * * * *')
         self.autoscale_client.delete_scaling_policy(
-            group.id, at_style_policy['id'])
+            group.id, at_policy['id'])
         self.autoscale_client.delete_scaling_policy(
-            group.id, cron_style_policy['id'])
+            group.id, cron_policy['id'])
         sleep(60 + self.scheduler_interval)
         self.verify_group_state(group.id, self.gc_min_entities)
 
     def test_system_scheduler_down(self):
         """
-        Stop the scheduler. Create at style and cron style schedule (every n seconds)and
-        verify events accumulate in scaling schedule table.
-        Start scheduler and ensure all policies are executed.
+        Stop the scheduler. Create at style and cron style schedule
+        (every n seconds) and verify events accumulate in scaling schedule
+        table. Start scheduler and ensure all policies are executed.
         """
         pass
 
     @tags(speed='quick', convergence='yes')
     def test_system_scheduler_batch(self):
         """
-        Create more number of policies than specified in scheduler batch size and verify all
-        of them are executed in the batch size specified.
+        Create more number of policies than specified in scheduler batch size
+        and verify all of them are executed in the batch size specified.
         """
         lc_name = rand_name('scheduler_batch_size_check')
         at_style_policies_list = []
@@ -145,21 +147,22 @@ class ExecuteNegativeSchedulerPolicy(AutoscaleFixture):
                 'name': 'multi_at_style{0}'.format(policy),
                 'change': 1}
             at_style_policies_list.append(policy)
-        create_group_response = self.autoscale_behaviors.create_scaling_group_given(
+        response = self.autoscale_behaviors.create_scaling_group_given(
             lc_name=lc_name, gc_cooldown=0,
             sp_list=at_style_policies_list)
-        group = create_group_response.entity
+        group = response.entity
         self.resources.add(group, self.empty_scaling_group)
         sleep(self.scheduler_interval * 2)
-        self.check_for_expected_number_of_building_servers(group.id, self.scheduler_batch * size)
+        self.check_for_expected_number_of_building_servers(
+            group.id, self.scheduler_batch * size)
         self.verify_group_state(group.id, self.scheduler_batch * size)
 
     @tags(speed='slow', convergence='yes')
-    def test_create_multiple_scheduler_policies_to_execute_simaltaneously(self):
+    def test_multiple_scheduler_policies_execute_simaltaneously(self):
         """
-        Create multiple scheduler policies within the same group such that all of them are
-        triggered by the scheduler, at the same time, and ensure all the policies
-        are executed successfully.
+        Create multiple scheduler policies within the same group such that
+        all of them are triggered by the scheduler, at the same time,
+        and ensure all the policies are executed successfully.
         """
         at_style_policies_list = []
         for policy in (1, 2, 3):
@@ -170,32 +173,32 @@ class ExecuteNegativeSchedulerPolicy(AutoscaleFixture):
                 'name': 'multi_at_style{0}'.format(policy),
                 'change': policy}
             at_style_policies_list.append(policy)
-        create_group_reponse = self.autoscale_behaviors.create_scaling_group_given(
+        reponse = self.autoscale_behaviors.create_scaling_group_given(
             lc_name='multi_scheduling', gc_cooldown=0,
             sp_list=at_style_policies_list)
-        group = create_group_reponse.entity
+        group = reponse.entity
         self.resources.add(group, self.empty_scaling_group)
         sleep(5 + self.scheduler_interval)
         self.verify_group_state(group.id, 1 + 2 + 3)
 
     @tags(speed='quick', convergence='yes')
-    def test_system_update_at_and_cron_style_scheduler_policy_to_webhook_type(self):
+    def test_update_at_and_cron_style_scheduler_policy_to_webhook_type(self):
         """
-        Policy updation fails when a cron style scheduler /at style scheduler is updated to
-        be of type webhook, with error 400
+        Policy updation fails when a cron style scheduler /at style scheduler
+        is updated to be of type webhook, with error 400
         """
         group = self._create_group()
-        at_style_policy = self.autoscale_behaviors.create_schedule_policy_given(
+        at_policy = self.autoscale_behaviors.create_schedule_policy_given(
             group_id=group.id,
             sp_cooldown=0,
             sp_change=self.sp_change,
             schedule_at=self.autoscale_behaviors.get_time_in_utc(600))
-        cron_style_policy = self.autoscale_behaviors.create_schedule_policy_given(
+        cron_policy = self.autoscale_behaviors.create_schedule_policy_given(
             group_id=group.id,
             sp_cooldown=0,
             sp_change=self.sp_change,
             schedule_cron='* * * * *')
-        for each_policy in [at_style_policy['id'], cron_style_policy['id']]:
+        for each_policy in [at_policy['id'], cron_policy['id']]:
             upd_policy_response = self.autoscale_client.update_policy(
                 group_id=group.id,
                 policy_id=each_policy,
@@ -203,20 +206,21 @@ class ExecuteNegativeSchedulerPolicy(AutoscaleFixture):
                 cooldown=self.sp_cooldown,
                 change=self.sp_change,
                 policy_type='webhook')
-            self.assertEquals(upd_policy_response.status_code, 400,
-                              msg='Update scheduler policy to webhook policy type'
-                              ' on the group {0} with response code {1}'.format(
-                              group.id, upd_policy_response.status_code))
+            self.assertEquals(
+                upd_policy_response.status_code, 400,
+                msg=('Update scheduler policy to webhook policy type '
+                     'on the group {0} with response code {1}'.format(
+                        group.id, upd_policy_response.status_code)))
 
     def _create_group(self, minentities=None, maxentities=None, cooldown=None):
         """
         Create a group, add group to resource pool and return the group
         """
-        create_group_response = self.autoscale_behaviors.create_scaling_group_given(
+        response = self.autoscale_behaviors.create_scaling_group_given(
             gc_cooldown=cooldown,
             gc_min_entities=minentities,
             gc_max_entities=maxentities,
             lc_name='execute_scheduled')
-        group = create_group_response.entity
+        group = response.entity
         self.resources.add(group, self.empty_scaling_group)
         return group

--- a/autoscale_cloudroast/test_repo/autoscale/system/schedule_policies/test_system_multi_scheduler_webhook_policies.py
+++ b/autoscale_cloudroast/test_repo/autoscale/system/schedule_policies/test_system_multi_scheduler_webhook_policies.py
@@ -46,8 +46,8 @@ class MultipleSchedulerWebhookPoliciesTest(AutoscaleFixture):
     @tags(speed='quick', convergence='yes')
     def test_system_create_multiple_scheduler_policies_same_payload(self):
         """
-        Creating a group with a list of multiple scheduler policies, (at style and
-        cron style) with the same attributes, is succcessful
+        Creating a group with a list of multiple scheduler policies,
+        (at style and cron style) with the same attributes, is succcessful
         """
         self._create_multi_policy_group(
             2, 201, self.at_style_policy, self.cron_style_policy)
@@ -59,7 +59,8 @@ class MultipleSchedulerWebhookPoliciesTest(AutoscaleFixture):
         servers after their executions are as exepected
         """
         group = self._create_multi_policy_group(
-            1, 201, self.wb_policy, self.at_style_policy, self.cron_style_policy)
+            1, 201, self.wb_policy, self.at_style_policy,
+            self.cron_style_policy)
         self._execute_webhook_policies_within_group(group)
         sleep(60 + self.scheduler_interval)
         self.verify_group_state(group.id, 3 * self.change)
@@ -67,13 +68,15 @@ class MultipleSchedulerWebhookPoliciesTest(AutoscaleFixture):
     @tags(speed='slow', convergence='yes')
     def test_system_webhook_and_scheduler_policies_different_groups(self):
         """
-        Create 2 groups each with the same type of scheduler and webhook policies and
-        verify the servers after each of their executions
+        Create 2 groups each with the same type of scheduler and webhook
+        policies and verify the servers after each of their executions
         """
         group1 = self._create_multi_policy_group(
-            1, 201, self.wb_policy, self.at_style_policy, self.cron_style_policy)
+            1, 201, self.wb_policy, self.at_style_policy,
+            self.cron_style_policy)
         group2 = self._create_multi_policy_group(
-            1, 201, self.wb_policy, self.at_style_policy, self.cron_style_policy)
+            1, 201, self.wb_policy, self.at_style_policy,
+            self.cron_style_policy)
         self._execute_webhook_policies_within_group(group1, group2)
         sleep(60 + self.scheduler_interval)
         self.verify_group_state(group1.id, 3 * self.change)
@@ -82,8 +85,8 @@ class MultipleSchedulerWebhookPoliciesTest(AutoscaleFixture):
     @tags(speed='quick', convergence='yes')
     def test_system_all_types_webhook_and_scheduler_policies(self):
         """
-        Creating a group with scheduler and webhook policies for all types of changes
-        is successful.
+        Creating a group with scheduler and webhook policies for all types
+        of changes is successful.
         """
         wb_policy_cp = self._unchanged_policy(self.wb_policy)
         wb_policy_cp['changePercent'] = 100
@@ -98,16 +101,17 @@ class MultipleSchedulerWebhookPoliciesTest(AutoscaleFixture):
         cron_style_policy_dc = self._unchanged_policy(self.cron_style_policy)
         cron_style_policy_dc['desiredCapacity'] = 1
         self._create_multi_policy_group(
-            1, 201, self.wb_policy, self.at_style_policy, self.cron_style_policy,
-            wb_policy_cp, at_style_policy_cp, cron_style_policy_cp,
-            wb_policy_dc, at_style_policy_dc, cron_style_policy_dc)
+            1, 201, self.wb_policy, self.at_style_policy,
+            self.cron_style_policy, wb_policy_cp, at_style_policy_cp,
+            cron_style_policy_cp, wb_policy_dc, at_style_policy_dc,
+            cron_style_policy_dc)
 
     @tags(speed='quick', convergence='yes')
     def test_system_all_types_webhook_and_scheduler_policies_negative(self):
         """
-        Creating a group with scheduler and webhook policies for all types of changes
-        with invalid inputs for the chnge type and at style time, and verify reponse code
-        400 is returned.
+        Creating a group with scheduler and webhook policies for all types
+        of changes with invalid inputs for the chnge type and at style time,
+        and verify reponse code 400 is returned.
         """
         invalid_item = 0.0001
         wb_policy_cp = self._unchanged_policy(self.wb_policy)
@@ -124,9 +128,10 @@ class MultipleSchedulerWebhookPoliciesTest(AutoscaleFixture):
         cron_style_policy_dc = self._unchanged_policy(self.cron_style_policy)
         cron_style_policy_dc['desiredCapacity'] = invalid_item
         self._create_multi_policy_group(
-            1, 400, self.wb_policy, self.at_style_policy, self.cron_style_policy,
-            wb_policy_cp, at_style_policy_cp, cron_style_policy_cp,
-            wb_policy_dc, at_style_policy_dc, cron_style_policy_dc)
+            1, 400, self.wb_policy, self.at_style_policy,
+            self.cron_style_policy, wb_policy_cp, at_style_policy_cp,
+            cron_style_policy_cp, wb_policy_dc, at_style_policy_dc,
+            cron_style_policy_dc)
 
     @tags(speed='quick', convergence='yes')
     def test_system_webhook_and_scheduler_policies_many_different_groups(self):
@@ -155,14 +160,15 @@ class MultipleSchedulerWebhookPoliciesTest(AutoscaleFixture):
         policy_list = []
         for each_policy in args:
             policy_list.extend([each_policy] * multi_num)
-        create_group_reponse = self.autoscale_behaviors.create_scaling_group_given(
+        response = self.autoscale_behaviors.create_scaling_group_given(
             lc_name='multi_scheduling',
             sp_list=policy_list,
             gc_cooldown=0)
-        self.assertEquals(create_group_reponse.status_code, response,
-                          msg='Creating multiple scaling policies within a group failed with '
-                          'response code: {0}'.format(create_group_reponse.status_code))
-        group = create_group_reponse.entity
+        self.assertEquals(
+            response.status_code, response,
+            msg=('Creating multiple scaling policies within a group failed '
+                 'with response code: {0}'.format(response.status_code)))
+        group = response.entity
         self.resources.add(group, self.empty_scaling_group)
         return group
 
@@ -176,6 +182,8 @@ class MultipleSchedulerWebhookPoliciesTest(AutoscaleFixture):
                 if not hasattr(each_policy, 'args'):
                     execute_policy = self.autoscale_client.execute_policy(
                         each_group.id, each_policy.id)
-                    self.assertEquals(execute_policy.status_code, 202,
-                                      msg='Executing the scaling policies within a group failed with '
-                                      'response code: {0}'.format(execute_policy.status_code))
+                    self.assertEquals(
+                        execute_policy.status_code, 202,
+                        msg=('Executing the scaling policies within a group '
+                             'failed with response code: {0}'.format(
+                                 execute_policy.status_code)))

--- a/autoscale_cloudroast/test_repo/autoscale/system/schedule_policies/test_system_multi_scheduler_webhook_policies.py
+++ b/autoscale_cloudroast/test_repo/autoscale/system/schedule_policies/test_system_multi_scheduler_webhook_policies.py
@@ -35,7 +35,7 @@ class MultipleSchedulerWebhookPoliciesTest(AutoscaleFixture):
             cooldown=self.gc_cooldown, type='schedule', name='multi_at_style',
             change=self.change)
 
-    @tags(speed='quick')
+    @tags(speed='quick', convergence='yes')
     def test_group_multiple_webhook_policies_with_same_attributes(self):
         """
         Creating a group with a list of multiple webhook policies,
@@ -43,7 +43,7 @@ class MultipleSchedulerWebhookPoliciesTest(AutoscaleFixture):
         """
         self._create_multi_policy_group(2, 201, self.wb_policy)
 
-    @tags(speed='quick')
+    @tags(speed='quick', convergence='yes')
     def test_system_create_multiple_scheduler_policies_same_payload(self):
         """
         Creating a group with a list of multiple scheduler policies, (at style and
@@ -52,7 +52,7 @@ class MultipleSchedulerWebhookPoliciesTest(AutoscaleFixture):
         self._create_multi_policy_group(
             2, 201, self.at_style_policy, self.cron_style_policy)
 
-    @tags(speed='slow')
+    @tags(speed='slow', convergence='yes')
     def test_system_webhook_and_scheduler_policies_same_group(self):
         """
         Create a group with scheduler and webhook policies and verify the
@@ -64,7 +64,7 @@ class MultipleSchedulerWebhookPoliciesTest(AutoscaleFixture):
         sleep(60 + self.scheduler_interval)
         self.verify_group_state(group.id, 3 * self.change)
 
-    @tags(speed='slow')
+    @tags(speed='slow', convergence='yes')
     def test_system_webhook_and_scheduler_policies_different_groups(self):
         """
         Create 2 groups each with the same type of scheduler and webhook policies and
@@ -79,7 +79,7 @@ class MultipleSchedulerWebhookPoliciesTest(AutoscaleFixture):
         self.verify_group_state(group1.id, 3 * self.change)
         self.verify_group_state(group2.id, 3 * self.change)
 
-    @tags(speed='quick')
+    @tags(speed='quick', convergence='yes')
     def test_system_all_types_webhook_and_scheduler_policies(self):
         """
         Creating a group with scheduler and webhook policies for all types of changes
@@ -102,7 +102,7 @@ class MultipleSchedulerWebhookPoliciesTest(AutoscaleFixture):
             wb_policy_cp, at_style_policy_cp, cron_style_policy_cp,
             wb_policy_dc, at_style_policy_dc, cron_style_policy_dc)
 
-    @tags(speed='quick')
+    @tags(speed='quick', convergence='yes')
     def test_system_all_types_webhook_and_scheduler_policies_negative(self):
         """
         Creating a group with scheduler and webhook policies for all types of changes
@@ -128,7 +128,7 @@ class MultipleSchedulerWebhookPoliciesTest(AutoscaleFixture):
             wb_policy_cp, at_style_policy_cp, cron_style_policy_cp,
             wb_policy_dc, at_style_policy_dc, cron_style_policy_dc)
 
-    @tags(speed='quick')
+    @tags(speed='quick', convergence='yes')
     def test_system_webhook_and_scheduler_policies_many_different_groups(self):
         """
         Create many groups each with the same type of scheduler and webhook

--- a/autoscale_cloudroast/test_repo/autoscale/system/schedule_policies/test_system_scheduler_update_group.py
+++ b/autoscale_cloudroast/test_repo/autoscale/system/schedule_policies/test_system_scheduler_update_group.py
@@ -21,7 +21,7 @@ class UpdateSchedulerScalingPolicy(AutoscaleFixture):
         cls.upd_image_ref = cls.lc_image_ref_alt
         cls.upd_flavor_ref = "3"
 
-    @tags(speed='slow')
+    @tags(speed='slow', convergence='yes')
     def test_system_min_max_entities_at_style(self):
         """
         Create a scaling group with minentities between 0 and maxentities and
@@ -42,7 +42,7 @@ class UpdateSchedulerScalingPolicy(AutoscaleFixture):
             scale_down=True)
         self.verify_group_state(group.id, group.groupConfiguration.minEntities)
 
-    @tags(speed='slow')
+    @tags(speed='slow', convergence='yes')
     def test_system_min_max_entities_cron_style(self):
         """
         Create a scaling group with minentities between 0 and maxentities and maxentities=change,
@@ -74,7 +74,7 @@ class UpdateSchedulerScalingPolicy(AutoscaleFixture):
         sleep(60 + self.scheduler_interval)
         self.verify_group_state(group.id, group.groupConfiguration.minEntities)
 
-    @tags(speed='slow')
+    @tags(speed='slow', convergence='yes')
     def test_system_group_cooldown_at_style(self):
         """
         Create a scaling group with cooldown>0, create a scheduler at style policy
@@ -91,7 +91,7 @@ class UpdateSchedulerScalingPolicy(AutoscaleFixture):
         self.create_default_at_style_policy_wait_for_execution(group.id)
         self.verify_group_state(group.id, self.sp_change * 2)
 
-    @tags(speed='slow')
+    @tags(speed='slow', convergence='yes')
     def test_system_upd_launch_config_at_style_scheduler(self):
         """
         Create a scaling group with minentities>0, update launch config, schedule at style
@@ -119,7 +119,7 @@ class UpdateSchedulerScalingPolicy(AutoscaleFixture):
             expected_servers=group.groupConfiguration.minEntities)
         self._verify_server_list_for_launch_config(active_list_on_scale_down)
 
-    @tags(speed='slow')
+    @tags(speed='slow', convergence='yes')
     def test_system_upd_launch_config_cron_style_scheduler(self):
         """
         Create a scaling group with minentities>0, update launch config, schedule cron style

--- a/autoscale_cloudroast/test_repo/autoscale/system/schedule_policies/test_system_scheduler_update_group.py
+++ b/autoscale_cloudroast/test_repo/autoscale/system/schedule_policies/test_system_scheduler_update_group.py
@@ -1,16 +1,18 @@
 """
 Test execution of at and cron style scheduler policies when group has updates
 """
-from test_repo.autoscale.fixtures import AutoscaleFixture
 from time import sleep
+
 from cafe.drivers.unittest.decorators import tags
+
+from test_repo.autoscale.fixtures import AutoscaleFixture
 
 
 class UpdateSchedulerScalingPolicy(AutoscaleFixture):
-
     """
     Verify update scheduler policy
     """
+
     @classmethod
     def setUpClass(cls):
         """
@@ -25,9 +27,9 @@ class UpdateSchedulerScalingPolicy(AutoscaleFixture):
     def test_system_min_max_entities_at_style(self):
         """
         Create a scaling group with minentities between 0 and maxentities and
-        maxentities=change, with 2 at style scheduler policies with change= +2 and -2,
-        cooldown=0 and verify that the scale up scheduler policy scales upto the
-        max entities specified on the group
+        maxentities=change, with 2 at style scheduler policies with change= +2
+        and -2, cooldown=0 and verify that the scale up scheduler policy
+        scales upto the max entities specified on the group
         and scale down scheduler policy scales down upto the minentities.
         """
         minentities = 1
@@ -45,13 +47,15 @@ class UpdateSchedulerScalingPolicy(AutoscaleFixture):
     @tags(speed='slow', convergence='yes')
     def test_system_min_max_entities_cron_style(self):
         """
-        Create a scaling group with minentities between 0 and maxentities and maxentities=change,
-        with 2 cron style scheduler policies with change= +2 and -2, cooldown=0 and verify that
-        the scale up scheduler policy scales upto the maxentities specified on the group
-        and scale down scheduler policy scales down upto the minentities.
-        Note: The group and policy cooldown are 0 and the scale up and scale down policies
-        will keep trying to scale up beyond maxentities and scale down below minentities
-        but will not be executed as min/maxenetities are met, until group is deleted.
+        Create a scaling group with minentities between 0 and maxentities and
+        maxentities=change, with 2 cron style scheduler policies with
+        change= +2 and -2, cooldown=0 and verify that the scale up scheduler
+        policy scales upto the maxentities specified on the group and scale
+        down scheduler policy scales down upto the minentities.
+        Note: The group and policy cooldown are 0 and the scale up and scale
+        down policies will keep trying to scale up beyond maxentities and
+        scale down below minentities but will not be executed as
+        min/maxenetities are met, until group is deleted.
         """
         minentities = 1
         maxentities = 2
@@ -77,10 +81,11 @@ class UpdateSchedulerScalingPolicy(AutoscaleFixture):
     @tags(speed='slow', convergence='yes')
     def test_system_group_cooldown_at_style(self):
         """
-        Create a scaling group with cooldown>0, create a scheduler at style policy
-        and wait for its execution, creating another at style policy scheduled
-        to execute before the cooldown period expires does not trigger.
-        Creating a 3rd at style policy after the cooldown, executes successfully.
+        Create a scaling group with cooldown>0, create a scheduler at style
+        policy and wait for its execution, creating another at style policy
+        scheduled to execute before the cooldown period expires does not
+        trigger. Creating a 3rd at style policy after the cooldown,
+        executes successfully.
         """
         group = self._create_group(cooldown=60)
         self.create_default_at_style_policy_wait_for_execution(group.id)
@@ -94,10 +99,10 @@ class UpdateSchedulerScalingPolicy(AutoscaleFixture):
     @tags(speed='slow', convergence='yes')
     def test_system_upd_launch_config_at_style_scheduler(self):
         """
-        Create a scaling group with minentities>0, update launch config, schedule at style
-        policy to scale up and verify the new servers of the latest launch config,
-        then schedule an at style policy to scale down and verify the servers remaining
-        are of the latest launch config.
+        Create a scaling group with minentities>0, update launch config,
+        schedule at style policy to scale up and verify the new servers of the
+        latest launch config, then schedule an at style policy to scale down
+        and verify the servers remaining are of the latest launch config.
         """
         group = self._create_group(minentities=self.sp_change, cooldown=0)
         active_list_b4_upd = self.wait_for_expected_number_of_active_servers(
@@ -106,26 +111,27 @@ class UpdateSchedulerScalingPolicy(AutoscaleFixture):
         self._update_launch_config(group)
         self.create_default_at_style_policy_wait_for_execution(group.id)
         active_servers = self.sp_change + group.groupConfiguration.minEntities
-        active_list_after_scale_up = self.wait_for_expected_number_of_active_servers(
+        active_after_scaleup = self.wait_for_expected_number_of_active_servers(
             group_id=group.id,
             expected_servers=active_servers)
         upd_lc_server = set(
-            active_list_after_scale_up) - set(active_list_b4_upd)
+            active_after_scaleup) - set(active_list_b4_upd)
         self._verify_server_list_for_launch_config(upd_lc_server)
         self.create_default_at_style_policy_wait_for_execution(
             group.id, scale_down=True)
-        active_list_on_scale_down = self.wait_for_expected_number_of_active_servers(
+        active_on_scale_down = self.wait_for_expected_number_of_active_servers(
             group_id=group.id,
             expected_servers=group.groupConfiguration.minEntities)
-        self._verify_server_list_for_launch_config(active_list_on_scale_down)
+        self._verify_server_list_for_launch_config(active_on_scale_down)
 
     @tags(speed='slow', convergence='yes')
     def test_system_upd_launch_config_cron_style_scheduler(self):
         """
-        Create a scaling group with minentities>0, update launch config, schedule cron style
-        policy to scale up and verify the new servers of the latest launch config,
-        then schedule another cron style policy to scale down and verify the servers remaining
-        are of the latest launch config.
+        Create a scaling group with minentities>0, update launch config,
+        schedule cron style policy to scale up and verify the new servers
+        of the latest launch config, then schedule another cron style policy
+        to scale down and verify the servers remaining are of the latest
+        launch config.
         """
         group = self._create_group(minentities=self.sp_change, cooldown=0)
         active_list_b4_upd = self.wait_for_expected_number_of_active_servers(
@@ -139,11 +145,11 @@ class UpdateSchedulerScalingPolicy(AutoscaleFixture):
             schedule_cron='* * * * *')
         sleep(60 + self.scheduler_interval)
         active_servers = self.sp_change + group.groupConfiguration.minEntities
-        active_list_after_scale_up = self.wait_for_expected_number_of_active_servers(
+        active_after_scaleup = self.wait_for_expected_number_of_active_servers(
             group_id=group.id,
             expected_servers=active_servers)
         upd_lc_server = set(
-            active_list_after_scale_up) - set(active_list_b4_upd)
+            active_after_scaleup) - set(active_list_b4_upd)
         self._verify_server_list_for_launch_config(upd_lc_server)
         self.autoscale_behaviors.create_schedule_policy_given(
             group_id=group.id,
@@ -151,18 +157,18 @@ class UpdateSchedulerScalingPolicy(AutoscaleFixture):
             sp_change=-self.sp_change,
             schedule_cron='* * * * *')
         sleep(60 + self.scheduler_interval)
-        active_list_on_scale_down = self.wait_for_expected_number_of_active_servers(
+        active_on_scale_down = self.wait_for_expected_number_of_active_servers(
             group_id=group.id,
             expected_servers=group.groupConfiguration.minEntities)
-        self._verify_server_list_for_launch_config(active_list_on_scale_down)
+        self._verify_server_list_for_launch_config(active_on_scale_down)
 
     def _create_group(self, cooldown=None, minentities=None, maxentities=None):
-        create_group_response = self.autoscale_behaviors.create_scaling_group_given(
+        response = self.autoscale_behaviors.create_scaling_group_given(
             gc_cooldown=cooldown,
             gc_min_entities=minentities,
             gc_max_entities=maxentities,
             lc_name='upd_grp_scheduled')
-        group = create_group_response.entity
+        group = response.entity
         self.resources.add(group, self.empty_scaling_group)
         return group
 
@@ -171,14 +177,15 @@ class UpdateSchedulerScalingPolicy(AutoscaleFixture):
         Update the scaling group's launch configuration and
         assert the update was successful.
         """
-        update_launch_config_response = self.autoscale_client.update_launch_config(
+        response = self.autoscale_client.update_launch_config(
             group_id=group.id,
             name=self.upd_server_name,
             image_ref=self.upd_image_ref,
             flavor_ref=self.upd_flavor_ref)
-        self.assertEquals(update_launch_config_response.status_code, 204,
-                          msg='Updating launch config failed with {0} for group {1}'
-                          .format(update_launch_config_response, group.id))
+        self.assertEquals(
+            response.status_code, 204,
+            msg='Updating launch config failed with {0} for group {1}'.format(
+                response, group.id))
 
     def _verify_server_list_for_launch_config(self, server_list):
         for each in list(server_list):

--- a/autoscale_cloudroast/test_repo/autoscale/system/schedule_policies/test_system_update_scheduler.py
+++ b/autoscale_cloudroast/test_repo/autoscale/system/schedule_policies/test_system_update_scheduler.py
@@ -2,9 +2,11 @@
 Test update scheduler policies are executed as expected before and after
 updates
 """
-from test_repo.autoscale.fixtures import AutoscaleFixture
 from time import sleep
+
 from cafe.drivers.unittest.decorators import tags
+
+from test_repo.autoscale.fixtures import AutoscaleFixture
 
 
 class UpdateSchedulerTests(AutoscaleFixture):
@@ -18,13 +20,14 @@ class UpdateSchedulerTests(AutoscaleFixture):
         Create a scaling group with minentities=0 and cooldown=0
         """
         super(UpdateSchedulerTests, self).setUp()
-        create_group_response = self.autoscale_behaviors.create_scaling_group_given(
+        response = self.autoscale_behaviors.create_scaling_group_given(
             lc_name="update_scheduler",
             gc_cooldown=0)
-        self.group = create_group_response.entity
+        self.group = response.entity
         self.resources.add(self.group, self.empty_scaling_group)
         self.cron_policy_args = {'cron': '* * * * *'}
-        self.policy_style_args = {'at': self.autoscale_behaviors.get_time_in_utc(30)}
+        self.policy_style_args = {
+            'at': self.autoscale_behaviors.get_time_in_utc(30)}
 
     @tags(speed='slow', convergence='yes')
     def test_system_update_at_style_scheduler_to_execute_now(self):
@@ -33,36 +36,41 @@ class UpdateSchedulerTests(AutoscaleFixture):
         update the policy to execute in the next few seconds and
         verify the servers are as expected.
         """
-        at_style_policy = self.autoscale_behaviors.create_schedule_policy_given(
+        at_policy = self.autoscale_behaviors.create_schedule_policy_given(
             group_id=self.group.id,
             schedule_at=self.autoscale_behaviors.get_time_in_utc(604800))
         sleep(self.scheduler_interval)
-        self.verify_group_state(self.group.id, self.group.groupConfiguration.minEntities)
+        self.verify_group_state(
+            self.group.id, self.group.groupConfiguration.minEntities)
         upd_args = {'at': self.autoscale_behaviors.get_time_in_utc(10)}
-        self._update_policy(self.group.id, at_style_policy, upd_args)
+        self._update_policy(self.group.id, at_policy, upd_args)
         sleep(10 + self.scheduler_interval)
-        self.verify_group_state(self.group.id, self.group.groupConfiguration.minEntities +
-                                at_style_policy['change'])
+        self.verify_group_state(
+            self.group.id,
+            self.group.groupConfiguration.minEntities + at_policy['change'])
 
     @tags(speed='slow', convergence='yes')
     def test_system_update_at_style_scheduler_to_execute_in_the_future(self):
         """
         Create an at style scheduler policy to execute in the next few seconds,
-        update the policy to execute after 10 secs and verify the scheduler policy
-        triggers server creation as expected.
+        update the policy to execute after 10 secs and verify the scheduler
+        policy triggers server creation as expected.
         """
-        at_style_policy = self.autoscale_behaviors.create_schedule_policy_given(
+        at_policy = self.autoscale_behaviors.create_schedule_policy_given(
             group_id=self.group.id,
             schedule_at=self.autoscale_behaviors.get_time_in_utc(5),
             sp_cooldown=0)
         sleep(5 + self.scheduler_interval)
-        self.verify_group_state(self.group.id, self.group.groupConfiguration.minEntities +
-                                at_style_policy['change'])
+        self.verify_group_state(
+            self.group.id,
+            self.group.groupConfiguration.minEntities + at_policy['change'])
         upd_args = {'at': self.autoscale_behaviors.get_time_in_utc(10)}
-        self._update_policy(self.group.id, at_style_policy, upd_args)
+        self._update_policy(self.group.id, at_policy, upd_args)
         sleep(10 + self.scheduler_interval)
-        self.verify_group_state(self.group.id, self.group.groupConfiguration.minEntities +
-                                (at_style_policy['change'] * 2))
+        self.verify_group_state(
+            self.group.id,
+            self.group.groupConfiguration.minEntities +
+            (at_policy['change'] * 2))
 
     @tags(speed='slow', convergence='yes')
     def test_system_update_cron_style_scheduler_to_execute_now(self):
@@ -72,37 +80,43 @@ class UpdateSchedulerTests(AutoscaleFixture):
         verify the server count on the group is as expected.
         """
         upd_args = {'cron': '* * * * *'}
-        cron_style_policy = self.autoscale_behaviors.create_schedule_policy_given(
+        cron_policy = self.autoscale_behaviors.create_schedule_policy_given(
             group_id=self.group.id,
             schedule_cron='0 23 1 12 *')
         sleep(self.scheduler_interval)
-        self.verify_group_state(self.group.id, self.group.groupConfiguration.minEntities)
-        self._update_policy(self.group.id, cron_style_policy, upd_args)
+        self.verify_group_state(
+            self.group.id, self.group.groupConfiguration.minEntities)
+        self._update_policy(self.group.id, cron_policy, upd_args)
         sleep(60 + self.scheduler_interval)
-        self.verify_group_state(self.group.id, self.group.groupConfiguration.minEntities +
-                                cron_style_policy['change'])
+        self.verify_group_state(
+            self.group.id,
+            self.group.groupConfiguration.minEntities + cron_policy['change'])
 
     @tags(speed='slow', convergence='yes')
     def test_system_update_cron_style_scheduler_to_execute_in_the_future(self):
         """
         Create an cron style scheduler policy to execute the next minute,
         update the policy to execute every 2 minutes and
-        verify the server count on the group is as expected when the policy is updated,
-        wait one minute after the policy update and verify the older policy (every minute)
-        is not executed.
+        verify the server count on the group is as expected when the policy
+        is updated, wait one minute after the policy update and verify the
+        older policy (every minute) is not executed.
         """
         upd_args = {'cron': '*/2 * * * *'}
-        cron_style_policy = self.autoscale_behaviors.create_schedule_policy_given(
+        cron_policy = self.autoscale_behaviors.create_schedule_policy_given(
             group_id=self.group.id,
             schedule_cron='* * * * *',
             sp_cooldown=0)
         sleep(60 + self.scheduler_interval)
-        self.verify_group_state(self.group.id, self.group.groupConfiguration.minEntities +
-                                cron_style_policy['change'])
-        self._update_policy(self.group.id, cron_style_policy, upd_args, change_value=2)
+        self.verify_group_state(
+            self.group.id,
+            self.group.groupConfiguration.minEntities + cron_policy['change'])
+        self._update_policy(
+            self.group.id, cron_policy, upd_args, change_value=2)
         sleep(120 + self.scheduler_interval)
-        self.verify_group_state(self.group.id, self.group.groupConfiguration.minEntities +
-                                (cron_style_policy['change'] + 2))
+        self.verify_group_state(
+            self.group.id,
+            self.group.groupConfiguration.minEntities +
+            (cron_policy['change'] + 2))
 
     @tags(speed='slow', convergence='yes')
     def test_system_update_change_for_cron_style_scheduled_policy(self):
@@ -132,81 +146,94 @@ class UpdateSchedulerTests(AutoscaleFixture):
     def test_system_update_name_for_cron_style_scheduled_policy(self):
         """
         Create an cron style scheduler policy to execute the next minute,
-        update only the name of the policy and verify the scheduled policy executes.
+        update only the name of the policy and verify the scheduled policy
+        executes.
         """
-        cron_style_policy = self.autoscale_behaviors.create_schedule_policy_given(
+        cron_policy = self.autoscale_behaviors.create_schedule_policy_given(
             group_id=self.group.id,
             schedule_cron=self.cron_policy_args['cron'])
-        self.verify_group_state(self.group.id, self.group.groupConfiguration.minEntities)
-        self._update_policy(self.group.id, cron_style_policy, self.cron_policy_args,
+        self.verify_group_state(
+            self.group.id, self.group.groupConfiguration.minEntities)
+        self._update_policy(self.group.id, cron_policy, self.cron_policy_args,
                             name='test-only-upd-name')
         sleep(60 + self.scheduler_interval)
-        self.verify_group_state(self.group.id, self.group.groupConfiguration.minEntities +
-                                cron_style_policy['change'])
+        self.verify_group_state(
+            self.group.id,
+            self.group.groupConfiguration.minEntities + cron_policy['change'])
 
     @tags(speed='slow', convergence='yes')
     def test_system_update_cooldown_for_cron_style_scheduled_policy(self):
         """
         Create an cron style scheduler policy to execute the next minute,
-        update only the cooldown in the policy and verify the scheduled policy executes.
+        update only the cooldown in the policy and verify the scheduled policy
+        executes.
         """
-        cron_style_policy = self.autoscale_behaviors.create_schedule_policy_given(
+        cron_policy = self.autoscale_behaviors.create_schedule_policy_given(
             group_id=self.group.id,
             schedule_cron=self.cron_policy_args['cron'])
         sleep(self.scheduler_interval)
-        self.verify_group_state(self.group.id, self.group.groupConfiguration.minEntities)
-        self._update_policy(self.group.id, cron_style_policy, self.cron_policy_args,
+        self.verify_group_state(
+            self.group.id, self.group.groupConfiguration.minEntities)
+        self._update_policy(self.group.id, cron_policy, self.cron_policy_args,
                             cooldown=100)
         sleep(60 + self.scheduler_interval)
-        self.verify_group_state(self.group.id, self.group.groupConfiguration.minEntities +
-                                cron_style_policy['change'])
+        self.verify_group_state(
+            self.group.id,
+            self.group.groupConfiguration.minEntities + cron_policy['change'])
 
     @tags(speed='quick', convergence='yes')
     def test_system_update_name_for_at_style_scheduler_policy(self):
         """
         Create an at style scheduler policy to execute in the next few seconds,
-        update the name of the policy before it executes and verify the scheduler policy
-        triggers server creation as expected.
+        update the name of the policy before it executes and verify the
+        scheduler policy triggers server creation as expected.
         """
-        at_style_policy = self.autoscale_behaviors.create_schedule_policy_given(
+        at_policy = self.autoscale_behaviors.create_schedule_policy_given(
             group_id=self.group.id,
             schedule_at=self.policy_style_args['at'])
-        self._update_policy(self.group.id, at_style_policy, self.policy_style_args, name='upd-name')
+        self._update_policy(
+            self.group.id, at_policy, self.policy_style_args, name='upd-name')
         sleep(30 + self.scheduler_interval)
-        self.verify_group_state(self.group.id, self.group.groupConfiguration.minEntities +
-                                at_style_policy['change'])
+        self.verify_group_state(
+            self.group.id,
+            self.group.groupConfiguration.minEntities + at_policy['change'])
 
     @tags(speed='quick', convergence='yes')
     def test_system_update_cooldown_for_at_style_scheduler_policy(self):
         """
         Create an at style scheduler policy to execute in the next few seconds,
-        update the cooldown of the policy before it executes and verify the scheduler policy
-        triggers server creation as expected.
+        update the cooldown of the policy before it executes and verify the
+        scheduler policy triggers server creation as expected.
         """
-        at_style_policy = self.autoscale_behaviors.create_schedule_policy_given(
+        at_policy = self.autoscale_behaviors.create_schedule_policy_given(
             group_id=self.group.id,
             schedule_at=self.policy_style_args['at'])
-        self._update_policy(self.group.id, at_style_policy, self.policy_style_args, cooldown=900)
+        self._update_policy(
+            self.group.id, at_policy, self.policy_style_args, cooldown=900)
         sleep(30 + self.scheduler_interval)
-        self.verify_group_state(self.group.id, self.group.groupConfiguration.minEntities +
-                                at_style_policy['change'])
+        self.verify_group_state(
+            self.group.id,
+            self.group.groupConfiguration.minEntities + at_policy['change'])
 
     @tags(speed='quick', convergence='yes')
     def test_system_update_change_for_at_style_scheduler_policy(self):
         """
         Create an at style scheduler policy to execute in the next few seconds,
-        update the change of the policy before it executes and verify the scheduler policy
-        triggers server creation as expected.
+        update the change of the policy before it executes and verify the
+        scheduler policy triggers server creation as expected.
         """
-        at_style_policy = self.autoscale_behaviors.create_schedule_policy_given(
+        at_policy = self.autoscale_behaviors.create_schedule_policy_given(
             group_id=self.group.id,
             sp_change=1,
             schedule_at=self.policy_style_args['at'])
-        self._update_policy(self.group.id, at_style_policy, self.policy_style_args, change_value=2)
+        self._update_policy(
+            self.group.id, at_policy, self.policy_style_args, change_value=2)
         sleep(30 + self.scheduler_interval)
-        self.verify_group_state(self.group.id, self.group.groupConfiguration.minEntities + 2)
+        self.verify_group_state(
+            self.group.id, self.group.groupConfiguration.minEntities + 2)
 
-    def _update_policy(self, group_id, policy, upd_args, cooldown=None, change_value=None, name=None):
+    def _update_policy(self, group_id, policy, upd_args, cooldown=None,
+                       change_value=None, name=None):
         """
         Updates the policy with the given values
         """
@@ -221,8 +248,10 @@ class UpdateSchedulerTests(AutoscaleFixture):
             change=change_value,
             policy_type=policy['type'],
             args=upd_args)
-        self.assertEqual(update_policy_response.status_code, 204, msg='update scheduler'
-                         ' policy resulted in {0}'.format(update_policy_response.status_code))
-        updated_policy = (self.autoscale_client.get_policy_details(group_id,
-                                                                   policy['id'])).entity
+        self.assertEqual(
+            update_policy_response.status_code, 204,
+            msg='update scheduler policy resulted in {0}'.format(
+                update_policy_response.status_code))
+        updated_policy = self.autoscale_client.get_policy_details(
+            group_id, policy['id']).entity
         return updated_policy

--- a/autoscale_cloudroast/test_repo/autoscale/system/schedule_policies/test_system_update_scheduler.py
+++ b/autoscale_cloudroast/test_repo/autoscale/system/schedule_policies/test_system_update_scheduler.py
@@ -26,7 +26,7 @@ class UpdateSchedulerTests(AutoscaleFixture):
         self.cron_policy_args = {'cron': '* * * * *'}
         self.policy_style_args = {'at': self.autoscale_behaviors.get_time_in_utc(30)}
 
-    @tags(speed='slow')
+    @tags(speed='slow', convergence='yes')
     def test_system_update_at_style_scheduler_to_execute_now(self):
         """
         Create an at style scheduler policy to execute next week,
@@ -44,7 +44,7 @@ class UpdateSchedulerTests(AutoscaleFixture):
         self.verify_group_state(self.group.id, self.group.groupConfiguration.minEntities +
                                 at_style_policy['change'])
 
-    @tags(speed='slow')
+    @tags(speed='slow', convergence='yes')
     def test_system_update_at_style_scheduler_to_execute_in_the_future(self):
         """
         Create an at style scheduler policy to execute in the next few seconds,
@@ -64,7 +64,7 @@ class UpdateSchedulerTests(AutoscaleFixture):
         self.verify_group_state(self.group.id, self.group.groupConfiguration.minEntities +
                                 (at_style_policy['change'] * 2))
 
-    @tags(speed='slow')
+    @tags(speed='slow', convergence='yes')
     def test_system_update_cron_style_scheduler_to_execute_now(self):
         """
         Create an cron style scheduler policy to execute on a future day,
@@ -82,7 +82,7 @@ class UpdateSchedulerTests(AutoscaleFixture):
         self.verify_group_state(self.group.id, self.group.groupConfiguration.minEntities +
                                 cron_style_policy['change'])
 
-    @tags(speed='slow')
+    @tags(speed='slow', convergence='yes')
     def test_system_update_cron_style_scheduler_to_execute_in_the_future(self):
         """
         Create an cron style scheduler policy to execute the next minute,
@@ -104,7 +104,7 @@ class UpdateSchedulerTests(AutoscaleFixture):
         self.verify_group_state(self.group.id, self.group.groupConfiguration.minEntities +
                                 (cron_style_policy['change'] + 2))
 
-    @tags(speed='slow')
+    @tags(speed='slow', convergence='yes')
     def test_system_update_change_for_cron_style_scheduled_policy(self):
         """
         Create an cron style scheduler policy to execute the next minute,
@@ -128,7 +128,7 @@ class UpdateSchedulerTests(AutoscaleFixture):
             self.group.id, self.group.groupConfiguration.minEntities + 3,
             60 + self.scheduler_interval, time_scale=False)
 
-    @tags(speed='slow')
+    @tags(speed='slow', convergence='yes')
     def test_system_update_name_for_cron_style_scheduled_policy(self):
         """
         Create an cron style scheduler policy to execute the next minute,
@@ -144,7 +144,7 @@ class UpdateSchedulerTests(AutoscaleFixture):
         self.verify_group_state(self.group.id, self.group.groupConfiguration.minEntities +
                                 cron_style_policy['change'])
 
-    @tags(speed='slow')
+    @tags(speed='slow', convergence='yes')
     def test_system_update_cooldown_for_cron_style_scheduled_policy(self):
         """
         Create an cron style scheduler policy to execute the next minute,
@@ -161,7 +161,7 @@ class UpdateSchedulerTests(AutoscaleFixture):
         self.verify_group_state(self.group.id, self.group.groupConfiguration.minEntities +
                                 cron_style_policy['change'])
 
-    @tags(speed='quick')
+    @tags(speed='quick', convergence='yes')
     def test_system_update_name_for_at_style_scheduler_policy(self):
         """
         Create an at style scheduler policy to execute in the next few seconds,
@@ -176,7 +176,7 @@ class UpdateSchedulerTests(AutoscaleFixture):
         self.verify_group_state(self.group.id, self.group.groupConfiguration.minEntities +
                                 at_style_policy['change'])
 
-    @tags(speed='quick')
+    @tags(speed='quick', convergence='yes')
     def test_system_update_cooldown_for_at_style_scheduler_policy(self):
         """
         Create an at style scheduler policy to execute in the next few seconds,
@@ -191,7 +191,7 @@ class UpdateSchedulerTests(AutoscaleFixture):
         self.verify_group_state(self.group.id, self.group.groupConfiguration.minEntities +
                                 at_style_policy['change'])
 
-    @tags(speed='quick')
+    @tags(speed='quick', convergence='yes')
     def test_system_update_change_for_at_style_scheduler_policy(self):
         """
         Create an at style scheduler policy to execute in the next few seconds,


### PR DESCRIPTION
All the scheduler tests pass with convergence. They will become more deterministic after doing #1404. 