### PR TITLE
Make integration tests fail faster, other cleanup

### DIFF
--- a/otter/integration/lib/autoscale.py
+++ b/otter/integration/lib/autoscale.py
@@ -666,12 +666,15 @@ class ScalingPolicy(object):
             .addCallback(check_success, [204, 404])
         ).addCallback(lambda _: rcs)
 
-    def execute(self, rcs):
+    def execute(self, rcs, success_codes=None):
         """Executes the scaling policy.
 
         :param TestResources rcs: The integration test resources instance.
             This provides useful information to complete the request, like
             which endpoint to use to make the API request.
+
+        :param iterable success_codes: An iterable of HTTP status codes to
+            expect in the success case.  Defaults to 202.
 
         :return: A :class:`Deferred` which, when triggered, removes the scaling
             policy.  It returns the test resources supplied, easing continuity
@@ -682,7 +685,8 @@ class ScalingPolicy(object):
                 "%sexecute" % self.link,
                 headers=headers(str(rcs.token)),
                 pool=self.scaling_group.pool,
-            ).addCallback(check_success, [202])
+            ).addCallback(check_success,
+                          [202] if success_codes is None else success_codes)
             # Policy execution does not return anything meaningful,
             # per http://tinyurl.com/ndds6ap (link to docs.rackspace).
             # So, we forcefully return our resources here.

--- a/otter/integration/lib/autoscale.py
+++ b/otter/integration/lib/autoscale.py
@@ -21,7 +21,7 @@ from otter.util.http import check_success, headers
 from otter.util.retry import (
     TransientRetryError,
     repeating_interval,
-    transient_errors_except,
+    terminal_errors_except
 )
 
 pp = pprint.PrettyPrinter(indent=4)
@@ -348,7 +348,7 @@ class ScalingGroup(object):
 
         return retry_and_timeout(
             poll, timeout,
-            can_retry=transient_errors_except(BreakLoopException),
+            can_retry=terminal_errors_except(TransientRetryError),
             next_interval=repeating_interval(period),
             clock=clock or reactor,
             deferred_description=(
@@ -482,7 +482,7 @@ class ScalingGroup(object):
 
         return retry_and_timeout(
             poll, timeout,
-            can_retry=transient_errors_except(BreakLoopException),
+            can_retry=terminal_errors_except(TransientRetryError),
             next_interval=repeating_interval(period),
             clock=reactor,
             deferred_description=report,
@@ -527,7 +527,7 @@ class ScalingGroup(object):
             )
         return retry_and_timeout(
             poll, timeout,
-            can_retry=transient_errors_except(BreakLoopException),
+            can_retry=terminal_errors_except(TransientRetryError),
             next_interval=repeating_interval(period),
             clock=reactor,
             deferred_description=report

--- a/otter/integration/lib/cloud_load_balancer.py
+++ b/otter/integration/lib/cloud_load_balancer.py
@@ -17,7 +17,7 @@ from otter.util.http import check_success, headers
 from otter.util.retry import (
     TransientRetryError,
     repeating_interval,
-    transient_errors_except,
+    terminal_errors_except
 )
 
 
@@ -29,7 +29,6 @@ class CloudLoadBalancer(object):
     """The CloudLoadBalancer class represents a Rackspace Cloud Load Balancer
     resource.
     """
-
     def config(self):
         """Returns the JSON structure (as a Python dictionary) used to
         configure the cloud load balancer via API operations.
@@ -111,7 +110,7 @@ class CloudLoadBalancer(object):
 
         return retry_and_timeout(
             poll, timeout,
-            can_retry=transient_errors_except(),
+            can_retry=terminal_errors_except(TransientRetryError),
             next_interval=repeating_interval(period),
             clock=clock or reactor,
             deferred_description=(
@@ -227,7 +226,7 @@ class CloudLoadBalancer(object):
 
         return retry_and_timeout(
             poll, timeout,
-            can_retry=transient_errors_except(),
+            can_retry=terminal_errors_except(TransientRetryError),
             next_interval=repeating_interval(period),
             clock=clock or reactor,
             deferred_description="Waiting for nodes to reach state {0}".format(

--- a/otter/integration/lib/nova.py
+++ b/otter/integration/lib/nova.py
@@ -10,8 +10,7 @@ from twisted.internet.defer import gatherResults
 from otter.util.http import check_success, headers
 
 
-@attributes(["id",
-             Attribute("pool", default_value=None),
+@attributes(["id", "pool",
              Attribute("treq", default_value=treq)])
 class NovaServer(object):
     """

--- a/otter/integration/tests/test_convergence.py
+++ b/otter/integration/tests/test_convergence.py
@@ -10,7 +10,6 @@ from twisted.internet import reactor
 from twisted.internet.defer import gatherResults
 from twisted.internet.task import deferLater
 from twisted.internet.tcp import Client
-from twisted.python.failure import Failure
 from twisted.trial import unittest
 from twisted.web.client import HTTPConnectionPool
 
@@ -25,8 +24,6 @@ from otter.integration.lib.cloud_load_balancer import CloudLoadBalancer
 from otter.integration.lib.identity import IdentityV2
 from otter.integration.lib.nova import NovaServer, delete_servers
 from otter.integration.lib.resources import TestResources
-
-from otter.util.http import APIError
 
 
 username = os.environ['AS_USERNAME']

--- a/otter/integration/tests/test_convergence.py
+++ b/otter/integration/tests/test_convergence.py
@@ -656,7 +656,7 @@ class ConvergenceSet1(unittest.TestCase):
                 total_servers=set_to_servers,
             )
             .addCallback(self.scaling_group.wait_for_expected_state, rcs,
-                         active=converged_servers, pending=0)
+                         timeout=1800, active=converged_servers, pending=0)
         )
 
     def test_scale_up_after_oobd_at_group_max(self):
@@ -844,7 +844,7 @@ class ConvergenceSet1(unittest.TestCase):
             rcs,
             total_servers=set_to_servers,)
          .addCallback(self.scaling_group.wait_for_expected_state, rcs,
-                      active=converged_servers, pending=0))
+                      timeout=1800, active=converged_servers, pending=0))
 
         return d
 

--- a/otter/integration/tests/test_convergence.py
+++ b/otter/integration/tests/test_convergence.py
@@ -62,13 +62,7 @@ class TestConvergence(unittest.TestCase):
         """Destroy the HTTP connection pool, so that we close the reactor
         cleanly.
         """
-
-        def _check_fds(_):
-            fds = set(reactor.getReaders() + reactor.getWriters())
-            if not [fd for fd in fds if isinstance(fd, Client)]:
-                return
-            return deferLater(reactor, 0, _check_fds, None)
-        return self.pool.closeCachedConnections().addBoth(_check_fds)
+        return self.pool.closeCachedConnections()
 
     def test_scale_over_group_max_after_metadata_removal_reduced_grp_max(self):
         """
@@ -357,13 +351,7 @@ class ConvergenceSet1(unittest.TestCase):
         """Destroy the HTTP connection pool, so that we close the reactor
         cleanly.
         """
-
-        def _check_fds(_):
-            fds = set(reactor.getReaders() + reactor.getWriters())
-            if not [fd for fd in fds if isinstance(fd, Client)]:
-                return
-            return deferLater(reactor, 0, _check_fds, None)
-        return self.pool.closeCachedConnections().addBoth(_check_fds)
+        return self.pool.closeCachedConnections()
 
     def test_reaction_to_oob_server_deletion_below_min(self):
         """

--- a/otter/integration/tests/test_convergence.py
+++ b/otter/integration/tests/test_convergence.py
@@ -149,8 +149,7 @@ class TestConvergence(unittest.TestCase):
             ).addCallback(self.scaling_group.choose_random_servers, 3)
             .addCallback(self._remove_metadata, rcs)
             .addCallback(lambda _: rcs)
-            .addCallback(self.scale_beyond_max.execute)
-            .addBoth(self._assert_error_status_code, 403, rcs)
+            .addCallback(self.scale_beyond_max.execute, success_codes=[403])
             .addCallback(lambda _: self.removed_ids)
             .addCallback(
                 self.scaling_group.wait_for_deleted_id_removal,
@@ -192,14 +191,6 @@ class TestConvergence(unittest.TestCase):
             scaling_group=self.scaling_group
         )
 
-        def expect_403(failure):
-            if not isinstance(failure, Failure):
-                raise Exception("Failure expected")
-            failure.trap(APIError)
-            if failure.value.code != 403:
-                failure.raiseException()
-            return rcs
-
         return (
             self.identity.authenticate_user(
                 rcs,
@@ -217,8 +208,7 @@ class TestConvergence(unittest.TestCase):
             ).addCallback(self.scaling_group.choose_random_servers, 3)
             .addCallback(self._remove_metadata, rcs)
             .addCallback(lambda _: rcs)
-            .addCallback(self.scale_beyond_max.execute)
-            .addBoth(expect_403)
+            .addCallback(self.scale_beyond_max.execute, success_codes=[403])
             .addCallback(lambda _: self.removed_ids)
             .addCallback(
                 self.scaling_group.wait_for_deleted_id_removal,
@@ -326,25 +316,6 @@ class TestConvergence(unittest.TestCase):
             )
 
         return create_clb_first().addCallback(then_test)
-
-    def _assert_error_status_code(self, result, code, rcs):
-        """
-        FACTOR_OUT
-
-        Validate that the returned value was a failure with the specified
-        status code.
-        """
-        if not isinstance(result, Failure):
-            self.fail('Unexpectedly, this succeeded when it was '
-                      'expected to fail')
-        elif not result.check(APIError):
-            self.fail('Received {0} instead of expected APIError'.format(
-                      result.type))
-        elif result.value.code != code:
-            self.fail('Expected status code {0} but received {1}'.format(
-                      code, result.value.code))
-        else:
-            return rcs
 
     def _delete_those_servers(self, ids, rcs):
         """
@@ -770,25 +741,6 @@ class ConvergenceSet1(unittest.TestCase):
             )
         )
 
-    def _assert_error_status_code(self, result, code, rcs):
-        """
-        FACTOR_OUT
-
-        Validate that the returned value was a failure with the specified
-        status code.
-        """
-        if not isinstance(result, Failure):
-            self.fail('Unexpectedly, this succeeded when it was '
-                      'expected to fail')
-        elif not result.check(APIError):
-            self.fail('Received {0} instead of expected APIError'.format(
-                      result.type))
-        elif result.value.code != code:
-            self.fail('Expected status code {0} but received {1}'.format(
-                      code, result.value.code))
-        else:
-            return rcs
-
     def _scale_down_after_oobd_hitting_constraints(
             self, rcs, min_servers=0, max_servers=25, set_to_servers=None,
             oobd_servers=0, scale_servers=1, converged_servers=0):
@@ -835,9 +787,7 @@ class ConvergenceSet1(unittest.TestCase):
          .addCallback(self._delete_those_servers, rcs)
          # The execution of the policy triggers convergence
          .addCallback(self.policy_scale.start, self)
-         .addCallback(self.policy_scale.execute)
-         .addBoth(self._assert_error_status_code, 403, rcs)
-         # Need to add a check for the expected 403
+         .addCallback(self.policy_scale.execute, success_codes=[403])
          .addCallback(lambda _: self.removed_ids)
          .addCallback(
             self.scaling_group.wait_for_deleted_id_removal,

--- a/otter/integration/tests/test_convergence.py
+++ b/otter/integration/tests/test_convergence.py
@@ -8,8 +8,6 @@ import os
 
 from twisted.internet import reactor
 from twisted.internet.defer import gatherResults
-from twisted.internet.task import deferLater
-from twisted.internet.tcp import Client
 from twisted.trial import unittest
 from twisted.web.client import HTTPConnectionPool
 

--- a/otter/integration/tests/test_convergence.py
+++ b/otter/integration/tests/test_convergence.py
@@ -329,8 +329,9 @@ class TestConvergence(unittest.TestCase):
         This will strip them of their association with Autoscale.
         """
         self.removed_ids = ids
-        return gatherResults([NovaServer(id=_id).update_metadata({}, rcs)
-                              for _id in ids]).addCallback(lambda _: rcs)
+        return gatherResults([
+            NovaServer(id=_id, pool=self.pool).update_metadata({}, rcs)
+            for _id in ids]).addCallback(lambda _: rcs)
 
 
 class ConvergenceSet1(unittest.TestCase):
@@ -810,5 +811,6 @@ class ConvergenceSet1(unittest.TestCase):
         This will strip them of their association with Autoscale.
         """
         self.removed_ids = ids
-        return gatherResults([NovaServer(id=_id).update_metadata({}, rcs)
-                              for _id in ids]).addCallback(lambda _: rcs)
+        return gatherResults([
+            NovaServer(id=_id, pool=self.pool).update_metadata({}, rcs)
+            for _id in ids]).addCallback(lambda _: rcs)


### PR DESCRIPTION
This PR does the following:

1. Make all errors (except the transient error) terminal while waiting for the state.  This way if there's an error in the code or some issue with mimic or otter, things fail immediately.
1. Fixes the bug where the pool was not being passed to the Nova API when deleting metadata, meaning that the tests hung forever.
1. @glyph suggests that waiting for the FDs is unnecessary, and closing the pool's cached connections will do the right thing.  So remove that.
1. Minor other cleanup with allowing the success code to be passed to execute scaling policy, so we can assert that an execution should have failed.
1. Makes all the waiting time out at 1800.