### PR TITLE
Using wait_for_expected_group_state instead of sleeping

### DIFF
--- a/autoscale_cloudroast/test_repo/autoscale/fixtures.py
+++ b/autoscale_cloudroast/test_repo/autoscale/fixtures.py
@@ -188,6 +188,7 @@ class AutoscaleFixture(BaseTestFixture):
         cls.interval_time = int(cls.autoscale_config.interval_time)
         cls.timeout = int(cls.autoscale_config.timeout)
         cls.scheduler_interval = OtterConstants.SCHEDULER_INTERVAL
+        cls.cron_wait_timeout = 60 + cls.scheduler_interval + 5
         cls.scheduler_batch = OtterConstants.SCHEDULER_BATCH
         cls.max_maxentities = OtterConstants.MAX_MAXENTITIES
         cls.max_cooldown = OtterConstants.MAX_COOLDOWN

--- a/autoscale_cloudroast/test_repo/autoscale/system/schedule_policies/test_system_at_style_scheduler.py
+++ b/autoscale_cloudroast/test_repo/autoscale/system/schedule_policies/test_system_at_style_scheduler.py
@@ -10,7 +10,6 @@ from test_repo.autoscale.fixtures import AutoscaleFixture
 
 
 class AtStyleSchedulerTests(AutoscaleFixture):
-
     """
     Verify at style scheduler policy executes for all policy change types
     """

--- a/autoscale_cloudroast/test_repo/autoscale/system/schedule_policies/test_system_cron_style_scheduler.py
+++ b/autoscale_cloudroast/test_repo/autoscale/system/schedule_policies/test_system_cron_style_scheduler.py
@@ -2,8 +2,6 @@
 Test cron scheduler policies are executed via change, change percent
 and desired caapacity
 """
-from time import sleep
-
 from cafe.drivers.unittest.decorators import tags
 
 from test_repo.autoscale.fixtures import AutoscaleFixture
@@ -40,16 +38,17 @@ class CronStyleSchedulerTests(AutoscaleFixture):
             sp_cooldown=360,
             sp_change=self.sp_change,
             schedule_cron='* * * * *')
-        sleep(60 + self.scheduler_interval)
-        self.verify_group_state(self.group.id, self.sp_change)
+        self.wait_for_expected_group_state(
+            self.group.id, self.sp_change,
+            60 + self.scheduler_interval, 2, time_scale=False)
         self.autoscale_behaviors.create_schedule_policy_given(
             group_id=self.group.id,
             sp_cooldown=360,
             sp_change=-self.sp_change,
             schedule_cron='* * * * *')
-        sleep(60 + self.scheduler_interval)
-        self.verify_group_state(
-            self.group.id, self.group.groupConfiguration.minEntities)
+        self.wait_for_expected_group_state(
+            self.group.id, self.group.groupConfiguration.minEntities,
+            60 + self.scheduler_interval, 2, time_scale=False)
 
     @tags(speed='slow', convergence='yes')
     def test_system_cron_style_desired_capacity_policy_up_down(self):
@@ -64,16 +63,17 @@ class CronStyleSchedulerTests(AutoscaleFixture):
             sp_cooldown=360,
             sp_desired_capacity=self.sp_desired_capacity,
             schedule_cron='* * * * *')
-        sleep(60 + self.scheduler_interval)
-        self.verify_group_state(self.group.id, self.sp_desired_capacity)
+        self.wait_for_expected_group_state(
+            self.group.id, self.sp_desired_capacity,
+            60 + self.scheduler_interval, 2, time_scale=False)
         self.autoscale_behaviors.create_schedule_policy_given(
             group_id=self.group.id,
             sp_cooldown=360,
             sp_desired_capacity=self.group.groupConfiguration.minEntities,
             schedule_cron='* * * * *')
-        sleep(60 + self.scheduler_interval)
-        self.verify_group_state(
-            self.group.id, self.group.groupConfiguration.minEntities)
+        self.wait_for_expected_group_state(
+            self.group.id, self.group.groupConfiguration.minEntities,
+            60 + self.scheduler_interval, 2, time_scale=False)
 
     @tags(speed='slow', convergence='yes')
     def test_system_cron_style_policy_cooldown(self):
@@ -87,8 +87,9 @@ class CronStyleSchedulerTests(AutoscaleFixture):
             sp_cooldown=75,
             sp_change=self.sp_change,
             schedule_cron='* * * * *')
-        sleep(60 + self.scheduler_interval)
-        self.verify_group_state(self.group.id, self.sp_change)
+        self.wait_for_expected_group_state(
+            self.group.id, self.sp_change,
+            60 + self.scheduler_interval, 2, time_scale=False)
         execute_scheduled_policy = self.autoscale_client.execute_policy(
             group_id=self.group.id,
             policy_id=cron_policy['id'])

--- a/autoscale_cloudroast/test_repo/autoscale/system/schedule_policies/test_system_cron_style_scheduler.py
+++ b/autoscale_cloudroast/test_repo/autoscale/system/schedule_policies/test_system_cron_style_scheduler.py
@@ -40,7 +40,7 @@ class CronStyleSchedulerTests(AutoscaleFixture):
             schedule_cron='* * * * *')
         self.wait_for_expected_group_state(
             self.group.id, self.sp_change,
-            60 + self.scheduler_interval, 2, time_scale=False)
+            self.cron_wait_timeout, 2, time_scale=False)
         self.autoscale_behaviors.create_schedule_policy_given(
             group_id=self.group.id,
             sp_cooldown=360,
@@ -48,7 +48,7 @@ class CronStyleSchedulerTests(AutoscaleFixture):
             schedule_cron='* * * * *')
         self.wait_for_expected_group_state(
             self.group.id, self.group.groupConfiguration.minEntities,
-            60 + self.scheduler_interval, 2, time_scale=False)
+            self.cron_wait_timeout, 2, time_scale=False)
 
     @tags(speed='slow', convergence='yes')
     def test_system_cron_style_desired_capacity_policy_up_down(self):
@@ -65,7 +65,7 @@ class CronStyleSchedulerTests(AutoscaleFixture):
             schedule_cron='* * * * *')
         self.wait_for_expected_group_state(
             self.group.id, self.sp_desired_capacity,
-            60 + self.scheduler_interval, 2, time_scale=False)
+            self.cron_wait_timeout, 2, time_scale=False)
         self.autoscale_behaviors.create_schedule_policy_given(
             group_id=self.group.id,
             sp_cooldown=360,
@@ -73,7 +73,7 @@ class CronStyleSchedulerTests(AutoscaleFixture):
             schedule_cron='* * * * *')
         self.wait_for_expected_group_state(
             self.group.id, self.group.groupConfiguration.minEntities,
-            60 + self.scheduler_interval, 2, time_scale=False)
+            self.cron_wait_timeout, 2, time_scale=False)
 
     @tags(speed='slow', convergence='yes')
     def test_system_cron_style_policy_cooldown(self):
@@ -89,7 +89,7 @@ class CronStyleSchedulerTests(AutoscaleFixture):
             schedule_cron='* * * * *')
         self.wait_for_expected_group_state(
             self.group.id, self.sp_change,
-            60 + self.scheduler_interval, 2, time_scale=False)
+            self.cron_wait_timeout, 2, time_scale=False)
         execute_scheduled_policy = self.autoscale_client.execute_policy(
             group_id=self.group.id,
             policy_id=cron_policy['id'])
@@ -110,9 +110,9 @@ class CronStyleSchedulerTests(AutoscaleFixture):
         self.wait_for_expected_group_state(
             self.group.id,
             self.group.groupConfiguration.minEntities + self.sp_change,
-            60 + self.scheduler_interval, 2, time_scale=False)
+            self.cron_wait_timeout, 2, time_scale=False)
         # Now wait for next execution
         self.wait_for_expected_group_state(
             self.group.id,
             self.group.groupConfiguration.minEntities + self.sp_change * 2,
-            60 + self.scheduler_interval, 2, time_scale=False)
+            self.cron_wait_timeout, 2, time_scale=False)

--- a/autoscale_cloudroast/test_repo/autoscale/system/schedule_policies/test_system_execute_scheduler_negative.py
+++ b/autoscale_cloudroast/test_repo/autoscale/system/schedule_policies/test_system_execute_scheduler_negative.py
@@ -57,7 +57,7 @@ class ExecuteNegativeSchedulerPolicy(AutoscaleFixture):
     def check_cooldown_over_trigger(self, group):
         self.wait_for_expected_group_state(
             group.id, self.sp_change,
-            60 + self.scheduler_interval, 1, time_scale=False)
+            self.cron_wait_timeout, 1, time_scale=False)
         # This is sometime between 0 to scheduler_interval of minute.
         # Sleeping for another minute + interval + 30s should be time after
         # next execution which must have same state
@@ -121,7 +121,7 @@ class ExecuteNegativeSchedulerPolicy(AutoscaleFixture):
             group.id, cron_policy['id'])
         self.wait_for_expected_group_state(
             group.id, self.gc_min_entities,
-            60 + self.scheduler_interval, 2, time_scale=False)
+            self.cron_wait_timeout, 2, time_scale=False)
 
     def test_system_scheduler_down(self):
         """

--- a/autoscale_cloudroast/test_repo/autoscale/system/schedule_policies/test_system_multi_scheduler_webhook_policies.py
+++ b/autoscale_cloudroast/test_repo/autoscale/system/schedule_policies/test_system_multi_scheduler_webhook_policies.py
@@ -64,7 +64,7 @@ class MultipleSchedulerWebhookPoliciesTest(AutoscaleFixture):
         self._execute_webhook_policies_within_group(group)
         self.wait_for_expected_group_state(
             group.id, 3 * self.change,
-            60 + self.scheduler_interval, 2, time_scale=False)
+            self.cron_wait_timeout, 2, time_scale=False)
 
     @tags(speed='slow', convergence='yes')
     def test_system_webhook_and_scheduler_policies_different_groups(self):
@@ -79,7 +79,7 @@ class MultipleSchedulerWebhookPoliciesTest(AutoscaleFixture):
             1, 201, self.wb_policy, self.at_style_policy,
             self.cron_style_policy)
         self._execute_webhook_policies_within_group(group1, group2)
-        sleep(60 + self.scheduler_interval)
+        sleep(self.cron_wait_timeout)
         self.verify_group_state(group1.id, 3 * self.change)
         self.verify_group_state(group2.id, 3 * self.change)
 
@@ -144,7 +144,7 @@ class MultipleSchedulerWebhookPoliciesTest(AutoscaleFixture):
         group_ids = [
             self._create_multi_policy_group(1, 201, self.at_style_policy).id
             for _ in range(4)]
-        sleep(self.scheduler_interval + 30)
+        sleep(2 + self.scheduler_interval + 30)
         for group_id in group_ids:
             self.verify_group_state(group_id, self.change)
             self.verify_server_count_using_server_metadata(group_id,

--- a/autoscale_cloudroast/test_repo/autoscale/system/schedule_policies/test_system_multi_scheduler_webhook_policies.py
+++ b/autoscale_cloudroast/test_repo/autoscale/system/schedule_policies/test_system_multi_scheduler_webhook_policies.py
@@ -62,8 +62,9 @@ class MultipleSchedulerWebhookPoliciesTest(AutoscaleFixture):
             1, 201, self.wb_policy, self.at_style_policy,
             self.cron_style_policy)
         self._execute_webhook_policies_within_group(group)
-        sleep(60 + self.scheduler_interval)
-        self.verify_group_state(group.id, 3 * self.change)
+        self.wait_for_expected_group_state(
+            group.id, 3 * self.change,
+            60 + self.scheduler_interval, 2, time_scale=False)
 
     @tags(speed='slow', convergence='yes')
     def test_system_webhook_and_scheduler_policies_different_groups(self):

--- a/autoscale_cloudroast/test_repo/autoscale/system/schedule_policies/test_system_scheduler_update_group.py
+++ b/autoscale_cloudroast/test_repo/autoscale/system/schedule_policies/test_system_scheduler_update_group.py
@@ -68,7 +68,7 @@ class UpdateSchedulerScalingPolicy(AutoscaleFixture):
             schedule_cron='* * * * *')
         self.wait_for_expected_group_state(
             group.id, group.groupConfiguration.maxEntities,
-            60 + self.scheduler_interval, 2, time_scale=False)
+            self.cron_wait_timeout, 2, time_scale=False)
         self.autoscale_client.delete_scaling_policy(
             group.id, policy_dict['id'])
         self.autoscale_behaviors.create_schedule_policy_given(
@@ -78,7 +78,7 @@ class UpdateSchedulerScalingPolicy(AutoscaleFixture):
             schedule_cron='* * * * *')
         self.wait_for_expected_group_state(
             group.id, group.groupConfiguration.minEntities,
-            60 + self.scheduler_interval, 2, time_scale=False)
+            self.cron_wait_timeout, 2, time_scale=False)
 
     @tags(speed='slow', convergence='yes')
     def test_system_group_cooldown_at_style(self):
@@ -148,7 +148,7 @@ class UpdateSchedulerScalingPolicy(AutoscaleFixture):
         active_servers = self.sp_change + group.groupConfiguration.minEntities
         active_after_scaleup = self.wait_for_expected_number_of_active_servers(
             group_id=group.id, expected_servers=active_servers,
-            timeout=(60 + self.scheduler_interval), interval_time=2,
+            timeout=self.cron_wait_timeout, interval_time=2,
             time_scale=False)
         upd_lc_server = set(active_after_scaleup) - set(active_list_b4_upd)
         self._verify_server_list_for_launch_config(upd_lc_server)
@@ -160,7 +160,7 @@ class UpdateSchedulerScalingPolicy(AutoscaleFixture):
         active_on_scale_down = self.wait_for_expected_number_of_active_servers(
             group_id=group.id,
             expected_servers=group.groupConfiguration.minEntities,
-            timeout=(60 + self.scheduler_interval), interval_time=2,
+            timeout=self.cron_wait_timeout, interval_time=2,
             time_scale=False)
         self._verify_server_list_for_launch_config(active_on_scale_down)
 

--- a/autoscale_cloudroast/test_repo/autoscale/system/schedule_policies/test_system_update_scheduler.py
+++ b/autoscale_cloudroast/test_repo/autoscale/system/schedule_policies/test_system_update_scheduler.py
@@ -90,7 +90,7 @@ class UpdateSchedulerTests(AutoscaleFixture):
         self.wait_for_expected_group_state(
             self.group.id,
             self.group.groupConfiguration.minEntities + cron_policy['change'],
-            60 + self.scheduler_interval, 2, time_scale=False)
+            self.cron_wait_timeout, 2, time_scale=False)
 
     @tags(speed='slow', convergence='yes')
     def test_system_update_cron_style_scheduler_to_execute_in_the_future(self):
@@ -109,7 +109,7 @@ class UpdateSchedulerTests(AutoscaleFixture):
         self.wait_for_expected_group_state(
             self.group.id,
             self.group.groupConfiguration.minEntities + cron_policy['change'],
-            60 + self.scheduler_interval, 1, time_scale=False)
+            self.cron_wait_timeout, 1, time_scale=False)
         self._update_policy(
             self.group.id, cron_policy, upd_args, change_value=2)
         sleep(120 + self.scheduler_interval)
@@ -134,13 +134,13 @@ class UpdateSchedulerTests(AutoscaleFixture):
             sp_cooldown=0)
         self.wait_for_expected_group_state(
             self.group.id, self.group.groupConfiguration.minEntities + 1,
-            60 + self.scheduler_interval, 2, time_scale=False)
+            self.cron_wait_timeout, 2, time_scale=False)
         self._update_policy(
             self.group.id, cron_style_policy, self.cron_policy_args,
             change_value=2)
         self.wait_for_expected_group_state(
             self.group.id, self.group.groupConfiguration.minEntities + 3,
-            60 + self.scheduler_interval, time_scale=False)
+            self.cron_wait_timeout, time_scale=False)
 
     @tags(speed='slow', convergence='yes')
     def test_system_update_name_for_cron_style_scheduled_policy(self):
@@ -159,7 +159,7 @@ class UpdateSchedulerTests(AutoscaleFixture):
         self.wait_for_expected_group_state(
             self.group.id,
             self.group.groupConfiguration.minEntities + cron_policy['change'],
-            60 + self.scheduler_interval, 2, time_scale=False)
+            self.cron_wait_timeout, 2, time_scale=False)
 
     @tags(speed='slow', convergence='yes')
     def test_system_update_cooldown_for_cron_style_scheduled_policy(self):
@@ -173,10 +173,10 @@ class UpdateSchedulerTests(AutoscaleFixture):
             schedule_cron=self.cron_policy_args['cron'])
         self.wait_for_expected_group_state(
             self.group.id, self.group.groupConfiguration.minEntities,
-            60 + self.scheduler_interval, 1, time_scale=False)
+            self.cron_wait_timeout, 1, time_scale=False)
         self._update_policy(self.group.id, cron_policy, self.cron_policy_args,
                             cooldown=100)
-        sleep(60 + self.scheduler_interval)
+        sleep(self.cron_wait_timeout)
         self.verify_group_state(
             self.group.id,
             self.group.groupConfiguration.minEntities + cron_policy['change'])

--- a/autoscale_cloudroast/test_repo/autoscale/system/schedule_policies/test_system_update_scheduler.py
+++ b/autoscale_cloudroast/test_repo/autoscale/system/schedule_policies/test_system_update_scheduler.py
@@ -87,10 +87,10 @@ class UpdateSchedulerTests(AutoscaleFixture):
         self.verify_group_state(
             self.group.id, self.group.groupConfiguration.minEntities)
         self._update_policy(self.group.id, cron_policy, upd_args)
-        sleep(60 + self.scheduler_interval)
-        self.verify_group_state(
+        self.wait_for_expected_group_state(
             self.group.id,
-            self.group.groupConfiguration.minEntities + cron_policy['change'])
+            self.group.groupConfiguration.minEntities + cron_policy['change'],
+            60 + self.scheduler_interval, 2, time_scale=False)
 
     @tags(speed='slow', convergence='yes')
     def test_system_update_cron_style_scheduler_to_execute_in_the_future(self):
@@ -106,10 +106,10 @@ class UpdateSchedulerTests(AutoscaleFixture):
             group_id=self.group.id,
             schedule_cron='* * * * *',
             sp_cooldown=0)
-        sleep(60 + self.scheduler_interval)
-        self.verify_group_state(
+        self.wait_for_expected_group_state(
             self.group.id,
-            self.group.groupConfiguration.minEntities + cron_policy['change'])
+            self.group.groupConfiguration.minEntities + cron_policy['change'],
+            60 + self.scheduler_interval, 1, time_scale=False)
         self._update_policy(
             self.group.id, cron_policy, upd_args, change_value=2)
         sleep(120 + self.scheduler_interval)
@@ -156,10 +156,10 @@ class UpdateSchedulerTests(AutoscaleFixture):
             self.group.id, self.group.groupConfiguration.minEntities)
         self._update_policy(self.group.id, cron_policy, self.cron_policy_args,
                             name='test-only-upd-name')
-        sleep(60 + self.scheduler_interval)
-        self.verify_group_state(
+        self.wait_for_expected_group_state(
             self.group.id,
-            self.group.groupConfiguration.minEntities + cron_policy['change'])
+            self.group.groupConfiguration.minEntities + cron_policy['change'],
+            60 + self.scheduler_interval, 2, time_scale=False)
 
     @tags(speed='slow', convergence='yes')
     def test_system_update_cooldown_for_cron_style_scheduled_policy(self):
@@ -171,9 +171,9 @@ class UpdateSchedulerTests(AutoscaleFixture):
         cron_policy = self.autoscale_behaviors.create_schedule_policy_given(
             group_id=self.group.id,
             schedule_cron=self.cron_policy_args['cron'])
-        sleep(self.scheduler_interval)
-        self.verify_group_state(
-            self.group.id, self.group.groupConfiguration.minEntities)
+        self.wait_for_expected_group_state(
+            self.group.id, self.group.groupConfiguration.minEntities,
+            60 + self.scheduler_interval, 1, time_scale=False)
         self._update_policy(self.group.id, cron_policy, self.cron_policy_args,
                             cooldown=100)
         sleep(60 + self.scheduler_interval)


### PR DESCRIPTION
Closes #1404. The tests now wait for expected group state for maximum scheduled time. This way the tests will wake up at beginning of minute in cron based tests and continue accordingly.