### PR TITLE
fix broken tests

### DIFF
--- a/autoscale_cloudroast/test_repo/autoscale/system/schedule_policies/test_system_multi_scheduler_webhook_policies.py
+++ b/autoscale_cloudroast/test_repo/autoscale/system/schedule_policies/test_system_multi_scheduler_webhook_policies.py
@@ -160,12 +160,12 @@ class MultipleSchedulerWebhookPoliciesTest(AutoscaleFixture):
         policy_list = []
         for each_policy in args:
             policy_list.extend([each_policy] * multi_num)
-        response = self.autoscale_behaviors.create_scaling_group_given(
+        create_response = self.autoscale_behaviors.create_scaling_group_given(
             lc_name='multi_scheduling',
             sp_list=policy_list,
             gc_cooldown=0)
         self.assertEquals(
-            response.status_code, response,
+            create_response.status_code, response,
             msg=('Creating multiple scaling policies within a group failed '
                  'with response code: {0}'.format(response.status_code)))
         group = response.entity

--- a/autoscale_cloudroast/test_repo/autoscale/system/schedule_policies/test_system_multi_scheduler_webhook_policies.py
+++ b/autoscale_cloudroast/test_repo/autoscale/system/schedule_policies/test_system_multi_scheduler_webhook_policies.py
@@ -152,7 +152,7 @@ class MultipleSchedulerWebhookPoliciesTest(AutoscaleFixture):
     def _unchanged_policy(self, policy_list):
         return {i: policy_list[i] for i in policy_list if i != 'change'}
 
-    def _create_multi_policy_group(self, multi_num, response, *args):
+    def _create_multi_policy_group(self, multi_num, expected_code, *args):
         """
         Creates a group with the given list of policies and asserts the
         group creation was successful
@@ -160,12 +160,12 @@ class MultipleSchedulerWebhookPoliciesTest(AutoscaleFixture):
         policy_list = []
         for each_policy in args:
             policy_list.extend([each_policy] * multi_num)
-        create_response = self.autoscale_behaviors.create_scaling_group_given(
+        response = self.autoscale_behaviors.create_scaling_group_given(
             lc_name='multi_scheduling',
             sp_list=policy_list,
             gc_cooldown=0)
         self.assertEquals(
-            create_response.status_code, response,
+            response.status_code, expected_code,
             msg=('Creating multiple scaling policies within a group failed '
                  'with response code: {0}'.format(response.status_code)))
         group = response.entity


### PR DESCRIPTION
There turned out to be 2 response variables due to last lint change. Now renamed the argument passed to `expected_code`. 