### PR TITLE
wait_for_state on autoscale group with  matchers.

### DIFF
--- a/otter/integration/lib/autoscale.py
+++ b/otter/integration/lib/autoscale.py
@@ -10,8 +10,7 @@ import random
 
 from characteristic import Attribute, attributes
 
-from testtools.matchers import (
-    ContainsDict, Equals, MatchesAll, MatchesPredicateWithParams)
+from testtools.matchers import MatchesPredicateWithParams
 
 import treq
 

--- a/otter/integration/lib/test_autoscale.py
+++ b/otter/integration/lib/test_autoscale.py
@@ -9,7 +9,7 @@ from twisted.internet.task import Clock
 from twisted.trial.unittest import SynchronousTestCase
 
 from otter.integration.lib.autoscale import (
-    HasActive, ExcludesServers, ScalingGroup)
+    ExcludesServers, HasActive, ScalingGroup)
 
 from otter.util.deferredutils import TimedOutError
 

--- a/otter/integration/lib/test_autoscale.py
+++ b/otter/integration/lib/test_autoscale.py
@@ -55,7 +55,7 @@ class WaitForStateTestCase(SynchronousTestCase):
 
         This version emulates completion after a period of time.
         """
-        self.assertEquals([200], success_codes)
+        self.assertEquals(success_codes, [200])
         if self.counter == self.threshold:
             return defer.succeed((200, self.group_state_w_2_servers))
         else:
@@ -70,7 +70,7 @@ class WaitForStateTestCase(SynchronousTestCase):
 
         This version never yields the desired number of servers.
         """
-        self.assertEquals([200], success_codes)
+        self.assertEquals(success_codes, [200])
         return defer.succeed((200, self.empty_group_state))
 
     def test_poll_until_happy(self):
@@ -116,7 +116,7 @@ class MatcherTestCase(SynchronousTestCase):
         mismatch = matcher.match(
             {'active': [{'id': "id{0}".format(i)} for i in (3, 4)]}
         )
-        self.assertEqual(None, mismatch)
+        self.assertEqual(mismatch, None)
 
     def test_excludes_servers_failure(self):
         """
@@ -125,15 +125,15 @@ class MatcherTestCase(SynchronousTestCase):
         """
         matcher = ExcludesServers(['id1', 'id2'])
         self.assertNotEqual(
-            None,
             matcher.match(
                 {'active': [{'id': "id{0}".format(i)} for i in (1, 2)]}),
-            "Complete match succeeds when none should be present."
+            "Complete match succeeds when none should be present.",
+            None
         )
         self.assertNotEqual(
-            None,
             matcher.match({'active': [{'id': "id1"}]}),
-            "Partial match succeeds when none should be present."
+            "Partial match succeeds when none should be present.",
+            None
         )
 
     def test_has_active(self):
@@ -142,15 +142,12 @@ class MatcherTestCase(SynchronousTestCase):
         matches the length given.
         """
         matcher = HasActive(2)
-        self.assertNotEqual(
-            None,
-            matcher.match({'active': [{'id': "id1"}]})
-        )
-        self.assertNotEqual(None, matcher.match({'active': []}))
+        self.assertNotEqual(matcher.match({'active': [{'id': "id1"}]}), None)
+        self.assertNotEqual(matcher.match({'active': []}), None)
         self.assertEqual(
-            None,
             matcher.match(
-                {'active': [{'id': "id{0}".format(i)} for i in (1, 2)]}))
+                {'active': [{'id': "id{0}".format(i)} for i in (1, 2)]}),
+            None)
 
 
 class GetServicenetIPs(SynchronousTestCase):

--- a/otter/integration/lib/test_autoscale.py
+++ b/otter/integration/lib/test_autoscale.py
@@ -46,7 +46,7 @@ class WaitForNServersTestCase(SynchronousTestCase):
         self.sg = ScalingGroup(group_config={}, pool=None, reactor=self.clock)
         self.counter = 0
 
-    def get_scaling_group_state_happy(self, rcs):
+    def get_scaling_group_state_happy(self, rcs, success_codes=None):
         """This method implements a synchronous simulation of what we'd expect
         to see over the wire on an HTTP API transaction.  This method replaces
         the actual ScalingGroup method on instances.  (See setUp for an example
@@ -54,14 +54,14 @@ class WaitForNServersTestCase(SynchronousTestCase):
 
         This version emulates completion after a period of time.
         """
-
+        self.assertEquals([200], success_codes)
         if self.counter == self.threshold:
             return defer.succeed((200, self.group_state_w_2_servers))
         else:
             self.counter = self.counter + 1
             return defer.succeed((200, self.empty_group_state))
 
-    def get_scaling_group_state_timeout(self, rcs):
+    def get_scaling_group_state_timeout(self, rcs, success_codes=None):
         """This method implements a synchronous simulation of what we'd expect
         to see over the wire on an HTTP API transaction.  This method replaces
         the actual ScalingGroup method on instances.  (See setUp for an example
@@ -69,7 +69,7 @@ class WaitForNServersTestCase(SynchronousTestCase):
 
         This version never yields the desired number of servers.
         """
-
+        self.assertEquals([200], success_codes)
         return defer.succeed((200, self.empty_group_state))
 
     def test_poll_until_happy(self):


### PR DESCRIPTION
This PR replaces `wait_for_N_servers`, `wait_for_deleted_id_removal`, and `wait_for_expected_state` with a function that takes matchers (`wait_for_state`).

It also replaced usages of those functions with this one.