### PR TITLE
Set ERROR state when a step returns StepResult.FAILURE

### DIFF
--- a/otter/models/intents.py
+++ b/otter/models/intents.py
@@ -60,11 +60,23 @@ def perform_delete_group(log, store, dispatcher, intent):
     return group.delete_group()
 
 
+@attributes(['scaling_group', 'status'])
+class UpdateGroupStatus(object):
+    """An Effect intent which updates the status of a scaling group."""
+
+
+@deferred_performer
+def perform_update_group_status(dispatcher, ugs_intent):
+    """Perform an :obj:`UpdateGroupStatus`."""
+    return ugs_intent.scaling_group.update_status(ugs_intent.status)
+
+
 def get_model_dispatcher(log, store):
     """Get a dispatcher that can handle all the model-related intents."""
     return TypeDispatcher({
         ModifyGroupState: perform_modify_group_state,
         GetScalingGroupInfo:
             partial(perform_get_scaling_group_info, log, store),
-        DeleteGroup: partial(perform_delete_group, log, store)
+        DeleteGroup: partial(perform_delete_group, log, store),
+        UpdateGroupStatus: perform_update_group_status,
     })

--- a/otter/test/convergence/test_service.py
+++ b/otter/test/convergence/test_service.py
@@ -47,6 +47,7 @@ from otter.test.utils import (
     CheckFailureValue, FakePartitioner,
     TestStep,
     mock_group, mock_log,
+    noop,
     raise_,
     test_dispatcher,
     transform_eq,
@@ -759,9 +760,6 @@ class ExecuteConvergenceTests(SynchronousTestCase):
                 TestStep(Effect(Constant((StepResult.FAILURE, [])))),
                 TestStep(Effect(Constant((StepResult.SUCCESS, [])))),
             ])
-
-        def noop(i):
-            pass
 
         eff = execute_convergence(self.tenant_id, self.group_id,
                                   plan=plan,

--- a/otter/test/models/test_intents.py
+++ b/otter/test/models/test_intents.py
@@ -5,8 +5,9 @@ from twisted.internet.defer import succeed
 from twisted.trial.unittest import SynchronousTestCase
 
 from otter.models.intents import (
-    DeleteGroup, GetScalingGroupInfo, ModifyGroupState, get_model_dispatcher)
-from otter.models.interface import IScalingGroupCollection
+    DeleteGroup, GetScalingGroupInfo, ModifyGroupState, UpdateGroupStatus,
+    get_model_dispatcher)
+from otter.models.interface import IScalingGroupCollection, ScalingGroupStatus
 from otter.test.utils import iMock, mock_group, mock_log
 
 
@@ -71,3 +72,12 @@ class ScalingGroupIntentsTests(SynchronousTestCase):
                 self.dispatcher,
                 Effect(DeleteGroup(tenant_id='00', group_id='g1'))),
             'del')
+
+    def test_update_group_status(self):
+        """Performing :obj:`UpdateGroupStatus` invokes group.update_status."""
+        eff = Effect(UpdateGroupStatus(scaling_group=self.group,
+                                       status=ScalingGroupStatus.ERROR))
+        self.group.update_status.return_value = None
+        self.assertIs(sync_perform(self.dispatcher, eff), None)
+        self.group.update_status.assert_called_once_with(
+            ScalingGroupStatus.ERROR)

--- a/otter/test/utils.py
+++ b/otter/test/utils.py
@@ -816,3 +816,8 @@ class TestStep(object):
 
     def as_effect(self):
         return self.effect
+
+
+def noop(_):
+    """Ignore input and return None."""
+    pass


### PR DESCRIPTION
Pretty straightforward! Had to add an `UpdateGroupStatus` intent/performer.