### PR TITLE
Add GroupState.status

### DIFF
--- a/otter/models/cass.py
+++ b/otter/models/cass.py
@@ -456,7 +456,8 @@ def _unmarshal_state(state_dict):
         state_dict["groupTouched"],
         _jsonloads_data(state_dict["policyTouched"]),
         state_dict["paused"],
-        desired=desired_capacity
+        ScalingGroupStatus.ACTIVE,
+        desired=desired_capacity,
     )
 
 
@@ -1405,6 +1406,7 @@ class CassScalingGroupCollection:
                 data['created_at'],
                 {},
                 data['paused'],
+                ScalingGroupStatus.ACTIVE,
                 desired=data['desired']
             )
             outpolicies = _build_policies(

--- a/otter/models/interface.py
+++ b/otter/models/interface.py
@@ -32,6 +32,7 @@ class GroupState(object):
         they were executed, if ever. The time is stored as ISO860 format str
     :ivar bool paused: whether the scaling group is paused in
         scaling activities
+    :ivar GroupStatus status: status of the group.
     :ivar int desired: the desired capacity of the scaling group
     :ivar callable now: callable that returns a :class:`bytes` timestamp
         used for testing purposes. Defaults to :func:`timestamp.now`
@@ -39,7 +40,7 @@ class GroupState(object):
     TODO: ``remove_active``, ``pause`` and ``resume`` ?
     """
     def __init__(self, tenant_id, group_id, group_name, active, pending,
-                 group_touched, policy_touched, paused, desired=0,
+                 group_touched, policy_touched, paused, status, desired=0,
                  now=timestamp.now):
         self.tenant_id = tenant_id
         self.group_id = group_id
@@ -50,6 +51,7 @@ class GroupState(object):
         self.paused = paused
         self.policy_touched = policy_touched
         self.group_touched = group_touched
+        self.status = status
 
         if self.group_touched is None:
             self.group_touched = timestamp.MIN
@@ -58,7 +60,7 @@ class GroupState(object):
 
         self._attributes = (
             'tenant_id', 'group_id', 'group_name', 'desired', 'active',
-            'pending', 'group_touched', 'policy_touched', 'paused')
+            'pending', 'group_touched', 'policy_touched', 'paused', 'status')
 
     def __eq__(self, other):
         """

--- a/otter/test/convergence/test_service.py
+++ b/otter/test/convergence/test_service.py
@@ -539,7 +539,8 @@ class ExecuteConvergenceTests(SynchronousTestCase):
         self.tenant_id = 'tenant-id'
         self.group_id = 'group-id'
         self.state = GroupState(self.tenant_id, self.group_id, 'group-name',
-                                {}, {}, None, {}, False, desired=2)
+                                {}, {}, None, {}, False,
+                                ScalingGroupStatus.ACTIVE, desired=2)
         self.group = mock_group(self.state, self.tenant_id, self.group_id)
         self.lc = {'args': {'server': {'name': 'foo'}, 'loadBalancers': []}}
         self.desired_lbs = s(CLBDescription(lb_id='23', port=80))

--- a/otter/test/models/test_cass_models.py
+++ b/otter/test/models/test_cass_models.py
@@ -536,6 +536,7 @@ class CassScalingGroupTests(CassScalingGroupTestCase):
                                  group_touched='2014-01-01T00:00:05Z.1234',
                                  policy_touched={'PT': 'R'},
                                  paused=False,
+                                 status=ScalingGroupStatus.ACTIVE,
                                  desired=10)
         self.assertEqual(r, group_state)
 
@@ -563,6 +564,7 @@ class CassScalingGroupTests(CassScalingGroupTestCase):
                                        '2014-01-01T00:00:05Z.1234',
                                        {'PT': 'R'},
                                        False,
+                                       ScalingGroupStatus.ACTIVE,
                                        desired=0))
 
     def test_view_respsects_consistency_argument(self):
@@ -657,6 +659,7 @@ class CassScalingGroupTests(CassScalingGroupTestCase):
                                        '2014-01-01T00:00:05Z.1234',
                                        {'PT': 'R'},
                                        True,
+                                       ScalingGroupStatus.ACTIVE,
                                        desired=0))
 
     def test_modify_state_calls_modifier_with_group_and_state_and_others(self):
@@ -703,6 +706,7 @@ class CassScalingGroupTests(CassScalingGroupTestCase):
                                      group_touched=None,
                                      policy_touched={},
                                      paused=True,
+                                     status=ScalingGroupStatus.ACTIVE,
                                      desired=5)
             return group_state
 
@@ -744,6 +748,7 @@ class CassScalingGroupTests(CassScalingGroupTestCase):
                                      group_touched=None,
                                      policy_touched={},
                                      paused=True,
+                                     status=ScalingGroupStatus.ACTIVE,
                                      desired=5)
             return group_state
 
@@ -814,6 +819,7 @@ class CassScalingGroupTests(CassScalingGroupTestCase):
                                      pending={},
                                      group_touched=None,
                                      policy_touched={},
+                                     status=ScalingGroupStatus.ACTIVE,
                                      paused=True)
             return group_state
 
@@ -857,6 +863,7 @@ class CassScalingGroupTests(CassScalingGroupTestCase):
                                      pending={},
                                      group_touched=None,
                                      policy_touched={},
+                                     status=ScalingGroupStatus.ACTIVE,
                                      paused=True)
             return group_state
 
@@ -881,6 +888,7 @@ class CassScalingGroupTests(CassScalingGroupTestCase):
                                      pending={},
                                      group_touched=None,
                                      policy_touched={},
+                                     status=ScalingGroupStatus.ACTIVE,
                                      paused=True)
             return group_state
 
@@ -1833,7 +1841,8 @@ class CassScalingGroupTests(CassScalingGroupTestCase):
         group state is not empty
         """
         mock_view_state.return_value = defer.succeed(GroupState(
-            self.tenant_id, self.group_id, '', {'1': {}}, {}, None, {}, False))
+            self.tenant_id, self.group_id, '', {'1': {}}, {}, None, {}, False,
+            ScalingGroupStatus.ACTIVE))
         self.failureResultOf(self.group.delete_group(), GroupNotEmptyError)
 
         # nothing else called except view
@@ -1852,7 +1861,8 @@ class CassScalingGroupTests(CassScalingGroupTestCase):
         policies and webhooks if the scaling group is empty.
         """
         mock_view_state.return_value = defer.succeed(GroupState(
-            self.tenant_id, self.group_id, '', {}, {}, None, {}, False))
+            self.tenant_id, self.group_id, '', {}, {}, None, {}, False,
+            ScalingGroupStatus.ACTIVE))
         mock_naive.return_value = defer.succeed(
             [{'webhookKey': 'w1'}, {'webhookKey': 'w2'}])
 
@@ -1905,7 +1915,8 @@ class CassScalingGroupTests(CassScalingGroupTestCase):
         has no policies.
         """
         mock_view_state.return_value = defer.succeed(GroupState(
-            self.tenant_id, self.group_id, '', {}, {}, None, {}, False))
+            self.tenant_id, self.group_id, '', {}, {}, None, {}, False,
+            ScalingGroupStatus.ACTIVE))
         mock_naive.return_value = defer.succeed([])
 
         self.returns = [None]
@@ -1949,7 +1960,8 @@ class CassScalingGroupTests(CassScalingGroupTestCase):
             lambda timeout: defer.fail(ValueError('a'))
 
         mock_view_state.return_value = defer.succeed(GroupState(
-            self.tenant_id, self.group_id, 'a', {}, {}, None, {}, False))
+            self.tenant_id, self.group_id, 'a', {}, {}, None, {}, False,
+            ScalingGroupStatus.ACTIVE))
 
         d = self.group.delete_group()
         self.failureResultOf(d, ValueError)
@@ -1985,7 +1997,8 @@ class CassScalingGroupTests(CassScalingGroupTestCase):
         the lock asynchronously.  If it never succeeds, an error is logged.
         """
         mock_view_state.return_value = defer.succeed(GroupState(
-            self.tenant_id, self.group_id, '', {}, {}, None, {}, False))
+            self.tenant_id, self.group_id, '', {}, {}, None, {}, False,
+            ScalingGroupStatus.ACTIVE))
         mock_naive.return_value = defer.succeed([])
         called = []
 
@@ -2132,7 +2145,8 @@ class ViewManifestTests(CassScalingGroupTestCase):
                 self.group_id,
                 'a', {'A': 'R'},
                 {'P': 'R'}, '2014-01-01T00:00:05Z.1234',
-                {'PT': 'R'}, False)
+                {'PT': 'R'}, False,
+                ScalingGroupStatus.ACTIVE)
         }
         self.group._naive_list_policies = mock.Mock()
         self.group._naive_list_all_webhooks = mock.Mock()
@@ -3199,7 +3213,8 @@ class CassScalingGroupsCollectionTestCase(IScalingGroupCollectionProviderMixin,
                                      pending={},
                                      group_touched='0001-01-01T00:00:00Z',
                                      policy_touched={},
-                                     paused=False)
+                                     paused=False,
+                                     status=ScalingGroupStatus.ACTIVE)
             return group_state
 
         self.assertEqual(r, [group_state_with_id("group0"),
@@ -3288,7 +3303,8 @@ class CassScalingGroupsCollectionTestCase(IScalingGroupCollectionProviderMixin,
                                         pending={},
                                         group_touched='0001-01-01T00:00:00Z',
                                         policy_touched={},
-                                        paused=False)])
+                                        paused=False,
+                                        status=ScalingGroupStatus.ACTIVE)])
         self.mock_log.msg.assert_called_once_with(
             'Resurrected rows',
             tenant_id='123',
@@ -3351,7 +3367,8 @@ class CassScalingGroupsCollectionTestCase(IScalingGroupCollectionProviderMixin,
                                         pending={},
                                         group_touched='0001-01-01T00:00:00Z',
                                         policy_touched={},
-                                        paused=False)])
+                                        paused=False,
+                                        status=ScalingGroupStatus.ACTIVE)])
 
     def _extract_execute_query(self, call):
         args, _ = call

--- a/otter/test/test_controller.py
+++ b/otter/test/test_controller.py
@@ -68,7 +68,8 @@ class CalculateDeltaTestCase(SynchronousTestCase):
         Only care about the active and pending values, so generate a whole
         :class:`GroupState` with other fake info
         """
-        return GroupState(1, 1, "test", active, pending, None, {}, False)
+        return GroupState(1, 1, "test", active, pending, None, {}, False,
+                          ScalingGroupStatus.ACTIVE)
 
     def test_positive_change_within_min_max(self):
         """
@@ -545,7 +546,8 @@ class CheckCooldownsTestCase(SynchronousTestCase):
         Only care about the group_touched and policy_touched values, so
         generate a whole :class:`GroupState` with other fake info
         """
-        return GroupState(1, 1, "test", {}, {}, group_touched, policy_touched, False)
+        return GroupState(1, 1, "test", {}, {}, group_touched, policy_touched,
+                          False, ScalingGroupStatus.ACTIVE)
 
     def test_check_cooldowns_global_cooldown_and_policy_cooldown_pass(self):
         """
@@ -791,7 +793,8 @@ class TriggerConvergenceDeletionTests(SynchronousTestCase):
 
 def sample_group_state():
     """ GroupState object for test """
-    return GroupState('tid', 'gid', 'g', {}, {}, False, None, {})
+    return GroupState('tid', 'gid', 'g', {}, {}, False, None, {},
+                      ScalingGroupStatus.ACTIVE)
 
 
 class DeleteGroupTests(SynchronousTestCase):
@@ -1337,7 +1340,7 @@ class ConvergeTestCase(SynchronousTestCase):
         """
         log = mock_log()
         state = GroupState('tenant', 'group', "test", [], [], None, {},
-                           False)
+                           False, ScalingGroupStatus.ACTIVE)
         group_config = {'maxEntities': 100, 'minEntities': 0}
         policy = {'change': 5}
         config_data = {'convergence-tenants': ['tenant']}
@@ -1362,7 +1365,7 @@ class ConvergeTestCase(SynchronousTestCase):
         """
         log = mock_log()
         state = GroupState('tenant', 'group-id', "test", [], [], None, {},
-                           False)
+                           False, ScalingGroupStatus.ACTIVE)
         group_config = {'maxEntities': 100, 'minEntities': 0}
         policy = {'change': 0}
         config_data = {'convergence-tenants': ['tenant']}
@@ -1405,6 +1408,7 @@ class ConvergenceRemoveServerTests(SynchronousTestCase):
                                 group_touched=None,
                                 policy_touched=None,
                                 paused=None,
+                                status=ScalingGroupStatus.ACTIVE,
                                 desired=1)
         self.group = iMock(IScalingGroup, tenant_id='tenant_id',
                            uuid='group_id')

--- a/otter/test/test_supervisor.py
+++ b/otter/test/test_supervisor.py
@@ -18,7 +18,7 @@ from otter.auth import IAuthenticator
 from otter.cloud_client import TenantScope
 from otter.constants import ServiceType
 from otter.models.interface import (
-    GroupState, IScalingGroup, NoSuchScalingGroupError)
+    GroupState, IScalingGroup, NoSuchScalingGroupError, ScalingGroupStatus)
 from otter.supervisor import (
     CannotDeleteServerBelowMinError,
     ISupervisor,
@@ -442,8 +442,9 @@ class FindPendingJobsToCancelTests(SynchronousTestCase):
             '5': {'created': '2014-01-05T00:00:00Z'}
         }  # ascending order by time would be: 1, 4, 3, 2, 5
 
-        self.cancellable_state = GroupState('t', 'g', 'n', {}, self.data, None, {},
-                                            False)
+        self.cancellable_state = GroupState(
+            't', 'g', 'n', {}, self.data, None, {}, False,
+            ScalingGroupStatus.ACTIVE)
 
     def test_returns_most_recent_jobs(self):
         """
@@ -485,8 +486,8 @@ class FindServersToEvictTests(SynchronousTestCase):
             '5': {'created': '2014-01-05T00:00:00Z', 'id': '5', 'lb': 'lb'}
         }  # ascending order by time would be: 1, 4, 3, 2, 5
 
-        self.deletable_state = GroupState('t', 'g', 'n', self.data, {}, None, {},
-                                          False)
+        self.deletable_state = GroupState('t', 'g', 'n', self.data, {}, None,
+                                          {}, False, ScalingGroupStatus.ACTIVE)
 
     def test_returns_oldest_servers(self):
         """
@@ -528,8 +529,8 @@ class DeleteActiveServersTests(SynchronousTestCase):
                   'lb': 'lb'},
             '5': {'created': '2014-01-05T00:00:00Z', 'id': '5', 'lb': 'lb'}
         }  # ascending order by time would be: 1, 4, 3, 2, 5
-        self.fake_state = GroupState('t', 'g', 'n', self.data, {}, False, False,
-                                     False)
+        self.fake_state = GroupState('t', 'g', 'n', self.data, {}, False,
+                                     False, False, ScalingGroupStatus.ACTIVE)
         self.evict_servers = {'1': self.data['1'], '4': self.data['4'],
                               '3': self.data['3']}
 
@@ -703,7 +704,8 @@ class ExecScaleDownTests(SynchronousTestCase):
             'a5': {'created': '2014-01-05T00:00:00Z', 'id': '5', 'lb': 'lb'}
         }  # ascending order by time would be: a1, a4, a3, a2, a5
         self.fake_state = GroupState('t', 'g', '', self.active, self.pending,
-                                     False, False, False)
+                                     False, False, False,
+                                     ScalingGroupStatus.ACTIVE)
         self.find_pending_jobs_to_cancel = patch(
             self, 'otter.supervisor.find_pending_jobs_to_cancel')
         self.del_active_servers = patch(
@@ -768,7 +770,8 @@ class ExecuteLaunchConfigTestCase(SynchronousTestCase):
                 return jself.d
 
         patch(self, 'otter.supervisor._Job', new=FakeJob)
-        self.state = GroupState('t', 'g', 'n', {}, {}, *range(3))
+        self.state = GroupState('t', 'g', 'n', {}, {}, 0, 1, 2,
+                                ScalingGroupStatus.ACTIVE)
 
     def test_no_jobs_started(self):
         """
@@ -809,8 +812,10 @@ class PrivateJobHelperTestCase(SynchronousTestCase):
         """
         self.transaction_id = 'transaction_id'
         self.job_id = 'job_id'
-        patch(self, 'otter.supervisor.generate_job_id', return_value=self.job_id)
-        self.state = GroupState('tenant', 'group', 'name', {}, {}, None, {}, False)
+        patch(self, 'otter.supervisor.generate_job_id',
+              return_value=self.job_id)
+        self.state = GroupState('tenant', 'group', 'name', {}, {}, None, {},
+                                False, ScalingGroupStatus.ACTIVE)
         self.group = mock_group(self.state, 'tenant', 'group')
 
         self.supervisor = iMock(ISupervisor)
@@ -948,7 +953,8 @@ class PrivateJobHelperTestCase(SynchronousTestCase):
         audit logged as a "server.deletable" event.
         """
         self.state = GroupState('tenant', 'group', 'name', {}, {}, None,
-                                {}, False, desired=0)
+                                {}, False, ScalingGroupStatus.ACTIVE,
+                                desired=0)
         self.job.start(self.mock_launch)
         self.completion_deferred.callback({'id': 'yay'})
 
@@ -1087,9 +1093,11 @@ class RemoveServerTests(SynchronousTestCase):
         self.tid = 'trans_id'
         self.log = mock_log()
         self.state = GroupState('tid', 'gid', 'g', {'s0': {'id': 's0'}}, {},
-                                None, None, None, desired=1)
+                                None, None, None, ScalingGroupStatus.ACTIVE,
+                                desired=1)
         self.group = mock_group(self.state)
-        self.gen_jobid = patch(self, 'otter.supervisor.generate_job_id', return_value='jid')
+        self.gen_jobid = patch(self, 'otter.supervisor.generate_job_id',
+                               return_value='jid')
         self.supervisor = FakeSupervisor()
         set_supervisor(self.supervisor)
         self.addCleanup(set_supervisor, None)


### PR DESCRIPTION
This doesn't do anything interesting, just add a `status` parameter/attribute to GroupState. All code that created GroupState has been updated to pass ACTIVE.

In later PRs we'll populate this value from the database properly.