### PR TITLE
Status in rest

### DIFF
--- a/otter/json_schema/rest_schemas.py
+++ b/otter/json_schema/rest_schemas.py
@@ -9,7 +9,8 @@ from copy import deepcopy
 from itertools import cycle
 
 from otter.json_schema.group_schemas import (
-    policy, config, launch_config, webhook)
+    config, launch_config, policy, webhook)
+from otter.models.interface import ScalingGroupStatus
 from otter.util.config import config_value
 
 
@@ -144,6 +145,12 @@ group_state = _openstackify_schema("group", {
             'type': 'integer',
             'minimum': 0,
             'required': True
+        },
+        'status': {
+            'type': 'string',
+            'required': True,
+            'pattern': '|'.join(
+                x.name for x in ScalingGroupStatus.iterconstants())
         }
     },
     'additionalProperties': False

--- a/otter/rest/groups.py
+++ b/otter/rest/groups.py
@@ -66,6 +66,7 @@ def format_state_dict(state):
         'desiredCapacity': desired,
         'name': state.group_name,
         'paused': state.paused,
+        'status': state.status.name,
         'active': [
             {
                 'id': key,

--- a/otter/test/rest/test_groups.py
+++ b/otter/test/rest/test_groups.py
@@ -158,12 +158,6 @@ class FormatterHelpers(SynchronousTestCase):
             ScalingGroupStatus.ERROR,
             desired=10)
         result = format_state_dict(state)
-        self.assertEqual(result['desiredCapacity'], 10)
-        self.assertEqual(result['pendingCapacity'], 7)
-
-        # And a non-convergence tenant still gets old-style data
-        state.tenant_id = '11112'
-        result = format_state_dict(state)
         self.assertEqual(result['status'], 'ERROR')
 
 


### PR DESCRIPTION
implements part 2 of #885.

This makes it so the 'state' object in REST results for creation/getting groups has the 'status' key.