### PR TITLE
Copy over select test methods from other test case classes

### DIFF
--- a/otter/integration/tests/test_convergence.py
+++ b/otter/integration/tests/test_convergence.py
@@ -162,18 +162,6 @@ def tag(*tags):
     return decorate
 
 
-def skip(reason):
-    """
-    Decorator that sets the skip property on to a function.
-
-    This should be added upstream to Twisted's trial.
-    """
-    def decorate(function):
-        function.skip = reason
-        return function
-    return decorate
-
-
 class TestConvergence(unittest.TestCase):
     """This class contains test cases aimed at the Otter Converger."""
     timeout = 1800
@@ -783,9 +771,9 @@ class ConvergenceSet1WithCLB(unittest.TestCase):
 
         if any(tag in tags for tag in
                ["CATC-0{0:02d}".format(i) for i in range(4, 9)]):
-            wrapper = skip(
+            wrapper.skip = (
                 "Autoscale does not clean up servers deleted OOB yet. "
-                "See #881.")(wrapper)
+                "See #881.")
         return (name, wrapper)
 
 

--- a/otter/integration/tests/test_convergence.py
+++ b/otter/integration/tests/test_convergence.py
@@ -747,9 +747,9 @@ class ConvergenceSet1(unittest.TestCase):
         )
 
 
-class ConvergenceSet1WithCLB(unittest.TestCase):
+class ConvergenceTestsWith1CLB(unittest.TestCase):
     """
-    Class for CATC 4-12 that run with CLB.
+    Tests for convergence that require a single CLB.
     """
     timeout = 1800
 
@@ -780,16 +780,23 @@ class ConvergenceSet1WithCLB(unittest.TestCase):
         )
 
     @classmethod
-    def _copy_catc_4_to_12(cls, name, method):
+    def _only_oob_del_and_error_tests(cls, name, method):
         """
-        To be used to copy over methods from ConvergenceSet1 using
-        :func:`duplicate_test_methods`.  Note that the methods copied
-        should all return the scaling group, so that the group's active
-        servers can be checked against the CLB.
+        To be used by :func:`copy_test_methods` to filter only certain non-CLB
+        tests (the ones testing out of band deletions, servers going into
+        error, servers timing out from builds), and ensure that active servers
+        on the group, when the test has finished, are all properly on the CLB.
+
+        Note that the methods copied should all return the scaling group, so
+        that the group's active servers can be checked against the CLB.
+
+        Also note that this filters out only the tests tagged CATC-004 through
+        CATC-013, because those where the numbers in the original test plan
+        corresponding to the OOB-delete/error test cases.
         """
         tags = getattr(method, 'tags', ())
         if not any(tag in tags for tag in
-                   ["CATC-0{0:02d}".format(i) for i in range(4, 13)]):
+                   ["CATC-0{0:02d}".format(i) for i in range(4, 14)]):
             return None
 
         @wraps(method)
@@ -815,5 +822,5 @@ class ConvergenceSet1WithCLB(unittest.TestCase):
 
 
 copy_test_methods(
-    ConvergenceSet1, ConvergenceSet1WithCLB,
-    filter_and_change=ConvergenceSet1WithCLB._copy_catc_4_to_12)
+    ConvergenceSet1, ConvergenceTestsWith1CLB,
+    filter_and_change=ConvergenceTestsWith1CLB._only_oob_del_and_error_tests)

--- a/otter/integration/tests/test_convergence.py
+++ b/otter/integration/tests/test_convergence.py
@@ -747,6 +747,15 @@ class ConvergenceSet1(unittest.TestCase):
         )
 
 
+def _catc_tags(start_num, end_num):
+    """
+    Return a list of CATC tags corresponding to the start test number and end
+    test number.  For example, start=1 and end=3 would return:
+    ["CATC-001", "CATC-002", "CATC-003"].
+    """
+    return ["CATC-0{0:02d}".format(i) for i in range(start_num, end_num + 1)]
+
+
 class ConvergenceTestsWith1CLB(unittest.TestCase):
     """
     Tests for convergence that require a single CLB.
@@ -795,8 +804,7 @@ class ConvergenceTestsWith1CLB(unittest.TestCase):
         corresponding to the OOB-delete/error test cases.
         """
         tags = getattr(method, 'tags', ())
-        if not any(tag in tags for tag in
-                   ["CATC-0{0:02d}".format(i) for i in range(4, 14)]):
+        if not any(tag in tags for tag in _catc_tags(4, 13)):
             return None
 
         @wraps(method)
@@ -813,8 +821,7 @@ class ConvergenceTestsWith1CLB(unittest.TestCase):
                 clb.wait_for_nodes(self.rcs, checks, timeout=1800)
                 for clb in self.helper.clbs])
 
-        if any(tag in tags for tag in
-               ["CATC-0{0:02d}".format(i) for i in range(4, 9)]):
+        if any(tag in tags for tag in _catc_tags(4, 8)):
             wrapper.skip = (
                 "Autoscale does not clean up servers deleted OOB yet. "
                 "See #881.")

--- a/otter/integration/tests/test_convergence.py
+++ b/otter/integration/tests/test_convergence.py
@@ -150,6 +150,30 @@ class TestHelper(object):
         return decorated
 
 
+def tag(*tags):
+    """
+    Decorator that adds tags to a function by setting the property "tags".
+
+    This should be added upstream to Twisted trial.
+    """
+    def decorate(function):
+        function.tags = tags
+        return function
+    return decorate
+
+
+def skip(reason):
+    """
+    Decorator that sets the skip property on to a function.
+
+    This should be added upstream to Twisted's trial.
+    """
+    def decorate(function):
+        function.skip = reason
+        return function
+    return decorate
+
+
 class TestConvergence(unittest.TestCase):
     """This class contains test cases aimed at the Otter Converger."""
     timeout = 1800
@@ -483,6 +507,7 @@ class ConvergenceSet1(unittest.TestCase):
             region=region
         )
 
+    @tag("CATC-004")
     def test_reaction_to_oob_server_deletion_below_min(self):
         """
         CATC-004-a
@@ -509,8 +534,8 @@ class ConvergenceSet1(unittest.TestCase):
                 self.rcs, self.scaling_group, N_SERVERS / 2)(
                 self.scaling_group.trigger_convergence))
         )
-    test_reaction_to_oob_server_deletion_below_min.tags = ["CATC-004"]
 
+    @tag("CATC-005")
     def test_reaction_to_oob_deletion_then_scale_up(self):
         """
         CATC-005-a
@@ -529,8 +554,8 @@ class ConvergenceSet1(unittest.TestCase):
         return _test_scaling_after_oobd(
             self.helper, self.rcs, min_servers=3, oobd_servers=1,
             scale_servers=2, converged_servers=5)
-    test_reaction_to_oob_deletion_then_scale_up.tags = ["CATC-005"]
 
+    @tag("CATC-006")
     def test_scale_down_after_oobd_non_constrained_z_lessthan_y(self):
         """
         CATC-006-a
@@ -558,8 +583,8 @@ class ConvergenceSet1(unittest.TestCase):
         return _test_scaling_after_oobd(
             self.helper, self.rcs, min_servers=N, set_to_servers=x,
             oobd_servers=z, scale_servers=y, converged_servers=(x + y))
-    test_scale_down_after_oobd_non_constrained_z_lessthan_y.tags = ["CATC-006"]
 
+    @tag("CATC-006")
     def test_scale_down_after_oobd_non_constrained_z_greaterthan_y(self):
         """
         CATC-006-b
@@ -587,9 +612,8 @@ class ConvergenceSet1(unittest.TestCase):
         return _test_scaling_after_oobd(
             self.helper, self.rcs, min_servers=N, set_to_servers=x,
             oobd_servers=z, scale_servers=y, converged_servers=(x + y))
-    test_scale_down_after_oobd_non_constrained_z_greaterthan_y.tags = [
-        "CATC-006"]
 
+    @tag("CATC-006")
     def test_scale_down_after_oobd_non_constrained_z_equal_y(self):
         """
         CATC-006-c
@@ -617,8 +641,8 @@ class ConvergenceSet1(unittest.TestCase):
         return _test_scaling_after_oobd(
             self.helper, self.rcs, min_servers=N, set_to_servers=x,
             oobd_servers=z, scale_servers=y, converged_servers=(x + y))
-    test_scale_down_after_oobd_non_constrained_z_equal_y.tags = ["CATC-006"]
 
+    @tag("CATC-007")
     def test_scale_up_after_oobd_at_group_max(self):
         """
         CATC-007-a
@@ -643,8 +667,8 @@ class ConvergenceSet1(unittest.TestCase):
             self.helper, self.rcs, set_to_servers=x, oobd_servers=z,
             max_servers=max_servers, scale_servers=y,
             converged_servers=max_servers, scale_should_fail=True)
-    test_scale_up_after_oobd_at_group_max.tags = ["CATC-007"]
 
+    @tag("CATC-007")
     def test_scale_down_past_group_min_after_oobd(self):
         """
         CATC-007-b
@@ -668,8 +692,8 @@ class ConvergenceSet1(unittest.TestCase):
             self.helper, self.rcs, oobd_servers=z, min_servers=min_servers,
             scale_servers=y, converged_servers=min_servers,
             scale_should_fail=True)
-    test_scale_down_past_group_min_after_oobd.tags = ["CATC-007"]
 
+    @tag("CATC-008")
     def test_group_config_update_triggers_convergence(self):
         """
         CATC-008-a
@@ -696,7 +720,6 @@ class ConvergenceSet1(unittest.TestCase):
                     self.scaling_group.update_group_config),
                 maxEntities=max_servers + 2)
         )
-    test_group_config_update_triggers_convergence.tags = ["CATC-008"]
 
 
 class ConvergenceSet1WithCLB(unittest.TestCase):
@@ -760,9 +783,9 @@ class ConvergenceSet1WithCLB(unittest.TestCase):
 
         if any(tag in tags for tag in
                ["CATC-0{0:02d}".format(i) for i in range(4, 9)]):
-            wrapper.skip = (
+            wrapper = skip(
                 "Autoscale does not clean up servers deleted OOB yet. "
-                "See #881.")
+                "See #881.")(wrapper)
         return (name, wrapper)
 
 

--- a/otter/integration/tests/test_convergence.py
+++ b/otter/integration/tests/test_convergence.py
@@ -190,7 +190,7 @@ def copy_test_methods(from_class, to_class, filter_and_change=None):
         method name to change, the method to be decorated and/or skipped.
     """
     for name, attr in from_class.__dict__.items():
-        if name.startswith('test_') and isinstance(attr, type(lambda: None)):
+        if name.startswith('test_') and callable(attr):
             if filter_and_change is not None:
                 filtered = filter_and_change(name, attr)
                 if filtered is not None:

--- a/otter/integration/tests/test_convergence.py
+++ b/otter/integration/tests/test_convergence.py
@@ -162,7 +162,7 @@ def tag(*tags):
     return decorate
 
 
-def skip_me(*tags):
+def skip_me(reason):
     """
     Decorator that skips a test method or test class by setting the property
     "skip".  This decorator is not named "skip", because setting "skip" on a
@@ -171,7 +171,7 @@ def skip_me(*tags):
     This should be added upstream to Twisted trial.
     """
     def decorate(function):
-        function.tags = tags
+        function.skip = reason
         return function
     return decorate
 

--- a/otter/integration/tests/test_convergence.py
+++ b/otter/integration/tests/test_convergence.py
@@ -509,6 +509,7 @@ class ConvergenceSet1(unittest.TestCase):
                 self.rcs, self.scaling_group, N_SERVERS / 2)(
                 self.scaling_group.trigger_convergence))
         )
+    test_reaction_to_oob_server_deletion_below_min.tags = ["CATC-004"]
 
     def test_reaction_to_oob_deletion_then_scale_up(self):
         """
@@ -528,6 +529,7 @@ class ConvergenceSet1(unittest.TestCase):
         return _test_scaling_after_oobd(
             self.helper, self.rcs, min_servers=3, oobd_servers=1,
             scale_servers=2, converged_servers=5)
+    test_reaction_to_oob_deletion_then_scale_up.tags = ["CATC-005"]
 
     def test_scale_down_after_oobd_non_constrained_z_lessthan_y(self):
         """
@@ -556,6 +558,7 @@ class ConvergenceSet1(unittest.TestCase):
         return _test_scaling_after_oobd(
             self.helper, self.rcs, min_servers=N, set_to_servers=x,
             oobd_servers=z, scale_servers=y, converged_servers=(x + y))
+    test_scale_down_after_oobd_non_constrained_z_lessthan_y.tags = ["CATC-006"]
 
     def test_scale_down_after_oobd_non_constrained_z_greaterthan_y(self):
         """
@@ -584,6 +587,8 @@ class ConvergenceSet1(unittest.TestCase):
         return _test_scaling_after_oobd(
             self.helper, self.rcs, min_servers=N, set_to_servers=x,
             oobd_servers=z, scale_servers=y, converged_servers=(x + y))
+    test_scale_down_after_oobd_non_constrained_z_greaterthan_y.tags = [
+        "CATC-006"]
 
     def test_scale_down_after_oobd_non_constrained_z_equal_y(self):
         """
@@ -612,6 +617,7 @@ class ConvergenceSet1(unittest.TestCase):
         return _test_scaling_after_oobd(
             self.helper, self.rcs, min_servers=N, set_to_servers=x,
             oobd_servers=z, scale_servers=y, converged_servers=(x + y))
+    test_scale_down_after_oobd_non_constrained_z_equal_y.tags = ["CATC-006"]
 
     def test_scale_up_after_oobd_at_group_max(self):
         """
@@ -637,6 +643,7 @@ class ConvergenceSet1(unittest.TestCase):
             self.helper, self.rcs, set_to_servers=x, oobd_servers=z,
             max_servers=max_servers, scale_servers=y,
             converged_servers=max_servers, scale_should_fail=True)
+    test_scale_up_after_oobd_at_group_max.tags = ["CATC-007"]
 
     def test_scale_down_past_group_min_after_oobd(self):
         """
@@ -661,6 +668,7 @@ class ConvergenceSet1(unittest.TestCase):
             self.helper, self.rcs, oobd_servers=z, min_servers=min_servers,
             scale_servers=y, converged_servers=min_servers,
             scale_should_fail=True)
+    test_scale_down_past_group_min_after_oobd.tags = ["CATC-007"]
 
     def test_group_config_update_triggers_convergence(self):
         """
@@ -688,6 +696,7 @@ class ConvergenceSet1(unittest.TestCase):
                     self.scaling_group.update_group_config),
                 maxEntities=max_servers + 2)
         )
+    test_group_config_update_triggers_convergence.tags = ["CATC-008"]
 
 
 class ConvergenceSet1WithCLB(unittest.TestCase):
@@ -723,13 +732,18 @@ class ConvergenceSet1WithCLB(unittest.TestCase):
         )
 
     @classmethod
-    def _copy_methods(cls, name, method):
+    def _copy_catc_4_to_12(cls, name, method):
         """
         To be used to copy over methods from ConvergenceSet1 using
         :func:`duplicate_test_methods`.  Note that the methods copied
         should all return the scaling group, so that the group's active
         servers can be checked against the CLB.
         """
+        tags = getattr(method, 'tags', ())
+        if not any(tag in tags for tag in
+                   ["CATC-0{0:02d}".format(i) for i in range(4, 13)]):
+            return None
+
         @wraps(method)
         @inlineCallbacks
         def wrapper(self, *args, **kwargs):
@@ -744,7 +758,8 @@ class ConvergenceSet1WithCLB(unittest.TestCase):
                 clb.wait_for_nodes(self.rcs, checks, timeout=1800)
                 for clb in self.helper.clbs])
 
-        if "_oobd" in name or "_oob_" in name:
+        if any(tag in tags for tag in
+               ["CATC-0{0:02d}".format(i) for i in range(4, 9)]):
             wrapper.skip = (
                 "Autoscale does not clean up servers deleted OOB yet. "
                 "See #881.")
@@ -775,4 +790,4 @@ def duplicate_test_methods(from_class, to_class, filter_and_change=None):
 
 duplicate_test_methods(
     ConvergenceSet1, ConvergenceSet1WithCLB,
-    filter_and_change=ConvergenceSet1WithCLB._copy_methods)
+    filter_and_change=ConvergenceSet1WithCLB._copy_catc_4_to_12)

--- a/otter/integration/tests/test_convergence.py
+++ b/otter/integration/tests/test_convergence.py
@@ -766,7 +766,7 @@ class ConvergenceSet1WithCLB(unittest.TestCase):
         return (name, wrapper)
 
 
-def duplicate_test_methods(from_class, to_class, filter_and_change=None):
+def copy_test_methods(from_class, to_class, filter_and_change=None):
     """
     Copy test methods (methods that start with `test_*`) from ``from_class`` to
     ``to_class``.  If a decorator is provided, the test method on the
@@ -788,6 +788,6 @@ def duplicate_test_methods(from_class, to_class, filter_and_change=None):
             setattr(to_class, name, attr)
 
 
-duplicate_test_methods(
+copy_test_methods(
     ConvergenceSet1, ConvergenceSet1WithCLB,
     filter_and_change=ConvergenceSet1WithCLB._copy_catc_4_to_12)


### PR DESCRIPTION
So we don't have to structure our test class methods so they need composing.

Also, this way we can selectively copy and skip methods.

This PR has been split out from #1428.

This also fixes #1410 because the test methods copied over have their CLB info checked.