### PR TITLE
Delete a load balancer and scale

### DIFF
--- a/otter/integration/lib/cloud_load_balancer.py
+++ b/otter/integration/lib/cloud_load_balancer.py
@@ -155,11 +155,13 @@ class CloudLoadBalancer(object):
                 .addCallback(self.treq.json_content)
                 .addCallback(record_results))
 
-    def delete(self, rcs):
+    def delete(self, rcs, success_codes=None):
         """Stops and deletes the cloud load balancer.
 
         :param TestResources rcs: The resources used to make appropriate API
             calls with.
+        :param list success_codes: A list of HTTP status codes to count as
+            a successful call.
         """
         return (
             self.treq.delete(
@@ -169,7 +171,9 @@ class CloudLoadBalancer(object):
                 ),
                 headers=headers(str(rcs.token)),
                 pool=self.pool
-            ).addCallback(check_success, [202, 404])
+            ).addCallback(
+                check_success,
+                [202, 404] if success_codes is None else success_codes)
         ).addCallback(lambda _: rcs)
 
     def wait_for_nodes(self, rcs, matcher, timeout, period=10, clock=None):

--- a/otter/integration/lib/cloud_load_balancer.py
+++ b/otter/integration/lib/cloud_load_balancer.py
@@ -161,7 +161,8 @@ class CloudLoadBalancer(object):
         :param TestResources rcs: The resources used to make appropriate API
             calls with.
         :param list success_codes: A list of HTTP status codes to count as
-            a successful call.
+            a successful call.  If not provided, defaults to ``[202, 404]``
+            (404 is a successful result because deletes should be idempotent).
         """
         return (
             self.treq.delete(

--- a/otter/integration/tests/test_convergence.py
+++ b/otter/integration/tests/test_convergence.py
@@ -130,7 +130,7 @@ class TestHelper(object):
             :class:`otter.integration.lib.resources.TestResources`
         :param ScalingGroup group: An instance of
             :class:`otter.integration.lib.autoscale.ScalingGroup` to start -
-            this group should not have been started already.
+            this group should have been started already.
         :param int num: The number of servers to delete out of band.
         """
         def decorated(function):

--- a/otter/integration/tests/test_convergence.py
+++ b/otter/integration/tests/test_convergence.py
@@ -114,6 +114,13 @@ class TestHelper(object):
         Return a decorator that wraps a function call with logic to out-of-band
         delete (not disown) some number of servers, and verifies that the
         servers are deleted and cleaned up from CLBs.
+
+        :param TestResources rcs: An instance of
+            :class:`otter.integration.lib.resources.TestResources`
+        :param ScalingGroup group: An instance of
+            :class:`otter.integration.lib.autoscale.ScalingGroup` to start -
+            this group should not have been started already.
+        :param int num: The number of servers to delete out of band.
         """
         def decorated(function):
             @wraps(function)

--- a/otter/integration/tests/test_convergence.py
+++ b/otter/integration/tests/test_convergence.py
@@ -763,6 +763,28 @@ def _catc_tags(start_num, end_num):
     return ["CATC-0{0:02d}".format(i) for i in range(start_num, end_num + 1)]
 
 
+def _delete_a_clb_and_scale(rcs, helper, group, scale_by, delete_clb=None):
+    """
+    1. Delete the first load balancer using the provided function (it may set
+       the load balancer to PENDING_DELETE instead, for example)
+    2. Scale.
+
+    :param callable delete_clb: function that takes a test resource
+        and a load balancer and deletes (or pending-deletes) the
+        load balancer.
+    """
+    if delete_clb is not None:
+        d = delete_clb(helper.clbs[0](rcs))
+    else:
+        d = helper.clbs[0].delete(rcs, success_codes=[202])
+
+    policy = ScalingPolicy(scale_by=scale_by, scaling_group=group)
+    d.addCallback(lambda _: policy.start(rcs, helper.test_case))
+    d.addCallback(policy.execute)
+    d.addCallback(lambda _: rcs)
+    return d
+
+
 class ConvergenceTestsWith1CLB(unittest.TestCase):
     """
     Tests for convergence that require a single CLB.
@@ -836,9 +858,9 @@ class ConvergenceTestsWith1CLB(unittest.TestCase):
 
     @skip_me("Autoscale does not support error status yet. See #885")
     @tag("CATC-020")
-    def test_delete_loadbalancer_and_scale_up(self, delete_command=None):
+    def test_delete_all_loadbalancers_and_scale_up(self, delete_clb=None):
         """
-        CATC-020-a
+        CATC-020-a. This will also tested with starting with 2 load balancers.
 
         1. Creates a scaling group with a load balancer and 1 server.
         2. Ensure that the server is active and added to the load balancer.
@@ -849,36 +871,34 @@ class ConvergenceTestsWith1CLB(unittest.TestCase):
            no more active servers added to the group, but the previous active
            server is not deleted.
 
-        :param callable delete_command: function that takes a test resource
+        :param callable delete_clb: function that takes a test resource
             and a load balancer and deletes (or pending-deletes) the
             load balancer.
         """
         group = self.helper.create_group(
             image_ref=image_ref, flavor_ref=flavor_ref, min_entities=1)
 
-        d = self.helper.start_group_and_wait(group, self.rcs)
-        if delete_command is not None:
-            d.addCallback(delete_command, self.helper.clbs[0])
-        else:
-            d.addCallback(self.helper.clbs[0].delete, success_codes=[202])
+        return (
+            self.helper.start_group_and_wait(group, self.rcs)
+            .addCallback(_delete_a_clb_and_scale, self.helper, group,
+                         scale_by=1, delete_clb=delete_clb)
+            .addCallback(
+                group.wait_for_state,
+                MatchesAll(
+                    ContainsDict({
+                        'pendingCapacity': Equals(1),
+                        'desiredCapacity': Equals(2),
+                        'status': Equals("ERROR")
+                    }),
+                    HasActive(1)),
+                timeout=600
+            )
+        )
 
-        policy = ScalingPolicy(scale_by=1, scaling_group=group)
-        d.addCallback(lambda _: policy.start(self.rcs, self))
-        d.addCallback(policy.execute)
-        d.addCallback(lambda _: group.wait_for_state(
-            self.rcs, MatchesAll(
-                ContainsDict({
-                    'pendingCapacity': Equals(1),
-                    'desiredCapacity': Equals(2),
-                    'status': Equals("ERROR")
-                }),
-                HasActive(1)),
-            timeout=600))
-        return d
-
-    def test_delete_loadbalancer_and_scale_down(self, delete_command=None):
+    @tag("CATC-020")
+    def test_delete_all_loadbalancers_and_scale_down(self, delete_clb=None):
         """
-        CATC-020-a
+        CATC-020-b.  This will also tested with starting with 2 load balancers.
 
         1. Creates a scaling group with a load balancer, and scale to 1 server.
         2. Ensure that the servers are active and added to the load balancer.
@@ -887,31 +907,83 @@ class ConvergenceTestsWith1CLB(unittest.TestCase):
         4. Scale down by 1.
         5. Assert that the scaling group does not go into error state, and that
            the server is successfully deleted.
+
+        :param callable delete_clb: function that takes a test resource
+            and a load balancer and deletes (or pending-deletes) the
+            load balancer.
         """
         group = self.helper.create_group(
             image_ref=image_ref, flavor_ref=flavor_ref)
 
-        d = self.helper.start_group_and_wait(group, self.rcs, desired=1)
-        if delete_command is not None:
-            d.addCallback(delete_command, self.helper.clbs[0])
-        else:
-            d.addCallback(self.helper.clbs[0].delete, success_codes=[202])
-
-        policy = ScalingPolicy(scale_by=-1, scaling_group=group)
-        d.addCallback(lambda _: policy.start(self.rcs, self))
-        d.addCallback(policy.execute)
-        d.addCallback(lambda _: group.wait_for_state(
-            self.rcs, MatchesAll(
-                ContainsDict({
-                    'pendingCapacity': Equals(0),
-                    'desiredCapacity': Equals(0),
-                    # 'status': Equals("ACTIVE")
-                }),
-                HasActive(0)),
-            timeout=600))
-        return d
+        return (
+            self.helper.start_group_and_wait(group, self.rcs, desired=1)
+            .addCallback(_delete_a_clb_and_scale, self.helper, group,
+                         scale_by=-1, delete_clb=delete_clb)
+            .addCallback(
+                group.wait_for_state,
+                MatchesAll(
+                    ContainsDict({
+                        'pendingCapacity': Equals(0),
+                        'desiredCapacity': Equals(0)
+                    }),
+                    HasActive(0)),
+                timeout=600
+            )
+        )
 
 
 copy_test_methods(
     ConvergenceSet1, ConvergenceTestsWith1CLB,
     filter_and_change=ConvergenceTestsWith1CLB._only_oob_del_and_error_tests)
+
+
+class ConvergenceTestsWith2CLBs(unittest.TestCase):
+    """
+    Tests that require a two load balancers.
+    """
+    timeout = 1800
+
+    def setUp(self):
+        """Establish an HTTP connection pool and commonly used resources for
+        each test.  The HTTP connection pool is important for maintaining a
+        clean Twisted reactor.
+        """
+        self.helper = TestHelper(self, num_clbs=2)
+        self.rcs = TestResources()
+        self.identity = IdentityV2(
+            auth=auth, username=username, password=password,
+            endpoint=endpoint, pool=self.helper.pool,
+            convergence_tenant_override=convergence_tenant,
+        )
+        return self.identity.authenticate_user(
+            self.rcs,
+            resources={
+                "otter": (otter_key, otter_url),
+                "nova": (nova_key,),
+                "loadbalancers": (clb_key,)
+            },
+            region=region
+        ).addCallback(lambda _: gatherResults([
+            clb.start(self.rcs, self)
+            .addCallback(clb.wait_for_state, "ACTIVE", 600)
+            for clb in self.helper.clbs])
+        )
+
+    @classmethod
+    def _only_delete_clb_while_scaling(cls, name, method):
+        """
+        To be used by :func:`copy_test_methods` to filter only certain
+        single-CLB tests (the where the CLB is deleted before scaling)
+
+        This filters out only the tests tagged CATC-020, because that is the
+        number in the original test plan corresponding to the CLB deletion test
+        case.
+        """
+        if "CATC-020" in getattr(method, 'tags', ()):
+            return (name.replace("all_loadbalancers", "one_loadbalancer"),
+                    method)
+
+
+copy_test_methods(
+    ConvergenceTestsWith1CLB, ConvergenceTestsWith2CLBs,
+    filter_and_change=ConvergenceTestsWith2CLBs._only_delete_clb_while_scaling)

--- a/otter/integration/tests/test_convergence.py
+++ b/otter/integration/tests/test_convergence.py
@@ -993,7 +993,7 @@ class ConvergenceTestsWith1CLB(unittest.TestCase):
     @tag("CATC-020")
     def test_delete_all_loadbalancers_and_scale_up(self, delete_clb=None):
         """
-        CATC-020-a. This will also tested with starting with 2 load balancers.
+        CATC-020-a. This will also be tested with 2 load balancers.
 
         1. Creates a scaling group with a load balancer and 1 server.
         2. Ensure that the server is active and added to the load balancer.
@@ -1030,7 +1030,7 @@ class ConvergenceTestsWith1CLB(unittest.TestCase):
     @tag("CATC-020")
     def test_delete_all_loadbalancers_and_scale_down(self, delete_clb=None):
         """
-        CATC-020-b.  This will also tested with starting with 2 load balancers.
+        CATC-020-b.  This will also be tested with 2 load balancers.
 
         1. Creates a scaling group with a load balancer, and scale to 1 server.
         2. Ensure that the servers are active and added to the load balancer.

--- a/otter/integration/tests/test_convergence.py
+++ b/otter/integration/tests/test_convergence.py
@@ -869,9 +869,9 @@ class ConvergenceTestsWith1CLB(unittest.TestCase):
         d.addCallback(lambda _: group.wait_for_state(
             self.rcs, MatchesAll(
                 ContainsDict({
-                    'pendingCapacity': 1,
-                    'desiredCapacity': 2,
-                    'status': "ERROR"
+                    'pendingCapacity': Equals(1),
+                    'desiredCapacity': Equals(2),
+                    'status': Equals("ERROR")
                 }),
                 HasActive(1)),
             timeout=600))

--- a/otter/integration/tests/test_convergence.py
+++ b/otter/integration/tests/test_convergence.py
@@ -834,6 +834,8 @@ class ConvergenceTestsWith1CLB(unittest.TestCase):
                 "See #881.")
         return (name, wrapper)
 
+    @skip_me("Autoscale does not support error status yet. See #885")
+    @tag("CATC-020")
     def test_delete_loadbalancer_and_scale_up(self, delete_command=None):
         """
         CATC-020-a
@@ -874,9 +876,6 @@ class ConvergenceTestsWith1CLB(unittest.TestCase):
                 HasActive(1)),
             timeout=600))
         return d
-
-    test_delete_loadbalancer_and_scale_up.skip = (
-        "Autoscale does not support error status yet. See #885")
 
     def test_delete_loadbalancer_and_scale_down(self, delete_command=None):
         """

--- a/otter/integration/tests/test_convergence.py
+++ b/otter/integration/tests/test_convergence.py
@@ -894,6 +894,14 @@ def _delete_a_clb_and_scale(rcs, helper, group, scale_by, delete_clb=None):
        the load balancer to PENDING_DELETE instead, for example)
     2. Scale.
 
+    :param TestResources rcs: An instance of
+        :class:`otter.integration.lib.resources.TestResources`
+    :param ScalingGroup group: An instance of
+        :class:`otter.integration.lib.autoscale.ScalingGroup` to start -
+        this group should not have been started already.
+    :param int scale_by: How much to scale by.  This is assumed to never be
+        zero.  If it is zero, this function will fail because autoscale
+        prevents the creation of a policy that scales by zero.
     :param callable delete_clb: function that takes a test resource
         and a load balancer and deletes (or pending-deletes) the
         load balancer.


### PR DESCRIPTION
This creates a group with either one or two load balancers, deletes one load balancer, and attempts to scale.

Fixes #1328.