### PR TITLE
Fix LogErr when passed None as failure

### DIFF
--- a/otter/log/intents.py
+++ b/otter/log/intents.py
@@ -10,6 +10,8 @@ from effect import ComposedDispatcher, Effect, TypeDispatcher, perform
 
 from toolz.dicttoolz import merge
 
+from twisted.python.failure import Failure
+
 
 @attr.s
 class Log(object):
@@ -20,7 +22,7 @@ class Log(object):
     fields = attr.ib()
 
 
-@attr.s
+@attr.s(init=False)
 class LogErr(object):
     """
     Intent to log error
@@ -28,6 +30,17 @@ class LogErr(object):
     failure = attr.ib()
     msg = attr.ib()
     fields = attr.ib()
+
+    def __init__(self, failure, msg, fields):
+        # `failure` being `None` means "get the exception from context".
+        # We can't wait until the intent is performed to do that, because the
+        # exception context will be lost, so we explicitly instantiate a new
+        # Failure here.
+        if failure is None:
+            failure = Failure()
+        self.failure = failure
+        self.msg = msg
+        self.fields = fields
 
 
 @attr.s

--- a/otter/test/log/test_intents.py
+++ b/otter/test/log/test_intents.py
@@ -18,7 +18,7 @@ from otter.log.intents import (
     get_log_dispatcher,
     msg,
     with_log)
-from otter.test.utils import mock_log, transform_eq
+from otter.test.utils import CheckFailureValue, mock_log
 
 
 class LogDispatcherTests(SynchronousTestCase):
@@ -99,8 +99,7 @@ class LogDispatcherTests(SynchronousTestCase):
         except RuntimeError:
             sync_perform(self.disp, eff)
         self.log.err.assert_called_once_with(
-            transform_eq(lambda f: (f.type, str(f.value)),
-                         (RuntimeError, 'original')),
+            CheckFailureValue(RuntimeError('original')),
             'why', f1='v')
 
     def test_err_with_params(self):

--- a/otter/test/utils.py
+++ b/otter/test/utils.py
@@ -751,19 +751,32 @@ def transform_eq(transformer, rhs):
     Return an object that can be compared to another object after transforming
     that other object.
 
+    The returned object will keep a log of equality checks done to it, and when
+    formatted as a string (with ``repr``), will show the history of transformed
+    objects and the ``rhs``.
+
     :param transformer: a function that takes the compared objects and returns
         a transformed version
     :param rhs: the actual data that should be compared with the result of
         transforming the compared object
     """
-    class Foo(object):
+    class TransformedEq(object):
+        def __init__(self):
+            self.comparisons = []
+
         def __eq__(self, other):
-            return transformer(other) == rhs
+            transformed = transformer(other)
+            self.comparisons.append(transformed)
+            return transformed == rhs
 
         def __ne__(self, other):
             return not self == other
 
-    return Foo()
+        def __repr__(self):
+            return "<TransformedEq comparisons=%r, operand=%r>" % (
+                self.comparisons, rhs)
+
+    return TransformedEq()
 
 
 def get_fake_service_request_performer(stub_response):


### PR DESCRIPTION
When LogErr was passed None, it wouldn't properly get the exception from the context, since the exception context was lost by the time the intent was performed. This changes the code so that LogErr checks if failure is None and explicitly creates a Failure object.

I also updated transform_eq to be a bit more useful when debugging - it now __repr__s to have a lot more useful information.