### PR TITLE
Add a mimic API for specifying sequenced behaviors

### DIFF
--- a/otter/integration/lib/autoscale.py
+++ b/otter/integration/lib/autoscale.py
@@ -49,7 +49,7 @@ def extract_active_ids(group_status):
 
 def create_scaling_group_dict(
     image_ref=None, flavor_ref=None, min_entities=0, name=None,
-    max_entities=25, use_lbs=None
+    max_entities=25, use_lbs=None, server_name=None
 ):
     """This function returns a dictionary containing a scaling group's JSON
     payload.  Note: this function does NOT create a scaling group.
@@ -71,6 +71,9 @@ def create_scaling_group_dict(
         ``otter.lib.CloudLoadBalancer``.  However, you can get the dicts by
         invoking the o.l.CLB.scaling_group_spec() method on such objects.  If
         not given, no load balancers will be used.
+    :param str server_name: Specifies a server name to autoscale - autoscale
+        will use this as the prefix of all server names created by the group.
+
     :return: A dictionary containing a scaling group JSON descriptor.  Inside,
         it will contain a default launch config with the provided (or assumed)
         flavor and image IDs.
@@ -102,8 +105,12 @@ def create_scaling_group_dict(
         "scalingPolicies": [],
     }
 
+    launch_config_args = obj["launchConfiguration"]["args"]
     if use_lbs:
-        obj["launchConfiguration"]["args"]["loadBalancers"] = use_lbs
+        launch_config_args["loadBalancers"] = use_lbs
+
+    if server_name is not None:
+        launch_config_args["server"]["name"] = server_name
 
     return obj
 

--- a/otter/integration/lib/mimic.py
+++ b/otter/integration/lib/mimic.py
@@ -15,6 +15,10 @@ from otter.util.http import check_success, headers
 class MimicNova(object):
     """
     Class that handles HTTP requests to the mimic nova control plane.
+
+    Please see the mimic control plane API
+    (:class:`mimic.rest.nova_api.NovaControlAPIRegion`) in the mimic
+    codebase for more information.
     """
     def change_server_statuses(self, rcs, ids_to_status):
         """
@@ -33,6 +37,38 @@ class MimicNova(object):
         return self.treq.post(
             "{0}/attributes".format(rcs.endpoints["mimic_nova"]),
             json.dumps({"status": ids_to_status}),
+            headers=headers(str(rcs.token)),
+            pool=self.pool
+        ).addCallback(check_success, [201]).addCallback(self.treq.content)
+
+    def sequenced_behaviors(self, rcs, criteria, behaviors,
+                            event_description="creation"):
+        """
+        Cause nova to fail sometimes or all the time, with a pre-determined
+        sequence of successes and/or failures.
+
+        :param rcs: A :class:`otter.integration.lib.resources.TestResources`
+            instance.
+        :param criteria: The criteria for the servers that should exhibit
+            this behavior.  See, in mimic the control plane API,
+            :func:`register_creation_behavior`, for more information.
+        :param behaviors:  A list of dictionaries containing the names of
+            creation behaviors parameters.
+            See, in the mimic codebase,
+            :func:`mimic.model.nova_objects.sequence` for more information.
+        :param event_description: Which event this sequence of behaviors
+            should apply to - the default event is server creation.
+        """
+        return self.treq.post(
+            "{0}/behaviors/{1}".format(rcs.endpoints['mimic_nova'],
+                                       event_description),
+            json.dumps({
+                "criteria": criteria,
+                "name": "sequence",
+                "parameters": {
+                    "behaviors": behaviors
+                }
+            }),
             headers=headers(str(rcs.token)),
             pool=self.pool
         ).addCallback(check_success, [201]).addCallback(self.treq.content)

--- a/otter/integration/lib/test_mimic.py
+++ b/otter/integration/lib/test_mimic.py
@@ -42,3 +42,24 @@ class MimicNovaTestCase(SynchronousTestCase):
         d = MimicNova(pool=self.pool, treq=_treq).change_server_statuses(
             self.rcs, {'id1': 'ERROR', 'id2': 'DELETED'})
         self.assertEqual('successful change response', self.successResultOf(d))
+
+    def test_sequenced_behaviors(self):
+        """
+        Cause a sequence of behaviors, and succeeds on 201.
+        """
+        criteria = [{"server_name": "name_criteria_.*"}]
+        behaviors = [{'name': "behavior name",
+                      'parameters': {"behavior": "params"}}]
+
+        _treq = get_fake_treq(
+            self, 'POST', "mimicnovaurl/behaviors/some_event",
+            ((json.dumps({'criteria': criteria,
+                          'name': "sequence",
+                          'parameters': {"behaviors": behaviors}}),),
+             self.expected_kwargs),
+            (Response(201), "successful behavior response"))
+
+        d = MimicNova(pool=self.pool, treq=_treq).sequenced_behaviors(
+            self.rcs, criteria, behaviors, event_description="some_event")
+        self.assertEqual('successful behavior response',
+                         self.successResultOf(d))


### PR DESCRIPTION
Also, take a server name in the creation json helper so that we can use the server name as the criteria to which we can apply behavior.

This is needed by #1433 