### PR TITLE
cron cooldown test fix

### DIFF
--- a/autoscale_cloudroast/test_repo/autoscale/system/schedule_policies/test_system_execute_scheduler_negative.py
+++ b/autoscale_cloudroast/test_repo/autoscale/system/schedule_policies/test_system_execute_scheduler_negative.py
@@ -71,14 +71,15 @@ class ExecuteNegativeSchedulerPolicy(AutoscaleFixture):
     @tags(speed='slow', convergence='yes')
     def test_cron_style_when_policy_cooldown_over_trigger_period(self):
         """
-        When policy cooldown is set to be greater than a minute by few seconds
+        When policy cooldown is set to be greater than a minute by
+        seconds that is greater than scheduler interval
         for a cron style policy that is set to trigger every minute, that
         policy is executed every other time.
         """
         group = self._create_group(cooldown=0)
         self.autoscale_behaviors.create_schedule_policy_given(
             group_id=group.id,
-            sp_cooldown=65,
+            sp_cooldown=60 + self.scheduler_interval + 5,
             sp_change=self.sp_change,
             schedule_cron='* * * * *')
         self.check_cooldown_over_trigger(group)
@@ -86,11 +87,12 @@ class ExecuteNegativeSchedulerPolicy(AutoscaleFixture):
     @tags(speed='slow', convergence='yes')
     def test_cron_style_when_group_cooldown_over_trigger_period(self):
         """
-        When group cooldown is set to be greater than a minute by few seconds
+        When group cooldown is set to be greater than a minute by
+        seconds that is greater than scheduler interval
         for a cron style policy that is set to trigger every minute, that
         policy is executed every other time.
         """
-        group = self._create_group(cooldown=65)
+        group = self._create_group(cooldown=60 + self.scheduler_interval + 5)
         self.autoscale_behaviors.create_schedule_policy_given(
             group_id=group.id,
             sp_cooldown=0,

--- a/autoscale_cloudroast/test_repo/autoscale/system/schedule_policies/test_system_execute_scheduler_negative.py
+++ b/autoscale_cloudroast/test_repo/autoscale/system/schedule_policies/test_system_execute_scheduler_negative.py
@@ -71,10 +71,9 @@ class ExecuteNegativeSchedulerPolicy(AutoscaleFixture):
     @tags(speed='slow', convergence='yes')
     def test_cron_style_when_policy_cooldown_over_trigger_period(self):
         """
-        When policy cooldown is set to be greater than a minute by
-        seconds that is greater than scheduler interval
-        for a cron style policy that is set to trigger every minute, that
-        policy is executed every other time.
+        When policy cooldown is set to be greater than
+        (a minute + scheduler interval) by a few seconds for an every minute
+        cron style policy, then that policy is executed every other minute.
         """
         group = self._create_group(cooldown=0)
         self.autoscale_behaviors.create_schedule_policy_given(
@@ -87,10 +86,9 @@ class ExecuteNegativeSchedulerPolicy(AutoscaleFixture):
     @tags(speed='slow', convergence='yes')
     def test_cron_style_when_group_cooldown_over_trigger_period(self):
         """
-        When group cooldown is set to be greater than a minute by
-        seconds that is greater than scheduler interval
-        for a cron style policy that is set to trigger every minute, that
-        policy is executed every other time.
+        When group cooldown is set to be greater than
+        (a minute + scheduler interval) by a few seconds for an every minute
+        cron style policy, then that policy is executed every other minute.
         """
         group = self._create_group(cooldown=60 + self.scheduler_interval + 5)
         self.autoscale_behaviors.create_schedule_policy_given(


### PR DESCRIPTION
The below test failed sometimes because policy could get triggered after 65 seconds. This can happen if policy executed at beginning of minute and next execution happened at next minute's 10s due to scheduler processing events every 10s. Now, changed the cooldown to be higher than minute + scheduler interval