### PR TITLE
reactivate group when convergence completes

### DIFF
--- a/otter/test/convergence/test_service.py
+++ b/otter/test/convergence/test_service.py
@@ -787,7 +787,7 @@ class ExecuteConvergenceTests(SynchronousTestCase):
     def test_reactivate_group_on_success(self):
         """
         When the group started in ERROR state, and convergence succeeds, the
-        group is put back into SUCCESS.
+        group is put back into ACTIVE.
         """
         gacd = self._get_gacd_func(self.group.uuid)
         self.manifest['state'].status = ScalingGroupStatus.ERROR

--- a/otter/test/convergence/test_service.py
+++ b/otter/test/convergence/test_service.py
@@ -784,6 +784,35 @@ class ExecuteConvergenceTests(SynchronousTestCase):
         with sequence.consume():
             self.assertEqual(sync_perform(dispatcher, eff), StepResult.FAILURE)
 
+    def test_reactivate_group_on_success(self):
+        """
+        When the group started in ERROR state, and convergence succeeds, the
+        group is put back into SUCCESS.
+        """
+        gacd = self._get_gacd_func(self.group.uuid)
+        self.manifest['state'].status = ScalingGroupStatus.ERROR
+
+        def plan(*args, **kwargs):
+            return pbag([TestStep(Effect(Constant((StepResult.SUCCESS, []))))])
+
+        eff = execute_convergence(self.tenant_id, self.group_id,
+                                  plan=plan,
+                                  get_all_convergence_data=gacd)
+
+        sequence = SequenceDispatcher([
+            (self.gsgi, lambda i: self.gsgi_result),
+            (Log(msg='execute-convergence', fields=mock.ANY), noop),
+            (ModifyGroupState(scaling_group=self.group, modifier=mock.ANY),
+             noop),
+            (Log(msg='execute-convergence-results', fields=mock.ANY), noop),
+            (UpdateGroupStatus(scaling_group=self.group,
+                               status=ScalingGroupStatus.ACTIVE),
+             noop),
+        ])
+        dispatcher = ComposedDispatcher([sequence, test_dispatcher()])
+        with sequence.consume():
+            self.assertEqual(sync_perform(dispatcher, eff), StepResult.SUCCESS)
+
 
 class DetermineActiveTests(SynchronousTestCase):
     """Tests for :func:`determine_active`."""


### PR DESCRIPTION
As described in #885 -- when convergence completes with SUCCESS, put the group back into ACTIVE (if it was in ERROR).