### PR TITLE
Group status change logs to cloud feeds

### DIFF
--- a/otter/convergence/service.py
+++ b/otter/convergence/service.py
@@ -32,7 +32,7 @@ from otter.convergence.effecting import steps_to_effect
 from otter.convergence.gathering import get_all_convergence_data
 from otter.convergence.model import ServerState, StepResult
 from otter.convergence.planning import plan
-from otter.log.cloudfeeds import cf_msg
+from otter.log.cloudfeeds import cf_err, cf_msg
 from otter.log.intents import err, msg, with_log
 from otter.models.intents import (
     DeleteGroup, GetScalingGroupInfo, ModifyGroupState, UpdateGroupStatus)
@@ -154,7 +154,7 @@ def execute_convergence(tenant_id, group_id,
     elif worst_status == StepResult.FAILURE:
         yield Effect(UpdateGroupStatus(scaling_group=scaling_group,
                                        status=ScalingGroupStatus.ERROR))
-        yield cf_msg(
+        yield cf_err(
             'group-status-error', status=ScalingGroupStatus.ERROR.name)
 
     yield do_return(worst_status)

--- a/otter/convergence/service.py
+++ b/otter/convergence/service.py
@@ -155,22 +155,9 @@ def execute_convergence(tenant_id, group_id,
         yield Effect(UpdateGroupStatus(scaling_group=scaling_group,
                                        status=ScalingGroupStatus.ERROR))
         yield cf_msg(
-            'group-status-error', status=ScalingGroupStatus.ERROR.name,
-            reasons=','.join(worst_reasons_from_sorted_results(priority)))
+            'group-status-error', status=ScalingGroupStatus.ERROR.name)
 
     yield do_return(worst_status)
-
-
-def worst_reasons_from_sorted_results(results):
-    """
-    Return worst reasons from list of results sorted based on severity of
-    StepResults
-    """
-    for result, reasons in results:
-        if result == StepResult.FAILURE:
-            yield ','.join(reasons)
-        else:
-            return
 
 
 def format_dirty_flag(tenant_id, group_id):

--- a/otter/log/cloudfeeds.py
+++ b/otter/log/cloudfeeds.py
@@ -19,7 +19,7 @@ from otter.constants import ServiceType
 from otter.effect_dispatcher import get_full_dispatcher
 from otter.log import log as otter_log
 from otter.log.formatters import PEP3101FormattingWrapper
-from otter.log.intents import msg as msg_effect
+from otter.log.intents import err as err_effect, msg as msg_effect
 from otter.util.http import append_segments
 from otter.util.pure_http import has_code
 from otter.util.retry import (
@@ -56,14 +56,14 @@ def cf_msg(msg, **fields):
     return msg_effect(msg, cloud_feed=True, **fields)
 
 
-def cf_err_no_failure(msg, **fields):
+def cf_err(msg, **fields):
     """
     Log cloud feed error event without failure
     """
     return msg_effect(msg, isError=True, cloud_feed=True, **fields)
 
 
-def cf_err(failure, msg, **fields):
+def cf_fail(failure, msg, **fields):
     """
     Log cloud feed error event with failure
     """

--- a/otter/log/cloudfeeds.py
+++ b/otter/log/cloudfeeds.py
@@ -56,6 +56,20 @@ def cf_msg(msg, **fields):
     return msg_effect(msg, cloud_feed=True, **fields)
 
 
+def cf_err_no_failure(msg, **fields):
+    """
+    Log cloud feed error event without failure
+    """
+    return msg_effect(msg, isError=True, cloud_feed=True, **fields)
+
+
+def cf_err(failure, msg, **fields):
+    """
+    Log cloud feed error event with failure
+    """
+    return err_effect(failure, msg, cloud_feed=True, **fields)
+
+
 def sanitize_event(event):
     """
     Sanitize event by removing all items except the ones in autoscale schema.

--- a/otter/log/cloudfeeds.py
+++ b/otter/log/cloudfeeds.py
@@ -19,6 +19,7 @@ from otter.constants import ServiceType
 from otter.effect_dispatcher import get_full_dispatcher
 from otter.log import log as otter_log
 from otter.log.formatters import PEP3101FormattingWrapper
+from otter.log.intents import msg as msg_effect
 from otter.util.http import append_segments
 from otter.util.pure_http import has_code
 from otter.util.retry import (
@@ -46,6 +47,13 @@ log_cf_mapping = {
     "current_capacity": "currentCapacity",
     "message": "message"
 }
+
+
+def cf_msg(msg, **fields):
+    """
+    Helper function to log cloud feeds event
+    """
+    return msg_effect(msg, cloud_feed=True, **fields)
 
 
 def sanitize_event(event):

--- a/otter/log/spec.py
+++ b/otter/log/spec.py
@@ -21,8 +21,7 @@ msg_types = {
     "execute-convergence-results": (
         "Got result of {worst_status} after executing convergence"),
     "group-status-active": "Group has become ACTIVE",
-    "group-status-error": ("Group's status is changed to ERROR "
-                           "due to {reasons}"),
+    "group-status-error": "Group's status is changed to ERROR",
     "launch-servers": "Launching {num_servers} servers",
     "mark-clean-success": "Marked group {scaling_group_id} clean",
     "mark-clean-failure": "Failed to mark group {scaling_group_id} clean",

--- a/otter/log/spec.py
+++ b/otter/log/spec.py
@@ -20,6 +20,9 @@ msg_types = {
     "execute-convergence": "Executing convergence",
     "execute-convergence-results": (
         "Got result of {worst_status} after executing convergence"),
+    "group-status-active": "Group has become ACTIVE",
+    "group-status-error": ("Group's status is changed to ERROR "
+                           "due to {reasons}"),
     "launch-servers": "Launching {num_servers} servers",
     "mark-clean-success": "Marked group {scaling_group_id} clean",
     "mark-clean-failure": "Failed to mark group {scaling_group_id} clean",

--- a/otter/log/spec.py
+++ b/otter/log/spec.py
@@ -20,7 +20,7 @@ msg_types = {
     "execute-convergence": "Executing convergence",
     "execute-convergence-results": (
         "Got result of {worst_status} after executing convergence"),
-    "group-status-active": "Group has become ACTIVE",
+    "group-status-active": "Group's status is changed to ACTIVE",
     "group-status-error": "Group's status is changed to ERROR",
     "launch-servers": "Launching {num_servers} servers",
     "mark-clean-success": "Marked group {scaling_group_id} clean",

--- a/otter/test/convergence/test_service.py
+++ b/otter/test/convergence/test_service.py
@@ -779,7 +779,8 @@ class ExecuteConvergenceTests(SynchronousTestCase):
             (UpdateGroupStatus(scaling_group=self.group,
                                status=ScalingGroupStatus.ERROR),
              noop),
-            (Log('group-status-error', dict(cloud_feed=True, status='ERROR')),
+            (Log('group-status-error', dict(isError=True, cloud_feed=True,
+                                            status='ERROR')),
              noop)
         ])
         dispatcher = ComposedDispatcher([sequence, test_dispatcher()])

--- a/otter/test/convergence/test_service.py
+++ b/otter/test/convergence/test_service.py
@@ -762,8 +762,9 @@ class ExecuteConvergenceTests(SynchronousTestCase):
                 TestStep(Effect(Constant((StepResult.SUCCESS, [])))),
                 ConvergeLater(reasons=['mywish']),
                 TestStep(Effect(Constant((StepResult.SUCCESS, [])))),
-                TestStep(Effect(Constant((StepResult.FAILURE, [])))),
+                TestStep(Effect(Constant((StepResult.FAILURE, ['bad'])))),
                 TestStep(Effect(Constant((StepResult.SUCCESS, [])))),
+                TestStep(Effect(Constant((StepResult.FAILURE, ['morebad']))))
             ])
 
         eff = execute_convergence(self.tenant_id, self.group_id,
@@ -779,6 +780,9 @@ class ExecuteConvergenceTests(SynchronousTestCase):
             (UpdateGroupStatus(scaling_group=self.group,
                                status=ScalingGroupStatus.ERROR),
              noop),
+            (Log('group-status-error',
+                 dict(cloud_feed=True, status='ERROR', reasons='morebad,bad')),
+             noop)
         ])
         dispatcher = ComposedDispatcher([sequence, test_dispatcher()])
         with sequence.consume():
@@ -808,6 +812,8 @@ class ExecuteConvergenceTests(SynchronousTestCase):
             (UpdateGroupStatus(scaling_group=self.group,
                                status=ScalingGroupStatus.ACTIVE),
              noop),
+            (Log('group-status-active',
+                 dict(cloud_feed=True, status='ACTIVE')), noop)
         ])
         dispatcher = ComposedDispatcher([sequence, test_dispatcher()])
         with sequence.consume():

--- a/otter/test/convergence/test_service.py
+++ b/otter/test/convergence/test_service.py
@@ -763,8 +763,7 @@ class ExecuteConvergenceTests(SynchronousTestCase):
                 ConvergeLater(reasons=['mywish']),
                 TestStep(Effect(Constant((StepResult.SUCCESS, [])))),
                 TestStep(Effect(Constant((StepResult.FAILURE, ['bad'])))),
-                TestStep(Effect(Constant((StepResult.SUCCESS, [])))),
-                TestStep(Effect(Constant((StepResult.FAILURE, ['morebad']))))
+                TestStep(Effect(Constant((StepResult.SUCCESS, []))))
             ])
 
         eff = execute_convergence(self.tenant_id, self.group_id,
@@ -780,8 +779,7 @@ class ExecuteConvergenceTests(SynchronousTestCase):
             (UpdateGroupStatus(scaling_group=self.group,
                                status=ScalingGroupStatus.ERROR),
              noop),
-            (Log('group-status-error',
-                 dict(cloud_feed=True, status='ERROR', reasons='morebad,bad')),
+            (Log('group-status-error', dict(cloud_feed=True, status='ERROR')),
              noop)
         ])
         dispatcher = ComposedDispatcher([sequence, test_dispatcher()])

--- a/otter/test/log/test_cloudfeeds.py
+++ b/otter/test/log/test_cloudfeeds.py
@@ -20,16 +20,54 @@ from otter.log.cloudfeeds import (
     CloudFeedsObserver,
     UnsuitableMessage,
     add_event,
+    cf_err, cf_fail, cf_msg,
     prepare_request,
     request_format,
     sanitize_event
 )
+from otter.log.intents import Log, LogErr
 from otter.test.utils import CheckFailure, mock_log, resolve_effect
 from otter.util.retry import (
     ShouldDelayAndRetry,
     exponential_backoff_interval,
     retry_times
 )
+
+
+class CFHelperTests(SynchronousTestCase):
+    """
+    Tests for cf_* functions
+    """
+
+    def test_cf_msg(self):
+        """
+        `cf_msg` returns Effect with `Log` intent with cloud_feed=True
+        """
+        self.assertEqual(
+            cf_msg('message', a=2, b=3),
+            Effect(Log('message', dict(cloud_feed=True, a=2, b=3)))
+        )
+
+    def test_cf_err(self):
+        """
+        `cf_err` returns Effect with `Log` intent with cloud_feed=True
+        and isError=True
+        """
+        self.assertEqual(
+            cf_err('message', a=2, b=3),
+            Effect(Log('message', dict(isError=True, cloud_feed=True,
+                                       a=2, b=3)))
+        )
+
+    def test_cf_fail(self):
+        """
+        `cf_err` returns Effect with `LogErr` intent with cloud_feed=True
+        """
+        f = object()
+        self.assertEqual(
+            cf_fail(f, 'message', a=2, b=3),
+            Effect(LogErr(f, 'message', dict(cloud_feed=True, a=2, b=3)))
+        )
 
 
 def sample_event_pair():


### PR DESCRIPTION
Adding logs to cloud feeds when group status is changed after executing convergence. Currently, the code just combines all steps' all reasons as comma separated string for the event message which may not be the best thing to do. Would like other's opinions about it.