### PR TITLE
Combine the two helper functions that disable servers OOB

### DIFF
--- a/otter/integration/tests/test_convergence.py
+++ b/otter/integration/tests/test_convergence.py
@@ -447,6 +447,9 @@ def _oob_disable_then(helper, rcs, num_to_disable, disabler, then,
         out with the minimum number of servers. If provided, immediately after
         creation the group will be scaled to this number before any deletions
         or other scaling occurs.
+    :param int final_servers: The number of servers to expect at the end as
+        both active and desired servers.  If not passed, defaults to the
+        number of desired servers, or min servers.
 
     :return: The scaling group that was created and tested.
     """

--- a/otter/integration/tests/test_convergence.py
+++ b/otter/integration/tests/test_convergence.py
@@ -477,59 +477,50 @@ class TestConvergence(unittest.TestCase):
             for _id in ids]).addCallback(lambda _: rcs)
 
 
-def _test_scaling_after_oobd(
-        helper, rcs, min_servers=0, max_servers=25,
-        set_to_servers=None, oobd_servers=0, scale_servers=1,
-        converged_servers=0, scale_should_fail=False):
-    """
-    Helper function that creates a scaling group and sets the desired capacity
-    to a certain number.  Then OOB-deletes some number of servers and scales.
-    Then it waits for some number of servers to be active.
-    """
-    scaling_group = helper.create_group(
-        image_ref=image_ref, flavor_ref=flavor_ref,
-        min_entities=min_servers, max_entities=max_servers
-    )
-
-    policy_scale = ScalingPolicy(
-        scale_by=scale_servers,
-        scaling_group=scaling_group
-    )
-
-    return (
-        helper.start_group_and_wait(scaling_group, rcs,
-                                    desired=set_to_servers)
-        .addCallback(policy_scale.start, helper.test_case)
-        .addCallback(
-            helper.oob_delete_then(
-                rcs, scaling_group, oobd_servers)(policy_scale.execute),
-            success_codes=(
-                [403] if scale_should_fail else [202]))
-        .addCallback(lambda _: scaling_group.wait_for_state(
-            rcs, MatchesAll(
-                HasActive(converged_servers),
-                ContainsDict({
-                    'pendingCapacity': Equals(0),
-                    'desiredCapacity': Equals(converged_servers)
-                })
-            ), timeout=600)
-        )
-        .addCallback(lambda _: scaling_group)
-    )
-
-
 @inlineCallbacks
-def _test_error_active_and_converge(
-        helper, rcs, num_to_error, scale_by=0,
-        min_servers=0, max_servers=25, desired_servers=None):
+def _oob_disable_then(helper, rcs, num_to_disable, disabler, then,
+                      min_servers=0, max_servers=25, desired_servers=None,
+                      final_servers=None):
     """
-    Helper function that creates a scaling group and sets the desired capacity
-    to a certain number.  It waits for those servers to become active.  Once
-    active, uses Mimic to error those servers.
+    Helper function that tests that convergence will heal out-of-band disabling
+    of servers, whether by deletion, or errors.
 
-    It then either scales up or down (or just triggers convergence, based on
-    the scale_by number), and waits for the final number of servers to
-    stabilize and for the errored servers to be deleted.
+    1.  Creates a scaling group with the given min and max entities.
+    2.  If ``desired_servers`` is provided, sets the desired capacity to
+        ``desired_servers`` using a scaling policy.
+    3.  Waits for those servers (either ``desired_servers`` or ``min_servers``
+        to become active and added to any load balancers.
+    4.  Disable ``num_to_disable`` random servers using the provided function,
+        ``disabler``.
+    5.  Executes the function provided by the parameter ``then``.
+    6.  Waits for:
+        - ``final_servers`` active servers that are all on the requisite load
+          balancers.
+        - the disabled servers to have been removed from the active server list
+        - the disabled servers to have been removed from any load balancers
+        - the group to be in ACTIVE state
+
+    :param TestHelper helper: An instance of :class:`TestHelper`
+    :param TestResources rcs: An instance of
+        :class:`otter.integration.lib.resources.TestResources`
+    :param int num_to_disable: How many servers to out-of-band disable.
+    :param callable disabler: Function that takes the helper, rcs, and an
+        iterable of server IDs, and disables them somehow, either by deleting
+        them, erroring them, or disassociating them from the group.
+    :param callable then: Function that takes a helper, RCS, and group, and
+        does something (such as scale up or trigger convergence).
+
+    :param int min_servers: The min entities for the scaling group - defaults
+        to zero.
+    :param int max_servers: The min entities for the scaling group - defaults
+        to 25.
+    :param int desired_servers: The initial desired capacity of the scaling
+        group.  If not provided, by default, the scaling group will just start
+        out with the minimum number of servers. If provided, immediately after
+        creation the group will be scaled to this number before any deletions
+        or other scaling occurs.
+
+    :return: The scaling group that was created and tested.
     """
     scaling_group = helper.create_group(
         image_ref=image_ref, flavor_ref=flavor_ref,
@@ -539,35 +530,28 @@ def _test_error_active_and_converge(
     yield helper.start_group_and_wait(scaling_group, rcs,
                                       desired=desired_servers)
 
-    to_error = yield scaling_group.choose_random_servers(rcs, num_to_error)
+    to_disable = yield scaling_group.choose_random_servers(rcs, num_to_disable)
 
     ips = {}
     if helper.clbs:
-        ips = yield scaling_group.get_servicenet_ips(rcs, to_error)
+        ips = yield scaling_group.get_servicenet_ips(rcs, to_disable)
 
-    # cause mimic to error the chosen servers
-    yield MimicNova(pool=helper.pool).change_server_statuses(
-        rcs, {server_id: "ERROR" for server_id in to_error})
+    yield disabler(helper, rcs, to_disable)
+    yield then(helper, rcs, scaling_group)
 
-    if scale_by == 0:
-        yield scaling_group.trigger_convergence(rcs)
-    else:
-        p = ScalingPolicy(scale_by=scale_by, scaling_group=scaling_group)
-        yield p.start(rcs, helper.test_case)
-        yield p.execute(rcs)
-
-    if desired_servers is None:
-        desired_servers = min_servers
+    if final_servers is None:
+        final_servers = (
+            min_servers if desired_servers is None else desired_servers)
 
     end_state = [scaling_group.wait_for_state(
         rcs,
         MatchesAll(
-            HasActive(desired_servers + scale_by),
+            HasActive(final_servers),
             ContainsDict({
                 'pendingCapacity': Equals(0),
-                'desiredCapacity': Equals(desired_servers + scale_by)
+                'desiredCapacity': Equals(final_servers)
             }),
-            ExcludesServers(to_error)
+            ExcludesServers(to_disable)
         ),
         timeout=600
     )]
@@ -579,6 +563,49 @@ def _test_error_active_and_converge(
 
     yield gatherResults(end_state)
     returnValue(scaling_group)
+
+
+def _deleter(helper, rcs, server_ids):
+    """
+    A disabler function to be passed to :func:`_oob_disable_then` that deletes
+    the servers out of band.
+    """
+    return delete_servers(server_ids, rcs, pool=helper.pool)
+
+
+def _errorer(helper, rcs, server_ids):
+    """
+    A disabler function to be passed to :func:`_oob_disable_then` that invokes
+    Mimic to set the server statuses to "ERROR"
+    """
+    return MimicNova(pool=helper.pool).change_server_statuses(
+        rcs, {server_id: "ERROR" for server_id in server_ids})
+
+
+def _scale_by(number, should_fail=False):
+    """
+    A helper function that creates a scaling policy and scales by the given
+    number, if the number is not zero.  Otherwise, just triggers convergence.
+
+    :param int number: The number to scale by.
+    :param bool should_fail: Whether or not the policy execution should fail.
+    :return: A function that can be passed to :func:`_oob_disable_then` as the
+        ``then`` parameter.
+    """
+    def _then(helper, rcs, group):
+        policy = ScalingPolicy(scale_by=number, scaling_group=group)
+        return (policy.start(rcs, helper.test_case)
+                .addCallback(policy.execute,
+                             success_codes=[403] if should_fail else [202]))
+    return _then
+
+
+def _converge(helper, rcs, group):
+    """
+    Function to be passed to :func:`_oob_disable_then` as the ``then``
+    parameter that triggers convergence.
+    """
+    return group.trigger_convergence(rcs)
 
 
 class ConvergenceSet1(unittest.TestCase):
@@ -655,9 +682,9 @@ class ConvergenceSet1(unittest.TestCase):
         by, say, two servers.  If convergence is working as expected, we expect
         five servers at the end.
         """
-        return _test_scaling_after_oobd(
-            self.helper, self.rcs, min_servers=3, oobd_servers=1,
-            scale_servers=2, converged_servers=5)
+        return _oob_disable_then(
+            self.helper, self.rcs, num_to_disable=1, disabler=_deleter,
+            then=_scale_by(2), min_servers=3, final_servers=5)
 
     @tag("CATC-006")
     def test_scale_down_after_oobd_non_constrained_z_lessthan_y(self):
@@ -684,9 +711,10 @@ class ConvergenceSet1(unittest.TestCase):
         z = 2
         y = -3
 
-        return _test_scaling_after_oobd(
-            self.helper, self.rcs, min_servers=N, set_to_servers=x,
-            oobd_servers=z, scale_servers=y, converged_servers=(x + y))
+        return _oob_disable_then(
+            self.helper, self.rcs, num_to_disable=z, disabler=_deleter,
+            then=_scale_by(y), min_servers=N, desired_servers=x,
+            final_servers=(x + y))
 
     @tag("CATC-006")
     def test_scale_down_after_oobd_non_constrained_z_greaterthan_y(self):
@@ -713,9 +741,10 @@ class ConvergenceSet1(unittest.TestCase):
         z = 3
         y = -2
 
-        return _test_scaling_after_oobd(
-            self.helper, self.rcs, min_servers=N, set_to_servers=x,
-            oobd_servers=z, scale_servers=y, converged_servers=(x + y))
+        return _oob_disable_then(
+            self.helper, self.rcs, num_to_disable=z, disabler=_deleter,
+            then=_scale_by(y), min_servers=N, desired_servers=x,
+            final_servers=(x + y))
 
     @tag("CATC-006")
     def test_scale_down_after_oobd_non_constrained_z_equal_y(self):
@@ -742,9 +771,10 @@ class ConvergenceSet1(unittest.TestCase):
         z = 3
         y = -3
 
-        return _test_scaling_after_oobd(
-            self.helper, self.rcs, min_servers=N, set_to_servers=x,
-            oobd_servers=z, scale_servers=y, converged_servers=(x + y))
+        return _oob_disable_then(
+            self.helper, self.rcs, num_to_disable=z, disabler=_deleter,
+            then=_scale_by(y), min_servers=N, desired_servers=x,
+            final_servers=(x + y))
 
     @tag("CATC-007")
     def test_scale_up_after_oobd_at_group_max(self):
@@ -767,10 +797,11 @@ class ConvergenceSet1(unittest.TestCase):
         z = 2
         y = 5
 
-        return _test_scaling_after_oobd(
-            self.helper, self.rcs, set_to_servers=x, oobd_servers=z,
-            max_servers=max_servers, scale_servers=y,
-            converged_servers=max_servers, scale_should_fail=True)
+        return _oob_disable_then(
+            self.helper, self.rcs, num_to_disable=z, disabler=_deleter,
+            then=_scale_by(y, should_fail=True),
+            max_servers=max_servers, desired_servers=x,
+            final_servers=max_servers)
 
     @tag("CATC-007")
     def test_scale_down_past_group_min_after_oobd(self):
@@ -792,10 +823,10 @@ class ConvergenceSet1(unittest.TestCase):
         z = 2
         y = -2
 
-        return _test_scaling_after_oobd(
-            self.helper, self.rcs, oobd_servers=z, min_servers=min_servers,
-            scale_servers=y, converged_servers=min_servers,
-            scale_should_fail=True)
+        return _oob_disable_then(
+            self.helper, self.rcs, num_to_disable=z, disabler=_deleter,
+            then=_scale_by(y, should_fail=True),
+            min_servers=min_servers, final_servers=min_servers)
 
     @tag("CATC-008")
     def test_group_config_update_triggers_convergence(self):
@@ -838,9 +869,9 @@ class ConvergenceSet1(unittest.TestCase):
         4. Assert that there should be M active servers on the group, and
            that the active servers do not include the ones that errored.
         """
-        return _test_error_active_and_converge(
-            self.helper, self.rcs, num_to_error=1, scale_by=2,
-            min_servers=2, max_servers=4)
+        return _oob_disable_then(
+            self.helper, self.rcs, num_to_disable=1, disabler=_errorer,
+            then=_scale_by(2), min_servers=2, max_servers=4, final_servers=4)
 
     @tag("CATC-012")
     def test_scale_down_after_servers_error_from_active(self):
@@ -856,9 +887,10 @@ class ConvergenceSet1(unittest.TestCase):
         4. Assert that there should be N active servers on the group, and
            that the active servers do not include the ones that errored.
         """
-        return _test_error_active_and_converge(
-            self.helper, self.rcs, num_to_error=2, scale_by=-1,
-            min_servers=2, max_servers=4, desired_servers=3)
+        return _oob_disable_then(
+            self.helper, self.rcs, num_to_disable=2, disabler=_errorer,
+            then=_scale_by(-1), min_servers=2, max_servers=4,
+            desired_servers=3, final_servers=2)
 
     @tag("CATC-013")
     def test_trigger_convergence_after_servers_error_from_active(self):
@@ -874,9 +906,10 @@ class ConvergenceSet1(unittest.TestCase):
         4. Assert that there should be X active servers on the group, and
            that the active servers do not include the ones that errored.
         """
-        return _test_error_active_and_converge(
-            self.helper, self.rcs, num_to_error=2, scale_by=0,
-            min_servers=2, max_servers=4, desired_servers=3)
+        return _oob_disable_then(
+            self.helper, self.rcs, num_to_disable=2, disabler=_errorer,
+            then=_converge, min_servers=2, max_servers=4,
+            desired_servers=3, final_servers=3)
 
 
 def _catc_tags(start_num, end_num):

--- a/otter/integration/tests/test_convergence.py
+++ b/otter/integration/tests/test_convergence.py
@@ -329,6 +329,7 @@ class TestConvergence(unittest.TestCase):
             )
         )
 
+    @skip_me("Autoscale does not clean up servers deleted OOB yet. See #881.")
     def test_scaling_to_clb_max_after_oob_delete_type1(self):
         """
         CATC-015-a
@@ -347,6 +348,7 @@ class TestConvergence(unittest.TestCase):
         """
         return self._perform_oobd_clb_test(25)
 
+    @skip_me("Autoscale does not clean up servers deleted OOB yet. See #881.")
     def test_scaling_to_clb_max_after_oob_delete_type2(self):
         """
         CATC-015-b
@@ -370,6 +372,7 @@ class TestConvergence(unittest.TestCase):
 
         def create_clb_first():
             self.clb = CloudLoadBalancer(pool=self.helper.pool)
+            self.helper.clbs = [self.clb]
             return (
                 self.identity.authenticate_user(
                     rcs,


### PR DESCRIPTION
This also ensures checking the final state of the group in several tests that weren't before.

This also uses a `then` parameter for the `_oob_disable_then` function - thanks @sam-falvo and @kivattik 

Fixes #1442.