### PR TITLE
removed unnecessary wait_for_exp..building_servers

### DIFF
--- a/autoscale_cloudroast/test_repo/autoscale/system/policies/test_system_execute_webhook_scaledown.py
+++ b/autoscale_cloudroast/test_repo/autoscale/system/policies/test_system_execute_webhook_scaledown.py
@@ -33,6 +33,11 @@ class ScalingDownExecuteWebhookTest(AutoscaleFixture):
             self.group.id,
             self.servers_before_scaledown)
 
+    def _wait_for_group_and_servers(self, servers):
+        self.wait_for_expected_group_state(self.group.id, servers)
+        self.assert_servers_deleted_successfully(
+            self.group.launchConfiguration.server.name, servers)
+
     @tags(speed='slow', convergence='yes')
     def test_system_execute_webhook_scale_down_change(self):
         """
@@ -48,8 +53,7 @@ class ScalingDownExecuteWebhookTest(AutoscaleFixture):
                 execute_webhook=True)
         self.assertEquals(execute_scale_down_webhook[
                           'execute_response'], 202)
-        self.assert_servers_deleted_successfully(
-            self.group.launchConfiguration.server.name,
+        self._wait_for_group_and_servers(
             self.group.groupConfiguration.minEntities)
 
     @tags(speed='slow', convergence='yes')
@@ -69,9 +73,7 @@ class ScalingDownExecuteWebhookTest(AutoscaleFixture):
             current=self.group.groupConfiguration.minEntities +
             self.policy_up['change'],
             percentage=policy_down['change_percent'])
-        self.assert_servers_deleted_successfully(
-            self.group.launchConfiguration.server.name,
-            servers_from_scale_down)
+        self._wait_for_group_and_servers(servers_from_scale_down)
 
     @tags(speed='slow', convergence='yes')
     def test_system_execute_webhook_scale_down_desired_capacity(self):
@@ -88,6 +90,4 @@ class ScalingDownExecuteWebhookTest(AutoscaleFixture):
                 execute_webhook=True)
         self.assertEquals(execute_webhook_desired_capacity[
                           'execute_response'], 202)
-        self.assert_servers_deleted_successfully(
-            self.group.launchConfiguration.server.name,
-            policy_down['desired_capacity'])
+        self._wait_for_group_and_servers(policy_down['desired_capacity'])

--- a/autoscale_cloudroast/test_repo/autoscale/system/policies/test_system_execute_webhook_scaledown.py
+++ b/autoscale_cloudroast/test_repo/autoscale/system/policies/test_system_execute_webhook_scaledown.py
@@ -7,7 +7,6 @@ from test_repo.autoscale.fixtures import AutoscaleFixture
 
 
 class ScalingDownExecuteWebhookTest(AutoscaleFixture):
-
     """
     System tests to verify execute scaling policies scenarios
     """
@@ -49,9 +48,6 @@ class ScalingDownExecuteWebhookTest(AutoscaleFixture):
                 execute_webhook=True)
         self.assertEquals(execute_scale_down_webhook[
                           'execute_response'], 202)
-        self.check_for_expected_number_of_building_servers(
-            self.group.id,
-            self.group.groupConfiguration.minEntities)
         self.assert_servers_deleted_successfully(
             self.group.launchConfiguration.server.name,
             self.group.groupConfiguration.minEntities)
@@ -73,8 +69,6 @@ class ScalingDownExecuteWebhookTest(AutoscaleFixture):
             current=self.group.groupConfiguration.minEntities +
             self.policy_up['change'],
             percentage=policy_down['change_percent'])
-        self.check_for_expected_number_of_building_servers(
-            self.group.id, servers_from_scale_down)
         self.assert_servers_deleted_successfully(
             self.group.launchConfiguration.server.name,
             servers_from_scale_down)
@@ -94,8 +88,6 @@ class ScalingDownExecuteWebhookTest(AutoscaleFixture):
                 execute_webhook=True)
         self.assertEquals(execute_webhook_desired_capacity[
                           'execute_response'], 202)
-        self.check_for_expected_number_of_building_servers(
-            self.group.id, policy_down['desired_capacity'])
         self.assert_servers_deleted_successfully(
             self.group.launchConfiguration.server.name,
             policy_down['desired_capacity'])


### PR DESCRIPTION
since the next line `assert_servers_deleted` is checking for number of servers in the account anyways. Also, above wait_* function was not checking for servers for a long time causing tests to fail in prod sometimes since it takes time to delete servers sometimes.