### PR TITLE
cloudfeeds observer chain

### DIFF
--- a/otter/log/cloudfeeds.py
+++ b/otter/log/cloudfeeds.py
@@ -21,8 +21,8 @@ from otter.constants import ServiceType
 from otter.effect_dispatcher import get_full_dispatcher
 from otter.log import log as otter_log
 from otter.log.formatters import (
-    ErrorFormattingWrapper, LogLevel, PEP3101FormattingWrapper,
-    SpecificationObserverWrapper)
+    ErrorFormattingWrapper, LogLevel, PEP3101FormattingWrapper)
+from otter.log.spec import SpecificationObserverWrapper
 from otter.util.http import append_segments
 from otter.util.pure_http import has_code
 from otter.util.retry import (

--- a/otter/log/cloudfeeds.py
+++ b/otter/log/cloudfeeds.py
@@ -22,8 +22,8 @@ from otter.effect_dispatcher import get_full_dispatcher
 from otter.log import log as otter_log
 from otter.log.formatters import (
     ErrorFormattingWrapper, LogLevel, PEP3101FormattingWrapper)
-from otter.log.spec import SpecificationObserverWrapper
 from otter.log.intents import err as err_effect, msg as msg_effect
+from otter.log.spec import SpecificationObserverWrapper
 from otter.util.http import append_segments
 from otter.util.pure_http import has_code
 from otter.util.retry import (

--- a/otter/log/cloudfeeds.py
+++ b/otter/log/cloudfeeds.py
@@ -12,8 +12,6 @@ from effect import Effect, Func
 
 from toolz.dicttoolz import keyfilter
 
-from twisted.python.log import addObserver
-
 from txeffect import perform
 
 from otter.cloud_client import TenantScope, service_request
@@ -198,15 +196,14 @@ class CloudFeedsObserver(object):
                 eff).addErrback(log.err, 'cf-add-failure')
 
 
-def add_cf_observer(reactor, authenticator, tenant_id, region,
+def get_cf_observer(reactor, authenticator, tenant_id, region,
                     service_configs):
     """
-    Add cloud feeds observer after setting up some intial formatting
+    Return cloud feeds observer after setting up some intial formatting
     """
     cf_observer = CloudFeedsObserver(
         reactor=reactor, authenticator=authenticator, tenant_id=tenant_id,
         region=region, service_configs=service_configs)
-    addObserver(
-        SpecificationObserverWrapper(
+    return SpecificationObserverWrapper(
             PEP3101FormattingWrapper(
-                ErrorFormattingWrapper(cf_observer))))
+                ErrorFormattingWrapper(cf_observer)))

--- a/otter/log/formatters.py
+++ b/otter/log/formatters.py
@@ -250,6 +250,12 @@ def serialize_to_jsonable(obj):
     return repr(obj)
 
 
+class LogLevel(object):
+    """ Log levels """
+    INFO = 6
+    ERROR = 3
+
+
 def ErrorFormattingWrapper(observer):
     """
     Return log observer that will format error if any and delegate it to
@@ -267,7 +273,7 @@ def ErrorFormattingWrapper(observer):
         message = ""
 
         if event.get("isError", False):
-            level = 3
+            level = LogLevel.ERROR
 
             if 'failure' in event:
                 excp = event['failure'].value
@@ -282,7 +288,7 @@ def ErrorFormattingWrapper(observer):
                 message = '{0}: {1}'.format(event['why'], message)
 
         else:
-            level = 6
+            level = LogLevel.INFO
 
         event.update({
             "message": (''.join(event.get("message", '')) or message, ),

--- a/otter/log/spec.py
+++ b/otter/log/spec.py
@@ -16,6 +16,10 @@ msg_types = {
         "Fatal error while converging group {scaling_group_id}."),
     "converge-non-fatal-error": (
         "Non-fatal error while converging group {scaling_group_id}"),
+    "cf-add-failure": "Failed to add event to cloud feeds",
+    "cf-unsuitable-message": (
+        "Tried to add unsuitable message in cloud feeds: "
+        "{unsuitable_message}"),
     "delete-server": "Deleting {server_id} server",
     "execute-convergence": "Executing convergence",
     "execute-convergence-results": (

--- a/otter/tap/api.py
+++ b/otter/tap/api.py
@@ -19,6 +19,7 @@ from twisted.internet.defer import gatherResults, maybeDeferred
 from twisted.internet.endpoints import clientFromString
 from twisted.internet.task import coiterate
 from twisted.python import usage
+from twisted.python.log import addObserver
 from twisted.python.threadpool import ThreadPool
 from twisted.web.server import Site
 
@@ -36,7 +37,7 @@ from otter.convergence.service import (
     ConvergenceStarter, Converger, set_convergence_starter)
 from otter.effect_dispatcher import get_full_dispatcher
 from otter.log import log
-from otter.log.cloudfeeds import add_cf_observer
+from otter.log.cloudfeeds import get_cf_observer
 from otter.models.cass import CassAdmin, CassScalingGroupCollection
 from otter.rest.admin import OtterAdmin
 from otter.rest.application import Otter
@@ -245,8 +246,9 @@ def makeService(config):
     if cf_conf is not None:
         id_conf = deepcopy(config['identity'])
         id_conf['strategy'] = 'single_tenant'
-        add_cf_observer(reactor, generate_authenticator(reactor, id_conf),
-                        cf_conf['tenant_id'], region, service_configs)
+        addObserver(
+            get_cf_observer(reactor, generate_authenticator(reactor, id_conf),
+                            cf_conf['tenant_id'], region, service_configs))
 
     # Setup Kazoo client
     if config_value('zookeeper'):

--- a/otter/tap/api.py
+++ b/otter/tap/api.py
@@ -19,7 +19,6 @@ from twisted.internet.defer import gatherResults, maybeDeferred
 from twisted.internet.endpoints import clientFromString
 from twisted.internet.task import coiterate
 from twisted.python import usage
-from twisted.python.log import addObserver
 from twisted.python.threadpool import ThreadPool
 from twisted.web.server import Site
 
@@ -37,7 +36,7 @@ from otter.convergence.service import (
     ConvergenceStarter, Converger, set_convergence_starter)
 from otter.effect_dispatcher import get_full_dispatcher
 from otter.log import log
-from otter.log.cloudfeeds import CloudFeedsObserver
+from otter.log.cloudfeeds import add_cf_observer
 from otter.models.cass import CassAdmin, CassScalingGroupCollection
 from otter.rest.admin import OtterAdmin
 from otter.rest.application import Otter
@@ -246,12 +245,8 @@ def makeService(config):
     if cf_conf is not None:
         id_conf = deepcopy(config['identity'])
         id_conf['strategy'] = 'single_tenant'
-        addObserver(
-            CloudFeedsObserver(
-                reactor=reactor,
-                authenticator=generate_authenticator(reactor, id_conf),
-                region=region, tenant_id=cf_conf['tenant_id'],
-                service_configs=service_configs))
+        add_cf_observer(reactor, generate_authenticator(reactor, id_conf),
+                        cf_conf['tenant_id'], region, service_configs)
 
     # Setup Kazoo client
     if config_value('zookeeper'):

--- a/otter/test/log/test_log.py
+++ b/otter/test/log/test_log.py
@@ -25,9 +25,9 @@ from otter.log.formatters import (
     PEP3101FormattingWrapper,
     StreamObserverWrapper,
     SystemFilterWrapper,
-    throttling_wrapper,
     audit_log_formatter,
-    serialize_to_jsonable)
+    serialize_to_jsonable,
+    throttling_wrapper)
 from otter.test.utils import SameJSON, matches
 
 

--- a/otter/test/log/test_log.py
+++ b/otter/test/log/test_log.py
@@ -20,6 +20,7 @@ from otter.log.bound import BoundLog
 from otter.log.formatters import (
     ErrorFormattingWrapper,
     JSONObserverWrapper,
+    LogLevel,
     ObserverWrapper,
     PEP3101FormattingWrapper,
     StreamObserverWrapper,
@@ -377,14 +378,14 @@ class ErrorFormatterTests(SynchronousTestCase):
 
     def test_no_failure(self):
         """
-        If event does not have failure, it sets level=6 and removes
-        all error fields
+        If event does not have failure, it sets level to LogLevel.INFO
+        and removes all error fields
         """
         self.wrapper({'isError': False, 'failure': 'f', 'why': 'w',
                       'foo': 'bar'})
         self.assertEqual(
             self._formatted_event(),
-            {'level': 6, 'message': ('',), 'foo': 'bar'})
+            {'level': LogLevel.INFO, 'message': ('',), 'foo': 'bar'})
 
     def test_failure_include_traceback_in_event_dict(self):
         """
@@ -412,13 +413,13 @@ class ErrorFormatterTests(SynchronousTestCase):
         self.observer.assert_called_once_with(
             matches(ContainsDict({'message': Equals(('uh oh',))})))
 
-    def test_isError_sets_level_3(self):
+    def test_isError_sets_level_error(self):
         """
-        The observer sets the level to 3 (syslog ERROR) when isError is true.
+        The observer sets the level to LogLevel.ERROR when isError is true.
         """
         self.wrapper({'failure': Failure(ValueError()), 'isError': True})
         self.observer.assert_called_once_with(
-            matches(ContainsDict({'level': Equals(3)})))
+            matches(ContainsDict({'level': Equals(LogLevel.ERROR)})))
 
     def test_isError_removes_error_fields(self):
         """
@@ -472,7 +473,7 @@ class ErrorFormatterTests(SynchronousTestCase):
                       'why': 'reason', 'failure': failure})
         self.assertEqual(
             self._formatted_event(),
-            {'message': ('mineyours',), 'level': 3,
+            {'message': ('mineyours',), 'level': LogLevel.ERROR,
              'traceback': failure.getTraceback(),
              'exception_type': 'ValueError'})
 

--- a/otter/test/tap/test_api.py
+++ b/otter/test/tap/test_api.py
@@ -18,7 +18,6 @@ from otter.auth import CachingAuthenticator, SingleTenantAuthenticator
 from otter.constants import (
     CONVERGENCE_DIRTY_DIR, ServiceType, get_service_configs)
 from otter.convergence.service import Converger
-from otter.log.cloudfeeds import CloudFeedsObserver
 from otter.models.cass import CassScalingGroupCollection as OriginalStore
 from otter.supervisor import SupervisorService, get_supervisor, set_supervisor
 from otter.tap.api import (

--- a/otter/test/tap/test_api.py
+++ b/otter/test/tap/test_api.py
@@ -476,7 +476,7 @@ class APIMakeServiceTests(SynchronousTestCase):
 
         self.assertEqual(get_supervisor(), supervisor_service)
 
-    @mock.patch('otter.tap.api.addObserver')
+    @mock.patch('otter.tap.api.add_cf_observer')
     def test_cloudfeeds_setup(self, mock_addobserver):
         """
         Cloud feeds observer is setup if it is there in config
@@ -488,20 +488,17 @@ class APIMakeServiceTests(SynchronousTestCase):
         serv_confs = get_service_configs(conf)
         serv_confs[ServiceType.CLOUD_FEEDS] = {
             'name': 'cloudFeeds', 'region': 'ord', 'url': 'url'}
-        cf = CloudFeedsObserver(
-            reactor=self.reactor,
-            authenticator=matches(IsInstance(CachingAuthenticator)),
-            region='ord', tenant_id='tid',
-            service_configs=serv_confs)
-        mock_addobserver.assert_called_once_with(cf)
+        mock_addobserver.assert_called_once_with(
+            self.reactor, matches(IsInstance(CachingAuthenticator)), 'tid',
+            'ord', serv_confs)
 
-        # Observer has single tenant auth
-        real_cf = mock_addobserver.call_args[0][0]
+        # single tenant authenticator is created
+        real_auth = mock_addobserver.call_args[0][1]
         self.assertIsInstance(
-            real_cf.authenticator._authenticator._authenticator._authenticator,
+            real_auth._authenticator._authenticator._authenticator,
             SingleTenantAuthenticator)
 
-    @mock.patch('otter.tap.api.addObserver')
+    @mock.patch('otter.tap.api.add_cf_observer')
     def test_cloudfeeds_no_setup(self, mock_addobserver):
         """
         Cloud feeds observer is not setup if it is not there in config


### PR DESCRIPTION
cloudfeeds observer is added with spec, pep3103 and error formatter in it. One extra refactor done is replacing 3 and 6 in formatters with `LogLevel.INFO and ERROR`.