### PR TITLE
Configurable build timeout

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -62,12 +62,13 @@
     "cloudfeeds": {"service": "cloudFeeds", "tenant_id": "tenant",
                    "url": "http://cfurl.net/"},
     "converger": {
+        "build_timeout": 3600,
         "interval": 30
     },
     "cloud_client": {
-	"throttling": {
-	    "create_server_delay": 1,
-	    "delete_server_delay": 0.2
-	}
+    	"throttling": {
+    	    "create_server_delay": 1,
+    	    "delete_server_delay": 0.2
+    	}
     }
 }

--- a/otter/convergence/planning.py
+++ b/otter/convergence/planning.py
@@ -266,13 +266,14 @@ def converge(desired_state, servers_with_cheese, load_balancer_contents, now,
                 converge_later)
 
 
-def plan(desired_group_state, servers, lb_nodes, now):
+def plan(desired_group_state, servers, lb_nodes, now, build_timeout):
     """
     Get an optimized convergence plan.
 
     Takes the same arguments as :func:`converge`.
     """
-    steps = converge(desired_group_state, servers, lb_nodes, now)
+    steps = converge(desired_group_state, servers, lb_nodes, now,
+                     timeout=build_timeout)
     steps = limit_steps_by_count(steps)
     return optimize_steps(steps)
 

--- a/otter/convergence/service.py
+++ b/otter/convergence/service.py
@@ -315,15 +315,21 @@ def get_my_divergent_groups(my_buckets, all_buckets, divergent_flags):
 
 @do
 def converge_one_group(currently_converging, tenant_id, group_id, version,
-                       execute_convergence=execute_convergence):
+                       build_timeout, execute_convergence=execute_convergence):
     """
     Converge one group, non-concurrently, and clean up the dirty flag when
     done.
 
     :param Reference currently_converging: pset of currently converging groups
+    :param str tenant_id: the tenant ID of the group that is converging
+    :param str group_id: the ID of the group that is converging
     :param version: version number of ZNode of the group's dirty flag
+    :param number build_timeout: number of seconds to wait for servers to be in
+        building before it's is timed out and deleted
+    :param callable execute_convergence: like :func`execute_convergence`, to
+        be used for test injection only
     """
-    eff = execute_convergence(tenant_id, group_id)
+    eff = execute_convergence(tenant_id, group_id, build_timeout)
     try:
         result = yield non_concurrently(currently_converging, group_id, eff)
     except ConcurrentError:

--- a/otter/convergence/service.py
+++ b/otter/convergence/service.py
@@ -88,16 +88,20 @@ def _update_active(scaling_group, active):
 
 
 @do
-def execute_convergence(tenant_id, group_id,
+def execute_convergence(tenant_id, group_id, build_timeout,
                         get_all_convergence_data=get_all_convergence_data,
                         plan=plan):
     """
     Gather data, plan a convergence, save active and pending servers to the
     group state, and then execute the convergence.
 
-    :param group_id: group id
-    :param get_all_convergence_data: like :func`get_all_convergence_data`, used
-        for testing.
+    :param str tenant_id: the tenant ID for the group to converge
+    :param str group_id: the ID of the group to be converged
+    :param number build_timeout: number of seconds to wait for servers to be in
+        building before it's is timed out and deleted
+    :param callable get_all_convergence_data: like
+        :func`get_all_convergence_data`, used for testing.
+    :param callable plan: like :func:`plan`, to be used for test injection only
 
     :return: Effect of most severe StepResult
     :raise: :obj:`NoSuchScalingGroupError` if the group doesn't exist.
@@ -121,7 +125,7 @@ def execute_convergence(tenant_id, group_id,
                         else group_state.desired)
     desired_group_state = get_desired_group_state(
         group_id, launch_config, desired_capacity)
-    steps = plan(desired_group_state, servers, lb_nodes, now)
+    steps = plan(desired_group_state, servers, lb_nodes, now, build_timeout)
     active = determine_active(servers, lb_nodes)
     yield msg('execute-convergence',
               servers=servers, lb_nodes=lb_nodes, steps=steps, now=now,

--- a/otter/tap/api.py
+++ b/otter/tap/api.py
@@ -292,7 +292,8 @@ def makeService(config):
             set_convergence_starter(starter)
 
             setup_converger(s, kz_client, dispatcher,
-                            config_value('converger.interval') or 10)
+                            config_value('converger.interval') or 10,
+                            config_value('converger.build_timeout') or 3600)
 
         d.addCallback(on_client_ready)
         d.addErrback(log.err, 'Could not start TxKazooClient')
@@ -300,7 +301,7 @@ def makeService(config):
     return s
 
 
-def setup_converger(parent, kz_client, dispatcher, interval):
+def setup_converger(parent, kz_client, dispatcher, interval, build_timeout):
     """
     Create a Converger service, which has a Partitioner as a child service, so
     that if the Converger is stopped, the partitioner is also stopped.
@@ -314,7 +315,8 @@ def setup_converger(parent, kz_client, dispatcher, interval):
         converger_buckets,
         15,  # time boundary
     )
-    cvg = Converger(log, dispatcher, converger_buckets, partitioner_factory)
+    cvg = Converger(log, dispatcher, converger_buckets, partitioner_factory,
+                    build_timeout)
     cvg.setServiceParent(parent)
     watch_children(kz_client, CONVERGENCE_DIRTY_DIR, cvg.divergent_changed)
 

--- a/otter/test/convergence/test_service.py
+++ b/otter/test/convergence/test_service.py
@@ -100,7 +100,8 @@ class ConvergerTests(SynchronousTestCase):
             dispatcher = _get_dispatcher()
         return Converger(
             self.log, dispatcher, self.buckets,
-            self._pfactory, converge_all_groups=converge_all_groups)
+            self._pfactory, build_timeout=3600,
+            converge_all_groups=converge_all_groups)
 
     def _pfactory(self, log, callable):
         self.fake_partitioner = FakePartitioner(log, callable)
@@ -112,10 +113,10 @@ class ConvergerTests(SynchronousTestCase):
         performed.
         """
         def converge_all_groups(currently_converging, _my_buckets,
-                                all_buckets, divergent_flags):
+                                all_buckets, divergent_flags, build_timeout):
             return Effect(
                 ('converge-all', currently_converging, _my_buckets,
-                 all_buckets, divergent_flags))
+                 all_buckets, divergent_flags, build_timeout))
 
         my_buckets = [0, 5]
         bound_sequence = [
@@ -126,7 +127,8 @@ class ConvergerTests(SynchronousTestCase):
                              True),
                 my_buckets,
                 self.buckets,
-                ['flag1', 'flag2']),
+                ['flag1', 'flag2'],
+                3600),
                 lambda i: 'foo')
         ]
 
@@ -150,7 +152,7 @@ class ConvergerTests(SynchronousTestCase):
         logged, and None is the ultimate result.
         """
         def converge_all_groups(currently_converging, _my_buckets,
-                                all_buckets, divergent_flags):
+                                all_buckets, divergent_flags, build_timeout):
             return Effect('converge-all')
 
         bound_sequence = [
@@ -208,7 +210,7 @@ class ConvergerTests(SynchronousTestCase):
         :func:`converge_all_groups`.
         """
         def converge_all_groups(currently_converging, _my_buckets,
-                                all_buckets, divergent_flags):
+                                all_buckets, divergent_flags, build_timeout):
             return Effect(('converge-all-groups', divergent_flags))
         dispatcher = SequenceDispatcher([
             (('converge-all-groups', ['group1', 'group2']),

--- a/otter/test/tap/test_api.py
+++ b/otter/test/tap/test_api.py
@@ -677,7 +677,7 @@ class APIMakeServiceTests(SynchronousTestCase):
         parent = makeService(config)
 
         mock_setup_converger.assert_called_once_with(
-            parent, kz_client, mock.ANY, 10)
+            parent, kz_client, mock.ANY, 10, 3600)
 
         dispatcher = mock_setup_converger.call_args[0][2]
 
@@ -698,9 +698,10 @@ class ConvergerSetupTests(SynchronousTestCase):
         kz_client = object()
         dispatcher = object()
         interval = 50
-        setup_converger(ms, kz_client, dispatcher, interval)
+        setup_converger(ms, kz_client, dispatcher, interval, build_timeout=35)
         [converger] = ms.services
         self.assertIs(converger.__class__, Converger)
+        self.assertEqual(converger.build_timeout, 35)
         self.assertEqual(converger._dispatcher, dispatcher)
         [partitioner] = converger.services
         [timer] = partitioner.services


### PR DESCRIPTION
Fixes #1368 

I made this a required argument everywhere mainly because I found it annoying to propagate the exact same default everywhere.  On the other hand, I had to change all the tests.  On the third hand, doing so tests the propagation of the value.

I'm fine with changing it should anyone have strong feelings.

I left it optional in `planning.converge` because that's already well tested, and has a LOT of tests which call `converge` without the timeout.