### PR TITLE
Skip mimic-required tests if mimic is not configured

### DIFF
--- a/otter/integration/config.sh-template
+++ b/otter/integration/config.sh-template
@@ -49,3 +49,6 @@ export AS_NOVA_SC_KEY=cloudServersOpenStack
 # Adjust this if your your cloud load balancer service is registered under a
 # different key in the service catalog.
 export AS_CLB_SC_KEY=cloudLoadBalancers
+
+# Uncomment this if you are running tests against Mimic.
+# export AS_USING_MIMIC=true


### PR DESCRIPTION
Wasn't sure whether to do this or to check the service catalog.  Checking the service catalog would mean that the decorator would have to reach inside the decorated function, extract self, and get check the service catalog and raise `SkipTest`.

Since we rarely need to determine what kind of system we're testing against on the fly, I figure it can just be part of the config (similarly with RCv3 when we get to doing those tests).

I've tested this locally both with and without setting the environment variables - on Jenkins CI testing I've set the environment variable already, so jenkins would be testing this not-skipping.