### PR TITLE
Servers cache using changes-since filter

### DIFF
--- a/otter/convergence/gathering.py
+++ b/otter/convergence/gathering.py
@@ -51,15 +51,16 @@ def get_all_server_details(changes_since=None, batch_size=100):
     url = append_segments('servers', 'detail')
     query = {'limit': batch_size}
     if changes_since is not None:
-        query['changes_since'] = '{0}Z'.format(changes_since.isoformat())
+        query['changes-since'] = '{0}Z'.format(changes_since.isoformat())
 
     last_link = []
 
     def get_server_details(query_params):
+        params = sorted(query_params.items())
         eff = retry_effect(
             service_request(ServiceType.CLOUD_SERVERS, 'GET',
                             "{}?{}".format(url,
-                                           urlencode(query_params, True))),
+                                           urlencode(params, True))),
             retry_times(5), exponential_backoff_interval(2))
         return eff.on(continue_)
 

--- a/otter/convergence/gathering.py
+++ b/otter/convergence/gathering.py
@@ -151,12 +151,12 @@ def get_scaling_group_servers(tenant_id, group_id, now,
     cached_servers, last_update = yield cache.get_servers()
     if last_update is None or now - last_update >= timedelta(days=30):
         last_update = now - timedelta(days=30)
-        changes = (yield all_as_servers(last_update))[group_id]
-        current = (yield all_as_servers())[group_id]
+        changes = (yield all_as_servers(last_update)).get(group_id, [])
+        current = (yield all_as_servers()).get(group_id, [])
         servers = merge_servers(changes, current)
         yield cache.insert_servers(now, servers, True)
     else:
-        changes = (yield all_as_servers(last_update))[group_id]
+        changes = (yield all_as_servers(last_update)).get(group_id, [])
         servers = merge_servers(cached_servers, changes)
     yield do_return(servers)
 

--- a/otter/convergence/gathering.py
+++ b/otter/convergence/gathering.py
@@ -94,7 +94,7 @@ def _discard_response((response, body)):
 def get_all_scaling_group_servers(changes_since=None,
                                   server_predicate=identity):
     """
-    Return tenant's servers that belong to a scaling group as
+    Return tenant's servers that belong to any scaling group as
     {group_id: [server1, server2]} ``dict``. No specific ordering is guaranteed
 
     :param datetime changes_since: Get server since this time. Must be UTC
@@ -132,10 +132,10 @@ def all_servers(cache, changes):
 def get_scaling_group_servers(tenant_id, group_id, cache_coll=None):
     """
     Get a group's servers taken from cache if it exists. Updates cache as
-    part of getting the group
+    if it is empty from newly fetched servers
 
     :return: Servers as iterator of dicts
-    :rtype: ``iterator``
+    :rtype: Effect
     """
     coll = cache_coll or CassScalingGroupServersCache()
     cache, last_update = yield coll.get_servers(tenant_id, group_id)

--- a/otter/convergence/gathering.py
+++ b/otter/convergence/gathering.py
@@ -146,11 +146,11 @@ def get_scaling_group_servers(tenant_id, group_id, now,
     :rtype: Effect
     """
     coll = cache_class(tenant_id, group_id)
-    cache, last_update = yield coll.get_servers(tenant_id, group_id)
+    cache, last_update = yield coll.get_servers()
     if last_update is None or last_update - now >= timedelta(days=30):
         last_update = now - timedelta(days=30)
         changes = (yield get_all_scaling_group_servers(last_update))[group_id]
-        current = (yield get_all_server_details())[group_id]
+        current = (yield get_all_scaling_group_servers())[group_id]
         servers = merge_servers(changes, current)
         yield coll.insert_servers(now, servers, True)
     else:

--- a/otter/convergence/gathering.py
+++ b/otter/convergence/gathering.py
@@ -4,7 +4,8 @@ from functools import partial
 from urllib import urlencode
 from urlparse import parse_qs, urlparse
 
-from effect import catch, do, do_return, parallel
+from effect import catch, parallel
+from effect.do import do, do_return
 
 from toolz.curried import filter, groupby, keyfilter, map
 from toolz.dicttoolz import get_in, merge

--- a/otter/convergence/gathering.py
+++ b/otter/convergence/gathering.py
@@ -131,7 +131,7 @@ def merge_servers(first, second):
     def sdict(servers):
         return {s['id']: s for s in servers}
 
-    return merge(sdict(first), sdict(second)).itervalues()
+    return merge(sdict(first), sdict(second)).values()
 
 
 @do

--- a/otter/convergence/gathering.py
+++ b/otter/convergence/gathering.py
@@ -149,7 +149,10 @@ def get_scaling_group_servers(tenant_id, group_id, now,
     """
     cache = cache_class(tenant_id, group_id)
     cached_servers, last_update = yield cache.get_servers()
-    if last_update is None or now - last_update >= timedelta(days=30):
+    if last_update is None:
+        servers = (yield all_as_servers()).get(group_id, [])
+        yield cache.insert_servers(now, servers, True)
+    elif now - last_update >= timedelta(days=30):
         last_update = now - timedelta(days=30)
         changes = (yield all_as_servers(last_update)).get(group_id, [])
         current = (yield all_as_servers()).get(group_id, [])

--- a/otter/convergence/model.py
+++ b/otter/convergence/model.py
@@ -7,7 +7,7 @@ import re
 
 from characteristic import Attribute, attributes
 
-from pyrsistent import PSet, freeze, pmap, pset, pvector
+from pyrsistent import PMap, PSet, freeze, pmap, pset, pvector
 
 from toolz.dicttoolz import get_in
 from toolz.itertoolz import groupby
@@ -186,7 +186,8 @@ def _lbs_from_metadata(metadata):
              Attribute('desired_lbs', default_factory=pset, instance_of=PSet),
              Attribute('servicenet_address',
                        default_value='',
-                       instance_of=basestring)])
+                       instance_of=basestring),
+             Attribute('json', instance_of=PMap)])
 class NovaServer(object):
     """
     Information about a server that was retrieved from Nova.
@@ -238,7 +239,8 @@ class NovaServer(object):
             flavor_id=server_json['flavor']['id'],
             links=freeze(server_json['links']),
             desired_lbs=_lbs_from_metadata(metadata),
-            servicenet_address=_servicenet_address(server_json))
+            servicenet_address=_servicenet_address(server_json),
+            json=freeze(server_json))
 
 
 def group_id_from_metadata(metadata):

--- a/otter/convergence/model.py
+++ b/otter/convergence/model.py
@@ -189,7 +189,7 @@ def _lbs_from_metadata(metadata):
              Attribute('servicenet_address',
                        default_value='',
                        instance_of=basestring),
-             Attribute('json', instance_of=PMap)])
+             Attribute('json', instance_of=PMap, default_factory=pmap)])
 class NovaServer(object):
     """
     Information about a server that was retrieved from Nova.

--- a/otter/convergence/service.py
+++ b/otter/convergence/service.py
@@ -111,7 +111,7 @@ def execute_convergence(tenant_id, group_id, build_timeout,
     # fetching of the scaling group info from cassandra.
     sg_eff = Effect(GetScalingGroupInfo(tenant_id=tenant_id,
                                         group_id=group_id))
-    gather_eff = get_all_convergence_data(group_id)
+    gather_eff = get_all_convergence_data(tenant_id, group_id)
     try:
         data = yield parallel([sg_eff, gather_eff])
     except FirstError as fe:

--- a/otter/convergence/service.py
+++ b/otter/convergence/service.py
@@ -149,13 +149,13 @@ def execute_convergence(tenant_id, group_id, build_timeout,
               results=zip(steps, results),
               worst_status=worst_status)
 
-    cache_coll = cache_class(tenant_id, group_id)
+    cache = cache_class(tenant_id, group_id)
     if worst_status == StepResult.SUCCESS:
         if group_state.status == ScalingGroupStatus.DELETING:
             # servers have been deleted. Delete the group for real
             yield Effect(DeleteGroup(tenant_id=tenant_id, group_id=group_id))
             # Delete the cache too
-            yield cache_coll.delete_servers()
+            yield cache.delete_servers()
         elif group_state.status == ScalingGroupStatus.ERROR:
             yield Effect(UpdateGroupStatus(scaling_group=scaling_group,
                                            status=ScalingGroupStatus.ACTIVE))
@@ -163,7 +163,7 @@ def execute_convergence(tenant_id, group_id, build_timeout,
                          status=ScalingGroupStatus.ACTIVE.name)
         else:
             # Clear servers cache and update it with latest servers
-            yield cache_coll.insert_servers(
+            yield cache.insert_servers(
                 now_dt,
                 filter(lambda s: s.state != ServerState.DELETED, servers),
                 True)

--- a/otter/convergence/service.py
+++ b/otter/convergence/service.py
@@ -92,7 +92,7 @@ def _update_active(scaling_group, active):
 @do
 def execute_convergence(tenant_id, group_id, build_timeout,
                         get_all_convergence_data=get_all_convergence_data,
-                        plan=plan, cache_coll=None):
+                        plan=plan, cache_class=CassScalingGroupServersCache):
     """
     Gather data, plan a convergence, save active and pending servers to the
     group state, and then execute the convergence.
@@ -158,8 +158,7 @@ def execute_convergence(tenant_id, group_id, build_timeout,
                          status=ScalingGroupStatus.ACTIVE.name)
         else:
             # Clear servers cache that removes deleted servers
-            coll = cache_coll or CassScalingGroupServersCache()
-            yield coll.delete_servers(tenant_id, group_id)
+            yield cache_class(tenant_id, group_id).delete_servers()
     elif worst_status == StepResult.FAILURE:
         yield Effect(UpdateGroupStatus(scaling_group=scaling_group,
                                        status=ScalingGroupStatus.ERROR))

--- a/otter/convergence/service.py
+++ b/otter/convergence/service.py
@@ -115,7 +115,7 @@ def execute_convergence(tenant_id, group_id, build_timeout,
     # fetching of the scaling group info from cassandra.
     sg_eff = Effect(GetScalingGroupInfo(tenant_id=tenant_id,
                                         group_id=group_id))
-    now_dt = yield Effect(Func(datetime.now))
+    now_dt = yield Effect(Func(datetime.utcnow))
     gather_eff = get_all_convergence_data(tenant_id, group_id, now_dt)
     try:
         data = yield parallel([sg_eff, gather_eff])

--- a/otter/convergence/service.py
+++ b/otter/convergence/service.py
@@ -165,7 +165,8 @@ def execute_convergence(tenant_id, group_id, build_timeout,
             # Clear servers cache and update it with latest servers
             yield cache.insert_servers(
                 now_dt,
-                filter(lambda s: s.state != ServerState.DELETED, servers),
+                [thaw(s.json) for s in servers
+                 if s.state != ServerState.DELETED],
                 True)
     elif worst_status == StepResult.FAILURE:
         yield Effect(UpdateGroupStatus(scaling_group=scaling_group,

--- a/otter/convergence/service.py
+++ b/otter/convergence/service.py
@@ -163,9 +163,10 @@ def execute_convergence(tenant_id, group_id, build_timeout,
                          status=ScalingGroupStatus.ACTIVE.name)
         else:
             # Clear servers cache and update it with latest servers
-            yield cache_coll.insert_single_cache(
+            yield cache_coll.insert_servers(
                 now_dt,
-                filter(lambda s: s.state != ServerState.DELETED, servers))
+                filter(lambda s: s.state != ServerState.DELETED, servers),
+                True)
     elif worst_status == StepResult.FAILURE:
         yield Effect(UpdateGroupStatus(scaling_group=scaling_group,
                                        status=ScalingGroupStatus.ERROR))

--- a/otter/integration/tests/test_convergence.py
+++ b/otter/integration/tests/test_convergence.py
@@ -369,7 +369,6 @@ class TestConvergence(unittest.TestCase):
             )
         )
 
-    @skip_me("Autoscale does not clean up servers deleted OOB yet. See #881.")
     def test_scaling_to_clb_max_after_oob_delete_type1(self):
         """
         CATC-015-a
@@ -388,7 +387,6 @@ class TestConvergence(unittest.TestCase):
         """
         return self._perform_oobd_clb_test(25)
 
-    @skip_me("Autoscale does not clean up servers deleted OOB yet. See #881.")
     def test_scaling_to_clb_max_after_oob_delete_type2(self):
         """
         CATC-015-b
@@ -1097,10 +1095,6 @@ class ConvergenceTestsWith1CLB(unittest.TestCase):
                 clb.wait_for_nodes(self.rcs, checks, timeout=1800)
                 for clb in self.helper.clbs])
 
-        if any(tag in tags for tag in _catc_tags(4, 8)):
-            wrapper.skip = (
-                "Autoscale does not clean up servers deleted OOB yet. "
-                "See #881.")
         return (name, wrapper)
 
     @skip_me("Mimic does not support CLB limits, skipped pending Mimic #291")

--- a/otter/models/cass.py
+++ b/otter/models/cass.py
@@ -1736,6 +1736,10 @@ class CassScalingGroupServersCache(object):
                  "group_id=:group_id;")
         return cql_eff(query.format(cf=self.table), self.params)
 
+    def insert_single_cache(self, last_update, servers):
+        return self.delete_servers().on(
+            lambda _: self.insert_servers(last_update, servers))
+
 
 @implementer(IAdmin)
 class CassAdmin(object):

--- a/otter/models/cass.py
+++ b/otter/models/cass.py
@@ -1721,7 +1721,7 @@ class CassScalingGroupServersCache(object):
 
     def insert_servers(self, last_update, servers, clear_others):
         query = ("INSERT INTO {cf} (tenant_id, group_id, last_update, "
-                 "server_id, server_blob "
+                 "server_id, server_blob) "
                  "VALUES(:tenant_id, :group_id, :last_update, :server_id{i}, "
                  ":server_blob{i});")
         params = merge(self.params, {"last_update": last_update})

--- a/otter/models/cass.py
+++ b/otter/models/cass.py
@@ -1731,7 +1731,6 @@ class CassScalingGroupServersCache(object):
                          last_update))
 
     def insert_servers(self, last_update, servers, clear_others):
-        servers = list(servers)
         if len(servers) == 0:
             return Effect(Constant(None))
         query = ("INSERT INTO {cf} (tenant_id, group_id, last_update, "

--- a/otter/models/cass.py
+++ b/otter/models/cass.py
@@ -1719,6 +1719,9 @@ class CassScalingGroupServersCache(object):
 
     @do
     def get_servers(self):
+        """
+        See :method:`IScalingGroupServersCache.get_servers`
+        """
         query = ("SELECT server_blob, last_update FROM {cf} "
                  "WHERE tenant_id=:tenant_id AND group_id=:group_id "
                  "ORDER BY last_update DESC;")
@@ -1731,6 +1734,9 @@ class CassScalingGroupServersCache(object):
                          last_update))
 
     def insert_servers(self, last_update, servers, clear_others):
+        """
+        See :method:`IScalingGroupServersCache.insert_servers`
+        """
         if len(servers) == 0:
             return Effect(Constant(None))
         query = ("INSERT INTO {cf} (tenant_id, group_id, last_update, "
@@ -1750,6 +1756,9 @@ class CassScalingGroupServersCache(object):
             return cql_eff(batch(queries), params)
 
     def delete_servers(self):
+        """
+        See :method:`IScalingGroupServersCache.delete_servers`
+        """
         query = ("DELETE FROM {cf} WHERE tenant_id=:tenant_id AND "
                  "group_id=:group_id;")
         return cql_eff(query.format(cf=self.table), self.params)

--- a/otter/models/cass.py
+++ b/otter/models/cass.py
@@ -12,7 +12,7 @@ from datetime import datetime
 
 from characteristic import attributes
 
-from effect import Constant, Effect, parallel
+from effect import Constant, Effect, TypeDispatcher, parallel
 from effect.do import do, do_return
 
 from jsonschema import ValidationError
@@ -75,6 +75,17 @@ def perform_cql_query(conn, disp, intent):
     """
     return conn.execute(
         intent.query, intent.params, intent.consistency_level)
+
+
+def get_cql_dispatcher(connection):
+    """
+    Get dispatcher with `CQLQueryExecute`'s performer in it
+
+    :param connection: Silverberg connection
+    """
+    return TypeDispatcher({
+        CQLQueryExecute: functools.partial(perform_cql_query, connection)
+    })
 
 
 def cql_eff(query, params={}, consistency_level=ConsistencyLevel.ONE):

--- a/otter/models/cass.py
+++ b/otter/models/cass.py
@@ -12,7 +12,7 @@ from datetime import datetime
 
 from characteristic import attributes
 
-from effect import Effect, parallel
+from effect import Constant, Effect, parallel
 from effect.do import do, do_return
 
 from jsonschema import ValidationError
@@ -1720,6 +1720,9 @@ class CassScalingGroupServersCache(object):
                          last_update))
 
     def insert_servers(self, last_update, servers, clear_others):
+        servers = list(servers)
+        if len(servers) == 0:
+            return Effect(Constant(None))
         query = ("INSERT INTO {cf} (tenant_id, group_id, last_update, "
                  "server_id, server_blob) "
                  "VALUES(:tenant_id, :group_id, :last_update, :server_id{i}, "

--- a/otter/models/cass.py
+++ b/otter/models/cass.py
@@ -1729,6 +1729,12 @@ class CassScalingGroupServersCache(object):
             queries.append(query.format(cf=self.table, i=i))
         return cql_eff(batch(queries), params)
 
+    def delete_servers(self, tenant_id, group_id):
+        query = ("DELETE FROM {cf} WHERE tenant_id=:tenant_id AND "
+                 "group_id=:group_id;")
+        params = {"tenant_id": tenant_id, "group_id": group_id}
+        return cql_eff(query.format(cf=self.table), params)
+
 
 @implementer(IAdmin)
 class CassAdmin(object):

--- a/otter/models/cass.py
+++ b/otter/models/cass.py
@@ -12,7 +12,8 @@ from datetime import datetime
 
 from characteristic import attributes
 
-from effect import Effect, do, do_return, parallel
+from effect import Effect, parallel
+from effect.do import do, do_return
 
 from jsonschema import ValidationError
 

--- a/otter/models/interface.py
+++ b/otter/models/interface.py
@@ -643,6 +643,11 @@ class IScalingGroupServersCache(Interface):
         :return: Effect of None
         """
 
+    def delete_servers(tenant_id, group_id):
+        """
+        Remove all servers of the group
+        """
+
 
 class IScalingScheduleCollection(Interface):
     """

--- a/otter/models/interface.py
+++ b/otter/models/interface.py
@@ -614,92 +614,33 @@ class IScalingGroup(Interface):
         """
 
 
-class NoSuchServerIntentError(Exception):
+class IScalingGroupServersCache(Interface):
     """
-    Error to be raised when attempting operations on a server intent that does not
-    exist.
-    """
-    def __init__(self, tenant_id, group_id, server_id):
-        super(NoSuchServerIntentError, self).__init__(
-            "No such server {s} in group {g} for tenant {t}"
-            .format(t=tenant_id, g=group_id, s=server_id))
-
-
-class IScalingGroupServerIntentsCollection(Interface):
-    """
-    Collection of servers intended to be there in a scaling group. Each server in the
-    this group should eventually match to a real server in Nova. All operations on this
-    model will not have any impact on real Nova servers. It is the caller's responsibility
-    to sync them (if needed).
+    Cache of servers in scaling groups
     """
 
-    def create_server_intent(log, status='pending'):
+    def get_servers(tenant_id, group_id):
         """
-        Create server intended to be there in scaling group
+        Return latest cache of servers in a group along with last time the
+        cache was updated.
 
-        :param :class:`BoundLog` log: A bound logger
-        :param str status: status of the server. one of 'pending' or 'active'
-
-        :return: a :class:`twisted.internet.defer.Deferred` that fires with ``dict``
-                corresponding with :data:`otter.json_schema.model_schemas.server`
-        :raises NoSuchScalingGroupError: if this scaling group does not exist
-        """
-
-    def update_server_intent(log, server_intent_id, nova_id, status, lb_info):
-        """
-        Update existing server intent information
-
-        :param :class:`BoundLog` log: A bound logger
-        :param str server_intent_id: ID of server intent
-        :param str nova_id: Server ID of corresponding Nova instance
-        :param str status: server status. One of 'pending' or 'active'
-        :param `dict` lb_info: Load balancer information dict. This will be stored as JSON
-
-        :return: a :class:`twisted.internet.defer.Deferred` that fires with None
-
-        :raises NoSuchScalingGroupError: if this scaling group does not exist
-        :raises NoSuchServerIntentError: if the server intent id does not exist
+        :param str tenant_id: Tenant ID
+        :param str group_id: Scaling group ID
+        :return: Effect of (servers, last update time) tuple where servers
+            is list of dict and last update time is datetime object. Will
+            return last_update time as None if cache is empty
+        :rtype: Effect
         """
 
-    def list_server_intents(log, status=None, limit=100, marker=None):
+    def insert_servers(tenant_id, group_id, last_update, servers):
         """
-        List the server intents in the scaling group optionally filtered based on status
+        Update the servers cache of the group with last update time
 
-        :param :class:`BoundLog` log: A bound logger
-        :param str status: server status. One of 'pending' or 'active'
-        :param int limit: Limit number of server intents to return
-        :param str marker: Marker from which to fetch servers
-
-        :return: a :class:`twisted.internet.defer.Deferred` that fires with `list` of
-                server `dict` each corresponding with
-                :data:`otter.json_schema.model_schemas.server`
-
-        :raises NoSuchScalingGroupError: if this scaling group does not exist
-        """
-
-    def get_server_intent(log, server_intent_id):
-        """
-        Get server intent from scaling group
-
-        :param :class:`BoundLog` log: A bound logger
-        :param str server_intent_id: ID of server intent being requested
-
-        :return: a :class:`twisted.internet.defer.Deferred` that fires with
-                 server `dict` correspondgin with
-                :data:`otter.json_schema.model_schemas.server`
-
-        :raises NoSuchScalingGroupError: if this scaling group does not exist
-        :raises NoSuchServerIntentError: if the server intent id does not exist
-        """
-
-    def delete_server_intents(log, server_intent_ids):
-        """
-        Remove server intents from scaling group
-
-        :param :class:`BoundLog` log: A bound logger
-        :param list server_intent_ids: List of server intent IDs to be deleted
-
-        :raises NoSuchScalingGroupError: if this scaling group does not exist
+        :param str tenant_id: Tenant ID
+        :param str group_id: Scaling group ID
+        :param datetime last_update: Update time of the cache
+        :param list servers: List of server dicts
+        :return: Effect of None
         """
 
 

--- a/otter/models/interface.py
+++ b/otter/models/interface.py
@@ -641,6 +641,12 @@ class IScalingGroupServersCache(Interface):
         :return: Effect of None
         """
 
+    def insert_single_cache(last_update, servers):
+        """
+        Deletes any existing cache and inserts new cache. Basically
+        composition of `delete_servers` and `insert_servers`
+        """
+
     def delete_servers():
         """
         Remove all servers of the group

--- a/otter/models/interface.py
+++ b/otter/models/interface.py
@@ -618,32 +618,30 @@ class IScalingGroupServersCache(Interface):
     """
     Cache of servers in scaling groups
     """
+    tenant_id = Attribute("Rackspace Tenant ID of the owner of this group.")
+    group_id = Attribute("UUID of the scaling group - immutable.")
 
-    def get_servers(tenant_id, group_id):
+    def get_servers():
         """
         Return latest cache of servers in a group along with last time the
         cache was updated.
 
-        :param str tenant_id: Tenant ID
-        :param str group_id: Scaling group ID
         :return: Effect of (servers, last update time) tuple where servers
             is list of dict and last update time is datetime object. Will
             return last_update time as None if cache is empty
         :rtype: Effect
         """
 
-    def insert_servers(tenant_id, group_id, last_update, servers):
+    def insert_servers(last_update, servers):
         """
         Update the servers cache of the group with last update time
 
-        :param str tenant_id: Tenant ID
-        :param str group_id: Scaling group ID
         :param datetime last_update: Update time of the cache
         :param list servers: List of server dicts
         :return: Effect of None
         """
 
-    def delete_servers(tenant_id, group_id):
+    def delete_servers():
         """
         Remove all servers of the group
         """

--- a/otter/models/interface.py
+++ b/otter/models/interface.py
@@ -632,19 +632,15 @@ class IScalingGroupServersCache(Interface):
         :rtype: Effect
         """
 
-    def insert_servers(last_update, servers):
+    def insert_servers(last_update, servers, clear_others):
         """
         Update the servers cache of the group with last update time
 
         :param datetime last_update: Update time of the cache
         :param list servers: List of server dicts
+        :param bool clear_others: Should any other cache from a different
+            update_time be deleted?
         :return: Effect of None
-        """
-
-    def insert_single_cache(last_update, servers):
-        """
-        Deletes any existing cache and inserts new cache. Basically
-        composition of `delete_servers` and `insert_servers`
         """
 
     def delete_servers():

--- a/otter/tap/api.py
+++ b/otter/tap/api.py
@@ -272,7 +272,8 @@ def makeService(config):
         def on_client_ready(_):
             dispatcher = get_full_dispatcher(reactor, authenticator, log,
                                              get_service_configs(config),
-                                             kz_client, store, supervisor)
+                                             kz_client, store, supervisor,
+                                             cassandra_cluster)
             # Setup scheduler service after starting
             scheduler = setup_scheduler(s, store, kz_client)
             health_checker.checks['scheduler'] = scheduler.health_check

--- a/otter/test/convergence/test_gathering.py
+++ b/otter/test/convergence/test_gathering.py
@@ -288,7 +288,8 @@ class GetScalingGroupServersTests(SynchronousTestCase):
         asmetakey = "rax:autoscale:group:id"
         cache = [
             {'id': 'a', 'metadata': {asmetakey: "gid"}},
-            {'id': 'b', 'metadata': {asmetakey: "gid"}}]
+            {'id': 'b', 'metadata': {asmetakey: "gid"}},
+            {'id': 'd', 'metadata': {asmetakey: "gid"}}]
         changes = [
             {'id': 'a', 'b': 'c', 'metadata': {asmetakey: "gid"}},
             {'id': 'd', 'metadata': {"changed": "yes"}}]

--- a/otter/test/convergence/test_gathering.py
+++ b/otter/test/convergence/test_gathering.py
@@ -43,7 +43,6 @@ from otter.convergence.model import (
     CLBNode,
     CLBNodeCondition,
     CLBNodeType,
-    NovaServer,
     RCv3Description,
     RCv3Node,
     ServerState)
@@ -54,7 +53,8 @@ from otter.test.utils import (
     patch,
     resolve_effect,
     resolve_retry_stubs,
-    resolve_stubs
+    resolve_stubs,
+    server
 )
 from otter.util.retry import (
     Retry, ShouldDelayAndRetry, exponential_backoff_interval, retry_times)
@@ -752,20 +752,13 @@ class GetAllConvergenceDataTests(SynchronousTestCase):
             get_rcv3_contents=_constant_as_eff((), rcv3_nodes))
 
         expected_servers = [
-            NovaServer(id='a',
-                       state=ServerState.ACTIVE,
-                       image_id='image',
-                       flavor_id='flavor',
-                       created=0,
-                       servicenet_address='10.0.0.1',
-                       links=freeze([{'href': 'link1', 'rel': 'self'}])),
-            NovaServer(id='b',
-                       state=ServerState.ACTIVE,
-                       image_id='image',
-                       flavor_id='flavor',
-                       created=1,
-                       servicenet_address='10.0.0.2',
-                       links=freeze([{'href': 'link2', 'rel': 'self'}]))
+            server('a', ServerState.ACTIVE, servicenet_address='10.0.0.1',
+                   links=freeze([{'href': 'link1', 'rel': 'self'}]),
+                   json=freeze(self.servers[0])),
+            server('b', ServerState.ACTIVE, created=1,
+                   servicenet_address='10.0.0.2',
+                   links=freeze([{'href': 'link2', 'rel': 'self'}]),
+                   json=freeze(self.servers[1]))
         ]
         self.assertEqual(resolve_stubs(eff),
                          (expected_servers, clb_nodes + rcv3_nodes))

--- a/otter/test/convergence/test_gathering.py
+++ b/otter/test/convergence/test_gathering.py
@@ -30,6 +30,7 @@ from otter.convergence.gathering import (
     get_all_server_details,
     get_clb_contents,
     get_rcv3_contents,
+    get_all_scaling_group_servers,
     get_scaling_group_servers)
 from otter.convergence.model import (
     CLBDescription,
@@ -212,9 +213,9 @@ class GetAllServerDetailsTests(SynchronousTestCase):
                                 next_interval=exponential_backoff_interval(2)))
 
 
-class GetScalingGroupServersTests(SynchronousTestCase):
+class GetAllScalingGroupServersTests(SynchronousTestCase):
     """
-    Tests for :func:`get_scaling_group_servers`
+    Tests for :func:`get_all_scaling_group_servers`
     """
 
     def setUp(self):
@@ -228,7 +229,7 @@ class GetScalingGroupServersTests(SynchronousTestCase):
         """
         since = datetime(2010, 10, 10, 10, 10, 0)
         eff = resolve_retry_stubs(
-            get_scaling_group_servers(changes_since=since))
+            get_all_scaling_group_servers(changes_since=since))
         fake_response = object()
         body = {'servers': []}
         result = resolve_svcreq(
@@ -240,7 +241,7 @@ class GetScalingGroupServersTests(SynchronousTestCase):
         Servers without metadata are not included in the result.
         """
         servers = [{'id': i} for i in range(10)]
-        eff = resolve_retry_stubs(get_scaling_group_servers())
+        eff = resolve_retry_stubs(get_all_scaling_group_servers())
         fake_response = object()
         body = {'servers': servers}
         result = resolve_svcreq(eff, (fake_response, body), *self.req)
@@ -252,7 +253,7 @@ class GetScalingGroupServersTests(SynchronousTestCase):
         in it
         """
         servers = [{'id': i, 'metadata': {}} for i in range(10)]
-        eff = resolve_retry_stubs(get_scaling_group_servers())
+        eff = resolve_retry_stubs(get_all_scaling_group_servers())
         fake_response = object()
         body = {'servers': servers}
         result = resolve_svcreq(eff, (fake_response, body), *self.req)
@@ -269,7 +270,7 @@ class GetScalingGroupServersTests(SynchronousTestCase):
              for i in range(5, 8)] +
             [{'metadata': {'rax:auto_scaling_group_id': 'a'}, 'id': 10}])
         servers = as_servers + [{'metadata': 'junk'}] * 3
-        eff = resolve_retry_stubs(get_scaling_group_servers())
+        eff = resolve_retry_stubs(get_all_scaling_group_servers())
         fake_response = object()
         body = {'servers': servers}
         result = resolve_svcreq(eff, (fake_response, body), *self.req)
@@ -288,7 +289,7 @@ class GetScalingGroupServersTests(SynchronousTestCase):
              for i in range(5, 8)])
         servers = as_servers + [{'metadata': 'junk'}] * 3
         eff = resolve_retry_stubs(
-            get_scaling_group_servers(
+            get_all_scaling_group_servers(
                 server_predicate=lambda s: s['id'] % 3 == 0))
         fake_response = object()
         body = {'servers': servers}

--- a/otter/test/convergence/test_gathering.py
+++ b/otter/test/convergence/test_gathering.py
@@ -100,18 +100,6 @@ class GetAllServerDetailsTests(SynchronousTestCase):
         """Save basic reused data."""
         self.servers = [{'id': i} for i in range(9)]
 
-    def req(self, query_params=None):
-        """
-        Return the service request with the given query parameters
-        """
-        if query_params is None:
-            query_params = {'limit': 10}
-
-        url = "servers/detail?{}".format(
-            "&".join(["{}={}".format(k, v) for k, v in
-                      query_params.items()]))
-        return (ServiceType.CLOUD_SERVERS, 'GET', url)
-
     def test_get_all_without_link_to_next_page(self):
         """
         `get_all_server_details` will not fetch again if first does not have

--- a/otter/test/convergence/test_gathering.py
+++ b/otter/test/convergence/test_gathering.py
@@ -221,7 +221,7 @@ class GetAllServerDetailsTests(SynchronousTestCase):
                                 next_interval=exponential_backoff_interval(2)))
 
 
-class GetScalingGroupServerTests(SynchronousTestCase):
+class GetScalingGroupServersTests(SynchronousTestCase):
     """
     Tests for :func:`get_scaling_group_servers`
     """

--- a/otter/test/convergence/test_gathering.py
+++ b/otter/test/convergence/test_gathering.py
@@ -10,7 +10,6 @@ from effect import (
     Effect,
     ParallelEffects,
     TypeDispatcher,
-    base_dispatcher,
     sync_perform,
     sync_performer)
 
@@ -48,6 +47,7 @@ from otter.convergence.model import (
     ServerState)
 from otter.test.utils import (
     Cache,
+    get_dispatcher,
     intent_func,
     noop,
     patch,
@@ -240,8 +240,8 @@ class GetScalingGroupServersTests(SynchronousTestCase):
             ("cachegstidgid", lambda i: (object(), None)),
             (("all-as",), lambda i: {} if empty else {"gid": current}),
             (("cacheistidgid", self.now, current, True), noop)])
+        disp = get_dispatcher(sequence)
         with sequence.consume():
-            disp = ComposedDispatcher([sequence, base_dispatcher])
             self.assertEqual(
                 sync_perform(disp, self._invoke()), current)
 
@@ -264,8 +264,8 @@ class GetScalingGroupServersTests(SynchronousTestCase):
              lambda i: {'gid': as_servers} if as_srvs else {}),
             (("all-as",), lambda i: {"gid": current} if cur_srvs else {}),
             (("cacheistidgid", self.now, servers, True), noop)])
+        disp = get_dispatcher(sequence)
         with sequence.consume():
-            disp = ComposedDispatcher([sequence, base_dispatcher])
             self.assertEqual(
                 sync_perform(disp, self._invoke()), servers)
 
@@ -296,8 +296,8 @@ class GetScalingGroupServersTests(SynchronousTestCase):
         sequence = SequenceDispatcher([
             ("cachegstidgid", lambda i: (cache, last_update)),
             (("alls", last_update), lambda i: changes)])
+        disp = get_dispatcher(sequence)
         with sequence.consume():
-            disp = ComposedDispatcher([sequence, base_dispatcher])
             self.assertEqual(
                 self.freeze(sync_perform(disp, self._invoke())),
                 self.freeze([cache[1], changes[0]]))

--- a/otter/test/convergence/test_model.py
+++ b/otter/test/convergence/test_model.py
@@ -381,7 +381,8 @@ class ToNovaServerTests(SynchronousTestCase):
                        flavor_id='valid_flavor',
                        created=self.createds[0][1],
                        servicenet_address='',
-                       links=freeze(self.links[0])))
+                       links=freeze(self.links[0]),
+                       json=freeze(self.servers[0])))
 
     def test_without_private(self):
         """
@@ -396,7 +397,8 @@ class ToNovaServerTests(SynchronousTestCase):
                        flavor_id='valid_flavor',
                        created=self.createds[0][1],
                        servicenet_address='',
-                       links=freeze(self.links[0])))
+                       links=freeze(self.links[0]),
+                       json=freeze(self.servers[0])))
 
     def test_with_servicenet(self):
         """
@@ -410,7 +412,8 @@ class ToNovaServerTests(SynchronousTestCase):
                        flavor_id='valid_flavor',
                        created=self.createds[1][1],
                        servicenet_address='10.0.0.1',
-                       links=freeze(self.links[1])))
+                       links=freeze(self.links[1]),
+                       json=freeze(self.servers[1])))
 
     def test_without_image_id(self):
         """
@@ -427,7 +430,8 @@ class ToNovaServerTests(SynchronousTestCase):
                            flavor_id='valid_flavor',
                            created=self.createds[0][1],
                            servicenet_address='',
-                           links=freeze(self.links[0])))
+                           links=freeze(self.links[0]),
+                           json=freeze(self.servers[0])))
         del self.servers[0]['image']
         self.assertEqual(
             NovaServer.from_server_details_json(self.servers[0]),
@@ -437,7 +441,8 @@ class ToNovaServerTests(SynchronousTestCase):
                        flavor_id='valid_flavor',
                        created=self.createds[0][1],
                        servicenet_address='',
-                       links=freeze(self.links[0])))
+                       links=freeze(self.links[0]),
+                       json=freeze(self.servers[0])))
 
     def test_with_lb_metadata(self):
         """
@@ -471,7 +476,8 @@ class ToNovaServerTests(SynchronousTestCase):
                            CLBDescription(lb_id='1', port=80),
                            CLBDescription(lb_id='1', port=90)]),
                        servicenet_address='',
-                       links=freeze(self.links[0])))
+                       links=freeze(self.links[0]),
+                       json=freeze(self.servers[0])))
 
     def test_lbs_from_metadata_ignores_unsupported_lb_types(self):
         """
@@ -490,7 +496,8 @@ class ToNovaServerTests(SynchronousTestCase):
                        created=self.createds[0][1],
                        desired_lbs=pset(),
                        servicenet_address='',
-                       links=freeze(self.links[0])))
+                       links=freeze(self.links[0]),
+                       json=freeze(self.servers[0])))
 
     def test_draining_from_metadata_trumps_active_build_nova_states(self):
         """
@@ -510,7 +517,8 @@ class ToNovaServerTests(SynchronousTestCase):
                            created=self.createds[0][1],
                            desired_lbs=pset(),
                            servicenet_address='',
-                           links=freeze(self.links[0])))
+                           links=freeze(self.links[0]),
+                           json=freeze(self.servers[0])))
 
     def test_draining_state_invalid_values(self):
         """
@@ -528,7 +536,8 @@ class ToNovaServerTests(SynchronousTestCase):
                        created=self.createds[0][1],
                        desired_lbs=pset(),
                        servicenet_address='',
-                       links=freeze(self.links[0])))
+                       links=freeze(self.links[0]),
+                       json=freeze(self.servers[0])))
 
     def test_error_and_deleted_nova_state_trumps_draining_from_metadata(self):
         """
@@ -548,7 +557,8 @@ class ToNovaServerTests(SynchronousTestCase):
                            created=self.createds[0][1],
                            desired_lbs=pset(),
                            servicenet_address='',
-                           links=freeze(self.links[0])))
+                           links=freeze(self.links[0]),
+                           json=freeze(self.servers[0])))
 
 
 class IPAddressTests(SynchronousTestCase):

--- a/otter/test/convergence/test_planning.py
+++ b/otter/test/convergence/test_planning.py
@@ -493,7 +493,7 @@ def server(id, state, created=0, image_id='image', flavor_id='flavor',
            **kwargs):
     """Convenience for creating a :obj:`NovaServer`."""
     return NovaServer(id=id, state=state, created=created, image_id=image_id,
-                      flavor_id=flavor_id, **kwargs)
+                      flavor_id=flavor_id, json=pmap({'id': id}), **kwargs)
 
 
 class DrainAndDeleteServerTests(SynchronousTestCase):

--- a/otter/test/convergence/test_planning.py
+++ b/otter/test/convergence/test_planning.py
@@ -11,7 +11,6 @@ from otter.convergence.model import (
     CLBNodeType,
     DRAINING_METADATA,
     DesiredGroupState,
-    NovaServer,
     RCv3Description,
     RCv3Node,
     ServerState)
@@ -26,6 +25,7 @@ from otter.convergence.steps import (
     DeleteServer,
     RemoveNodesFromCLB,
     SetMetadataItemOnServer)
+from otter.test.utils import server
 
 
 def copy_clb_desc(clb_desc, condition=CLBNodeCondition.ENABLED, weight=1):
@@ -487,13 +487,6 @@ class ConvergeLBStateTests(SynchronousTestCase):
                     address_configs=s(('1.1.1.1',
                                        CLBDescription(lb_id='5', port=8081))))
                 ]))
-
-
-def server(id, state, created=0, image_id='image', flavor_id='flavor',
-           **kwargs):
-    """Convenience for creating a :obj:`NovaServer`."""
-    return NovaServer(id=id, state=state, created=created, image_id=image_id,
-                      flavor_id=flavor_id, json=pmap({'id': id}), **kwargs)
 
 
 class DrainAndDeleteServerTests(SynchronousTestCase):

--- a/otter/test/convergence/test_service.py
+++ b/otter/test/convergence/test_service.py
@@ -575,7 +575,7 @@ class ExecuteConvergenceTests(SynchronousTestCase):
         self.gsgi_result = (self.group, self.manifest)
         self.now = datetime(1970, 1, 1)
         self.expected_intents = [(gsgi, self.gsgi_result),
-                                 (Func(datetime.now), self.now)]
+                                 (Func(datetime.utcnow), self.now)]
         self.log = mock_log()
 
     def _get_dispatcher(self, expected_intents=None):
@@ -765,7 +765,7 @@ class ExecuteConvergenceTests(SynchronousTestCase):
         del_group = DeleteGroup(tenant_id=self.tenant_id,
                                 group_id=self.group_id)
         self.state.status = ScalingGroupStatus.DELETING
-        exp_intents = [(Func(datetime.now), self.now),
+        exp_intents = [(Func(datetime.utcnow), self.now),
                        (del_group, None),
                        (self.gsgi, (self.group, self.manifest)),
                        ("cachedstenant-idgroup-id", None)]
@@ -793,7 +793,7 @@ class ExecuteConvergenceTests(SynchronousTestCase):
                                   get_all_convergence_data=gacd, plan=fplan)
         disp = self._get_dispatcher(
             [(self.gsgi, (self.group, self.manifest)),
-             (Func(datetime.now), self.now)])
+             (Func(datetime.utcnow), self.now)])
         # This succeeded without DeleteGroup performer being there ensuring
         # that it was not called
         self.assertEqual(sync_perform(disp, eff), StepResult.RETRY)
@@ -846,7 +846,7 @@ class ExecuteConvergenceTests(SynchronousTestCase):
                                   get_all_convergence_data=gacd)
 
         sequence = SequenceDispatcher([
-            (Func(datetime.now), lambda i: self.now),
+            (Func(datetime.utcnow), lambda i: self.now),
             (self.gsgi, lambda i: self.gsgi_result),
             (Log(msg='execute-convergence', fields=mock.ANY), noop),
             (ModifyGroupState(scaling_group=self.group, modifier=mock.ANY),
@@ -882,7 +882,7 @@ class ExecuteConvergenceTests(SynchronousTestCase):
                                   get_all_convergence_data=gacd)
 
         sequence = SequenceDispatcher([
-            (Func(datetime.now), lambda i: self.now),
+            (Func(datetime.utcnow), lambda i: self.now),
             (self.gsgi, lambda i: self.gsgi_result),
             (Log(msg='execute-convergence', fields=mock.ANY), noop),
             (ModifyGroupState(scaling_group=self.group, modifier=mock.ANY),

--- a/otter/test/models/test_cass_models.py
+++ b/otter/test/models/test_cass_models.py
@@ -3635,6 +3635,33 @@ class CassScalingGroupsCollectionHealthCheckTestCase(
             (True, {'cassandra_time': 0}))
 
 
+class CassGroupServersCacheTests(SynchronousTestCase):
+    """
+    Tests for :class:`CassScalingGroupServersCache`
+    """
+
+    def test_get_servers_empty(self):
+        """
+        `get_servers` returns ([], None) if cache is empty
+        """
+
+    def test_get_servers(self):
+        """
+        `get_servers` fetches all servers that have highest last_fetch
+        time
+        """
+
+    def test_insert_servers(self):
+        """
+        `insert_servers` issues query to insert server as json blobs
+        """
+
+    def test_delete_servers(self):
+        """
+        `delete_servers` issues query to delete the whole cache
+        """
+
+
 class CassAdminTestCase(SynchronousTestCase):
     """
     Tests for :class:`CassAdmin`

--- a/otter/test/models/test_cass_models.py
+++ b/otter/test/models/test_cass_models.py
@@ -9,7 +9,7 @@ from datetime import datetime
 from functools import partial
 
 from effect import (
-    ComposedDispatcher, Effect, ParallelEffects, TypeDispatcher,
+    ComposedDispatcher, Constant, Effect, ParallelEffects, TypeDispatcher,
     base_dispatcher, sync_perform)
 from effect.testing import SequenceDispatcher, resolve_effect
 
@@ -3733,6 +3733,14 @@ class CassGroupServersCacheTests(SynchronousTestCase):
         self.assertEqual(eff.intent, "delete")
         eff = resolve_effect(eff, None)
         self._test_insert_servers(eff)
+
+    def test_insert_empty(self):
+        """
+        `insert_servers` does nothing if called with empty servers list
+        """
+        self.assertEqual(
+            self.cache.insert_servers(self.dt, [], False),
+            Effect(Constant(None)))
 
     def test_delete_servers(self):
         """

--- a/otter/test/models/test_cass_models.py
+++ b/otter/test/models/test_cass_models.py
@@ -3697,11 +3697,11 @@ class CassGroupServersCacheTests(SynchronousTestCase):
         query = (
             "BEGIN BATCH "
             "INSERT INTO servers_cache (tenant_id, group_id, last_update, "
-            "server_id, server_blob "
+            "server_id, server_blob) "
             "VALUES(:tenant_id, :group_id, :last_update, :server_id0, "
             ":server_blob0); "
             "INSERT INTO servers_cache (tenant_id, group_id, last_update, "
-            "server_id, server_blob "
+            "server_id, server_blob) "
             "VALUES(:tenant_id, :group_id, :last_update, :server_id1, "
             ":server_blob1); APPLY BATCH;")
         self.params.update(

--- a/otter/test/models/test_cass_models.py
+++ b/otter/test/models/test_cass_models.py
@@ -32,6 +32,8 @@ from twisted.internet import defer
 from twisted.internet.task import Clock
 from twisted.trial.unittest import SynchronousTestCase
 
+from txeffect import deferred_performer
+
 from otter.json_schema import group_examples
 from otter.models.cass import (
     CQLQueryExecute,
@@ -42,6 +44,7 @@ from otter.models.cass import (
     WeakLocks,
     _assemble_webhook_from_row,
     assemble_webhooks_in_policies,
+    get_cql_dispatcher,
     perform_cql_query,
     serialize_json_data,
     verified_view
@@ -119,14 +122,14 @@ def _cassandrify_data(list_of_dicts):
     return _de_identify(list_of_dicts)
 
 
-class PerformTests(SynchronousTestCase):
+class EffectTests(SynchronousTestCase):
     """
-    Tests for :func:`perform_cql_query` function
+    Tests for :func:`perform_cql_query` and :func:`get_cql_dispatcher`
     """
 
     def test_perform_cql_query(self):
         """
-        Calls given connection's execute
+        `perform_cql_query` calls given connection's execute
         """
         conn = mock.Mock(spec=CQLClient)
         conn.execute.return_value = defer.succeed('ret')
@@ -139,6 +142,24 @@ class PerformTests(SynchronousTestCase):
         self.assertEqual(r, 'ret')
         conn.execute.assert_called_once_with(
             'query', {'w': 2}, ConsistencyLevel.ONE)
+
+    @mock.patch('otter.models.cass.perform_cql_query')
+    def test_cql_disp(self, mock_pcq):
+        """
+        The :obj:`CQLQueryExecute` performer is called with
+        dispatcher returned from get_cql_dispatcher
+        """
+
+        @deferred_performer
+        def performer(c, d, i):
+            return defer.succeed('p' + c)
+
+        mock_pcq.side_effect = performer
+
+        dispatcher = get_cql_dispatcher('conn')
+        intent = CQLQueryExecute(query='q', params='p', consistency_level=1)
+        eff = Effect(intent)
+        self.assertEqual(sync_perform(dispatcher, eff), 'pconn')
 
 
 class SerialJsonDataTestCase(SynchronousTestCase):

--- a/otter/test/test_effect_dispatcher.py
+++ b/otter/test/test_effect_dispatcher.py
@@ -3,17 +3,11 @@
 from effect import Constant, Delay, Effect, sync_perform
 from effect.ref import ReadReference, Reference
 
-import mock
-
-from twisted.internet.defer import succeed
 from twisted.trial.unittest import SynchronousTestCase
-
-from txeffect import deferred_performer
 
 from otter.auth import Authenticate, InvalidateToken
 from otter.cloud_client import TenantScope
 from otter.effect_dispatcher import (
-    get_cql_dispatcher,
     get_full_dispatcher,
     get_legacy_dispatcher,
     get_simple_dispatcher)
@@ -51,7 +45,8 @@ def full_intents():
         EvictServerFromScalingGroup(log='log', transaction_id='transaction_id',
                                     scaling_group='scaling_group',
                                     server_id='server_id'),
-        Log('msg', {}), LogErr('f', 'msg', {}), BoundFields(Effect(None), {})
+        Log('msg', {}), LogErr('f', 'msg', {}), BoundFields(Effect(None), {}),
+        CQLQueryExecute(query='q', params={}, consistency_level=7)
     ]
 
 
@@ -92,8 +87,7 @@ class LegacyDispatcherTests(SynchronousTestCase, IntentSupportMixin):
         # This is not testing much, but at least that it calls
         # perform_tenant_scope in a vaguely working manner. There are
         # more specific TenantScope performer tests in otter.test.test_http
-        dispatcher = get_full_dispatcher(
-            None, None, None, None, None, None, None)
+        dispatcher = get_full_dispatcher(*([None] * 8))
         scope = TenantScope(Effect(Constant('foo')), 1)
         eff = Effect(scope)
         self.assertEqual(sync_perform(dispatcher, eff), 'foo')
@@ -103,32 +97,7 @@ class FullDispatcherTests(SynchronousTestCase, IntentSupportMixin):
     """Tests for :func:`get_full_dispatcher`."""
 
     def get_dispatcher(self):
-        return get_full_dispatcher(None, None, None, None, None, None, None)
+        return get_full_dispatcher(*([None] * 8))
 
     def get_intents(self):
         return full_intents()
-
-
-class CQLDispatcherTests(SynchronousTestCase):
-    """Tests for :func:`get_cql_dispatcher`."""
-
-    def test_intent_support(self):
-        """Basic intents are supported by the dispatcher."""
-        dispatcher = get_simple_dispatcher(None)
-        for intent in simple_intents():
-            self.assertIsNot(dispatcher(intent), None)
-
-    @mock.patch('otter.effect_dispatcher.perform_cql_query')
-    def test_cql_disp(self, mock_pcq):
-        """The :obj:`CQLQueryExecute` performer is called."""
-
-        @deferred_performer
-        def performer(c, d, i):
-            return succeed('p' + c)
-
-        mock_pcq.side_effect = performer
-
-        dispatcher = get_cql_dispatcher(object(), 'conn')
-        intent = CQLQueryExecute(query='q', params='p', consistency_level=1)
-        eff = Effect(intent)
-        self.assertEqual(sync_perform(dispatcher, eff), 'pconn')

--- a/otter/test/utils.py
+++ b/otter/test/utils.py
@@ -34,6 +34,7 @@ from zope.interface import directlyProvides, implementer, interface
 from zope.interface.verify import verifyObject
 
 from otter.cloud_client import concretize_service_request
+from otter.convergence.model import NovaServer
 from otter.log.bound import BoundLog
 from otter.models.interface import IScalingGroup
 from otter.supervisor import ISupervisor
@@ -864,3 +865,11 @@ class Cache(object):
 
     def delete_servers(self):
         return Effect(self.ids("ds"))
+
+
+def server(id, state, created=0, image_id='image', flavor_id='flavor',
+           json=None, **kwargs):
+    """Convenience for creating a :obj:`NovaServer`."""
+    return NovaServer(id=id, state=state, created=created, image_id=image_id,
+                      flavor_id=flavor_id,
+                      json=json or pmap({'id': id}), **kwargs)

--- a/otter/test/utils.py
+++ b/otter/test/utils.py
@@ -7,7 +7,7 @@ from functools import partial, wraps
 from inspect import getargspec
 
 from effect import (
-    ComposedDispatcher, ParallelEffects, TypeDispatcher,
+    ComposedDispatcher, Effect, ParallelEffects, TypeDispatcher,
     base_dispatcher, sync_perform, sync_performer)
 from effect.async import perform_parallel_async
 from effect.testing import (
@@ -835,3 +835,31 @@ class TestStep(object):
 def noop(_):
     """Ignore input and return None."""
     pass
+
+
+def intent_func(fname):
+    """
+    Return function that returns Effect of tuple of fname and its args. Useful
+    in writing tests that expect intent based on args
+    """
+    return lambda *a: Effect(tuple([fname] + list(a)))
+
+
+class Cache(object):
+    """ IScalingGroupServersCache impl for testing """
+
+    def __init__(self, tid, gid):
+        self.tid = tid
+        self.gid = gid
+
+    def ids(self, s):
+        return "cache" + s + self.tid + self.gid
+
+    def get_servers(self):
+        return Effect(self.ids("gs"))
+
+    def insert_servers(self, time, servers, clear):
+        return Effect((self.ids("is"), time, servers, clear))
+
+    def delete_servers(self):
+        return Effect(self.ids("ds"))

--- a/otter/test/utils.py
+++ b/otter/test/utils.py
@@ -882,3 +882,10 @@ def server(id, state, created=0, image_id='image', flavor_id='flavor',
     return NovaServer(id=id, state=state, created=created, image_id=image_id,
                       flavor_id=flavor_id,
                       json=json or pmap({'id': id}), **kwargs)
+
+
+def get_dispatcher(sequence):
+    """ Get dispatcher with given sequence in it """
+    return ComposedDispatcher([
+        sequence, base_dispatcher,
+        TypeDispatcher({ParallelEffects: perform_parallel_async})])

--- a/otter/test/utils.py
+++ b/otter/test/utils.py
@@ -842,7 +842,7 @@ def intent_func(fname):
     Return function that returns Effect of tuple of fname and its args. Useful
     in writing tests that expect intent based on args
     """
-    return lambda *a: Effect(tuple([fname] + list(a)))
+    return lambda *a: Effect((fname,) + a)
 
 
 class Cache(object):

--- a/otter/util/fp.py
+++ b/otter/util/fp.py
@@ -86,3 +86,16 @@ def assoc_obj(o, **k):
     new_o = deepcopy(o)
     new_o.__dict__.update(k)
     return new_o
+
+
+def take_while(pred, items):
+    """
+    Return list until pred is true for item in items. Similar to `takeWhile`
+    in Haskell
+
+    :param callable pred: item -> Bool predicate function
+    :param list items: List of items to extract
+    """
+    for item in items:
+        if pred(item):
+            yield item

--- a/otter/util/fp.py
+++ b/otter/util/fp.py
@@ -90,11 +90,11 @@ def assoc_obj(o, **k):
 
 def take_while(pred, items):
     """
-    Return list until pred is true for item in items. Similar to `takeWhile`
-    in Haskell
+    Returns the longest prefix (possibly empty) of items of elements that
+    satisfy pred. Similar to `takeWhile` in Haskell
 
     :param callable pred: item -> Bool predicate function
-    :param list items: List of items to extract
+    :param list items: List of items to extract from
     """
     for item in items:
         if pred(item):

--- a/otter/util/timestamp.py
+++ b/otter/util/timestamp.py
@@ -40,7 +40,16 @@ def timestamp_to_epoch(timestamp):
     :param str timestamp: A UTC timestamp string
     :return: EPOCH seconds as float
     """
-    dt = from_timestamp(timestamp)
+    return datetime_to_epoch(from_timestamp(timestamp))
+
+
+def datetime_to_epoch(dt):
+    """
+    Convert UTC datetime object to EPOCH seconds
+
+    :param datetime dt: A datetime object
+    :return: EPOCH seconds as float
+    """
     return calendar.timegm(dt.utctimetuple()) + dt.microsecond / 1000000.
 
 

--- a/schema/setup/control_50_servers_cache.cql
+++ b/schema/setup/control_50_servers_cache.cql
@@ -1,0 +1,14 @@
+USE @@KEYSPACE@@;
+
+CREATE TABLE servers_cache (
+    tenant_id ascii,
+    group_id ascii,
+    last_fetch timestamp,
+    server_id ascii,
+    server_blob ascii,
+    PRIMARY KEY((tenant_id, group_id), last_fetch, server_id)
+) WITH CLUSTERING ORDER BY (last_fetch DESC, server_id ASC) AND 
+compaction = {
+    'class' : 'SizeTieredCompactionStrategy',
+    'min_threshold' : '2'
+} AND gc_grace_seconds = 3600;

--- a/schema/setup/control_50_servers_cache.cql
+++ b/schema/setup/control_50_servers_cache.cql
@@ -6,7 +6,7 @@ CREATE TABLE servers_cache (
     last_update timestamp,
     server_id ascii,
     server_blob ascii,
-    PRIMARY KEY((tenant_id, group_id), last_fetch, server_id)
+    PRIMARY KEY((tenant_id, group_id), last_update, server_id)
 ) WITH CLUSTERING ORDER BY (last_update DESC, server_id ASC) AND
 compaction = {
     'class' : 'SizeTieredCompactionStrategy',

--- a/schema/setup/control_50_servers_cache.cql
+++ b/schema/setup/control_50_servers_cache.cql
@@ -7,7 +7,7 @@ CREATE TABLE servers_cache (
     server_id ascii,
     server_blob ascii,
     PRIMARY KEY((tenant_id, group_id), last_fetch, server_id)
-) WITH CLUSTERING ORDER BY (last_fetch DESC, server_id ASC) AND 
+) WITH CLUSTERING ORDER BY (last_update DESC, server_id ASC) AND
 compaction = {
     'class' : 'SizeTieredCompactionStrategy',
     'min_threshold' : '2'

--- a/schema/setup/control_50_servers_cache.cql
+++ b/schema/setup/control_50_servers_cache.cql
@@ -3,7 +3,7 @@ USE @@KEYSPACE@@;
 CREATE TABLE servers_cache (
     tenant_id ascii,
     group_id ascii,
-    last_fetch timestamp,
+    last_update timestamp,
     server_id ascii,
     server_blob ascii,
     PRIMARY KEY((tenant_id, group_id), last_fetch, server_id)


### PR DESCRIPTION
Implements first 3 tasks of #881. Reviewer question:

The cache model interface assumes multiple caches of a scaling group separated by `update_time`. `get_servers` is implemented with that assumption whereas in reality only one cache is always used. Should the model and/or the impl change with only one cache in mind? If so, I'll remove `take_while` and its usage. This is why I don't have its tests yet. 