### PR TITLE
Add a random string to the error injection server name criteria in trial tests

### DIFF
--- a/otter/integration/lib/autoscale.py
+++ b/otter/integration/lib/autoscale.py
@@ -98,7 +98,7 @@ def create_scaling_group_dict(
             }
         },
         "groupConfiguration": {
-            "name": "{}-{}".format(name, reactor.seconds()),
+            "name": name,
             "cooldown": 0,
             "minEntities": min_entities,
             "maxEntities": max_entities,
@@ -110,8 +110,11 @@ def create_scaling_group_dict(
     if use_lbs:
         launch_config_args["loadBalancers"] = use_lbs
 
+    server_name = "test-server"
     if server_name_prefix is not None:
-        launch_config_args["server"]["name"] = server_name_prefix
+        server_name = server_name_prefix
+    launch_config_args["server"]["name"] = "{}-{}".format(server_name,
+                                                          reactor.seconds())
 
     return obj
 

--- a/otter/integration/lib/autoscale.py
+++ b/otter/integration/lib/autoscale.py
@@ -98,7 +98,7 @@ def create_scaling_group_dict(
             }
         },
         "groupConfiguration": {
-            "name": name,
+            "name": "{}-{}".format(name, reactor.seconds()),
             "cooldown": 0,
             "minEntities": min_entities,
             "maxEntities": max_entities,

--- a/otter/integration/lib/autoscale.py
+++ b/otter/integration/lib/autoscale.py
@@ -110,11 +110,8 @@ def create_scaling_group_dict(
     if use_lbs:
         launch_config_args["loadBalancers"] = use_lbs
 
-    server_name = "test-server"
     if server_name_prefix is not None:
-        server_name = server_name_prefix
-    launch_config_args["server"]["name"] = "{}-{}".format(server_name,
-                                                          reactor.seconds())
+        launch_config_args["server"]["name"] = server_name_prefix
 
     return obj
 

--- a/otter/integration/tests/test_convergence.py
+++ b/otter/integration/tests/test_convergence.py
@@ -819,6 +819,7 @@ class ConvergenceTestsNoLBs(unittest.TestCase):
             criteria=[{"server_name": server_name_prefix + ".*"}],
             behaviors=[
                 {"name": "error", "parameters": {}},
+                {"name": "default"},
                 {"name": "default"}
             ])
         d.addCallback(
@@ -972,6 +973,8 @@ class ConvergenceTestsNoLBs(unittest.TestCase):
                 {"name": "false-negative",
                  "parameters": {"code": 500,
                                 "message": "Server creation failed."}},
+                {"name": "default"},
+                {"name": "default"}
             ])
         d.addCallback(
             lambda _: self.helper.start_group_and_wait(group, self.rcs))

--- a/otter/integration/tests/test_convergence.py
+++ b/otter/integration/tests/test_convergence.py
@@ -61,6 +61,7 @@ def not_mimic():
     """
     return not bool(os.environ.get("AS_USING_MIMIC", False))
 
+
 class TestHelper(object):
     """
     A helper class that contains useful functions for actual test cases.  This


### PR DESCRIPTION
While attempting to debug intermittent timeouts, realized this could also cause intermittent timeouts.  Since the test is just copied over from the test without CLBs to the test with CLBs, both will have the same server name as the criteria.  So if that the same test both with and without CLB are running at the same time (which can happen with parallelization), they'll use the same behavior counter in mimic.

Which may cause some non-deterministic behavior.

I am also adding behavior deletion/cleanup to mimic, so these tests can clean up the behavior they're injecting too, but that will be another PR.