### PR TITLE
Log mismatches when waiting for a desired state in trial tests

### DIFF
--- a/otter/integration/lib/autoscale.py
+++ b/otter/integration/lib/autoscale.py
@@ -14,9 +14,9 @@ from testtools.matchers import MatchesPredicateWithParams
 
 import treq
 
-from twisted.python.log import msg
 from twisted.internet import reactor
 from twisted.internet.defer import gatherResults, inlineCallbacks, returnValue
+from twisted.python.log import msg
 
 from otter.integration.lib.nova import NovaServer
 from otter.util.deferredutils import retry_and_timeout

--- a/otter/integration/lib/autoscale.py
+++ b/otter/integration/lib/autoscale.py
@@ -14,6 +14,7 @@ from testtools.matchers import MatchesPredicateWithParams
 
 import treq
 
+from twisted.python.log import msg
 from twisted.internet import reactor
 from twisted.internet.defer import gatherResults, inlineCallbacks, returnValue
 
@@ -448,6 +449,8 @@ class ScalingGroup(object):
             response, group_state = result
             mismatch = matcher.match(group_state['group'])
             if mismatch:
+                msg("Waiting for desired group state.\nMismatch: {}"
+                    .format(mismatch.describe()))
                 raise TransientRetryError(mismatch.describe())
             return rcs
 

--- a/otter/integration/lib/cloud_load_balancer.py
+++ b/otter/integration/lib/cloud_load_balancer.py
@@ -11,6 +11,7 @@ from testtools.matchers import MatchesPredicateWithParams
 import treq
 
 from twisted.internet import reactor
+from twisted.python.log import msg
 
 from otter.util.deferredutils import retry_and_timeout
 from otter.util.http import check_success, headers
@@ -212,6 +213,8 @@ class CloudLoadBalancer(object):
         def check(nodes):
             mismatch = matcher.match(nodes['nodes'])
             if mismatch:
+                msg("Waiting for CLB node state for CLB {}.\nMismatch: {}"
+                    .format(self.clb_id, mismatch.describe()))
                 raise TransientRetryError(mismatch.describe())
 
         def poll():

--- a/otter/integration/lib/nova.py
+++ b/otter/integration/lib/nova.py
@@ -7,6 +7,7 @@ import treq
 
 from twisted.internet import reactor
 from twisted.internet.defer import gatherResults, inlineCallbacks, returnValue
+from twisted.python.log import msg
 
 from otter.util.deferredutils import retry_and_timeout
 from otter.util.http import check_success, headers
@@ -132,6 +133,8 @@ def wait_for_servers(rcs, pool, group, matcher, timeout=600, period=10,
         ]
         mismatch = matcher.match(servers_in_group)
         if mismatch:
+            msg("Waiting for Nova servers in group {}.\nMismatch: {}"
+                .format(group.group_id, mismatch.describe()))
             raise TransientRetryError(mismatch.describe())
         returnValue(servers_in_group)
 


### PR DESCRIPTION
As in desired autoscale state, or desired nova server state, or desired CLB node state.

These will be logged in `_trial_temp/test.log` if running without concurrency, and in `_trial_temp/<#>/test.log` when running with concurrency.  (the # specifies which thread that test was running on).

This should probably be added to retry instead (see https://github.com/rackerlabs/otter/issues/1461), but this might be useful in the meantime.

Produces messages like:

```
2015-05-28 21:07:08+0000 [HTTP11ClientProtocol,client] Waiting for desired group state.
        Mismatch: Differences: [
        State {u'status': u'ACTIVE', u'desiredCapacity': 2, u'paused': False, u'active': [], u'pendingCapacity': 2, u'activeCapacity': 0, u'name': u'automatically-generated-test-configuration'} does not have 2 active servers.
        Differences: {
          'pendingCapacity': 0 != 2,
        }
        ]
```