### PR TITLE
Clean up created error behaviors in mimic

### DIFF
--- a/otter/integration/lib/mimic.py
+++ b/otter/integration/lib/mimic.py
@@ -95,13 +95,11 @@ class MimicNova(object):
 
         if self.test_case is not None:
             self.test_case.addCleanup(
-                self.delete_behavior, rcs, behavior_id, event_description,
-                [204])
+                self.delete_behavior, rcs, behavior_id, event_description)
 
         returnValue(behavior_id)
 
-    def delete_behavior(self, rcs, behavior_id, event_description="creation",
-                        success_codes=None):
+    def delete_behavior(self, rcs, behavior_id, event_description="creation"):
         """
         Given a behavior ID, delete it from mimic.
 
@@ -110,8 +108,6 @@ class MimicNova(object):
         :param event_description: What type of event this is that should be
             deleted.
         :param str behavior_id: The ID of the behavior to delete.
-        :param list success_codes: The list of codes to count as a successful
-            behavior deletion - defaults to 204 and 404.
         """
         d = self.treq.delete(
             "{0}/behaviors/{1}/{2}".format(rcs.endpoints['mimic_nova'],
@@ -119,7 +115,6 @@ class MimicNova(object):
             headers=headers(str(rcs.token)),
             pool=self.pool
         )
-        d.addCallback(check_success,
-                      [204, 404] if success_codes is None else success_codes)
+        d.addCallback(check_success, [204, 404])
         d.addCallback(self.treq.content)
         return d

--- a/otter/integration/lib/test_mimic.py
+++ b/otter/integration/lib/test_mimic.py
@@ -73,8 +73,7 @@ class MimicNovaTestCase(SynchronousTestCase):
         self.assertEqual("my_id", self.successResultOf(d))
         self.assertEqual(
             test_case.called_with,
-            ((mimic_nova.delete_behavior, self.rcs,
-              "my_id", "some_event", [204]),
+            ((mimic_nova.delete_behavior, self.rcs, "my_id", "some_event"),
              {}))
 
     def test_delete_behavior(self):

--- a/otter/integration/lib/test_mimic.py
+++ b/otter/integration/lib/test_mimic.py
@@ -67,10 +67,9 @@ class MimicNovaTestCase(SynchronousTestCase):
              self.expected_kwargs),
             (Response(201), '{"id": "my_id"}'))
 
-        mimic_nova = MimicNova(pool=self.pool, treq=_treq)
+        mimic_nova = MimicNova(pool=self.pool, test_case=test_case, treq=_treq)
         d = mimic_nova.sequenced_behaviors(
-            self.rcs, criteria, behaviors, event_description="some_event",
-            add_cleanup_to=test_case)
+            self.rcs, criteria, behaviors, event_description="some_event")
         self.assertEqual("my_id", self.successResultOf(d))
         self.assertEqual(
             test_case.called_with,

--- a/otter/integration/lib/test_mimic.py
+++ b/otter/integration/lib/test_mimic.py
@@ -45,8 +45,16 @@ class MimicNovaTestCase(SynchronousTestCase):
 
     def test_sequenced_behaviors(self):
         """
-        Cause a sequence of behaviors, and succeeds on 201.
+        Cause a sequence of behaviors, and succeeds on 201.  When a test case
+        is provided for which a cleanup should be added, delete is added as
+        a cleanup.
         """
+        class FakeTestCase(object):
+            def addCleanup(test_self, *args, **kwargs):
+                test_self.called_with = (args, kwargs)
+
+        test_case = FakeTestCase()
+
         criteria = [{"server_name": "name_criteria_.*"}]
         behaviors = [{'name': "behavior name",
                       'parameters': {"behavior": "params"}}]
@@ -57,9 +65,30 @@ class MimicNovaTestCase(SynchronousTestCase):
                           'name': "sequence",
                           'parameters': {"behaviors": behaviors}}),),
              self.expected_kwargs),
-            (Response(201), "successful behavior response"))
+            (Response(201), '{"id": "my_id"}'))
 
-        d = MimicNova(pool=self.pool, treq=_treq).sequenced_behaviors(
-            self.rcs, criteria, behaviors, event_description="some_event")
-        self.assertEqual('successful behavior response',
+        mimic_nova = MimicNova(pool=self.pool, treq=_treq)
+        d = mimic_nova.sequenced_behaviors(
+            self.rcs, criteria, behaviors, event_description="some_event",
+            add_cleanup_to=test_case)
+        self.assertEqual("my_id", self.successResultOf(d))
+        self.assertEqual(
+            test_case.called_with,
+            ((mimic_nova.delete_behavior, self.rcs,
+              "my_id", "some_event", [204]),
+             {}))
+
+    def test_delete_behavior(self):
+        """
+        Delete an existing behavior.
+        """
+        _treq = get_fake_treq(
+            self, 'DELETE', "mimicnovaurl/behaviors/some_event/behavior_id",
+            ((),
+             self.expected_kwargs),
+            (Response(204), "successfully deleted behavior"))
+
+        d = MimicNova(pool=self.pool, treq=_treq).delete_behavior(
+            self.rcs, "behavior_id", event_description="some_event")
+        self.assertEqual('successfully deleted behavior',
                          self.successResultOf(d))

--- a/otter/integration/tests/test_convergence.py
+++ b/otter/integration/tests/test_convergence.py
@@ -823,15 +823,15 @@ class ConvergenceTestsNoLBs(unittest.TestCase):
             min_entities=2, max_entities=10,
             server_name_prefix="build-to-error"
         )
-        d = MimicNova(pool=self.helper.pool).sequenced_behaviors(
+        mimic_nova = MimicNova(pool=self.helper.pool, test_case=self)
+        d = mimic_nova.sequenced_behaviors(
             self.rcs,
             criteria=[{"server_name": server_name_prefix + ".*"}],
             behaviors=[
                 {"name": "error", "parameters": {}},
                 {"name": "default"},
                 {"name": "default"}
-            ],
-            add_cleanup_to=self)
+            ])
         d.addCallback(
             lambda _: self.helper.start_group_and_wait(group, self.rcs))
         d.addCallback(wait_for_servers, pool=self.helper.pool, group=group,
@@ -860,8 +860,8 @@ class ConvergenceTestsNoLBs(unittest.TestCase):
             min_entities=2, max_entities=10,
             server_name_prefix="build-timeout"
         )
-
-        yield MimicNova(pool=self.helper.pool).sequenced_behaviors(
+        mimic_nova = MimicNova(pool=self.helper.pool, test_case=self)
+        yield mimic_nova.sequenced_behaviors(
             self.rcs,
             criteria=[{"server_name": server_name_prefix + ".*"}],
             behaviors=[
@@ -869,8 +869,7 @@ class ConvergenceTestsNoLBs(unittest.TestCase):
                  "parameters": {"duration": otter_build_timeout * 2}},
                 {"name": "default"},
                 {"name": "default"}
-            ],
-            add_cleanup_to=self)
+            ])
         yield group.start(self.rcs, self)
 
         initial_servers = yield wait_for_servers(
@@ -975,7 +974,8 @@ class ConvergenceTestsNoLBs(unittest.TestCase):
             min_entities=2, max_entities=10,
             server_name_prefix="false-negative"
         )
-        d = MimicNova(pool=self.helper.pool).sequenced_behaviors(
+        mimic_nova = MimicNova(pool=self.helper.pool, test_case=self)
+        d = mimic_nova.sequenced_behaviors(
             self.rcs,
             criteria=[{"server_name": server_name_prefix + ".*"}],
             behaviors=[
@@ -984,8 +984,7 @@ class ConvergenceTestsNoLBs(unittest.TestCase):
                                 "message": "Server creation failed."}},
                 {"name": "default"},
                 {"name": "default"}
-            ],
-            add_cleanup_to=self)
+            ])
         d.addCallback(
             lambda _: self.helper.start_group_and_wait(group, self.rcs))
         d.addCallback(wait_for_servers, pool=self.helper.pool, group=group,

--- a/otter/integration/tests/test_convergence.py
+++ b/otter/integration/tests/test_convergence.py
@@ -811,7 +811,8 @@ class ConvergenceTestsNoLBs(unittest.TestCase):
             behaviors=[
                 {"name": "error", "parameters": {}},
                 {"name": "default"}
-            ])
+            ],
+            add_cleanup_to=self)
         d.addCallback(
             lambda _: self.helper.start_group_and_wait(group, self.rcs))
         d.addCallback(wait_for_servers, pool=self.helper.pool, group=group,
@@ -848,7 +849,8 @@ class ConvergenceTestsNoLBs(unittest.TestCase):
                 {"name": "build",
                  "parameters": {"duration": otter_build_timeout * 2}},
                 {"name": "default"}
-            ])
+            ],
+            add_cleanup_to=self)
         yield group.start(self.rcs, self)
 
         initial_servers = yield wait_for_servers(
@@ -961,7 +963,8 @@ class ConvergenceTestsNoLBs(unittest.TestCase):
                  "parameters": {"code": 500,
                                 "message": "Server creation failed."}},
                 {"name": "default"}
-            ])
+            ],
+            add_cleanup_to=self)
         d.addCallback(
             lambda _: self.helper.start_group_and_wait(group, self.rcs))
         d.addCallback(wait_for_servers, pool=self.helper.pool, group=group,


### PR DESCRIPTION
With the name randomization this should be less of an issue, but also good not to have a ton of error behaviors sitting around in mimic, since mimic iterates through all of them on every server create.