### PR TITLE
Better logging for "reasons" for step errors

### DIFF
--- a/otter/convergence/effecting.py
+++ b/otter/convergence/effecting.py
@@ -2,12 +2,13 @@
 
 from effect import parallel
 
-from otter.convergence.model import StepResult
+from otter.convergence.model import ErrorReason, StepResult
 
 
 def steps_to_effect(steps):
     """Turns a collection of :class:`IStep` providers into an effect."""
     # Treat unknown errors as RETRY.
     return parallel([
-        s.as_effect().on(error=lambda e: (StepResult.RETRY, [e[1]]))
+        s.as_effect().on(error=lambda e: (StepResult.RETRY,
+                                          [ErrorReason.ExceptionOccured(e)]))
         for s in steps])

--- a/otter/convergence/effecting.py
+++ b/otter/convergence/effecting.py
@@ -10,5 +10,5 @@ def steps_to_effect(steps):
     # Treat unknown errors as RETRY.
     return parallel([
         s.as_effect().on(error=lambda e: (StepResult.RETRY,
-                                          [ErrorReason.ExceptionOccured(e)]))
+                                          [ErrorReason.Exception(e)]))
         for s in steps])

--- a/otter/convergence/errors.py
+++ b/otter/convergence/errors.py
@@ -1,0 +1,33 @@
+from singledispatch import singledispatch
+
+from sumtypes import match
+
+from otter.cloud_client import CLBDeletedError, NoSuchCLBError
+from otter.convergence.model import ErrorReason
+
+def present_reasons(reasons):
+    """
+    Get a list of user-presentable messages from a list of :obj:`ErrorReason`.
+    """
+    @match(ErrorReason)
+    class _present_reason(object):
+        def Exception(exc_info): return _present_exception(exc_info[1])
+        def _(_): return None
+    return filter(lambda: None, map(_present_reason, reasons))
+
+
+@singledispatch
+def _present_exception(exception):
+    """Get a user-presentable message or None from an exception instance."""
+    return None
+
+
+@_present_exception.register(NoSuchCLBError)
+def _present_no_such_clb_error(exception):
+    return "Cloud Load Balancer does not exist: %s" % (exception.lb_id,)
+
+
+@_present_exception.register(CLBDeletedError)
+def _present_clb_deleted_error(exception):
+    return ("Cloud Load Balancer is currently being deleted: %s"
+            % (exception.lb_id,))

--- a/otter/convergence/errors.py
+++ b/otter/convergence/errors.py
@@ -1,9 +1,14 @@
+import traceback
+
+from toolz.functoolz import identity
+
 from singledispatch import singledispatch
 
 from sumtypes import match
 
 from otter.cloud_client import CLBDeletedError, NoSuchCLBError
 from otter.convergence.model import ErrorReason
+from otter.log.formatters import serialize_to_jsonable
 
 def present_reasons(reasons):
     """
@@ -31,3 +36,12 @@ def _present_no_such_clb_error(exception):
 def _present_clb_deleted_error(exception):
     return ("Cloud Load Balancer is currently being deleted: %s"
             % (exception.lb_id,))
+
+
+@match(ErrorReason)
+class structure_reason(object):
+    def Exception(exc_info):
+        return  {
+            'exception': serialize_to_jsonable(exc_info[1]),
+            'traceback': ''.join(traceback.format_exception(*exc_info))}
+    _ = identity

--- a/otter/convergence/errors.py
+++ b/otter/convergence/errors.py
@@ -10,14 +10,19 @@ from otter.cloud_client import CLBDeletedError, NoSuchCLBError
 from otter.convergence.model import ErrorReason
 from otter.log.formatters import serialize_to_jsonable
 
+
 def present_reasons(reasons):
     """
     Get a list of user-presentable messages from a list of :obj:`ErrorReason`.
     """
     @match(ErrorReason)
     class _present_reason(object):
-        def Exception(exc_info): return _present_exception(exc_info[1])
-        def _(_): return None
+        def Exception(exc_info):
+            return _present_exception(exc_info[1])
+
+        def _(_):
+            return None
+
     return filter(None, map(_present_reason, reasons))
 
 

--- a/otter/convergence/errors.py
+++ b/otter/convergence/errors.py
@@ -50,4 +50,4 @@ class structure_reason(object):
             'exception': serialize_to_jsonable(exc_info[1]),
             'traceback': ''.join(traceback.format_exception(*exc_info))}
     Structured = identity
-    Other = identity
+    String = identity

--- a/otter/convergence/errors.py
+++ b/otter/convergence/errors.py
@@ -2,10 +2,9 @@ import traceback
 
 from singledispatch import singledispatch
 
-from toolz.functoolz import identity
-
-
 from sumtypes import match
+
+from toolz.functoolz import identity
 
 from otter.cloud_client import CLBDeletedError, NoSuchCLBError
 from otter.convergence.model import ErrorReason
@@ -42,7 +41,7 @@ def _present_clb_deleted_error(exception):
 @match(ErrorReason)
 class structure_reason(object):
     def Exception(exc_info):
-        return  {
+        return {
             'exception': serialize_to_jsonable(exc_info[1]),
             'traceback': ''.join(traceback.format_exception(*exc_info))}
     Structured = identity

--- a/otter/convergence/errors.py
+++ b/otter/convergence/errors.py
@@ -1,8 +1,9 @@
 import traceback
 
+from singledispatch import singledispatch
+
 from toolz.functoolz import identity
 
-from singledispatch import singledispatch
 
 from sumtypes import match
 
@@ -44,4 +45,5 @@ class structure_reason(object):
         return  {
             'exception': serialize_to_jsonable(exc_info[1]),
             'traceback': ''.join(traceback.format_exception(*exc_info))}
-    _ = identity
+    Structured = identity
+    Other = identity

--- a/otter/convergence/errors.py
+++ b/otter/convergence/errors.py
@@ -13,7 +13,7 @@ def present_reasons(reasons):
     class _present_reason(object):
         def Exception(exc_info): return _present_exception(exc_info[1])
         def _(_): return None
-    return filter(lambda: None, map(_present_reason, reasons))
+    return filter(None, map(_present_reason, reasons))
 
 
 @singledispatch

--- a/otter/convergence/model.py
+++ b/otter/convergence/model.py
@@ -121,8 +121,7 @@ class StepResult(Names):
 class ErrorReason(object):
     """A reason for a step to be in a RETRY or FAILURE state."""
     Exception = constructor('exc_info')
-    Other = constructor(
-        ('reason', attr.ib(validator=instance_of((unicode, str)))))
+    Other = constructor(reason=attr.ib(validator=instance_of((unicode, str))))
     Structured = constructor('structure')
 
 

--- a/otter/convergence/model.py
+++ b/otter/convergence/model.py
@@ -129,8 +129,7 @@ class StepResult(Names):
 @sumtype
 class ErrorReason(object):
     """A reason for a step to be in a RETRY or FAILURE state."""
-    Exception = constructor(
-        ('exc_info', attr.ib(validator=instance_of(tuple))))
+    Exception = constructor('exc_info')
     Other = constructor(
         ('reason', attr.ib(validator=instance_of((unicode, str)))))
     Structured = constructor('structure')

--- a/otter/convergence/model.py
+++ b/otter/convergence/model.py
@@ -121,7 +121,7 @@ class StepResult(Names):
 class ErrorReason(object):
     """A reason for a step to be in a RETRY or FAILURE state."""
     Exception = constructor('exc_info')
-    Other = constructor(reason=attr.ib(validator=instance_of((unicode, str))))
+    String = constructor(reason=attr.ib(validator=instance_of((unicode, str))))
     Structured = constructor('structure')
 
 

--- a/otter/convergence/model.py
+++ b/otter/convergence/model.py
@@ -117,15 +117,6 @@ class StepResult(Names):
     """
 
 
-# okay, so this is what we care about
-# - exceptions should have their full tracebacks rendered in the logs
-# - *some* things should either *have* user-presentable error messages or be
-#   mappable to them
-# - other things we want to log with some structure, in case we want to be able
-#   to filter on it later with ElasticSearch
-# - other arbitrary messages that we _don't_ want to show to the user.
-# - The question is whether we should
-
 @sumtype
 class ErrorReason(object):
     """A reason for a step to be in a RETRY or FAILURE state."""

--- a/otter/convergence/service.py
+++ b/otter/convergence/service.py
@@ -30,7 +30,7 @@ from otter.cloud_client import TenantScope
 from otter.constants import CONVERGENCE_DIRTY_DIR
 from otter.convergence.composition import get_desired_group_state
 from otter.convergence.effecting import steps_to_effect
-from otter.convergence.errors import present_reasons
+from otter.convergence.errors import present_reasons, structure_reason
 from otter.convergence.gathering import get_all_convergence_data
 from otter.convergence.model import ServerState, StepResult
 from otter.convergence.planning import plan
@@ -145,9 +145,13 @@ def execute_convergence(tenant_id, group_id, build_timeout,
     priority = sorted(results,
                       key=lambda (status, reasons): severity.index(status))
     worst_status = priority[0][0]
+    results_to_log = zip(
+        steps,
+        [(result, map(structure_reason, reasons))
+         for result, reasons in results])
     yield msg('execute-convergence-results',
-              results=zip(steps, results),
-              worst_status=worst_status)
+              results=results_to_log,
+              worst_status=worst_status.name)
 
     if worst_status == StepResult.SUCCESS:
         if group_state.status == ScalingGroupStatus.DELETING:

--- a/otter/convergence/service.py
+++ b/otter/convergence/service.py
@@ -19,11 +19,7 @@ from kazoo.recipe.partitioner import PartitionState
 from pyrsistent import pset
 from pyrsistent import thaw
 
-from singledispatch import singledispatch
-
 import six
-
-from sumtypes import match
 
 from twisted.application.service import MultiService
 
@@ -33,8 +29,9 @@ from otter.cloud_client import TenantScope
 from otter.constants import CONVERGENCE_DIRTY_DIR
 from otter.convergence.composition import get_desired_group_state
 from otter.convergence.effecting import steps_to_effect
+from otter.convergence.errors import present_reasons
 from otter.convergence.gathering import get_all_convergence_data
-from otter.convergence.model import ErrorReason, ServerState, StepResult
+from otter.convergence.model import ServerState, StepResult
 from otter.convergence.planning import plan
 from otter.log.cloudfeeds import cf_err, cf_msg
 from otter.log.intents import err, msg, with_log
@@ -165,40 +162,9 @@ def execute_convergence(tenant_id, group_id, build_timeout,
                                        status=ScalingGroupStatus.ERROR))
         yield cf_err(
             'group-status-error', status=ScalingGroupStatus.ERROR.name,
-            reasons='; '.join(_get_user_presentable_reasons(all_reasons)))
+            reasons='; '.join(present_reasons(all_reasons)))
 
     yield do_return(worst_status)
-
-
-@match(ErrorReason)
-class _present_reason(object):
-    """Get a user-presentable message or None from an :obj:`ErrorReason`."""
-    def Exception(exc_info): return _present_exception(exc_info[1])
-    def _(_): return None
-
-
-def _present_reasons(reasons):
-    """
-    Get a list of user-presentable messages from a list of :obj:`ErrorReason`.
-    """
-    return filter(lambda: None, map(_present_reason, reasons))
-
-
-@singledispatch
-def _present_exception(exception):
-    """Get a user-presentable message or None from an exception instance."""
-    return None
-
-
-@_present_exception.register(NoSuchCLBError):
-def _present_no_such_clb_error(exception):
-    return "Cloud Load Balancer does not exist: %s" % (exception.lb_id,)
-
-
-@present_exception.register(CLBDeletedError):
-def _present_clb_deleted_error(exception):
-    return ("Cloud Load Balancer is currently being deleted: %s"
-            % (exception.lb_id,))
 
 
 def format_dirty_flag(tenant_id, group_id):

--- a/otter/convergence/service.py
+++ b/otter/convergence/service.py
@@ -167,7 +167,7 @@ def execute_convergence(tenant_id, group_id, build_timeout,
                                        status=ScalingGroupStatus.ERROR))
         yield cf_err(
             'group-status-error', status=ScalingGroupStatus.ERROR.name,
-            reasons='; '.join(present_reasons(all_reasons)))
+            reasons='; '.join(sorted(present_reasons(all_reasons))))
 
     yield do_return(worst_status)
 

--- a/otter/convergence/service.py
+++ b/otter/convergence/service.py
@@ -5,6 +5,7 @@ The top-level entry-points into this module are :obj:`ConvergenceStarter` and
 :obj:`Converger`.
 """
 
+import operator
 import time
 import uuid
 from functools import partial
@@ -139,7 +140,7 @@ def execute_convergence(tenant_id, group_id, build_timeout,
         yield do_return(StepResult.SUCCESS)
     results = yield steps_to_effect(steps)
 
-    all_reasons = (x[1] for x in results)
+    all_reasons = reduce(operator.add, (x[1] for x in results))
     severity = [StepResult.FAILURE, StepResult.RETRY, StepResult.SUCCESS]
     priority = sorted(results,
                       key=lambda (status, reasons): severity.index(status))

--- a/otter/convergence/steps.py
+++ b/otter/convergence/steps.py
@@ -139,7 +139,7 @@ class CreateServer(object):
             active.
             """
             return StepResult.RETRY, [
-                ErrorReason.Other('waiting for server to become active')]
+                ErrorReason.String('waiting for server to become active')]
 
         def report_failure(result):
             """
@@ -152,7 +152,7 @@ class CreateServer(object):
             if err_type == APIError:
                 message = _parse_nova_user_error(error)
                 if message is not None:
-                    return StepResult.FAILURE, [ErrorReason.Other(message)]
+                    return StepResult.FAILURE, [ErrorReason.String(message)]
 
             return StepResult.RETRY, [ErrorReason.Exception(result)]
 
@@ -228,7 +228,7 @@ class DeleteServer(object):
 
         def report_success(result):
             return StepResult.RETRY, [
-                ErrorReason.Other(
+                ErrorReason.String(
                     'must re-gather after deletion in order to update the '
                     'active cache')]
 
@@ -340,7 +340,7 @@ class AddNodesToCLB(object):
 
         def report_success(result):
             return StepResult.RETRY, [
-                ErrorReason.Other(
+                ErrorReason.String(
                     'must re-gather after adding to CLB in order to update '
                     'the active cache')]
 
@@ -566,8 +566,8 @@ def _rcv3_check_bulk_add(attempted_pairs, result):
 
     if response.code == 201:  # All done!
         return StepResult.RETRY, [
-            ErrorReason.Other('must re-gather after adding to LB in order to '
-                              'update the active cache')]
+            ErrorReason.String('must re-gather after adding to LB in order to '
+                               'update the active cache')]
 
     failure_reasons = []
     to_retry = pset(attempted_pairs)

--- a/otter/convergence/steps.py
+++ b/otter/convergence/steps.py
@@ -21,7 +21,7 @@ from otter.cloud_client import (
     service_request,
     set_nova_metadata_item)
 from otter.constants import ServiceType
-from otter.convergence.model import StepResult
+from otter.convergence.model import ErrorReason, StepResult
 from otter.util.fp import predicate_any
 from otter.util.hashkey import generate_server_name
 from otter.util.http import APIError, append_segments, try_json_with_keys
@@ -38,7 +38,12 @@ class IStep(Interface):
     """
 
     def as_effect():
-        """Return an Effect which performs this step."""
+        """
+        Return an Effect which performs this step.
+
+        :return: A two-tuple of a :obj:`StepResult` and a list of
+        :obj:`ErrorReason`s.
+        """
 
 
 def set_server_name(server_config_args, name_suffix):
@@ -73,6 +78,7 @@ _NOVA_403_RACKCONNECT_NETWORK_REQUIRED = _forbidden_plaintext(
 
 
 def _parse_nova_user_error(api_error):
+    # TODO: Move this to cloud_client.py
     """
     Parse API errors for user failures on creating a server.
 
@@ -132,7 +138,8 @@ class CreateServer(object):
             a while, and we need to retry convergence to ensure it goes into
             active.
             """
-            return StepResult.RETRY, ['waiting for server to become active']
+            return StepResult.RETRY, [
+                ErrorReason.Other('waiting for server to become active')]
 
         def report_failure(result):
             """
@@ -145,9 +152,9 @@ class CreateServer(object):
             if err_type == APIError:
                 message = _parse_nova_user_error(error)
                 if message is not None:
-                    return StepResult.FAILURE, [message]
+                    return StepResult.FAILURE, [ErrorReason.Other(message)]
 
-            return StepResult.RETRY, [error]
+            return StepResult.RETRY, [ErrorReason.Exception(result)]
 
         return eff.on(got_name).on(success=report_success,
                                    error=report_failure)
@@ -221,8 +228,9 @@ class DeleteServer(object):
 
         def report_success(result):
             return StepResult.RETRY, [
-                'must re-gather after deletion in order to update the active '
-                'cache']
+                ErrorReason.Other(
+                    'must re-gather after deletion in order to update the '
+                    'active cache')]
 
         return eff.on(success=report_success)
 
@@ -332,8 +340,9 @@ class AddNodesToCLB(object):
 
         def report_success(result):
             return StepResult.RETRY, [
-                'must re-gather after adding to CLB in order to update the '
-                'active cache']
+                ErrorReason.Other(
+                    'must re-gather after adding to CLB in order to update '
+                    'the active cache')]
 
         def report_api_failure(result):
             """
@@ -342,12 +351,14 @@ class AddNodesToCLB(object):
             """
             err_type, error, traceback = result
             if error.code == 404:
-                return StepResult.FAILURE, [error]
+                return StepResult.FAILURE, [
+                    ErrorReason.Exception(result)]
             if error.code == 422:
                 message = try_json_with_keys(error.body, ("message",))
                 if message and _CLB_DELETED_PATTERN.search(message):
-                    return StepResult.FAILURE, [error]
-            return StepResult.RETRY, [error]
+                    return StepResult.FAILURE, [
+                        ErrorReason.Exception(result)]
+            return StepResult.RETRY, [ErrorReason.Exception(result)]
 
         return eff.on(success=report_success,
                       error=catch(APIError, report_api_failure))
@@ -460,9 +471,10 @@ def _clb_check_change_node_retry_on_404(step, result):
     """
     When updating a node results in a 404, convergence should be retried.
     """
-    return StepResult.RETRY, [{'reason': 'CLB node not found',
-                               'lb': step.lb_id,
-                               'node': step.node_id}]
+    return StepResult.RETRY, [
+        ErrorReason.Structured({'reason': 'CLB node not found',
+                                'lb': step.lb_id,
+                                'node': step.node_id})]
 
 
 _clb_check_change_node_handlers = {
@@ -554,8 +566,8 @@ def _rcv3_check_bulk_add(attempted_pairs, result):
 
     if response.code == 201:  # All done!
         return StepResult.RETRY, [
-            'must re-gather after adding to LB in order to update the active '
-            'cache']
+            ErrorReason.Other('must re-gather after adding to LB in order to '
+                              'update the active cache')]
 
     failure_reasons = []
     to_retry = pset(attempted_pairs)

--- a/otter/log/spec.py
+++ b/otter/log/spec.py
@@ -25,7 +25,8 @@ msg_types = {
     "execute-convergence-results": (
         "Got result of {worst_status} after executing convergence"),
     "group-status-active": "Group's status is changed to ACTIVE",
-    "group-status-error": "Group's status is changed to ERROR",
+    "group-status-error":
+        "Group's status is changed to ERROR. Reasons: {reasons}",
     "launch-servers": "Launching {num_servers} servers",
     "mark-clean-success": "Marked group {scaling_group_id} clean",
     "mark-clean-failure": "Failed to mark group {scaling_group_id} clean",

--- a/otter/test/convergence/test_effecting.py
+++ b/otter/test/convergence/test_effecting.py
@@ -2,15 +2,13 @@
 
 from effect import Constant, Effect, Error, ParallelEffects, sync_perform
 
-import mock
-
 from testtools.matchers import MatchesException
 
 from twisted.trial.unittest import SynchronousTestCase
 
 from otter.convergence.effecting import steps_to_effect
 from otter.convergence.model import ErrorReason, StepResult
-from otter.test.utils import TestStep, matches, test_dispatcher, transform_eq
+from otter.test.utils import TestStep, matches, test_dispatcher
 
 
 class StepsToEffectTests(SynchronousTestCase):

--- a/otter/test/convergence/test_effecting.py
+++ b/otter/test/convergence/test_effecting.py
@@ -2,11 +2,15 @@
 
 from effect import Constant, Effect, Error, ParallelEffects, sync_perform
 
+import mock
+
+from testtools.matchers import MatchesException
+
 from twisted.trial.unittest import SynchronousTestCase
 
 from otter.convergence.effecting import steps_to_effect
-from otter.convergence.model import StepResult
-from otter.test.utils import TestStep, test_dispatcher, transform_eq
+from otter.convergence.model import ErrorReason, StepResult
+from otter.test.utils import TestStep, matches, test_dispatcher, transform_eq
 
 
 class StepsToEffectTests(SynchronousTestCase):
@@ -17,8 +21,9 @@ class StepsToEffectTests(SynchronousTestCase):
                  TestStep(Effect(Error(RuntimeError('uh oh'))))]
         effect = steps_to_effect(steps)
         self.assertIs(type(effect.intent), ParallelEffects)
+        expected_exc_info = matches(MatchesException(RuntimeError('uh oh')))
         self.assertEqual(
             sync_perform(test_dispatcher(), effect),
             [(StepResult.SUCCESS, 'foo'),
-             (StepResult.RETRY, [transform_eq(lambda e: (type(e), e.args),
-                                              (RuntimeError, ('uh oh',)))])])
+             (StepResult.RETRY,
+              [ErrorReason.Exception(expected_exc_info)])])

--- a/otter/test/convergence/test_errors.py
+++ b/otter/test/convergence/test_errors.py
@@ -1,0 +1,33 @@
+from twisted.trial.unittest import SynchronousTestCase
+
+from otter.convergence.errors import present_reasons
+from otter.convergence.model import ErrorReason
+from otter.cloud_client import CLBDeletedError, NoSuchCLBError
+from otter.test.utils import raise_to_exc_info
+
+
+class PresentReasonsTests(SynchronousTestCase):
+    """Tests for :func:`present_reasons`."""
+    def test_present_other(self):
+        """non-Exceptions are not presented."""
+        self.assertEqual(present_reasons([ErrorReason.Other('foo')]), [])
+
+    def test_present_arbitrary_exception(self):
+        """Arbitrary exceptions are not presented."""
+        exc_info = raise_to_exc_info(ZeroDivisionError())
+        self.assertEqual(present_reasons([ErrorReason.Exception(exc_info)]),
+                         [])
+
+    def test_present_exceptions(self):
+        """Some exceptions are presented."""
+        excs = {
+            NoSuchCLBError(lb_id=u'lbid1'):
+                'Cloud Load Balancer does not exist: lbid1',
+            CLBDeletedError(lb_id=u'lbid2'):
+                'Cloud Load Balancer is currently being deleted: lbid2'
+        }
+        excs = excs.items()
+        self.assertEqual(
+            present_reasons([ErrorReason.Exception(raise_to_exc_info(exc))
+                             for (exc, _) in excs]),
+            [reason for (_, reason) in excs])

--- a/otter/test/convergence/test_errors.py
+++ b/otter/test/convergence/test_errors.py
@@ -12,7 +12,7 @@ class PresentReasonsTests(SynchronousTestCase):
     """Tests for :func:`present_reasons`."""
     def test_present_other(self):
         """non-Exceptions are not presented."""
-        self.assertEqual(present_reasons([ErrorReason.Other('foo')]), [])
+        self.assertEqual(present_reasons([ErrorReason.String('foo')]), [])
 
     def test_present_arbitrary_exception(self):
         """Arbitrary exceptions are not presented."""
@@ -49,9 +49,9 @@ class StructureReasonsTests(SynchronousTestCase):
              'traceback': expected_tb}
         )
 
-    def test_other(self):
-        """Other values get unwrapped."""
-        self.assertEqual(structure_reason(ErrorReason.Other('foo')), 'foo')
+    def test_string(self):
+        """String values get unwrapped."""
+        self.assertEqual(structure_reason(ErrorReason.String('foo')), 'foo')
 
     def test_structured(self):
         """Structured values get unwrapped."""

--- a/otter/test/convergence/test_service.py
+++ b/otter/test/convergence/test_service.py
@@ -705,7 +705,7 @@ class ExecuteConvergenceTests(SynchronousTestCase):
         step = TestStep(Effect(Constant(
             (StepResult.RETRY, [
                 ErrorReason.Exception(exc_info),
-                ErrorReason.Other('foo'),
+                ErrorReason.String('foo'),
                 ErrorReason.Structured({'foo': 'bar'})]))))
 
         def plan(*args, **kwargs):
@@ -803,7 +803,7 @@ class ExecuteConvergenceTests(SynchronousTestCase):
         def plan(*args, **kwargs):
             return pbag([
                 TestStep(Effect(Constant((StepResult.SUCCESS, [])))),
-                ConvergeLater(reasons=[ErrorReason.Other('mywish')]),
+                ConvergeLater(reasons=[ErrorReason.String('mywish')]),
                 TestStep(Effect(Constant((StepResult.SUCCESS, []))))])
 
         eff = execute_convergence(self.tenant_id, self.group_id,
@@ -825,7 +825,7 @@ class ExecuteConvergenceTests(SynchronousTestCase):
         def plan(*args, **kwargs):
             return pbag([
                 TestStep(Effect(Constant((StepResult.SUCCESS, [])))),
-                ConvergeLater(reasons=[ErrorReason.Other('mywish')]),
+                ConvergeLater(reasons=[ErrorReason.String('mywish')]),
                 TestStep(Effect(Constant((StepResult.SUCCESS, [])))),
                 TestStep(Effect(Constant(
                     (StepResult.FAILURE,

--- a/otter/test/convergence/test_service.py
+++ b/otter/test/convergence/test_service.py
@@ -698,11 +698,14 @@ class ExecuteConvergenceTests(SynchronousTestCase):
         """When a step doesn't succeed, useful information is logged."""
         try:
             1 / 0
-        except:
+        except ZeroDivisionError:
             exc_info = sys.exc_info()
 
         step = TestStep(Effect(Constant(
-            (StepResult.RETRY, [ErrorReason.Exception(exc_info)]))))
+            (StepResult.RETRY, [
+                ErrorReason.Exception(exc_info),
+                ErrorReason.Other('foo'),
+                ErrorReason.Structured({'foo': 'bar'})]))))
 
         def plan(*args, **kwargs):
             return pbag([step])
@@ -719,7 +722,9 @@ class ExecuteConvergenceTests(SynchronousTestCase):
             'results': [
                 (step, (StepResult.RETRY,
                         [{'exception': exc_msg,
-                          'traceback': tb_msg}]))],
+                          'traceback': tb_msg},
+                         'foo',
+                         {'foo': 'bar'}]))],
             'worst_status': 'RETRY'}
         sequence = SequenceDispatcher([
             (self.gsgi, lambda i: (self.group, self.manifest)),

--- a/otter/test/convergence/test_service.py
+++ b/otter/test/convergence/test_service.py
@@ -22,7 +22,7 @@ from otter.cloud_client import TenantScope
 from otter.constants import CONVERGENCE_DIRTY_DIR
 from otter.convergence.composition import get_desired_group_state
 from otter.convergence.model import (
-    CLBDescription, CLBNode, NovaServer, ServerState, StepResult)
+    CLBDescription, CLBNode, ErrorReason, NovaServer, ServerState, StepResult)
 from otter.convergence.service import (
     ConcurrentError,
     ConvergenceStarter,
@@ -751,7 +751,7 @@ class ExecuteConvergenceTests(SynchronousTestCase):
         def plan(*args, **kwargs):
             return pbag([
                 TestStep(Effect(Constant((StepResult.SUCCESS, [])))),
-                ConvergeLater(reasons=['mywish']),
+                ConvergeLater(reasons=[ErrorReason.Other('mywish')]),
                 TestStep(Effect(Constant((StepResult.SUCCESS, []))))])
 
         eff = execute_convergence(self.tenant_id, self.group_id,
@@ -770,9 +770,10 @@ class ExecuteConvergenceTests(SynchronousTestCase):
         def plan(*args, **kwargs):
             return pbag([
                 TestStep(Effect(Constant((StepResult.SUCCESS, [])))),
-                ConvergeLater(reasons=['mywish']),
+                ConvergeLater(reasons=[ErrorReason.Other('mywish')]),
                 TestStep(Effect(Constant((StepResult.SUCCESS, [])))),
-                TestStep(Effect(Constant((StepResult.FAILURE, ['bad'])))),
+                TestStep(Effect(Constant((StepResult.FAILURE,
+                                          [ErrorReason.Other('bad')])))),
                 TestStep(Effect(Constant((StepResult.SUCCESS, []))))
             ])
 
@@ -790,7 +791,7 @@ class ExecuteConvergenceTests(SynchronousTestCase):
                                status=ScalingGroupStatus.ERROR),
              noop),
             (Log('group-status-error', dict(isError=True, cloud_feed=True,
-                                            status='ERROR')),
+                                            status='ERROR', reasons='')),
              noop)
         ])
         dispatcher = ComposedDispatcher([sequence, test_dispatcher()])

--- a/otter/test/convergence/test_service.py
+++ b/otter/test/convergence/test_service.py
@@ -15,7 +15,7 @@ from kazoo.recipe.partitioner import PartitionState
 
 import mock
 
-from pyrsistent import freeze, pbag, pmap, pset, s
+from pyrsistent import freeze, pbag, pset, s
 
 from twisted.internet.defer import fail, succeed
 from twisted.trial.unittest import SynchronousTestCase

--- a/otter/test/convergence/test_steps.py
+++ b/otter/test/convergence/test_steps.py
@@ -133,7 +133,7 @@ class CreateServerTests(SynchronousTestCase):
         self.assertEqual(
             resolve_effect(eff, (StubResponse(202, {}), {"server": {}})),
             (StepResult.RETRY,
-             [ErrorReason.Other('waiting for server to become active')]))
+             [ErrorReason.String('waiting for server to become active')]))
 
     def test_create_server_400_parseable_failures(self):
         """
@@ -169,7 +169,7 @@ class CreateServerTests(SynchronousTestCase):
             self.assertEqual(
                 resolve_effect(eff, service_request_error_response(api_error),
                                is_error=True),
-                (StepResult.FAILURE, [ErrorReason.Other(message)]))
+                (StepResult.FAILURE, [ErrorReason.String(message)]))
 
     def test_create_server_400_unrecognized_failures_retry(self):
         """
@@ -232,7 +232,7 @@ class CreateServerTests(SynchronousTestCase):
             self.assertEqual(
                 resolve_effect(eff, service_request_error_response(api_error),
                                is_error=True),
-                (StepResult.FAILURE, [ErrorReason.Other(message)]))
+                (StepResult.FAILURE, [ErrorReason.String(message)]))
 
     def test_create_server_403_plaintext_parseable_failures(self):
         """
@@ -264,7 +264,7 @@ class CreateServerTests(SynchronousTestCase):
             self.assertEqual(
                 resolve_effect(eff, service_request_error_response(api_error),
                                is_error=True),
-                (StepResult.FAILURE, [ErrorReason.Other(message)]))
+                (StepResult.FAILURE, [ErrorReason.String(message)]))
 
     def test_create_server_403_unrecognized_failures_retry(self):
         """
@@ -334,8 +334,8 @@ class DeleteServerTests(SynchronousTestCase):
         self.assertEqual(
             resolve_effect(eff, (None, {})),
             (StepResult.RETRY,
-             [ErrorReason.Other('must re-gather after deletion in order to '
-                                'update the active cache')]))
+             [ErrorReason.String('must re-gather after deletion in order to '
+                                 'update the active cache')]))
 
     def test_delete_and_verify_del_404(self):
         """
@@ -546,8 +546,8 @@ class StepAsEffectTests(SynchronousTestCase):
         self.assertEqual(
             get_result(StubResponse(202, {}), ''),
             (StepResult.RETRY,
-             [ErrorReason.Other('must re-gather after adding to CLB in order '
-                                'to update the active cache')]))
+             [ErrorReason.String('must re-gather after adding to CLB in order '
+                                 'to update the active cache')]))
 
         self.assertEqual(
             get_result(
@@ -559,8 +559,8 @@ class StepAsEffectTests(SynchronousTestCase):
                     "code": 422
                 }),
             (StepResult.RETRY,
-             [ErrorReason.Other('must re-gather after adding to CLB in order '
-                                'to update the active cache')]))
+             [ErrorReason.String('must re-gather after adding to CLB in order '
+                                 'to update the active cache')]))
 
     def test_add_nodes_to_clb_failure_response_codes(self):
         """
@@ -967,7 +967,7 @@ class RCv3CheckBulkAddTests(SynchronousTestCase):
         self.assertEqual(
             res,
             (StepResult.RETRY,
-             [ErrorReason.Other(
+             [ErrorReason.String(
               'must re-gather after adding to LB in order to update the '
               'active cache')]))
 

--- a/otter/test/convergence/test_steps.py
+++ b/otter/test/convergence/test_steps.py
@@ -586,9 +586,7 @@ class StepAsEffectTests(SynchronousTestCase):
         # Fail on 404 or 422 PENDING_DELETE
         self.assertEqual(
             get_result(StubResponse(404, {}), ''),
-            (StepResult.FAILURE,
-             [ErrorReason.Exception(
-                 (APIError, matches(IsInstance(APIError)), ANY))]))
+            (StepResult.FAILURE, [any_api_error]))
         self.assertEqual(
             get_result(
                 StubResponse(422, {}),

--- a/otter/test/convergence/test_steps.py
+++ b/otter/test/convergence/test_steps.py
@@ -23,6 +23,7 @@ from otter.convergence.model import (
     CLBDescription,
     CLBNodeCondition,
     CLBNodeType,
+    ErrorReason,
     StepResult)
 from otter.convergence.steps import (
     AddNodesToCLB,
@@ -35,15 +36,16 @@ from otter.convergence.steps import (
     RemoveNodesFromCLB,
     SetMetadataItemOnServer,
     UnexpectedServerStatus,
-    _clb_check_change_node,
-    _clb_check_change_node_handlers,
     _RCV3_LB_DOESNT_EXIST_PATTERN,
     _RCV3_LB_INACTIVE_PATTERN,
     _RCV3_NODE_ALREADY_A_MEMBER_PATTERN,
     _RCV3_NODE_NOT_A_MEMBER_PATTERN,
-    delete_and_verify,
+    _clb_check_change_node,
+    _clb_check_change_node_handlers,
     _rcv3_check_bulk_add,
-    _rcv3_check_bulk_delete)
+    _rcv3_check_bulk_delete,
+    delete_and_verify,
+)
 from otter.test.utils import (
     StubResponse,
     get_fake_service_request_performer,
@@ -130,7 +132,8 @@ class CreateServerTests(SynchronousTestCase):
 
         self.assertEqual(
             resolve_effect(eff, (StubResponse(202, {}), {"server": {}})),
-            (StepResult.RETRY, ['waiting for server to become active']))
+            (StepResult.RETRY,
+             [ErrorReason.Other('waiting for server to become active')]))
 
     def test_create_server_400_parseable_failures(self):
         """
@@ -166,7 +169,7 @@ class CreateServerTests(SynchronousTestCase):
             self.assertEqual(
                 resolve_effect(eff, service_request_error_response(api_error),
                                is_error=True),
-                (StepResult.FAILURE, [message]))
+                (StepResult.FAILURE, [ErrorReason.Other(message)]))
 
     def test_create_server_400_unrecognized_failures_retry(self):
         """
@@ -189,10 +192,12 @@ class CreateServerTests(SynchronousTestCase):
 
         for message in invalid_400s:
             api_error = APIError(code=400, body=message, headers={})
+            exc_info = service_request_error_response(api_error)
             self.assertEqual(
-                resolve_effect(eff, service_request_error_response(api_error),
+                resolve_effect(eff, exc_info,
                                is_error=True),
-                (StepResult.RETRY, [api_error]))
+                (StepResult.RETRY,
+                 [ErrorReason.Exception(exc_info)]))
 
     def test_create_server_403_json_parseable_failures(self):
         """
@@ -227,7 +232,7 @@ class CreateServerTests(SynchronousTestCase):
             self.assertEqual(
                 resolve_effect(eff, service_request_error_response(api_error),
                                is_error=True),
-                (StepResult.FAILURE, [message]))
+                (StepResult.FAILURE, [ErrorReason.Other(message)]))
 
     def test_create_server_403_plaintext_parseable_failures(self):
         """
@@ -259,7 +264,7 @@ class CreateServerTests(SynchronousTestCase):
             self.assertEqual(
                 resolve_effect(eff, service_request_error_response(api_error),
                                is_error=True),
-                (StepResult.FAILURE, [message]))
+                (StepResult.FAILURE, [ErrorReason.Other(message)]))
 
     def test_create_server_403_unrecognized_failures_retry(self):
         """
@@ -282,10 +287,11 @@ class CreateServerTests(SynchronousTestCase):
 
         for message in invalid_403s:
             api_error = APIError(code=403, body=message, headers={})
+            exc_info = service_request_error_response(api_error)
             self.assertEqual(
-                resolve_effect(eff, service_request_error_response(api_error),
+                resolve_effect(eff, exc_info,
                                is_error=True),
-                (StepResult.RETRY, [api_error]))
+                (StepResult.RETRY, [ErrorReason.Exception(exc_info)]))
 
     def test_create_server_non_400_or_403_failures(self):
         """
@@ -298,10 +304,11 @@ class CreateServerTests(SynchronousTestCase):
         eff = resolve_effect(eff, 'random-name')
 
         api_error = APIError(code=500, body="this is a 500", headers={})
+        exc_info = service_request_error_response(api_error)
         self.assertEqual(
-            resolve_effect(eff, service_request_error_response(api_error),
+            resolve_effect(eff, exc_info,
                            is_error=True),
-            (StepResult.RETRY, [api_error]))
+            (StepResult.RETRY, [ErrorReason.Exception(exc_info)]))
 
 
 class DeleteServerTests(SynchronousTestCase):
@@ -326,9 +333,9 @@ class DeleteServerTests(SynchronousTestCase):
 
         self.assertEqual(
             resolve_effect(eff, (None, {})),
-            (StepResult.RETRY, [
-                'must re-gather after deletion in order to update the active '
-                'cache']))
+            (StepResult.RETRY,
+             [ErrorReason.Other('must re-gather after deletion in order to '
+                                'update the active cache')]))
 
     def test_delete_and_verify_del_404(self):
         """
@@ -539,8 +546,8 @@ class StepAsEffectTests(SynchronousTestCase):
         self.assertEqual(
             get_result(StubResponse(202, {}), ''),
             (StepResult.RETRY,
-             ['must re-gather after adding to CLB in order to update the '
-              'active cache']))
+             [ErrorReason.Other('must re-gather after adding to CLB in order '
+                                'to update the active cache')]))
 
         self.assertEqual(
             get_result(
@@ -552,8 +559,8 @@ class StepAsEffectTests(SynchronousTestCase):
                     "code": 422
                 }),
             (StepResult.RETRY,
-             ['must re-gather after adding to CLB in order to update the '
-              'active cache']))
+             [ErrorReason.Other('must re-gather after adding to CLB in order '
+                                'to update the active cache')]))
 
     def test_add_nodes_to_clb_failure_response_codes(self):
         """
@@ -573,9 +580,15 @@ class StepAsEffectTests(SynchronousTestCase):
                 }),
                 request)
 
+        any_api_error = ErrorReason.Exception(
+            (APIError, matches(IsInstance(APIError)), ANY))
+
         # Fail on 404 or 422 PENDING_DELETE
-        self.assertEqual(get_result(StubResponse(404, {}), ''),
-                         (StepResult.FAILURE, [matches(IsInstance(APIError))]))
+        self.assertEqual(
+            get_result(StubResponse(404, {}), ''),
+            (StepResult.FAILURE,
+             [ErrorReason.Exception(
+                 (APIError, matches(IsInstance(APIError)), ANY))]))
         self.assertEqual(
             get_result(
                 StubResponse(422, {}),
@@ -584,7 +597,7 @@ class StepAsEffectTests(SynchronousTestCase):
                                "'PENDING_DELETE' and is considered immutable.",
                     "code": 422
                 }),
-            (StepResult.FAILURE, [matches(IsInstance(APIError))]))
+            (StepResult.FAILURE, [any_api_error]))
         self.assertEqual(
             get_result(
                 StubResponse(422, {}),
@@ -593,7 +606,7 @@ class StepAsEffectTests(SynchronousTestCase):
                                "immutable.",
                     "code": 422
                 }),
-            (StepResult.FAILURE, [matches(IsInstance(APIError))]))
+            (StepResult.FAILURE, [any_api_error]))
 
         # Retry on other API errors
         self.assertEqual(
@@ -604,11 +617,11 @@ class StepAsEffectTests(SynchronousTestCase):
                                "'PENDING_UPDATE' and is considered immutable.",
                     "code": 422
                 }),
-            (StepResult.RETRY, [matches(IsInstance(APIError))]))
+            (StepResult.RETRY, [any_api_error]))
         self.assertEqual(get_result(StubResponse(413, {}), ''),
-                         (StepResult.RETRY, [matches(IsInstance(APIError))]))
+                         (StepResult.RETRY, [any_api_error]))
         self.assertEqual(get_result(StubResponse(500, {}), ''),
-                         (StepResult.RETRY, [matches(IsInstance(APIError))]))
+                         (StepResult.RETRY, [any_api_error]))
 
         # Any unknown errors are propogated
         self.assertRaises(
@@ -828,9 +841,11 @@ class CLBCheckChangeNodeTests(SynchronousTestCase):
         result = _clb_check_change_node(self.example_step, (response, body))
         self.assertEqual(
             result,
-            (StepResult.RETRY, [{"reason": "CLB node not found",
-                                 "node": self.example_step.node_id,
-                                 "lb": self.example_step.lb_id}]))
+            (StepResult.RETRY,
+             [ErrorReason.Structured(
+                 {"reason": "CLB node not found",
+                  "node": self.example_step.node_id,
+                  "lb": self.example_step.lb_id})]))
 
 
 _RCV3_TEST_DATA = {
@@ -954,8 +969,9 @@ class RCv3CheckBulkAddTests(SynchronousTestCase):
         self.assertEqual(
             res,
             (StepResult.RETRY,
-             ['must re-gather after adding to LB in order to update the '
-              'active cache']))
+             [ErrorReason.Other(
+              'must re-gather after adding to LB in order to update the '
+              'active cache')]))
 
     def test_try_again(self):
         """

--- a/otter/test/utils.py
+++ b/otter/test/utils.py
@@ -3,6 +3,7 @@ Mixins and utilities to be used for testing.
 """
 import json
 import os
+import sys
 from functools import partial, wraps
 from inspect import getargspec
 
@@ -821,6 +822,14 @@ def get_fake_service_request_performer(stub_response):
 def raise_(e):
     """Raise the exception. Useful for lambdas."""
     raise e
+
+
+def raise_to_exc_info(e):
+    """Raise an exception, and get the exc_info that results."""
+    try:
+        raise e
+    except type(e):
+        return sys.exc_info()
 
 
 class TestStep(object):

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,4 +19,4 @@ toolz==0.7.1
 pyrsistent==0.7.0
 singledispatch==3.4.0.3
 six==1.9.0
-sumtypes==0.1a3
+sumtypes==0.1a4

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ toolz==0.7.1
 pyrsistent==0.7.0
 singledispatch==3.4.0.3
 six==1.9.0
+sumtypes==0.1a3


### PR DESCRIPTION
This addresses #1448.

There are a couple changes in this branch related to the "reasons" associated with step errors.

- gave a specific type to the elements of the 'reasons' list, `ErrorReason`, a sumtype of Exception, Structured, and Other
- include the traceback along with the exception instance in Exception.ErrorReason
- log the traceback along with the exception in the `execute-convergence-results` message
- also add a mechanism for converting these reasons to end-user-appropriate versions, to be included in the Cloud Feeds `'group-status-error'` event.
- add user-presentable messages for NoSuchCLBError and CLBDeletedError, as a start.

edit: oh yeah, and this adds a dependency on the new `sumtypes` library