### PR TITLE
CATC25: Test that if Nova returns an over-quota error, the group goes into error

### DIFF
--- a/otter/integration/lib/autoscale.py
+++ b/otter/integration/lib/autoscale.py
@@ -452,6 +452,8 @@ class ScalingGroup(object):
                 msg("Waiting for desired group state.\nMismatch: {}"
                     .format(mismatch.describe()))
                 raise TransientRetryError(mismatch.describe())
+            msg("Success: desired group state reached:\n{}\nmatches:\n{}"
+                .format(group_state['group'], matcher))
             return rcs
 
         def poll():

--- a/otter/integration/tests/test_convergence.py
+++ b/otter/integration/tests/test_convergence.py
@@ -1047,7 +1047,6 @@ class ConvergenceTestsNoLBs(unittest.TestCase):
             ), timeout=600)
 
 
-
 def _catc_tags(start_num, end_num):
     """
     Return a list of CATC tags corresponding to the start test number and end


### PR DESCRIPTION
This is currently skipped because otter doesn't handle that case.

Fixes #1333 