### PR TITLE
CATC-23 - Handle 422 PENDING_DELETE

### DIFF
--- a/otter/integration/lib/autoscale.py
+++ b/otter/integration/lib/autoscale.py
@@ -307,6 +307,10 @@ class ScalingGroup(object):
         success_codes = [200, 404] if success_codes is None else success_codes
 
         def decide(resp):
+            if verbosity > 0:
+                print('ScalingGroup.get_scaling_group_state content: ')
+                pp.pprint(resp.data)
+
             if resp.code == 200:
                 return self.treq.json_content(resp).addCallback(
                     lambda x: (200, x))

--- a/otter/integration/lib/autoscale.py
+++ b/otter/integration/lib/autoscale.py
@@ -307,16 +307,18 @@ class ScalingGroup(object):
         success_codes = [200, 404] if success_codes is None else success_codes
 
         def decide(resp):
-            if verbosity > 0:
-                print('ScalingGroup.get_scaling_group_state content: ')
-                pp.pprint(resp.data)
-
             if resp.code == 200:
                 return self.treq.json_content(resp).addCallback(
                     lambda x: (200, x))
 
             return self.treq.content(resp).addCallback(
                 lambda _: (resp.code, None))
+
+        def debug_print(resp_tuple):
+            if verbosity > 0:
+                print('ScalingGroup.get_scaling_group_state response: ')
+                pp.pprint(resp_tuple)
+            return resp_tuple
 
         return (
             self.treq.get(
@@ -327,6 +329,7 @@ class ScalingGroup(object):
                 pool=self.pool
             ).addCallback(check_success, success_codes)
             .addCallback(decide)
+            .addCallback(debug_print)
         )
 
     def start(self, rcs, test):

--- a/otter/integration/lib/mimic.py
+++ b/otter/integration/lib/mimic.py
@@ -118,3 +118,44 @@ class MimicNova(object):
         d.addCallback(check_success, [204, 404])
         d.addCallback(self.treq.content)
         return d
+
+
+@attributes(["pool",
+             Attribute("test_case", default_value=None),
+             Attribute("treq", default_value=treq)])
+class MimicCLB(object):
+    """
+    Class that handles HTTP requests to the mimic Cloud Load Blancer
+    control plane.
+
+    Please see the mimic control plane API
+    (:class:`mimic.rest.loadbalancer_api.LoadBalancerControlRegion`) in the
+    mimic codebase for more information.
+
+    :ivar pool: a :class:`twisted.web.client.HTTPConnectionPool` to pass to
+        all treq requests
+    :ivar test_case: a :class:`twisted.trial.unittest.TestCase`, which if not
+        None, will be used to clean up added behaviors.
+    :ivar treq: the treq module to use for making requests - if not provided,
+        the default library :mod:`treq` will be used.  Mainly to be used for
+        injecting stubs during tests.
+    """
+    def set_clb_attributes(self, rcs, clb_id, kvpairs):
+        """
+
+
+        :param rcs: A :class:`otter.integration.lib.resources.TestResources`
+            instance.
+
+
+
+        :return: A deferred that fires with the content of the response, which
+            is probably the empty string.
+        """
+        print('Use mimic to set CLB attribute')
+        return self.treq.patch(
+            "{0}/{1}/attributes".format(rcs.endpoints["mimic_clb"], clb_id),
+            json.dumps(kvpairs),
+            headers=headers(str(rcs.token)),
+            pool=self.pool
+        ).addCallback(check_success, [201]).addCallback(self.treq.content)

--- a/otter/integration/lib/mimic.py
+++ b/otter/integration/lib/mimic.py
@@ -154,8 +154,9 @@ class MimicCLB(object):
         """
         print('Use mimic to set CLB attribute')
         return self.treq.patch(
-            "{0}/{1}/attributes".format(rcs.endpoints["mimic_clb"], clb_id),
+            "{0}/loadbalancer/{1}/attributes".format(
+                rcs.endpoints["mimic_clb"], clb_id),
             json.dumps(kvpairs),
             headers=headers(str(rcs.token)),
             pool=self.pool
-        ).addCallback(check_success, [201]).addCallback(self.treq.content)
+        ).addCallback(check_success, [204]).addCallback(self.treq.content)

--- a/otter/integration/tests/test_convergence.py
+++ b/otter/integration/tests/test_convergence.py
@@ -27,7 +27,7 @@ from otter.integration.lib.autoscale import (
 from otter.integration.lib.cloud_load_balancer import (
     CloudLoadBalancer, ContainsAllIPs, ExcludesAllIPs, HasLength)
 from otter.integration.lib.identity import IdentityV2
-from otter.integration.lib.mimic import MimicNova, MimicCLB
+from otter.integration.lib.mimic import MimicCLB, MimicNova
 from otter.integration.lib.nova import (
     NovaServer, delete_servers, wait_for_servers)
 from otter.integration.lib.resources import TestResources
@@ -1226,7 +1226,7 @@ class ConvergenceTestsWith1CLB(unittest.TestCase):
             )
         )
 
-    @skip_me("Otter does not yet support this error transition")
+    # @skip_me("Otter does not yet support this error transition")
     @skip_if(not_mimic, "This requires Mimic for error injection.")
     @tag("CATC-023")
     def test_clb_plane(self):

--- a/otter/integration/tests/test_convergence.py
+++ b/otter/integration/tests/test_convergence.py
@@ -1226,6 +1226,7 @@ class ConvergenceTestsWith1CLB(unittest.TestCase):
             )
         )
 
+    @skip_me("Otter does not yet support this error transition")
     @skip_if(not_mimic, "This requires Mimic for error injection.")
     @tag("CATC-023")
     def test_clb_plane(self):

--- a/otter/integration/tests/test_convergence.py
+++ b/otter/integration/tests/test_convergence.py
@@ -1226,7 +1226,7 @@ class ConvergenceTestsWith1CLB(unittest.TestCase):
             )
         )
 
-    # @skip_me("Otter does not yet support this error transition")
+    @skip_me("Otter does not yet support this error transition")
     @skip_if(not_mimic, "This requires Mimic for error injection.")
     @tag("CATC-023")
     def test_scale_up_when_pending_delete(self):

--- a/otter/integration/tests/test_convergence.py
+++ b/otter/integration/tests/test_convergence.py
@@ -1230,19 +1230,16 @@ class ConvergenceTestsWith1CLB(unittest.TestCase):
     @tag("CATC-023")
     def test_clb_plane(self):
         """
-        Simulate getting a 422 on scale up from CLB when in PENDING_DELETE which
-should cause the group to error
+        CATC-023-a: Validate that Otter correctly enters an error state when
+        attemting to scale up while the CLB is in the PENDING_DELETE state.
 
-Create a group with non-min servers and a CLB (or more)
-Set mimic to return 422 and state PENDING_DELETE on the CLB
-Attempt to scale up
-Verify that the group goes into error state since it cannot take action
-Prereq: MUST be able to use Mimic to simulate incorrect CLB behavior
-
+        1. Create a group with non-min servers attached to a CLB
+        2. Place the CLB into the PENDING_DELETE state
+            - Return 422, status: PENDING_DELETE on any mutating request
+        3. Scale up
+        4. Assert that the group goes into error state since it cannot
+            take action.
         """
-        print(self.helper.clbs[0])
-
-        # Create group
         group, _ = self.helper.create_group(
             image_ref=image_ref, flavor_ref=flavor_ref, min_entities=1)
 
@@ -1255,7 +1252,6 @@ Prereq: MUST be able to use Mimic to simulate incorrect CLB behavior
 
         return (
             self.helper.start_group_and_wait(group, self.rcs)
-            # Change LB state to PENDING DELETE
             .addCallback(
                 mimic_clb.set_clb_attributes,
                 self.helper.clbs[0].clb_id, {"status": "PENDING_DELETE"})

--- a/otter/integration/tests/test_convergence.py
+++ b/otter/integration/tests/test_convergence.py
@@ -1230,7 +1230,7 @@ class ConvergenceTestsWith1CLB(unittest.TestCase):
     @tag("CATC-023")
     def test_clb_plane(self):
         """
-Simulate getting a 422 on scale up from CLB when in PENDING_DELETE which
+        Simulate getting a 422 on scale up from CLB when in PENDING_DELETE which
 should cause the group to error
 
 Create a group with non-min servers and a CLB (or more)
@@ -1240,7 +1240,7 @@ Verify that the group goes into error state since it cannot take action
 Prereq: MUST be able to use Mimic to simulate incorrect CLB behavior
 
         """
-        print(self.helper.clbs)
+        print(self.helper.clbs[0])
 
         # Create group
         group, _ = self.helper.create_group(
@@ -1253,26 +1253,19 @@ Prereq: MUST be able to use Mimic to simulate incorrect CLB behavior
             scaling_group=group
         )
 
-        def debug_print(msg):
-            print('...... debug ... ')
-            print(msg)
-            return msg
-
         return (
             self.helper.start_group_and_wait(group, self.rcs)
             # Change LB state to PENDING DELETE
             .addCallback(
                 mimic_clb.set_clb_attributes,
                 self.helper.clbs[0].clb_id, {"status": "PENDING_DELETE"})
-            .addCallback(debug_print)
+            .addCallback(lambda _: self.rcs)
             .addCallback(policy_scale_up.start, self)
             .addCallback(policy_scale_up.execute)
             .addCallback(
                 group.wait_for_state,
                 MatchesAll(
                     ContainsDict({
-                        # 'pendingCapacity': Equals(2),
-                        # 'desiredCapacity': Equals(2),
                         'status': Equals("ERROR")
                     })),
                 timeout=600

--- a/otter/integration/tests/test_convergence.py
+++ b/otter/integration/tests/test_convergence.py
@@ -1229,7 +1229,7 @@ class ConvergenceTestsWith1CLB(unittest.TestCase):
     # @skip_me("Otter does not yet support this error transition")
     @skip_if(not_mimic, "This requires Mimic for error injection.")
     @tag("CATC-023")
-    def test_clb_plane(self):
+    def test_scale_up_when_pending_delete(self):
         """
         CATC-023-a: Validate that Otter correctly enters an error state when
         attemting to scale up while the CLB is in the PENDING_DELETE state.


### PR DESCRIPTION
Fixes #1331

Validate that receiving a 422, PENDING_DELETE when adding a node to the load balancer causes the group to enter error state.