### PR TITLE
Only private network when creating servers

### DIFF
--- a/otter/integration/lib/autoscale.py
+++ b/otter/integration/lib/autoscale.py
@@ -95,6 +95,11 @@ def create_scaling_group_dict(
                 "server": {
                     "flavorRef": flavor_ref,
                     "imageRef": image_ref,
+                    "networks": [
+                        {
+                            "uuid": "11111111-1111-1111-1111-111111111111"
+                        }
+                    ]
                 }
             }
         },


### PR DESCRIPTION
This is necessary when spinning many real servers in prod Nova since public IP address is scarce resource.