### PR TITLE
Test that otter recovers from impersonation failures

### DIFF
--- a/otter/integration/config.sh-template
+++ b/otter/integration/config.sh-template
@@ -25,7 +25,7 @@ export AS_REGION=IAD
 # Mimic defaults to using ORD as the region
 #export AS_REGION=ORD
 
-# This is the test tenant ID that is enabled for convergence in mimic.
+# This is the test tenant ID that is enabled for convergence in otter.
 export AS_CONVERGENCE_TENANT=000000
 
 # Use this to set the verbosity of the convergence tests.
@@ -57,6 +57,7 @@ export AS_CLB_SC_KEY=cloudLoadBalancers
 # testing
 # export AS_BUILD_TIMEOUT_SECONDS=30
 
-# The user name that otter uses to authenticate against identity - used to
-# test error injection.
-export AS_SERVICE_USERNAME=FAKEUSERNAME
+# This is a test tenant that is enabled for convergence in Otter.  This will
+# only be used for testing against mimic, to test otter reaction to auth
+# errors.  A random username and password will be generated for it.
+export AS_CONVERGENCE_TENANT_FOR_AUTH_ERRORS=000010

--- a/otter/integration/config.sh-template
+++ b/otter/integration/config.sh-template
@@ -52,3 +52,11 @@ export AS_CLB_SC_KEY=cloudLoadBalancers
 
 # Uncomment this if you are running tests against Mimic.
 # export AS_USING_MIMIC=true
+
+# Uncomment this to change the default value of the otter build timeout for
+# testing
+# export AS_BUILD_TIMEOUT_SECONDS=30
+
+# The user name that otter uses to authenticate against identity - used to
+# test error injection.
+export AS_SERVICE_USERNAME=FAKEUSERNAME

--- a/otter/integration/lib/mimic.py
+++ b/otter/integration/lib/mimic.py
@@ -177,7 +177,7 @@ class MimicIdentity(object):
         injecting stubs during tests.
     """
     def sequenced_behaviors(self, identity_endpoint, criteria, behaviors,
-                            event_description="authentication"):
+                            event_description="auth"):
         """
         Cause Identity to fail sometimes or all the time, with a pre-determined
         sequence of successes and/or failures.

--- a/otter/integration/tests/test_convergence.py
+++ b/otter/integration/tests/test_convergence.py
@@ -27,7 +27,7 @@ from otter.integration.lib.autoscale import (
 from otter.integration.lib.cloud_load_balancer import (
     CloudLoadBalancer, ContainsAllIPs, ExcludesAllIPs, HasLength)
 from otter.integration.lib.identity import IdentityV2
-from otter.integration.lib.mimic import MimicCLB, MimicNova
+from otter.integration.lib.mimic import MimicCLB, MimicIdentity, MimicNova
 from otter.integration.lib.nova import (
     NovaServer, delete_servers, wait_for_servers)
 from otter.integration.lib.resources import TestResources
@@ -1047,6 +1047,41 @@ class ConvergenceTestsNoLBs(unittest.TestCase):
                     'status': Equals("ACTIVE")
                 }),
             ), timeout=600)
+
+    @skip_if(not_mimic, "This requires Mimic for error injection.")
+    @tag("CATC-026")
+    def test_recover_from_identity_auth_failures(self):
+        """
+        CATC-026
+
+        Identity returns a 401 1/3 the time, a 500 1/3 the time, and a success
+        1/3 of the time.  Otter retries and recovers and there should be no
+        outward sign that anything is broken.
+        """
+        mimic_identity = MimicIdentity(pool=self.helper.pool, test_case=self)
+        group, _ = self.helper.create_group(
+            image_ref=image_ref, flavor_ref=flavor_ref, min_entities=2,
+            max_entities=10
+        )
+
+        d = mimic_identity.sequenced_behaviors(
+            endpoint,
+            criteria=[{"username": username + ".*"}],
+            behaviors=[
+                {"name": "fail",
+                 "parameters": {"code": 500,
+                                "message": "Authentication failed."}},
+                {"name": "fail",
+                 "parameters": {"code": 400,
+                                "message": "Invalid credentials."}},
+                {"name": "default"}
+            ])
+        d.addCallback(
+            lambda _: self.helper.start_group_and_wait(group, self.rcs,
+                                                       desired=5))
+        d.addCallback(wait_for_servers, pool=self.helper.pool, group=group,
+                      matcher=HasLength(5), timeout=600)
+        return d
 
 
 def _catc_tags(start_num, end_num):

--- a/otter/integration/tests/test_convergence.py
+++ b/otter/integration/tests/test_convergence.py
@@ -53,6 +53,7 @@ mimic_clb_key = os.environ.get("MIMICCLB_SC_KEY", 'cloudLoadBalancerControl')
 
 # otter configuration options for testing
 otter_build_timeout = float(os.environ.get("AS_BUILD_TIMEOUT_SECONDS", "30"))
+otter_username = os.environ.get("AS_SERVICE_USERNAME", "FAKEUSERNAME")
 
 
 def not_mimic():
@@ -868,7 +869,7 @@ class ConvergenceTestsNoLBs(unittest.TestCase):
             criteria=[{"server_name": server_name_prefix + ".*"}],
             behaviors=[
                 {"name": "build",
-                 "parameters": {"duration": otter_build_timeout * 2}},
+                 "parameters": {"duration": otter_build_timeout * 3000}},
                 {"name": "default"},
                 {"name": "default"}
             ])
@@ -1066,7 +1067,7 @@ class ConvergenceTestsNoLBs(unittest.TestCase):
 
         d = mimic_identity.sequenced_behaviors(
             endpoint,
-            criteria=[{"username": username + ".*"}],
+            criteria=[{"username": otter_username + ".*"}],
             behaviors=[
                 {"name": "fail",
                  "parameters": {"code": 500,

--- a/otter/integration/tests/test_convergence.py
+++ b/otter/integration/tests/test_convergence.py
@@ -1063,9 +1063,12 @@ class ConvergenceTestsNoLBs(unittest.TestCase):
         CATC-026
 
         Identity, when someone attempts to impersonate the test user, will
-        return a 401 1/3 the time, a 500 1/3 the time, and a success
-        1/3 of the time.  Otter retries and recovers and there should be no
-        outward sign that anything is broken.
+        first fail with a 401, then fail with a 500, then succeed, over and
+        over in a loop.  (Otter will probably only make a single cycle through
+        the sequence, but it shouldn't make a difference either way.)
+
+        Otter retries and recovers and there should be no outward sign that
+        anything is broken.
 
         Note that this uses a tenant that hopefully has not been used before.
         This is to prevent the case where Otter has cached the creds already,

--- a/otter/tap/api.py
+++ b/otter/tap/api.py
@@ -303,7 +303,7 @@ def setup_converger(parent, kz_client, dispatcher, interval, build_timeout):
     Create a Converger service, which has a Partitioner as a child service, so
     that if the Converger is stopped, the partitioner is also stopped.
     """
-    converger_buckets = range(1, 10)
+    converger_buckets = range(10)
     partitioner_factory = partial(
         Partitioner,
         kz_client,


### PR DESCRIPTION
It retries when it gets 401s and 500's.

By using a new tenant ID just for this test, we make sure otter doesn't have any of these creds cached (because otter otherwise does not hit identity again).

We can't easily test identity returning 401s and 500s on otter authenticating its service user, because

1. that would affect every single test that gets run concurrently
2. in order to ensure that otter doesn't have its service user creds cached, we'd have to make sure this test gets run before any other test.  or wait for the creds to expire before running this test in isolation.

Note that this is dependent upon the following first before this can be run on jenkins:
- [x] https://github.com/rackerlabs/mimic/pull/316 getting merged
- [x] bumping our CI system's mimic to include the above when it gets merged (see https://github.com/rackerlabs/autoscaling-chef/pull/735/)
- [x] adding a new test convergence tenant to our CI system. (same PR as above)