### PR TITLE
cache the pip cache on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,10 @@ sudo: false
 python:
     - 2.7
 
+cache:
+  directories:
+    - $HOME/.cache/pip
+
 install:
     - pip install -r dev_requirements.txt
     - pip install -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ cache:
     - $HOME/.cache/pip
 
 install:
+    - pip install -U pip wheel
     - pip install -r dev_requirements.txt
     - pip install -r requirements.txt
     - pip install coveralls


### PR DESCRIPTION
According to the docs here http://docs.travis-ci.com/user/caching/

Apparently we can't just use `cache: pip` because we've specified an `install` step.