### PR TITLE
Pyrsistent version bump and environment variable fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,8 @@ else
 endif
 
 coverage:
-	coverage run --source=${CODEDIR} --branch `which trial` \
+	PYRSISTENT_NO_C_EXTENSION=true coverage run --source=${CODEDIR} \
+		--branch `which trial` \
 	    ${TRIAL_OPTIONS} ${UNITTESTS}
 
 coverage-html: coverage

--- a/Makefile
+++ b/Makefile
@@ -70,11 +70,12 @@ TRIAL_OPTIONS_UNIT=${TRIAL_OPTIONS} --jobs 4
 
 unit:
 ifneq ($(JENKINS_URL), )
-	trial ${TRIAL_OPTIONS_UNIT} --reporter=subunit ${UNITTESTS} \
+	PYRSISTENT_NO_C_EXTENSION=true trial ${TRIAL_OPTIONS_UNIT} \
+		--reporter=subunit ${UNITTESTS} \
 		| subunit-1to2 | tee subunit-output.txt
 	tail -n +4 subunit-output.txt | subunit2junitxml > test-report.xml
 else
-	trial ${TRIAL_OPTIONS_UNIT} ${UNITTESTS}
+	PYRSISTENT_NO_C_EXTENSION=true trial ${TRIAL_OPTIONS_UNIT} ${UNITTESTS}
 endif
 
 integration:

--- a/otter/convergence/composition.py
+++ b/otter/convergence/composition.py
@@ -9,6 +9,7 @@ from otter.convergence.model import (
     CLBDescription,
     DesiredGroupState,
     generate_metadata)
+from otter.util.fp import set_in
 
 
 def tenant_is_enabled(tenant_id, get_config_value):
@@ -76,8 +77,8 @@ def prepare_server_launch_config(group_id, server_config, lb_descriptions):
     :param iterable lb_descriptions: iterable of
         :class:`ILBDescription` providers
     """
-    updated_metadata = freeze(merge(
+    updated_metadata = merge(
         get_in(('server', 'metadata'), server_config, {}),
-        generate_metadata(group_id, lb_descriptions)))
+        generate_metadata(group_id, lb_descriptions))
 
-    return server_config.set_in(('server', 'metadata'), updated_metadata)
+    return set_in(server_config, ('server', 'metadata'), updated_metadata)

--- a/otter/convergence/model.py
+++ b/otter/convergence/model.py
@@ -16,6 +16,7 @@ from twisted.python.constants import NamedConstant, Names
 
 from zope.interface import Attribute as IAttribute, Interface, implementer
 
+from otter.util.fp import set_in
 from otter.util.timestamp import timestamp_to_epoch
 
 
@@ -130,7 +131,8 @@ def get_service_metadata(service_name, metadata):
             m = key_pattern.match(k)
             if m:
                 subkeys = m.groupdict()['subkeys']
-                as_metadata = as_metadata.set_in(
+                as_metadata = set_in(
+                    as_metadata,
                     [sk for sk in subkeys.split(':') if sk],
                     v)
     return as_metadata

--- a/otter/convergence/steps.py
+++ b/otter/convergence/steps.py
@@ -22,7 +22,7 @@ from otter.cloud_client import (
     set_nova_metadata_item)
 from otter.constants import ServiceType
 from otter.convergence.model import StepResult
-from otter.util.fp import predicate_any
+from otter.util.fp import predicate_any, set_in
 from otter.util.hashkey import generate_server_name
 from otter.util.http import APIError, append_segments, try_json_with_keys
 from otter.util.retry import (
@@ -55,7 +55,7 @@ def set_server_name(server_config_args, name_suffix):
         name = '{0}-{1}'.format(name, name_suffix)
     else:
         name = name_suffix
-    return server_config_args.set_in(('server', 'name'), name)
+    return set_in(server_config_args, ('server', 'name'), name)
 
 
 def _forbidden_plaintext(message):

--- a/otter/tap/api.py
+++ b/otter/tap/api.py
@@ -1,6 +1,7 @@
 """
 Twisted Application plugin for otter API nodes.
 """
+import os
 
 from copy import deepcopy
 from functools import partial
@@ -48,6 +49,11 @@ from otter.util.config import config_value, set_config_data
 from otter.util.cqlbatch import TimingOutCQLClient
 from otter.util.deferredutils import timeout_deferred
 from otter.util.zkpartitioner import Partitioner
+
+assert os.environ.get("PYRSISTENT_NO_C_EXTENSION"), (
+    "The environment variable PYRSISTENT_NO_C_EXTENSION must be set to "
+    "a non-empty string because the C extension sometimes causes segfaults "
+    "in otter.")
 
 
 class Options(usage.Options):

--- a/otter/test/test_testutils.py
+++ b/otter/test/test_testutils.py
@@ -1,6 +1,8 @@
 """
 Tests for :obj:`otter.test.utils`.
 """
+from pyrsistent import pvector
+
 from twisted.trial.unittest import SynchronousTestCase
 
 from zope.interface import Attribute, Interface
@@ -135,7 +137,7 @@ class IMockTests(SynchronousTestCase):
                 im.one
 
         im = iMock(_ITest3, spec=spec)
-        self.assertEqual(im.spec, spec)
+        self.assertEqual(im.spec, pvector(spec))
 
     def test_extra_attributes_and_config_passed_to_mock(self):
         """

--- a/otter/test/util/test_fp.py
+++ b/otter/test/util/test_fp.py
@@ -1,8 +1,10 @@
 """Tests for otter.util.fp"""
 
+from pyrsistent import pmap
+
 from twisted.trial.unittest import SynchronousTestCase
 
-from otter.util.fp import predicate_all, predicate_any
+from otter.util.fp import predicate_all, predicate_any, set_in
 
 
 class PredicateAllTests(SynchronousTestCase):
@@ -93,3 +95,38 @@ class PredicateAnyTests(SynchronousTestCase):
             predicate_any(
                 lambda **k: k['a'] % 2 == 0 and k['b'] % 2 == 0,
                 lambda **k: k['a'] % 3 == 0 and k['b'] % 3 == 0)(a=2, b=4))
+
+
+class SetInTests(SynchronousTestCase):
+    """
+    Tests for :func:`otter.util.fp.set_in`
+    """
+    def test_insufficient_keys_raises_value_error(self):
+        """
+        If zero keys are passed, a :class:`ValueError` is raised.
+        """
+        self.assertRaises(ValueError, set_in, {1: 2}, (), None)
+
+    def test_returns_new_pmap_given_pmap(self):
+        """
+        If a PMap is passed in, a new PMap is returned, and even the new value
+        that was passed in gets frozen.
+        """
+        self.assertEquals(set_in(pmap({1: 2}), (1,), {1: 3}),
+                          pmap({1: pmap({1: 3})}))
+
+    def test_returns_new_pmap_given_dict(self):
+        """
+        If a dictionary is passed in, a new PMap is returned and the old
+        dictionary is unaffected.
+        """
+        a = {1: 2}
+        self.assertEquals(set_in(a, (1,), {1: 3}), pmap({1: pmap({1: 3})}))
+        self.assertEquals(a, {1: 2})
+
+    def test_creates_dictionaries(self):
+        """
+        Create dictionaries as needed, if the old dict didn't have them.
+        """
+        self.assertEquals(set_in({}, (1, 2, 3), 4),
+                          pmap({1: pmap({2: pmap({3: 4})})}))

--- a/otter/test/utils.py
+++ b/otter/test/utils.py
@@ -38,6 +38,7 @@ from otter.log.bound import BoundLog
 from otter.models.interface import IScalingGroup
 from otter.supervisor import ISupervisor
 from otter.util.deferredutils import DeferredPool
+from otter.util.fp import set_in
 from otter.util.retry import Retry
 
 
@@ -219,7 +220,7 @@ def iMock(*ifaces, **kwargs):
     for k, v in list(kwargs.iteritems()):
         result = k.split('.', 1)
         if result[0] in all_names:
-            attribute_kwargs = attribute_kwargs.set_in(result, v)
+            attribute_kwargs = set_in(attribute_kwargs, result, v)
             kwargs.pop(k)
 
     kwargs.pop('spec', None)

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,6 @@ txeffect==0.1a1
 characteristic==14.3.0
 attrs==15.0.0
 toolz==0.7.1
-pyrsistent==0.7.0
+pyrsistent==0.10.3
 singledispatch==3.4.0.3
 six==1.9.0


### PR DESCRIPTION
~~Waiting for https://github.com/rackerlabs/autoscaling-chef/pull/736 before this can be tested on jenkins.~~ Done.

Pyrsistent has removed `PMap.set_in`, so I just added it as an FP utility function with as little change to the signature and functionality as possible.