### PR TITLE
Fix convergence buckets to converge tenants that hash down to 0

### DIFF
--- a/otter/convergence/service.py
+++ b/otter/convergence/service.py
@@ -442,12 +442,13 @@ class Converger(MultiService):
         """
         :param log: a bound log
         :param dispatcher: The dispatcher to use to perform effects.
-        :param partitioner_factory: Callable of (log, callback) which should
-            create an :obj:`Partitioner` to distribute the buckets.
         :param int buckets: the number of logical `buckets` which are be
             shared between all Otter nodes running this service. The buckets
             will be partitioned up between nodes to detirmine which nodes
             should work on which groups.
+        :param partitioner_factory: Callable of (all_buckets, log, callback)
+            which should create an :obj:`Partitioner` to distribute the
+            buckets.
         :param number build_timeout: number of seconds to wait for servers to
             be in building before it's is timed out and deleted
         :param callable converge_all_groups: like :func:`converge_all_groups`,
@@ -456,8 +457,10 @@ class Converger(MultiService):
         MultiService.__init__(self)
         self.log = log.bind(otter_service='converger')
         self._dispatcher = dispatcher
-        self.partitioner = partitioner_factory(self.log, self.buckets_acquired)
         self._buckets = range(num_buckets)
+        self.partitioner = partitioner_factory(
+            buckets=self._buckets, log=self.log,
+            got_buckets=self.buckets_acquired)
         self.partitioner.setServiceParent(self)
         self.currently_converging = Reference(pset())
         self.build_timeout = build_timeout

--- a/otter/convergence/service.py
+++ b/otter/convergence/service.py
@@ -437,17 +437,17 @@ class Converger(MultiService):
     - we ensure we don't execute convergence for the same group concurrently.
     """
 
-    def __init__(self, log, dispatcher, buckets, partitioner_factory,
+    def __init__(self, log, dispatcher, num_buckets, partitioner_factory,
                  build_timeout, converge_all_groups=converge_all_groups):
         """
         :param log: a bound log
         :param dispatcher: The dispatcher to use to perform effects.
-        :param buckets: collection of logical `buckets` which are shared
-            between all Otter nodes running this service. Will be partitioned
-            up between nodes to detirmine which nodes should work on which
-            groups.
         :param partitioner_factory: Callable of (log, callback) which should
             create an :obj:`Partitioner` to distribute the buckets.
+        :param int buckets: the number of logical `buckets` which are be
+            shared between all Otter nodes running this service. The buckets
+            will be partitioned up between nodes to detirmine which nodes
+            should work on which groups.
         :param number build_timeout: number of seconds to wait for servers to
             be in building before it's is timed out and deleted
         :param callable converge_all_groups: like :func:`converge_all_groups`,
@@ -456,8 +456,8 @@ class Converger(MultiService):
         MultiService.__init__(self)
         self.log = log.bind(otter_service='converger')
         self._dispatcher = dispatcher
-        self._buckets = buckets
         self.partitioner = partitioner_factory(self.log, self.buckets_acquired)
+        self._buckets = range(num_buckets)
         self.partitioner.setServiceParent(self)
         self.currently_converging = Reference(pset())
         self.build_timeout = build_timeout

--- a/otter/tap/api.py
+++ b/otter/tap/api.py
@@ -303,17 +303,14 @@ def setup_converger(parent, kz_client, dispatcher, interval, build_timeout):
     Create a Converger service, which has a Partitioner as a child service, so
     that if the Converger is stopped, the partitioner is also stopped.
     """
-    converger_buckets = range(1, 10)
     partitioner_factory = partial(
         Partitioner,
-        kz_client,
-        interval,
-        CONVERGENCE_PARTITIONER_PATH,
-        converger_buckets,
-        15,  # time boundary
+        kz_client=kz_client,
+        interval=interval,
+        partitioner_path=CONVERGENCE_PARTITIONER_PATH,
+        time_boundary=15,  # time boundary
     )
-    cvg = Converger(log, dispatcher, converger_buckets, partitioner_factory,
-                    build_timeout)
+    cvg = Converger(log, dispatcher, 10, partitioner_factory, build_timeout)
     cvg.setServiceParent(parent)
     watch_children(kz_client, CONVERGENCE_DIRTY_DIR, cvg.divergent_changed)
 

--- a/otter/test/convergence/test_service.py
+++ b/otter/test/convergence/test_service.py
@@ -93,18 +93,19 @@ class ConvergerTests(SynchronousTestCase):
 
     def setUp(self):
         self.log = mock_log()
-        self.buckets = range(10)
+        self.num_buckets = 10
 
     def _converger(self, converge_all_groups, dispatcher=None):
         if dispatcher is None:
             dispatcher = _get_dispatcher()
         return Converger(
-            self.log, dispatcher, self.buckets,
+            self.log, dispatcher, self.num_buckets,
             self._pfactory, build_timeout=3600,
             converge_all_groups=converge_all_groups)
 
-    def _pfactory(self, log, callable):
-        self.fake_partitioner = FakePartitioner(log, callable)
+    def _pfactory(self, buckets, log, got_buckets):
+        self.assertEqual(buckets, range(self.num_buckets))
+        self.fake_partitioner = FakePartitioner(log, got_buckets)
         return self.fake_partitioner
 
     def _log_sequence(self, intents):
@@ -137,7 +138,7 @@ class ConvergerTests(SynchronousTestCase):
                 transform_eq(lambda cc: cc is converger.currently_converging,
                              True),
                 my_buckets,
-                self.buckets,
+                range(self.num_buckets),
                 ['flag1', 'flag2'],
                 3600),
                 lambda i: 'foo')


### PR DESCRIPTION
Fixes #1493 - previously, tenants whose modulo ends up being 0 would not get converged.