### PR TITLE
get_rcv3_contents return immediately on NoSuchEndpoint

### DIFF
--- a/otter/convergence/gathering.py
+++ b/otter/convergence/gathering.py
@@ -201,23 +201,17 @@ def get_rcv3_contents():
     """
     Get Rackspace Cloud Load Balancer contents as list of `RCv3Node`.
     """
-    eff = retry_effect(
-        service_request(ServiceType.RACKCONNECT_V3,
-                        'GET', 'load_balancer_pools'),
-        retry_times(5), exponential_backoff_interval(2))
+    eff = service_request(ServiceType.RACKCONNECT_V3, 'GET',
+                          'load_balancer_pools')
 
     def on_listing_pools(lblist_result):
         _, body = lblist_result
         return parallel([
-            retry_effect(
-                service_request(ServiceType.RACKCONNECT_V3, 'GET',
-                                append_segments('load_balancer_pools',
-                                                lb_pool['id'], 'nodes')),
-                retry_times(5), exponential_backoff_interval(2)
-            ).on(
+            service_request(ServiceType.RACKCONNECT_V3, 'GET',
+                            append_segments('load_balancer_pools',
+                                            lb_pool['id'], 'nodes')).on(
                 partial(on_listing_nodes,
                         RCv3Description(lb_id=lb_pool['id'])))
-
             for lb_pool in body
         ])
 

--- a/otter/test/convergence/test_gathering.py
+++ b/otter/test/convergence/test_gathering.py
@@ -10,8 +10,7 @@ from effect import (
     Effect,
     ParallelEffects,
     TypeDispatcher,
-    sync_perform,
-    sync_performer)
+    sync_perform)
 
 from effect.async import perform_parallel_async
 from effect.testing import EQDispatcher, EQFDispatcher, Stub
@@ -47,7 +46,7 @@ from otter.test.utils import (
     resolve_stubs
 )
 from otter.util.retry import (
-    Retry, ShouldDelayAndRetry, exponential_backoff_interval, retry_times)
+    ShouldDelayAndRetry, exponential_backoff_interval, retry_times)
 from otter.util.timestamp import timestamp_to_epoch
 
 

--- a/otter/test/convergence/test_gathering.py
+++ b/otter/test/convergence/test_gathering.py
@@ -483,22 +483,12 @@ class GetRCv3ContentsTests(SynchronousTestCase):
         Set up an empty dictionary of intents to fake responses, and set up
         the dispatcher.
         """
-        @sync_performer
-        def unwrap_retry(_, retry_intent):
-            self.assertEqual(
-                retry_intent.should_retry,
-                ShouldDelayAndRetry(
-                    can_retry=retry_times(5),
-                    next_interval=exponential_backoff_interval(2)))
-            return retry_intent.effect
-
         eq_dispatcher = EQDispatcher
         if callable(service_request_mappings[0][-1]):
             eq_dispatcher = EQFDispatcher
 
         return ComposedDispatcher([
             TypeDispatcher({
-                Retry: unwrap_retry,
                 ParallelEffects: perform_parallel_async
             }),
             eq_dispatcher(service_request_mappings)


### PR DESCRIPTION
Closes #1477.

Earlier, it was returning empty list on `NoSuchEndpoint` after it had finished retrying. Now, it is not doing any retry at all and returning empty list immediately. Similarly, I think other gathering functions should also not have any retries to ensure convergence works on most consistent snapshot of reality.