### PR TITLE
CLB weight is optional

### DIFF
--- a/otter/convergence/gathering.py
+++ b/otter/convergence/gathering.py
@@ -150,7 +150,7 @@ def get_clb_contents():
                 description=CLBDescription(
                     lb_id=str(_id),
                     port=node['port'],
-                    weight=node['weight'],
+                    weight=node.get('weight', 1),
                     condition=CLBNodeCondition.lookupByName(node['condition']),
                     type=CLBNodeType.lookupByName(node['type'])))
             for _id, nodes in zip(ids, all_lb_nodes) for node in nodes]

--- a/otter/test/convergence/test_gathering.py
+++ b/otter/test/convergence/test_gathering.py
@@ -350,7 +350,7 @@ class GetCLBContentsTests(SynchronousTestCase):
                 {'id': '21', 'port': 20, 'address': 'a21',
                  'weight': 3, 'condition': 'ENABLED', 'type': 'PRIMARY'},
                 {'id': '22', 'port': 20, 'address': 'a22',
-                 'weight': 3, 'condition': 'DRAINING', 'type': 'PRIMARY'}]},
+                 'condition': 'DRAINING', 'type': 'PRIMARY'}]},
             ('GET', 'loadbalancers/1/nodes/11.atom', False): '11feed',
             ('GET', 'loadbalancers/2/nodes/22.atom', False): '22feed'
         }
@@ -422,7 +422,7 @@ class GetCLBContentsTests(SynchronousTestCase):
                      address='a22',
                      drained_at=2.0,
                      description=make_desc(lb_id='2',
-                                           weight=3,
+                                           weight=1,
                                            condition=draining))])
 
     def test_no_lb(self):


### PR DESCRIPTION
According to CLB docs, weight is returned only for load balancers that use WEIGHTED_LEAST_CONNECTIONS or WEIGHTED_ROUND_ROBIN algorithms. This was causing failure of CLB related tests in prod.