### PR TITLE
Log steps to CF

### DIFF
--- a/otter/convergence/logging.py
+++ b/otter/convergence/logging.py
@@ -110,7 +110,8 @@ def _log_bulk_rcv3(event, steps):
     by_lbs = groupby(lambda s: s[0], concat(s.lb_node_pairs for s in steps))
     effs = [
         cf_msg(event,
-               lb_id=lb_id, nodes=', '.join(sorted(p[1] for p in pairs)))
+               lb_id=lb_id,
+               servers=', '.join(sorted(p[1] for p in pairs)))
         for lb_id, pairs in sorted(by_lbs.iteritems())
     ]
     return parallel(effs)

--- a/otter/convergence/logging.py
+++ b/otter/convergence/logging.py
@@ -1,0 +1,66 @@
+"""Utilities for formatting log messages."""
+
+from collections import defaultdict
+
+from effect import parallel
+
+from pyrsistent import thaw
+
+from toolz.curried import groupby
+
+from otter.convergence.steps import AddNodesToCLB, CreateServer, DeleteServer
+from otter.log.cloudfeeds import cf_msg
+
+
+_loggers = {}
+
+def _logger(step_type):
+    def _add_to_loggers(f):
+        _loggers[step_type] = f
+    return _add_to_loggers
+
+
+@_logger(CreateServer)
+def _(steps):
+    # Here we assume that all of the servers have the same server_config.
+    # Could also change this to support differing server_configs by producing
+    # one log message per config.
+    return cf_msg(
+        'convergence-create-servers',
+        num_servers=len(steps),
+        server_config=thaw(next(iter(steps)).server_config),
+    )
+
+
+@_logger(DeleteServer)
+def _(steps):
+    return cf_msg(
+        'convergence-delete-servers',
+        server_ids=sorted([s.server_id for s in steps]))
+
+## Intentionally leaving out SetMetadataItemOnServer for now, since it seems
+## kind of low-level
+
+@_logger(AddNodesToCLB)
+def _(steps):
+    lbs = defaultdict(list)
+    for step in steps:
+        for (address, config) in step.address_configs:
+            lbs[step.lb_id].append('%s:%s' % (address, config.port))
+
+    def msg(lb_id, addresses):
+        formatted_addresses = ', '.join(sorted(addresses))
+        return cf_msg('convergence-add-nodes-to-clb',
+                      lb_id=lb_id, addresses=formatted_addresses)
+
+    return parallel([msg(lb_id, addresses)
+                     for lb_id, addresses in sorted(lbs.iteritems())])
+
+
+def log_steps(steps):
+    steps_by_type = groupby(type, steps)
+    effs = []
+    for step_type, typed_steps in steps_by_type.iteritems():
+        if step_type in _loggers:
+            effs.append(_loggers[step_type](typed_steps))
+    return parallel(effs)

--- a/otter/convergence/logging.py
+++ b/otter/convergence/logging.py
@@ -16,7 +16,7 @@ from otter.convergence.steps import (
 from otter.log.cloudfeeds import cf_msg
 
 
-# Comments: - it kinda sucks that we're using separate effects for all of
+# - it kinda sucks that we're using separate effects for all of
 # these, maybe? CF has an API for sending a bunch of events at once and it'd be
 # good to use it. OTOH it could also be implemented at the logging observer
 # layer by using a "nagle".

--- a/otter/convergence/logging.py
+++ b/otter/convergence/logging.py
@@ -10,11 +10,19 @@ from toolz.curried import groupby
 from toolz.itertoolz import concat
 
 from otter.convergence.steps import (
-    AddNodesToCLB, CreateServer, DeleteServer, RemoveNodesFromCLB)
+    AddNodesToCLB, ChangeCLBNode, CreateServer, DeleteServer,
+    RemoveNodesFromCLB)
 from otter.log.cloudfeeds import cf_msg
 
 
+# Comments: - it kinda sucks that we're using separate effects for all of
+# these, maybe? CF has an API for sending a bunch of events at once and it'd be
+# good to use it. OTOH it could also be implemented at the logging observer
+# layer by using a "nagle".
+
+
 _loggers = {}
+
 
 def _logger(step_type):
     def _add_to_loggers(f):
@@ -24,9 +32,8 @@ def _logger(step_type):
 
 @_logger(CreateServer)
 def _(steps):
-    # Here we assume that all of the servers have the same server_config.
-    # Could also change this to support differing server_configs by producing
-    # one log message per config.
+    # XXX RADIX TODO: groupby the server_config so we don't assume they're all
+    # the same.
     return cf_msg(
         'convergence-create-servers',
         num_servers=len(steps),
@@ -34,17 +41,18 @@ def _(steps):
     )
 
 
+# Intentionally leaving out SetMetadataItemOnServer for now, since it seems
+# kind of low-level
+
 @_logger(DeleteServer)
-def _(steps):
+def _log_delete_servers(steps):
     return cf_msg(
         'convergence-delete-servers',
         server_ids=sorted([s.server_id for s in steps]))
 
-## Intentionally leaving out SetMetadataItemOnServer for now, since it seems
-## kind of low-level
 
 @_logger(AddNodesToCLB)
-def _(steps):
+def _log_add_nodes_clb(steps):
     lbs = defaultdict(list)
     for step in steps:
         for (address, config) in step.address_configs:
@@ -60,12 +68,27 @@ def _(steps):
 
 
 @_logger(RemoveNodesFromCLB)
-def _(steps):
+def _log_remove_from_clb(steps):
     lbs = groupby(lambda s: s.lb_id, steps)
     effs = [
         cf_msg('convergence-remove-nodes-from-clb',
                lb_id=lb, nodes=sorted(concat(s.node_ids for s in lbsteps)))
         for lb, lbsteps in sorted(lbs.iteritems())]
+    return parallel(effs)
+
+
+@_logger(ChangeCLBNode)
+def _log_change_clb_node(steps):
+    lbs = groupby(lambda s: (s.lb_id, s.condition, s.weight, s.type),
+                  steps)
+    effs = [
+        cf_msg('convergence-change-clb-nodes',
+               lb_id=lb,
+               nodes=', '.join(sorted([s.node_id for s in grouped_steps])),
+               condition=condition.name, weight=weight, type=node_type.name)
+        for (lb, condition, weight, node_type), grouped_steps
+        in sorted(lbs.iteritems())
+    ]
     return parallel(effs)
 
 

--- a/otter/convergence/service.py
+++ b/otter/convergence/service.py
@@ -32,6 +32,7 @@ from otter.convergence.composition import get_desired_group_state
 from otter.convergence.effecting import steps_to_effect
 from otter.convergence.errors import present_reasons, structure_reason
 from otter.convergence.gathering import get_all_convergence_data
+from otter.convergence.logging import log_steps
 from otter.convergence.model import ServerState, StepResult
 from otter.convergence.planning import plan
 from otter.log.cloudfeeds import cf_err, cf_msg
@@ -129,6 +130,7 @@ def execute_convergence(tenant_id, group_id, build_timeout,
     desired_group_state = get_desired_group_state(
         group_id, launch_config, desired_capacity)
     steps = plan(desired_group_state, servers, lb_nodes, now, build_timeout)
+    yield log_steps(steps)
     active = determine_active(servers, lb_nodes)
     yield msg('execute-convergence',
               servers=servers, lb_nodes=lb_nodes, steps=steps, now=now,

--- a/otter/log/spec.py
+++ b/otter/log/spec.py
@@ -16,16 +16,10 @@ msg_types = {
         "Fatal error while converging group {scaling_group_id}."),
     "converge-non-fatal-error": (
         "Non-fatal error while converging group {scaling_group_id}"),
-    "cf-add-failure": "Failed to add event to cloud feeds",
-    "cf-unsuitable-message": (
-        "Tried to add unsuitable message in cloud feeds: "
-        "{unsuitable_message}"),
     "delete-server": "Deleting {server_id} server",
     "execute-convergence": "Executing convergence",
     "execute-convergence-results": (
         "Got result of {worst_status} after executing convergence"),
-    "group-status-active": "Group's status is changed to ACTIVE",
-    "group-status-error": "Group's status is changed to ERROR",
     "launch-servers": "Launching {num_servers} servers",
     "mark-clean-success": "Marked group {scaling_group_id} clean",
     "mark-clean-failure": "Failed to mark group {scaling_group_id} clean",
@@ -33,6 +27,29 @@ msg_types = {
     "mark-dirty-failure": "Failed to mark group {scaling_group_id} dirty",
     "remove-server-clb": ("Removing server {server_id} with IP address "
                           "{ip_address} from CLB {clb_id}"),
+
+    # CF-published log messages
+    "cf-add-failure": "Failed to add event to cloud feeds",
+    "cf-unsuitable-message": (
+        "Tried to add unsuitable message in cloud feeds: "
+        "{unsuitable_message}"),
+    "convergence-create-servers":
+        "Creating {num_servers} with config {server_config}",
+    "convergence-delete-servers": "Deleting {servers}",
+    "convergence-add-clb-nodes":
+        "Adding IPs to CLB {lb_id}: {addresses}",
+    "convergence-remove-clb-nodes":
+        "Removing nodes from CLB {lb_id}: {nodes}",
+    "convergence-change-clb-nodes":
+        "Changing nodes on CLB {lb_id}: nodes={nodes}, type={type}, "
+        "condition={condition}, weight={weight}",
+    "convergence-add-rcv3-nodes":
+        "Adding servers to RCv3 LB {lb_id}: {servers}",
+    "convergence-remove-rcv3-nodes":
+        "Removing servers from RCv3 LB {lb_id}: {servers}",
+    "group-status-active": "Group's status is changed to ACTIVE",
+    "group-status-error": "Group's status is changed to ERROR",
+
 }
 
 

--- a/otter/log/spec.py
+++ b/otter/log/spec.py
@@ -48,8 +48,8 @@ msg_types = {
     "convergence-remove-rcv3-nodes":
         "Removing servers from RCv3 LB {lb_id}: {servers}",
     "group-status-active": "Group's status is changed to ACTIVE",
-    "group-status-error": "Group's status is changed to ERROR",
-
+    "group-status-error":
+        "Group's status is changed to ERROR. Reasons: {reasons}",
 }
 
 

--- a/otter/log/spec.py
+++ b/otter/log/spec.py
@@ -20,9 +20,6 @@ msg_types = {
     "execute-convergence": "Executing convergence",
     "execute-convergence-results": (
         "Got result of {worst_status} after executing convergence"),
-    "group-status-active": "Group's status is changed to ACTIVE",
-    "group-status-error":
-        "Group's status is changed to ERROR. Reasons: {reasons}",
     "launch-servers": "Launching {num_servers} servers",
     "mark-clean-success": "Marked group {scaling_group_id} clean",
     "mark-clean-failure": "Failed to mark group {scaling_group_id} clean",

--- a/otter/test/convergence/test_logging.py
+++ b/otter/test/convergence/test_logging.py
@@ -31,7 +31,7 @@ class LogStepsTests(SynchronousTestCase):
     def test_create_servers(self):
         """Logs :obj:`CreateServer`."""
         cfg = {'configgy': 'configged', 'nested': {'a': 'b'}}
-        cfg2 = {'configgy': 'conflagrated'}
+        cfg2 = {'configgy': 'configged', 'nested': {'a': 'c'}}
         creates = pbag([
             CreateServer(server_config=freeze(cfg)),
             CreateServer(server_config=freeze(cfg)),
@@ -53,8 +53,7 @@ class LogStepsTests(SynchronousTestCase):
                         DeleteServer(server_id='3')])
         self.assert_logs(deletes, [
             Log('convergence-delete-servers',
-                fields={'server_ids': ['1', '2', '3'],
-                        'cloud_feed': True})
+                fields={'servers': '1, 2, 3', 'cloud_feed': True})
         ])
 
     def test_add_nodes_to_clbs(self):

--- a/otter/test/convergence/test_logging.py
+++ b/otter/test/convergence/test_logging.py
@@ -151,15 +151,16 @@ class LogStepsTests(SynchronousTestCase):
         ])
         self.assert_logs(adds, [
             Log('convergence-add-rcv3-nodes',
-                fields={'lb_id': 'lb1', 'nodes': 'node1, node2, nodea',
+                fields={'lb_id': 'lb1', 'servers': 'node1, node2, nodea',
                         'cloud_feed': True}),
             Log('convergence-add-rcv3-nodes',
-                fields={'lb_id': 'lb2', 'nodes': 'node2, node3',
+                fields={'lb_id': 'lb2', 'servers': 'node2, node3',
                         'cloud_feed': True}),
             Log('convergence-add-rcv3-nodes',
-                fields={'lb_id': 'lb3', 'nodes': 'node4', 'cloud_feed': True}),
+                fields={'lb_id': 'lb3', 'servers': 'node4',
+                        'cloud_feed': True}),
             Log('convergence-add-rcv3-nodes',
-                fields={'lb_id': 'lba', 'nodes': 'nodea, nodeb',
+                fields={'lb_id': 'lba', 'servers': 'nodea, nodeb',
                         'cloud_feed': True})
         ])
 
@@ -176,15 +177,16 @@ class LogStepsTests(SynchronousTestCase):
         ])
         self.assert_logs(adds, [
             Log('convergence-remove-rcv3-nodes',
-                fields={'lb_id': 'lb1', 'nodes': 'node1, node2, nodea',
+                fields={'lb_id': 'lb1', 'servers': 'node1, node2, nodea',
                         'cloud_feed': True}),
             Log('convergence-remove-rcv3-nodes',
-                fields={'lb_id': 'lb2', 'nodes': 'node2, node3',
+                fields={'lb_id': 'lb2', 'servers': 'node2, node3',
                         'cloud_feed': True}),
             Log('convergence-remove-rcv3-nodes',
-                fields={'lb_id': 'lb3', 'nodes': 'node4', 'cloud_feed': True}),
+                fields={'lb_id': 'lb3', 'servers': 'node4',
+                        'cloud_feed': True}),
             Log('convergence-remove-rcv3-nodes',
-                fields={'lb_id': 'lba', 'nodes': 'nodea, nodeb',
+                fields={'lb_id': 'lba', 'servers': 'nodea, nodeb',
                         'cloud_feed': True})
         ])
 

--- a/otter/test/convergence/test_logging.py
+++ b/otter/test/convergence/test_logging.py
@@ -8,7 +8,7 @@ from twisted.trial.unittest import SynchronousTestCase
 from otter.convergence.logging import log_steps
 from otter.convergence.model import CLBDescription
 from otter.convergence.steps import (
-    AddNodesToCLB, CreateServer, DeleteServer
+    AddNodesToCLB, CreateServer, DeleteServer, RemoveNodesFromCLB
 )
 from otter.log.intents import Log, LogErr
 from otter.test.utils import noop, test_dispatcher
@@ -47,16 +47,13 @@ class LogStepsTests(SynchronousTestCase):
         adds = pbag([
             AddNodesToCLB(
                 lb_id='lbid1',
-                address_configs=pset([('10.0.0.1', _clbd('lbid1', 1234))]),
-                ),
+                address_configs=pset([('10.0.0.1', _clbd('lbid1', 1234))])),
             AddNodesToCLB(
                 lb_id='lbid1',
-                address_configs=pset([('10.0.0.2', _clbd('lbid1', 1235))]),
-                ),
+                address_configs=pset([('10.0.0.2', _clbd('lbid1', 1235))])),
             AddNodesToCLB(
                 lb_id='lbid2',
-                address_configs=pset([('10.0.0.1', _clbd('lbid2', 4321))]),
-                )])
+                address_configs=pset([('10.0.0.1', _clbd('lbid2', 4321))]))])
         self.assert_logs(log_steps(adds), [
             Log('convergence-add-nodes-to-clb',
                 fields={'lb_id': 'lbid1',
@@ -66,4 +63,21 @@ class LogStepsTests(SynchronousTestCase):
                 fields={'lb_id': 'lbid2',
                         'addresses': '10.0.0.1:4321',
                         'cloud_feed': True})
+        ])
+
+    def test_remove_nodes_from_clbs(self):
+        removes = pbag([
+            RemoveNodesFromCLB(lb_id='lbid1', node_ids=pset(['a', 'b', 'c'])),
+            RemoveNodesFromCLB(lb_id='lbid2', node_ids=pset(['d', 'e', 'f']))
+        ])
+
+        self.assert_logs(log_steps(removes), [
+            Log('convergence-remove-nodes-from-clb',
+                fields={'lb_id': 'lbid1',
+                        'nodes': ['a', 'b', 'c'],
+                        'cloud_feed': True}),
+            Log('convergence-remove-nodes-from-clb',
+                fields={'lb_id': 'lbid2',
+                        'nodes': ['d', 'e', 'f'],
+                        'cloud_feed': True}),
         ])

--- a/otter/test/convergence/test_logging.py
+++ b/otter/test/convergence/test_logging.py
@@ -9,9 +9,8 @@ from otter.convergence.logging import log_steps
 from otter.convergence.model import (
     CLBDescription, CLBNodeCondition, CLBNodeType)
 from otter.convergence.steps import (
-    AddNodesToCLB, BulkAddToRCv3, ChangeCLBNode, CreateServer, DeleteServer,
-    RemoveNodesFromCLB
-)
+    AddNodesToCLB, BulkAddToRCv3, BulkRemoveFromRCv3, ChangeCLBNode,
+    CreateServer, DeleteServer, RemoveNodesFromCLB)
 from otter.log.intents import Log
 from otter.test.utils import noop, test_dispatcher
 
@@ -143,6 +142,30 @@ class LogStepsTests(SynchronousTestCase):
             Log('convergence-add-rcv3-nodes',
                 fields={'lb_id': 'lb3', 'nodes': 'node4', 'cloud_feed': True}),
             Log('convergence-add-rcv3-nodes',
+                fields={'lb_id': 'lba', 'nodes': 'nodea, nodeb',
+                        'cloud_feed': True})
+        ])
+
+    def test_bulk_remove_from_rcv3(self):
+        adds = pbag([
+            BulkRemoveFromRCv3(lb_node_pairs=pset([
+                ('lb1', 'node1'), ('lb1', 'node2'),
+                ('lb2', 'node2'), ('lb2', 'node3'),
+                ('lb3', 'node4')])),
+            BulkRemoveFromRCv3(lb_node_pairs=pset([
+                ('lba', 'nodea'), ('lba', 'nodeb'),
+                ('lb1', 'nodea')]))
+        ])
+        self.assert_logs(adds, [
+            Log('convergence-remove-rcv3-nodes',
+                fields={'lb_id': 'lb1', 'nodes': 'node1, node2, nodea',
+                        'cloud_feed': True}),
+            Log('convergence-remove-rcv3-nodes',
+                fields={'lb_id': 'lb2', 'nodes': 'node2, node3',
+                        'cloud_feed': True}),
+            Log('convergence-remove-rcv3-nodes',
+                fields={'lb_id': 'lb3', 'nodes': 'node4', 'cloud_feed': True}),
+            Log('convergence-remove-rcv3-nodes',
                 fields={'lb_id': 'lba', 'nodes': 'nodea, nodeb',
                         'cloud_feed': True})
         ])

--- a/otter/test/convergence/test_logging.py
+++ b/otter/test/convergence/test_logging.py
@@ -27,11 +27,20 @@ class LogStepsTests(SynchronousTestCase):
 
     def test_create_servers(self):
         cfg = {'configgy': 'configged'}
-        creates = pbag([CreateServer(server_config=pmap(cfg))] * 3)
+        cfg2 = {'configgy': 'conflagrated'}
+        creates = pbag([
+            CreateServer(server_config=pmap(cfg)),
+            CreateServer(server_config=pmap(cfg)),
+            CreateServer(server_config=pmap(cfg2))
+            ])
         self.assert_logs(creates, [
             Log('convergence-create-servers',
-                fields={'num_servers': 3, 'server_config': cfg,
-                        'cloud_feed': True})])
+                fields={'num_servers': 2, 'server_config': cfg,
+                        'cloud_feed': True}),
+            Log('convergence-create-servers',
+                fields={'num_servers': 1, 'server_config': cfg2,
+                        'cloud_feed': True})
+            ])
 
     def test_delete_servers(self):
         deletes = pbag([DeleteServer(server_id='1'),

--- a/otter/test/convergence/test_logging.py
+++ b/otter/test/convergence/test_logging.py
@@ -6,28 +6,30 @@ from pyrsistent import pbag, pmap, pset
 from twisted.trial.unittest import SynchronousTestCase
 
 from otter.convergence.logging import log_steps
-from otter.convergence.model import CLBDescription
+from otter.convergence.model import (
+    CLBDescription, CLBNodeCondition, CLBNodeType)
 from otter.convergence.steps import (
-    AddNodesToCLB, CreateServer, DeleteServer, RemoveNodesFromCLB
+    AddNodesToCLB, ChangeCLBNode, CreateServer, DeleteServer,
+    RemoveNodesFromCLB
 )
-from otter.log.intents import Log, LogErr
+from otter.log.intents import Log
 from otter.test.utils import noop, test_dispatcher
 
 
 def _clbd(lbid, port):
     return CLBDescription(lb_id=lbid, port=port)
 
+
 class LogStepsTests(SynchronousTestCase):
-    def assert_logs(self, eff, intents):
+    def assert_logs(self, steps, intents):
         sequence = SequenceDispatcher([(intent, noop) for intent in intents])
         with sequence.consume():
-            sync_perform(test_dispatcher(sequence), eff)
+            sync_perform(test_dispatcher(sequence), log_steps(steps))
 
     def test_create_servers(self):
         cfg = {'configgy': 'configged'}
         creates = pbag([CreateServer(server_config=pmap(cfg))] * 3)
-        eff = log_steps(creates)
-        self.assert_logs(eff, [
+        self.assert_logs(creates, [
             Log('convergence-create-servers',
                 fields={'num_servers': 3, 'server_config': cfg,
                         'cloud_feed': True})])
@@ -36,11 +38,10 @@ class LogStepsTests(SynchronousTestCase):
         deletes = pbag([DeleteServer(server_id='1'),
                         DeleteServer(server_id='2'),
                         DeleteServer(server_id='3')])
-        eff = log_steps(deletes)
-        self.assert_logs(eff, [
+        self.assert_logs(deletes, [
             Log('convergence-delete-servers',
                 fields={'server_ids': ['1', '2', '3'],
-                'cloud_feed': True})
+                        'cloud_feed': True})
         ])
 
     def test_add_nodes_to_clbs(self):
@@ -54,7 +55,7 @@ class LogStepsTests(SynchronousTestCase):
             AddNodesToCLB(
                 lb_id='lbid2',
                 address_configs=pset([('10.0.0.1', _clbd('lbid2', 4321))]))])
-        self.assert_logs(log_steps(adds), [
+        self.assert_logs(adds, [
             Log('convergence-add-nodes-to-clb',
                 fields={'lb_id': 'lbid1',
                         'addresses': '10.0.0.1:1234, 10.0.0.2:1235',
@@ -71,7 +72,7 @@ class LogStepsTests(SynchronousTestCase):
             RemoveNodesFromCLB(lb_id='lbid2', node_ids=pset(['d', 'e', 'f']))
         ])
 
-        self.assert_logs(log_steps(removes), [
+        self.assert_logs(removes, [
             Log('convergence-remove-nodes-from-clb',
                 fields={'lb_id': 'lbid1',
                         'nodes': ['a', 'b', 'c'],
@@ -80,4 +81,44 @@ class LogStepsTests(SynchronousTestCase):
                 fields={'lb_id': 'lbid2',
                         'nodes': ['d', 'e', 'f'],
                         'cloud_feed': True}),
+        ])
+
+    def test_change_clb_node(self):
+        changes = pbag([
+            ChangeCLBNode(lb_id='lbid1', node_id='node1',
+                          condition=CLBNodeCondition.DRAINING,
+                          type=CLBNodeType.PRIMARY,
+                          weight=50),
+            ChangeCLBNode(lb_id='lbid1', node_id='node2',
+                          condition=CLBNodeCondition.DRAINING,
+                          type=CLBNodeType.PRIMARY,
+                          weight=50),
+            ChangeCLBNode(lb_id='lbid1', node_id='node3',
+                          condition=CLBNodeCondition.ENABLED,
+                          type=CLBNodeType.PRIMARY,
+                          weight=50),
+            ChangeCLBNode(lb_id='lbid2', node_id='node4',
+                          condition=CLBNodeCondition.ENABLED,
+                          type=CLBNodeType.PRIMARY,
+                          weight=50),
+        ])
+        self.assert_logs(changes, [
+            Log('convergence-change-clb-nodes',
+                fields={
+                    'lb_id': 'lbid1', 'nodes': 'node3',
+                    'type': 'PRIMARY', 'condition': 'ENABLED', 'weight': 50,
+                    'cloud_feed': True,
+                }),
+            Log('convergence-change-clb-nodes',
+                fields={
+                    'lb_id': 'lbid1', 'nodes': 'node1, node2',
+                    'type': 'PRIMARY', 'condition': 'DRAINING', 'weight': 50,
+                    'cloud_feed': True,
+                }),
+            Log('convergence-change-clb-nodes',
+                fields={
+                    'lb_id': 'lbid2', 'nodes': 'node4',
+                    'type': 'PRIMARY', 'condition': 'ENABLED', 'weight': 50,
+                    'cloud_feed': True,
+                }),
         ])

--- a/otter/test/convergence/test_logging.py
+++ b/otter/test/convergence/test_logging.py
@@ -7,10 +7,11 @@ from twisted.trial.unittest import SynchronousTestCase
 
 from otter.convergence.logging import log_steps
 from otter.convergence.model import (
-    CLBDescription, CLBNodeCondition, CLBNodeType)
+    CLBDescription, CLBNodeCondition, CLBNodeType, ErrorReason)
 from otter.convergence.steps import (
     AddNodesToCLB, BulkAddToRCv3, BulkRemoveFromRCv3, ChangeCLBNode,
-    CreateServer, DeleteServer, RemoveNodesFromCLB, SetMetadataItemOnServer)
+    ConvergeLater, CreateServer, DeleteServer, RemoveNodesFromCLB,
+    SetMetadataItemOnServer)
 from otter.log.intents import Log
 from otter.test.utils import noop, test_dispatcher
 
@@ -27,6 +28,13 @@ class LogStepsTests(SynchronousTestCase):
         sequence = SequenceDispatcher([(intent, noop) for intent in intents])
         with sequence.consume():
             sync_perform(test_dispatcher(sequence), log_steps(steps))
+
+    def test_unhandled_steps(self):
+        """
+        Arbitrary unhandled steps return an effect that performs no logging.
+        """
+        steps = pbag([ConvergeLater([ErrorReason.String("foo")])])
+        self.assert_logs(steps, [])
 
     def test_create_servers(self):
         """Logs :obj:`CreateServer`."""

--- a/otter/test/convergence/test_logging.py
+++ b/otter/test/convergence/test_logging.py
@@ -1,0 +1,69 @@
+from effect import sync_perform
+from effect.testing import SequenceDispatcher
+
+from pyrsistent import pbag, pmap, pset
+
+from twisted.trial.unittest import SynchronousTestCase
+
+from otter.convergence.logging import log_steps
+from otter.convergence.model import CLBDescription
+from otter.convergence.steps import (
+    AddNodesToCLB, CreateServer, DeleteServer
+)
+from otter.log.intents import Log, LogErr
+from otter.test.utils import noop, test_dispatcher
+
+
+def _clbd(lbid, port):
+    return CLBDescription(lb_id=lbid, port=port)
+
+class LogStepsTests(SynchronousTestCase):
+    def assert_logs(self, eff, intents):
+        sequence = SequenceDispatcher([(intent, noop) for intent in intents])
+        with sequence.consume():
+            sync_perform(test_dispatcher(sequence), eff)
+
+    def test_create_servers(self):
+        cfg = {'configgy': 'configged'}
+        creates = pbag([CreateServer(server_config=pmap(cfg))] * 3)
+        eff = log_steps(creates)
+        self.assert_logs(eff, [
+            Log('convergence-create-servers',
+                fields={'num_servers': 3, 'server_config': cfg,
+                        'cloud_feed': True})])
+
+    def test_delete_servers(self):
+        deletes = pbag([DeleteServer(server_id='1'),
+                        DeleteServer(server_id='2'),
+                        DeleteServer(server_id='3')])
+        eff = log_steps(deletes)
+        self.assert_logs(eff, [
+            Log('convergence-delete-servers',
+                fields={'server_ids': ['1', '2', '3'],
+                'cloud_feed': True})
+        ])
+
+    def test_add_nodes_to_clbs(self):
+        adds = pbag([
+            AddNodesToCLB(
+                lb_id='lbid1',
+                address_configs=pset([('10.0.0.1', _clbd('lbid1', 1234))]),
+                ),
+            AddNodesToCLB(
+                lb_id='lbid1',
+                address_configs=pset([('10.0.0.2', _clbd('lbid1', 1235))]),
+                ),
+            AddNodesToCLB(
+                lb_id='lbid2',
+                address_configs=pset([('10.0.0.1', _clbd('lbid2', 4321))]),
+                )])
+        self.assert_logs(log_steps(adds), [
+            Log('convergence-add-nodes-to-clb',
+                fields={'lb_id': 'lbid1',
+                        'addresses': '10.0.0.1:1234, 10.0.0.2:1235',
+                        'cloud_feed': True}),
+            Log('convergence-add-nodes-to-clb',
+                fields={'lb_id': 'lbid2',
+                        'addresses': '10.0.0.1:4321',
+                        'cloud_feed': True})
+        ])

--- a/otter/test/utils.py
+++ b/otter/test/utils.py
@@ -711,11 +711,14 @@ def unwrap_wrapped_effect(intent_class, kwargs,
     return (intent_class(effect=mock.ANY, **kwargs), function)
 
 
-def test_dispatcher():
-    return ComposedDispatcher([
+def test_dispatcher(disp=None):
+    disps = [
         base_dispatcher,
         TypeDispatcher({ParallelEffects: perform_parallel_async}),
-    ])
+    ]
+    if disp is not None:
+        disps.append(disp)
+    return ComposedDispatcher(disps)
 
 
 def defaults_by_name(fn):


### PR DESCRIPTION

This causes all steps to be logged to cloud feeds.

It tries to aggregate multiple similar steps into one log statement. So, for example, multiple CreateServers with the same config are aggregated into one log message like so:

```
cf_msg('convergence-create-servers', num_servers=3, server_config={'foo': 'bar'})
```

And if there were multiple CreateServer steps with different server configs, they would be multiple log messages. (that won't happen in practice for a single convergence iteration, AFAIK).