### PR TITLE
Scale up cloudcafe time convergence

### DIFF
--- a/autoscale_cloudcafe/autoscale/behaviors.py
+++ b/autoscale_cloudcafe/autoscale/behaviors.py
@@ -488,6 +488,14 @@ class AutoscaleBehaviors(BaseBehavior):
             # max out mimic waiting to 60 seconds, no matter what the timeout
             timeout = min(timeout, 60)
 
+        # convergence against a real system can take a little longer
+        elif (self.autoscale_config.convergence and
+                not self.autoscale_config.mimic):
+            # scale up because convergence takes longer - no longer than 15
+            # minutes though.
+            scale_up_factor = 2
+            timeout = min(timeout * scale_up_factor, 900)
+
         # retry uses millseconds, not seconds
         @retry(wait_fixed=interval_time * 1000, stop_max_delay=timeout * 1000)
         @wraps(callable)

--- a/autoscale_cloudcafe/autoscale/config.py
+++ b/autoscale_cloudcafe/autoscale/config.py
@@ -357,3 +357,10 @@ class AutoscaleConfig(ConfigSectionInterface):
         Specify whether this configuration is against a mimic instance.
         """
         return self.get('mimic', 'false').lower() == 'true'
+
+    @property
+    def convergence(self):
+        """
+        Specify whether this configuration is with a convergence tenant.
+        """
+        return self.get('convergence', 'false').lower() == 'true'

--- a/autoscale_cloudroast/test_repo/autoscale/fixtures.py
+++ b/autoscale_cloudroast/test_repo/autoscale/fixtures.py
@@ -485,15 +485,17 @@ class AutoscaleFixture(BaseTestFixture):
                     return server_list
 
             self.fail(
-                'Waited {0} secs for desired capacity/active server list to '
-                'reach the server count of {1}. Has desired capacity {2} on '
-                'the group {3} and {4} servers on the account. '
-                'Filtering by server_name={server_name}'.format(
+                'Waited {0} secs for desired capacity and actual number of '
+                'building or active servers to reach the server count of {1}. '
+                'Has desired capacity {2} on the group {3} and {4} servers on '
+                'the account. Filtering by server_name={server_name}'.format(
                     elapsed_time,
                     desired_capacity,
                     group_state.desiredCapacity, group_id,
                     len(server_list),
-                    server_name=server_name))
+                    server_name=(
+                        '<name from launch config>' if server_name is None
+                        else server_name)))
 
         return self.autoscale_behaviors.retry(
             check_servers, timeout=120, interval_time=5, time_scale=time_scale)


### PR DESCRIPTION
Some of the tests are failing because convergence is taking a little long to get to the right state (especially if it's also converging other groups and throttling).

The policy execution tests in particular start a group with some number of servers, and then test that further scaling up or down works.  Some of them have been failing in the setup (where it starts a group with some number of servers).

It times out at 120 seconds or so, and looking at the logs, that's right around when convergence gets around to finishing issuing the create server requests.

So increase the timeouts by 2 for now, if against convergence systems.  Note that the 'convergence' configuration option has already been set on all our configs - we're just going to read it in here.