### PR TITLE
Fail when adding nodes to a CLB results in a node limit error

### DIFF
--- a/otter/cloud_client.py
+++ b/otter/cloud_client.py
@@ -329,7 +329,7 @@ _CLB_DELETED_PATTERN = re.compile(
 _CLB_NO_SUCH_NODE_PATTERN = re.compile(
     "^Node with id #\d+ not found for loadbalancer #\d+$")
 _CLB_NO_SUCH_LB_PATTERN = re.compile(
-    "^Load balancer not found.$")
+    "^Load balancer not found\.$")
 _CLB_DUPLICATE_NODES_PATTERN = re.compile(
     "^Duplicate nodes detected. One or more nodes already configured "
     "on load balancer\.$")

--- a/otter/cloud_client.py
+++ b/otter/cloud_client.py
@@ -338,7 +338,7 @@ _CLB_DUPLICATE_NODES_PATTERN = re.compile(
     "on load balancer\.$")
 _CLB_NODE_LIMIT_PATTERN = re.compile(
     "^Nodes must not exceed \d+ per load balancer\.$")
-_CLB_OVER_LIMIT_PATTERN = re.compile("^OverLimit Retry...$")
+_CLB_OVER_LIMIT_PATTERN = re.compile("^OverLimit Retry\.{3}$")
 
 
 @attributes([Attribute('lb_id', instance_of=six.text_type)])

--- a/otter/convergence/steps.py
+++ b/otter/convergence/steps.py
@@ -17,6 +17,10 @@ from twisted.python.constants import NamedConstant
 from zope.interface import Interface, implementer
 
 from otter.cloud_client import (
+    CLBPendingUpdateError,
+    CLBRateLimitError,
+    CLBDuplicateNodesError,
+    add_clb_nodes,
     has_code,
     service_request,
     set_nova_metadata_item)
@@ -258,9 +262,6 @@ class SetMetadataItemOnServer(object):
         return eff.on(success=lambda _: (StepResult.SUCCESS, []))
 
 
-_CLB_DUPLICATE_NODES_PATTERN = re.compile(
-    "^Duplicate nodes detected. One or more nodes already configured "
-    "on load balancer.$")
 _CLB_PENDING_UPDATE_PATTERN = re.compile(
     "^Load Balancer '\d+' has a status of 'PENDING_UPDATE' and is considered "
     "immutable.$")
@@ -312,31 +313,21 @@ class AddNodesToCLB(object):
     :ivar iterable address_configs: A collection of two-tuples of address and
         :obj:`CLBDescription`.
 
-    Succeed unconditionally on 202 and 413 (over limit, so try again later).
+    Retry if successful (to re-gather to update the active cache) or if there
+    was a non-terminal failure (if there were duplicate nodes, if the CLB is
+    in PENDING_UDPATE, or if the CLB rate-limited the request).  These can
+    all be fixed in the next convergence cycle.
 
-    Succeed conditionally on 422 if duplicate nodes are detected - the
-    duplicate codes are not enumerated, so just try again the next convergence
-    cycle.
-
-    Succeed conditionally on 422 if the load balancer is in PENDING_UPDATE
-    state, which happens because CLB locks for a few seconds and cannot be
-    changed again after an update - can be fixed next convergence cycle.
+    Fail otherwise.
     """
-
     def as_effect(self):
         """Produce a :obj:`Effect` to add nodes to CLB"""
-        eff = service_request(
-            ServiceType.CLOUD_LOAD_BALANCERS,
-            'POST',
-            append_segments('loadbalancers', str(self.lb_id), "nodes"),
-            data={'nodes': [{'address': address, 'port': lbc.port,
-                             'condition': lbc.condition.name,
-                             'weight': lbc.weight,
-                             'type': lbc.type.name}
-                            for address, lbc in self.address_configs]},
-            success_pred=predicate_any(
-                has_code(202),
-                _check_clb_422(_CLB_DUPLICATE_NODES_PATTERN)))
+        eff = add_clb_nodes(
+            self.lb_id,
+            [{'address': address, 'port': lbc.port,
+              'condition': lbc.condition.name, 'weight': lbc.weight,
+              'type': lbc.type.name}
+             for address, lbc in self.address_configs])
 
         def report_success(result):
             return StepResult.RETRY, [
@@ -350,18 +341,15 @@ class AddNodesToCLB(object):
             Otherwise, retry.
             """
             err_type, error, traceback = result
-            if error.code == 404:
-                return StepResult.FAILURE, [
-                    ErrorReason.Exception(result)]
-            if error.code == 422:
-                message = try_json_with_keys(error.body, ("message",))
-                if message and _CLB_DELETED_PATTERN.search(message):
-                    return StepResult.FAILURE, [
-                        ErrorReason.Exception(result)]
-            return StepResult.RETRY, [ErrorReason.Exception(result)]
+            status = StepResult.FAILURE
 
-        return eff.on(success=report_success,
-                      error=catch(APIError, report_api_failure))
+            if err_type in (CLBDuplicateNodesError, CLBRateLimitError,
+                            CLBPendingUpdateError):
+                status = StepResult.RETRY
+
+            return status, [ErrorReason.Exception(result)]
+
+        return eff.on(success=report_success, error=report_api_failure)
 
 
 @implementer(IStep)

--- a/otter/convergence/steps.py
+++ b/otter/convergence/steps.py
@@ -17,9 +17,9 @@ from twisted.python.constants import NamedConstant
 from zope.interface import Interface, implementer
 
 from otter.cloud_client import (
+    CLBDuplicateNodesError,
     CLBPendingUpdateError,
     CLBRateLimitError,
-    CLBDuplicateNodesError,
     add_clb_nodes,
     has_code,
     service_request,

--- a/otter/test/convergence/test_steps.py
+++ b/otter/test/convergence/test_steps.py
@@ -15,6 +15,7 @@ from twisted.trial.unittest import SynchronousTestCase
 from otter.cloud_client import (
     CLBDeletedError,
     CLBDuplicateNodesError,
+    CLBNodeLimitError,
     CLBPendingUpdateError,
     CLBRateLimitError,
     NoSuchCLBError,
@@ -581,6 +582,7 @@ class StepAsEffectTests(SynchronousTestCase):
         result is a failure.
         """
         terminals = (CLBDeletedError(lb_id=u"12345"),
+                     CLBNodeLimitError(lb_id=u"12345"),
                      NoSuchCLBError(lb_id=u"12345"),
                      APIError(code=503, body="You're out of luck."),
                      TypeError("You did something wrong in your code."))

--- a/otter/test/convergence/test_steps.py
+++ b/otter/test/convergence/test_steps.py
@@ -1,21 +1,26 @@
 """Tests for convergence steps."""
 import json
 
-from effect import Effect, Func, TypeDispatcher, base_dispatcher, sync_perform
+from effect import Effect, Func, base_dispatcher, sync_perform
+from effect.testing import SequenceDispatcher
 
 from mock import ANY, patch
 
 from pyrsistent import freeze, pset
 
-from testtools.matchers import IsInstance
+from testtools.matchers import ContainsAll
 
 from twisted.trial.unittest import SynchronousTestCase
 
 from otter.cloud_client import (
+    CLBDeletedError,
+    CLBDuplicateNodesError,
+    CLBPendingUpdateError,
+    CLBRateLimitError,
+    NoSuchCLBError,
     NoSuchServerError,
     NovaRateLimitError,
     ServerMetadataOverLimitError,
-    ServiceRequest,
     has_code,
     service_request)
 from otter.constants import ServiceType
@@ -48,8 +53,8 @@ from otter.convergence.steps import (
 )
 from otter.test.utils import (
     StubResponse,
-    get_fake_service_request_performer,
     matches,
+    raise_,
     resolve_effect,
     transform_eq)
 from otter.util.hashkey import generate_server_name
@@ -494,10 +499,10 @@ class StepAsEffectTests(SynchronousTestCase):
             ('2.3.4.5', CLBDescription(lb_id=lb_id, port=80))
         ])
         step = AddNodesToCLB(lb_id=lb_id, address_configs=lb_nodes)
-        request = step.as_effect()
+        eff = step.as_effect()
 
         self.assertEqual(
-            request.intent,
+            eff.intent,
             service_request(
                 ServiceType.CLOUD_LOAD_BALANCERS,
                 'POST',
@@ -506,7 +511,7 @@ class StepAsEffectTests(SynchronousTestCase):
                 success_pred=ANY,
                 data={"nodes": ANY}).intent)
 
-        node_data = sorted(request.intent.data['nodes'],
+        node_data = sorted(eff.intent.data['nodes'],
                            key=lambda n: (n['address'], n['port']))
         self.assertEqual(node_data, [
             {'address': '1.2.3.4',
@@ -526,108 +531,68 @@ class StepAsEffectTests(SynchronousTestCase):
              'weight': 1}
         ])
 
+    def _add_one_node_to_clb(self):
+        """
+        Return an effect from adding nodes to CLB.  Uses 1 default node.
+        """
+        lb_id = "12345"
+        lb_nodes = pset([('1.2.3.4', CLBDescription(lb_id=lb_id, port=80))])
+        step = AddNodesToCLB(lb_id=lb_id, address_configs=lb_nodes)
+        return step.as_effect()
+
     def test_add_nodes_to_clb_success_response_codes(self):
         """
-        :obj:`AddNodesToCLB` succeeds on 202 or if duplicate nodes are detected
+        :obj:`AddNodesToCLB` succeeds on 202.
         """
-        lb_id = "12345"
-        lb_nodes = pset([('1.2.3.4', CLBDescription(lb_id=lb_id, port=80))])
-        step = AddNodesToCLB(lb_id=lb_id, address_configs=lb_nodes)
-        request = step.as_effect()
+        eff = self._add_one_node_to_clb()
+        seq = SequenceDispatcher([
+            (eff.intent, lambda i: (StubResponse(202, {}), ''))
+        ])
+        expected = (
+            StepResult.RETRY,
+            [ErrorReason.String('must re-gather after adding to CLB in order '
+                                'to update the active cache')])
 
-        def get_result(response, body):
-            return sync_perform(
-                TypeDispatcher({
-                    ServiceRequest:
-                    get_fake_service_request_performer((response, body))
-                }),
-                request)
+        with seq.consume():
+            self.assertEquals(sync_perform(seq, eff), expected)
 
-        self.assertEqual(
-            get_result(StubResponse(202, {}), ''),
-            (StepResult.RETRY,
-             [ErrorReason.String('must re-gather after adding to CLB in order '
-                                 'to update the active cache')]))
-
-        self.assertEqual(
-            get_result(
-                StubResponse(422, {}),
-                {
-                    "message": "Duplicate nodes detected. One or more "
-                               "nodes already configured on load "
-                               "balancer.",
-                    "code": 422
-                }),
-            (StepResult.RETRY,
-             [ErrorReason.String('must re-gather after adding to CLB in order '
-                                 'to update the active cache')]))
-
-    def test_add_nodes_to_clb_failure_response_codes(self):
+    def test_add_nodes_to_clb_non_terminal_failures(self):
         """
-        :obj:`AddNodesToCLB` returns FAILURE on 404 or 422 PENDING_DELETE and
-        returns RETRY on any other error.
+        :obj:`AddNodesToCLB` retries if the CLB is temporarily locked, or if
+        the request was rate-limited, or if there were duplicate nodes.
         """
-        lb_id = "12345"
-        lb_nodes = pset([('1.2.3.4', CLBDescription(lb_id=lb_id, port=80))])
-        step = AddNodesToCLB(lb_id=lb_id, address_configs=lb_nodes)
-        request = step.as_effect()
+        non_terminals = (CLBDuplicateNodesError(lb_id=u"12345"),
+                         CLBPendingUpdateError(lb_id=u"12345"),
+                         CLBRateLimitError(lb_id=u"12345"))
+        eff = self._add_one_node_to_clb()
 
-        def get_result(response, body):
-            return sync_perform(
-                TypeDispatcher({
-                    ServiceRequest:
-                    get_fake_service_request_performer((response, body))
-                }),
-                request)
+        for exc in non_terminals:
+            seq = SequenceDispatcher([(eff.intent, lambda i: raise_(exc))])
+            with seq.consume():
+                self.assertEquals(
+                    sync_perform(seq, eff),
+                    (StepResult.RETRY, [ErrorReason.Exception(
+                        matches(ContainsAll([type(exc), exc])))]))
 
-        any_api_error = ErrorReason.Exception(
-            (APIError, matches(IsInstance(APIError)), ANY))
+    def test_add_nodes_to_clb_terminal_failures(self):
+        """
+        :obj:`AddNodesToCLB` retries if the CLB is not found or deleted, or
+        if there is any other error, the error is propagated up and the
+        result is a failure.
+        """
+        terminals = (CLBDeletedError(lb_id=u"12345"),
+                     NoSuchCLBError(lb_id=u"12345"),
+                     APIError(code=503, body="You're out of luck."),
+                     TypeError("You did something wrong in your code."))
+        eff = self._add_one_node_to_clb()
 
-        # Fail on 404 or 422 PENDING_DELETE
-        self.assertEqual(
-            get_result(StubResponse(404, {}), ''),
-            (StepResult.FAILURE, [any_api_error]))
-        self.assertEqual(
-            get_result(
-                StubResponse(422, {}),
-                {
-                    "message": "Load Balancer '12345' has a status of "
-                               "'PENDING_DELETE' and is considered immutable.",
-                    "code": 422
-                }),
-            (StepResult.FAILURE, [any_api_error]))
-        self.assertEqual(
-            get_result(
-                StubResponse(422, {}),
-                {
-                    "message": "The load balancer is deleted and considered "
-                               "immutable.",
-                    "code": 422
-                }),
-            (StepResult.FAILURE, [any_api_error]))
-
-        # Retry on other API errors
-        self.assertEqual(
-            get_result(
-                StubResponse(422, {}),
-                {
-                    "message": "Load Balancer '12345' has a status of "
-                               "'PENDING_UPDATE' and is considered immutable.",
-                    "code": 422
-                }),
-            (StepResult.RETRY, [any_api_error]))
-        self.assertEqual(get_result(StubResponse(413, {}), ''),
-                         (StepResult.RETRY, [any_api_error]))
-        self.assertEqual(get_result(StubResponse(500, {}), ''),
-                         (StepResult.RETRY, [any_api_error]))
-
-        # Any unknown errors are propogated
-        self.assertRaises(
-            ValueError,
-            resolve_effect,
-            request,
-            service_request_error_response(ValueError('no')),
-            is_error=True)
+        for exc in terminals:
+            seq = SequenceDispatcher([(eff.intent, lambda i: raise_(exc))])
+            with seq.consume():
+                self.assertEquals(
+                    sync_perform(seq, eff),
+                    (StepResult.FAILURE, [ErrorReason.Exception(
+                        matches(ContainsAll([type(exc), exc])))]))
 
     def test_remove_nodes_from_clb(self):
         """

--- a/otter/test/utils.py
+++ b/otter/test/utils.py
@@ -9,7 +9,7 @@ from inspect import getargspec
 
 from effect import (
     ComposedDispatcher, ParallelEffects, TypeDispatcher,
-    base_dispatcher, sync_perform, sync_performer)
+    base_dispatcher, sync_perform)
 from effect.async import perform_parallel_async
 from effect.testing import (
     SequenceDispatcher,
@@ -34,7 +34,6 @@ from twisted.python.failure import Failure
 from zope.interface import directlyProvides, implementer, interface
 from zope.interface.verify import verifyObject
 
-from otter.cloud_client import concretize_service_request
 from otter.log.bound import BoundLog
 from otter.models.interface import IScalingGroup
 from otter.supervisor import ISupervisor
@@ -779,45 +778,6 @@ def transform_eq(transformer, rhs):
                 self.comparisons, rhs)
 
     return TransformedEq()
-
-
-def get_fake_service_request_performer(stub_response):
-    """
-    For sanity's sake, attempt to fake performing a service request, including
-    predicate handlers, so we can also test the predicate handlers.
-
-    :param service_request: the :class:`ServiceRequest` to "perform"
-    :param stub_response: a tuple of (:class:`StubResponse`, string body),
-        supposedly the "response" of an http request
-    """
-    if not isinstance(stub_response, basestring):
-        try:
-            stub_response = (stub_response[0], json.dumps(stub_response[-1]))
-        except TypeError:
-            stub_response = (stub_response[0], str(stub_response[-1]))
-
-    @sync_performer
-    def the_performer(_, service_request_intent):
-        service_configs = mock.MagicMock()
-        service_configs.__getitem__.return_value = {
-            'name': 'service_name',
-            'region': 'region',
-            'url': 'http://url'
-        }
-        eff = concretize_service_request(
-            authenticator=mock.MagicMock(),
-            log=mock.MagicMock(),
-            service_configs=service_configs,
-            throttler=lambda stype, method: None,
-            tenant_id='000000',
-            service_request=service_request_intent)
-
-        # "authenticate"
-        eff = resolve_effect(eff, ('token', []))
-        # make request
-        return resolve_effect(eff, stub_response)
-
-    return the_performer
 
 
 def raise_(e):


### PR DESCRIPTION
If the are more 25 nodes on a CLB and convergence tries to add more, then the step should fail and convergence should put the group into ERROR.

Since we're touching the add nodes code anyway, I moved it to cloud_client as per #1189.

This makes it so that all 4XX errors, unless we know we can retry, fail.  Other errors are retried.

Fixes #1214.  
Fixes #1244.
Fixes #1260. 