### PR TITLE
CQL dispatcher refactor

### DIFF
--- a/otter/models/cass.py
+++ b/otter/models/cass.py
@@ -12,8 +12,7 @@ from datetime import datetime
 
 from characteristic import attributes
 
-from effect import Constant, Effect, TypeDispatcher, parallel
-from effect.do import do, do_return
+from effect import Effect, TypeDispatcher, parallel
 
 from jsonschema import ValidationError
 

--- a/otter/models/cass.py
+++ b/otter/models/cass.py
@@ -12,7 +12,8 @@ from datetime import datetime
 
 from characteristic import attributes
 
-from effect import Effect, parallel
+from effect import Constant, Effect, TypeDispatcher, parallel
+from effect.do import do, do_return
 
 from jsonschema import ValidationError
 
@@ -72,6 +73,26 @@ def perform_cql_query(conn, disp, intent):
     """
     return conn.execute(
         intent.query, intent.params, intent.consistency_level)
+
+
+def get_cql_dispatcher(connection):
+    """
+    Get dispatcher with `CQLQueryExecute`'s performer in it
+
+    :param connection: Silverberg connection
+    """
+    return TypeDispatcher({
+        CQLQueryExecute: functools.partial(perform_cql_query, connection)
+    })
+
+
+def cql_eff(query, params={}, consistency_level=ConsistencyLevel.ONE):
+    """
+    Return Effect of CQLQueryExecute intent
+    """
+    return Effect(
+        CQLQueryExecute(query=query, params=params,
+                        consistency_level=consistency_level))
 
 
 def serialize_json_data(data, ver):

--- a/otter/tap/api.py
+++ b/otter/tap/api.py
@@ -275,7 +275,8 @@ def makeService(config):
         def on_client_ready(_):
             dispatcher = get_full_dispatcher(reactor, authenticator, log,
                                              get_service_configs(config),
-                                             kz_client, store, supervisor)
+                                             kz_client, store, supervisor,
+                                             cassandra_cluster)
             # Setup scheduler service after starting
             scheduler = setup_scheduler(s, store, kz_client)
             health_checker.checks['scheduler'] = scheduler.health_check

--- a/otter/test/test_effect_dispatcher.py
+++ b/otter/test/test_effect_dispatcher.py
@@ -3,17 +3,11 @@
 from effect import Constant, Delay, Effect, sync_perform
 from effect.ref import ReadReference, Reference
 
-import mock
-
-from twisted.internet.defer import succeed
 from twisted.trial.unittest import SynchronousTestCase
-
-from txeffect import deferred_performer
 
 from otter.auth import Authenticate, InvalidateToken
 from otter.cloud_client import TenantScope
 from otter.effect_dispatcher import (
-    get_cql_dispatcher,
     get_full_dispatcher,
     get_legacy_dispatcher,
     get_simple_dispatcher)
@@ -51,7 +45,8 @@ def full_intents():
         EvictServerFromScalingGroup(log='log', transaction_id='transaction_id',
                                     scaling_group='scaling_group',
                                     server_id='server_id'),
-        Log('msg', {}), LogErr('f', 'msg', {}), BoundFields(Effect(None), {})
+        Log('msg', {}), LogErr('f', 'msg', {}), BoundFields(Effect(None), {}),
+        CQLQueryExecute(query='q', params={}, consistency_level=7)
     ]
 
 
@@ -92,8 +87,7 @@ class LegacyDispatcherTests(SynchronousTestCase, IntentSupportMixin):
         # This is not testing much, but at least that it calls
         # perform_tenant_scope in a vaguely working manner. There are
         # more specific TenantScope performer tests in otter.test.test_http
-        dispatcher = get_full_dispatcher(
-            None, None, None, None, None, None, None)
+        dispatcher = get_full_dispatcher(*([None] * 8))
         scope = TenantScope(Effect(Constant('foo')), 1)
         eff = Effect(scope)
         self.assertEqual(sync_perform(dispatcher, eff), 'foo')
@@ -103,32 +97,7 @@ class FullDispatcherTests(SynchronousTestCase, IntentSupportMixin):
     """Tests for :func:`get_full_dispatcher`."""
 
     def get_dispatcher(self):
-        return get_full_dispatcher(None, None, None, None, None, None, None)
+        return get_full_dispatcher(*([None] * 8))
 
     def get_intents(self):
         return full_intents()
-
-
-class CQLDispatcherTests(SynchronousTestCase):
-    """Tests for :func:`get_cql_dispatcher`."""
-
-    def test_intent_support(self):
-        """Basic intents are supported by the dispatcher."""
-        dispatcher = get_simple_dispatcher(None)
-        for intent in simple_intents():
-            self.assertIsNot(dispatcher(intent), None)
-
-    @mock.patch('otter.effect_dispatcher.perform_cql_query')
-    def test_cql_disp(self, mock_pcq):
-        """The :obj:`CQLQueryExecute` performer is called."""
-
-        @deferred_performer
-        def performer(c, d, i):
-            return succeed('p' + c)
-
-        mock_pcq.side_effect = performer
-
-        dispatcher = get_cql_dispatcher(object(), 'conn')
-        intent = CQLQueryExecute(query='q', params='p', consistency_level=1)
-        eff = Effect(intent)
-        self.assertEqual(sync_perform(dispatcher, eff), 'pconn')


### PR DESCRIPTION
Moved `get_cql_dispatcher` to models/cass.py with only `CQLQueryExecute` performer. Changed load_cql.py to use new dispatcher. This is needed as part of #1458 splitup. 