### PR TITLE
Servers cache model

### DIFF
--- a/otter/models/cass.py
+++ b/otter/models/cass.py
@@ -1702,6 +1702,65 @@ class CassScalingGroupCollection:
         return d
 
 
+@implementer(IScalingGroupServersCache)
+class CassScalingGroupServersCache(object):
+    """
+    Collection of cache of scaling group servers
+    """
+
+    def __init__(self, tenant_id, group_id):
+        self.tenant_id = tenant_id
+        self.group_id = group_id
+        self.table = "servers_cache"
+        self.params = {"tenant_id": tenant_id, "group_id": group_id}
+
+    @do
+    def get_servers(self):
+        """
+        See :method:`IScalingGroupServersCache.get_servers`
+        """
+        query = ("SELECT server_blob, last_update FROM {cf} "
+                 "WHERE tenant_id=:tenant_id AND group_id=:group_id "
+                 "ORDER BY last_update DESC;")
+        rows = yield cql_eff(query.format(cf=self.table), self.params)
+        if len(rows) == 0:
+            yield do_return(([], None))
+        last_update = rows[0]['last_update']
+        rows = take_while(lambda r: r['last_update'] == last_update, rows)
+        yield do_return(([json.loads(r['server_blob']) for r in rows],
+                         last_update))
+
+    def insert_servers(self, last_update, servers, clear_others):
+        """
+        See :method:`IScalingGroupServersCache.insert_servers`
+        """
+        if len(servers) == 0:
+            return Effect(Constant(None))
+        query = ("INSERT INTO {cf} (tenant_id, group_id, last_update, "
+                 "server_id, server_blob) "
+                 "VALUES(:tenant_id, :group_id, :last_update, :server_id{i}, "
+                 ":server_blob{i});")
+        params = merge(self.params, {"last_update": last_update})
+        queries = []
+        for i, server in enumerate(servers):
+            params['server_id{}'.format(i)] = server['id']
+            params['server_blob{}'.format(i)] = json.dumps(server)
+            queries.append(query.format(cf=self.table, i=i))
+        if clear_others:
+            return self.delete_servers().on(
+                lambda _: cql_eff(batch(queries), params))
+        else:
+            return cql_eff(batch(queries), params)
+
+    def delete_servers(self):
+        """
+        See :method:`IScalingGroupServersCache.delete_servers`
+        """
+        query = ("DELETE FROM {cf} WHERE tenant_id=:tenant_id AND "
+                 "group_id=:group_id;")
+        return cql_eff(query.format(cf=self.table), self.params)
+
+
 @implementer(IAdmin)
 class CassAdmin(object):
     """

--- a/otter/models/cass.py
+++ b/otter/models/cass.py
@@ -671,6 +671,7 @@ class CassScalingGroup(object):
         self.webhooks_table = "policy_webhooks"
         self.webhooks_keys_table = "webhook_keys"
         self.event_table = "scaling_schedule_v2"
+        self.servers_cache_table = "servers_cache"
 
     def with_timestamp(self, func):
         """
@@ -1274,7 +1275,8 @@ class CassScalingGroup(object):
 
             queries.extend([
                 _cql_delete_all_in_group.format(cf=table, name='') for table in
-                (self.policies_table, self.webhooks_table)])
+                (self.policies_table, self.webhooks_table,
+                 self.servers_cache_table)])
             queries.append(_cql_delete_group.format(cf=self.group_table))
             params.update({'tenantId': self.tenant_id,
                            'groupId': self.uuid,

--- a/otter/models/cass.py
+++ b/otter/models/cass.py
@@ -1711,19 +1711,19 @@ class CassScalingGroupServersCache(object):
     """
 
     def __init__(self, tenant_id, group_id):
-        self.tenant_id = tenant_id
-        self.group_id = group_id
+        self.tenantId = tenant_id
+        self.groupId = group_id
         self.table = "servers_cache"
-        self.params = {"tenant_id": tenant_id, "group_id": group_id}
+        self.params = {"tenantId": self.tenantId, "groupId": self.groupId}
 
     @do
     def get_servers(self):
         """
         See :method:`IScalingGroupServersCache.get_servers`
         """
-        query = ("SELECT server_blob, last_update FROM {cf} "
-                 "WHERE tenant_id=:tenant_id AND group_id=:group_id "
-                 "ORDER BY last_update DESC;")
+        query = ('SELECT server_blob, last_update FROM {cf} '
+                 'WHERE "tenantId"=:tenantId AND "groupId"=:groupId '
+                 'ORDER BY last_update DESC;')
         rows = yield cql_eff(query.format(cf=self.table), self.params)
         if len(rows) == 0:
             yield do_return(([], None))
@@ -1738,10 +1738,10 @@ class CassScalingGroupServersCache(object):
         """
         if len(servers) == 0:
             return Effect(Constant(None))
-        query = ("INSERT INTO {cf} (tenant_id, group_id, last_update, "
-                 "server_id, server_blob) "
-                 "VALUES(:tenant_id, :group_id, :last_update, :server_id{i}, "
-                 ":server_blob{i});")
+        query = ('INSERT INTO {cf} ("tenantId", "groupId", last_update, '
+                 'server_id, server_blob) '
+                 'VALUES(:tenantId, :groupId, :last_update, :server_id{i}, '
+                 ':server_blob{i});')
         params = merge(self.params, {"last_update": last_update})
         queries = []
         for i, server in enumerate(servers):
@@ -1758,9 +1758,9 @@ class CassScalingGroupServersCache(object):
         """
         See :method:`IScalingGroupServersCache.delete_servers`
         """
-        query = ("DELETE FROM {cf} WHERE tenant_id=:tenant_id AND "
-                 "group_id=:group_id;")
-        return cql_eff(query.format(cf=self.table), self.params)
+        return cql_eff(
+            _cql_delete_all_in_group.format(cf=self.table, name=''),
+            self.params)
 
 
 @implementer(IAdmin)

--- a/otter/models/interface.py
+++ b/otter/models/interface.py
@@ -614,92 +614,36 @@ class IScalingGroup(Interface):
         """
 
 
-class NoSuchServerIntentError(Exception):
+class IScalingGroupServersCache(Interface):
     """
-    Error to be raised when attempting operations on a server intent that does not
-    exist.
+    Cache of servers in scaling groups
     """
-    def __init__(self, tenant_id, group_id, server_id):
-        super(NoSuchServerIntentError, self).__init__(
-            "No such server {s} in group {g} for tenant {t}"
-            .format(t=tenant_id, g=group_id, s=server_id))
+    tenant_id = Attribute("Rackspace Tenant ID of the owner of this group.")
+    group_id = Attribute("UUID of the scaling group - immutable.")
 
-
-class IScalingGroupServerIntentsCollection(Interface):
-    """
-    Collection of servers intended to be there in a scaling group. Each server in the
-    this group should eventually match to a real server in Nova. All operations on this
-    model will not have any impact on real Nova servers. It is the caller's responsibility
-    to sync them (if needed).
-    """
-
-    def create_server_intent(log, status='pending'):
+    def get_servers():
         """
-        Create server intended to be there in scaling group
-
-        :param :class:`BoundLog` log: A bound logger
-        :param str status: status of the server. one of 'pending' or 'active'
-
-        :return: a :class:`twisted.internet.defer.Deferred` that fires with ``dict``
-                corresponding with :data:`otter.json_schema.model_schemas.server`
-        :raises NoSuchScalingGroupError: if this scaling group does not exist
+        Return latest cache of servers in a group along with last time the
+        cache was updated.
+        :return: Effect of (servers, last update time) tuple where servers
+            is list of dict and last update time is datetime object. Will
+            return last_update time as None if cache is empty
+        :rtype: Effect
         """
 
-    def update_server_intent(log, server_intent_id, nova_id, status, lb_info):
+    def insert_servers(last_update, servers, clear_others):
         """
-        Update existing server intent information
-
-        :param :class:`BoundLog` log: A bound logger
-        :param str server_intent_id: ID of server intent
-        :param str nova_id: Server ID of corresponding Nova instance
-        :param str status: server status. One of 'pending' or 'active'
-        :param `dict` lb_info: Load balancer information dict. This will be stored as JSON
-
-        :return: a :class:`twisted.internet.defer.Deferred` that fires with None
-
-        :raises NoSuchScalingGroupError: if this scaling group does not exist
-        :raises NoSuchServerIntentError: if the server intent id does not exist
+        Update the servers cache of the group with last update time
+        :param datetime last_update: Update time of the cache
+        :param list servers: List of server dicts
+        :param bool clear_others: Should any other cache from a different
+            update_time be deleted?
+        :return: Effect of None
         """
 
-    def list_server_intents(log, status=None, limit=100, marker=None):
+    def delete_servers():
         """
-        List the server intents in the scaling group optionally filtered based on status
-
-        :param :class:`BoundLog` log: A bound logger
-        :param str status: server status. One of 'pending' or 'active'
-        :param int limit: Limit number of server intents to return
-        :param str marker: Marker from which to fetch servers
-
-        :return: a :class:`twisted.internet.defer.Deferred` that fires with `list` of
-                server `dict` each corresponding with
-                :data:`otter.json_schema.model_schemas.server`
-
-        :raises NoSuchScalingGroupError: if this scaling group does not exist
-        """
-
-    def get_server_intent(log, server_intent_id):
-        """
-        Get server intent from scaling group
-
-        :param :class:`BoundLog` log: A bound logger
-        :param str server_intent_id: ID of server intent being requested
-
-        :return: a :class:`twisted.internet.defer.Deferred` that fires with
-                 server `dict` correspondgin with
-                :data:`otter.json_schema.model_schemas.server`
-
-        :raises NoSuchScalingGroupError: if this scaling group does not exist
-        :raises NoSuchServerIntentError: if the server intent id does not exist
-        """
-
-    def delete_server_intents(log, server_intent_ids):
-        """
-        Remove server intents from scaling group
-
-        :param :class:`BoundLog` log: A bound logger
-        :param list server_intent_ids: List of server intent IDs to be deleted
-
-        :raises NoSuchScalingGroupError: if this scaling group does not exist
+        Remove all servers of the group
         """
 
 

--- a/otter/test/models/test_cass_models.py
+++ b/otter/test/models/test_cass_models.py
@@ -8,8 +8,10 @@ from copy import deepcopy
 from datetime import datetime
 from functools import partial
 
-from effect import Effect, ParallelEffects, TypeDispatcher, sync_perform
-from effect.testing import resolve_effect
+from effect import (
+    ComposedDispatcher, Constant, Effect, ParallelEffects, TypeDispatcher,
+    base_dispatcher, sync_perform)
+from effect.testing import SequenceDispatcher, resolve_effect
 
 from jsonschema import ValidationError
 
@@ -38,6 +40,7 @@ from otter.models.cass import (
     CassAdmin,
     CassScalingGroup,
     CassScalingGroupCollection,
+    CassScalingGroupServersCache,
     WeakLocks,
     _assemble_webhook_from_row,
     assemble_webhooks_in_policies,
@@ -3654,6 +3657,124 @@ class CassScalingGroupsCollectionHealthCheckTestCase(
         self.assertEqual(
             self.successResultOf(d),
             (True, {'cassandra_time': 0}))
+
+
+class CassGroupServersCacheTests(SynchronousTestCase):
+    """
+    Tests for :class:`CassScalingGroupServersCache`
+    """
+
+    def setUp(self):
+        self.tenant_id = 'tid'
+        self.group_id = 'gid'
+        self.params = {"tenant_id": self.tenant_id, "group_id": self.group_id}
+        self.cache = CassScalingGroupServersCache(
+            self.tenant_id, self.group_id)
+        self.dt = datetime(2010, 10, 20, 10, 0, 0)
+
+    def _test_get_servers(self, query_result, exp_result):
+        sequence = SequenceDispatcher([
+            (CQLQueryExecute(
+                query=("SELECT server_blob, last_update FROM servers_cache "
+                       "WHERE tenant_id=:tenant_id AND group_id=:group_id "
+                       "ORDER BY last_update DESC;"),
+                params=self.params, consistency_level=ConsistencyLevel.ONE),
+             lambda i: query_result)])
+        dispatcher = ComposedDispatcher([sequence, base_dispatcher])
+        with sequence.consume():
+            self.assertEqual(
+                sync_perform(dispatcher, self.cache.get_servers()),
+                exp_result)
+
+    def test_get_servers_empty(self):
+        """
+        `get_servers` returns ([], None) if cache is empty
+        """
+        self._test_get_servers([], ([], None))
+
+    def test_get_servers(self):
+        """
+        `get_servers` fetches all servers that have highest last_fetch
+        time
+        """
+        self._test_get_servers(
+            [{"server_blob": '{"a": "b"}', "last_update": self.dt},
+             {"server_blob": '{"d": "e"}', "last_update": self.dt}],
+            ([{"a": "b"}, {"d": "e"}], self.dt))
+
+    def test_get_servers_diff_last_update(self):
+        """
+        `get_servers` will return servers with only latest last_update time
+        if there are multiple caches
+        """
+        dt_earlier = datetime(2010, 10, 15, 10, 0, 0)
+        self._test_get_servers(
+            [{"server_blob": '{"a": "b"}', "last_update": dt_earlier},
+             {"server_blob": '{"d": "e"}', "last_update": dt_earlier},
+             {"server_blob": '{"c": "f"}', "last_update": self.dt}],
+            ([{"a": "b"}, {"d": "e"}], dt_earlier))
+
+    def _test_insert_servers(self, eff):
+        query = (
+            "BEGIN BATCH "
+            "INSERT INTO servers_cache (tenant_id, group_id, last_update, "
+            "server_id, server_blob) "
+            "VALUES(:tenant_id, :group_id, :last_update, :server_id0, "
+            ":server_blob0); "
+            "INSERT INTO servers_cache (tenant_id, group_id, last_update, "
+            "server_id, server_blob) "
+            "VALUES(:tenant_id, :group_id, :last_update, :server_id1, "
+            ":server_blob1); APPLY BATCH;")
+        self.params.update(
+            {"server_id0": "a", "server_blob0": '{"id": "a"}',
+             "server_id1": "b", "server_blob1": '{"id": "b"}',
+             "last_update": self.dt})
+        self.assertEqual(
+            eff.intent,
+            CQLQueryExecute(query=query, params=self.params,
+                            consistency_level=ConsistencyLevel.ONE))
+        self.assertEqual(resolve_effect(eff, None), None)
+
+    def test_insert_servers(self):
+        """
+        `insert_servers` issues query to insert server as json blobs
+        """
+        eff = self.cache.insert_servers(
+            self.dt, [{"id": "a"}, {"id": "b"}], False)
+        self._test_insert_servers(eff)
+
+    def test_insert_servers_delete(self):
+        """
+        `insert_servers` deletes existing caches before inserting
+        when clear_others=True
+        """
+        self.cache.delete_servers = lambda: Effect("delete")
+        eff = self.cache.insert_servers(
+            self.dt, [{"id": "a"}, {"id": "b"}], True)
+        self.assertEqual(eff.intent, "delete")
+        eff = resolve_effect(eff, None)
+        self._test_insert_servers(eff)
+
+    def test_insert_empty(self):
+        """
+        `insert_servers` does nothing if called with empty servers list
+        """
+        self.assertEqual(
+            self.cache.insert_servers(self.dt, [], False),
+            Effect(Constant(None)))
+
+    def test_delete_servers(self):
+        """
+        `delete_servers` issues query to delete the whole cache
+        """
+        self.assertEqual(
+            self.cache.delete_servers(),
+            Effect(
+                CQLQueryExecute(
+                    query=("DELETE FROM servers_cache WHERE "
+                           "tenant_id=:tenant_id AND group_id=:group_id;"),
+                    params=self.params,
+                    consistency_level=ConsistencyLevel.ONE)))
 
 
 class CassAdminTestCase(SynchronousTestCase):

--- a/otter/test/models/test_cass_models.py
+++ b/otter/test/models/test_cass_models.py
@@ -1953,6 +1953,9 @@ class CassScalingGroupTests(CassScalingGroupTestCase):
             'DELETE FROM policy_webhooks '
             'WHERE "tenantId" = :tenantId AND "groupId" = :groupId '
 
+            'DELETE FROM servers_cache '
+            'WHERE "tenantId" = :tenantId AND "groupId" = :groupId '
+
             'DELETE FROM scaling_group USING TIMESTAMP :ts '
             'WHERE "tenantId" = :tenantId AND "groupId" = :groupId '
 
@@ -1998,6 +2001,9 @@ class CassScalingGroupTests(CassScalingGroupTestCase):
             'WHERE "tenantId" = :tenantId AND "groupId" = :groupId '
 
             'DELETE FROM policy_webhooks '
+            'WHERE "tenantId" = :tenantId AND "groupId" = :groupId '
+
+            'DELETE FROM servers_cache '
             'WHERE "tenantId" = :tenantId AND "groupId" = :groupId '
 
             'DELETE FROM scaling_group USING TIMESTAMP :ts '

--- a/schema/setup/control_50_servers_cache.cql
+++ b/schema/setup/control_50_servers_cache.cql
@@ -1,8 +1,8 @@
 USE @@KEYSPACE@@;
 
 CREATE TABLE servers_cache (
-    tenant_id ascii,
-    group_id ascii,
+    "tenantId" ascii,
+    "groupId" ascii,
     last_update timestamp,
     server_id ascii,
     server_blob ascii,

--- a/schema/setup/control_50_servers_cache.cql
+++ b/schema/setup/control_50_servers_cache.cql
@@ -1,0 +1,14 @@
+USE @@KEYSPACE@@;
+
+CREATE TABLE servers_cache (
+    tenant_id ascii,
+    group_id ascii,
+    last_update timestamp,
+    server_id ascii,
+    server_blob ascii,
+    PRIMARY KEY((tenant_id, group_id), last_update, server_id)
+) WITH CLUSTERING ORDER BY (last_update DESC, server_id ASC) AND
+compaction = {
+    'class' : 'SizeTieredCompactionStrategy',
+    'min_threshold' : '2'
+} AND gc_grace_seconds = 3600;


### PR DESCRIPTION
interface and implementation. This cache will be used by convergence when gathering servers from Nova using changes-since filter. Part of #1458.

Note to reviewer: 
Cache is removed when group is deleted https://github.com/rackerlabs/otter/pull/1458/files#diff-5894116b577c37059087fcce5ce51693R165. I think its better to remove cache as part of group deletion. But adding that will require new query based on `tenant_id` and `group_id`. It would be easier if I chose existing columns `tenantId` and `groupId` as the cache table can be easily appended [here](https://github.com/rackerlabs/otter/blob/change-since/otter/models/cass.py#L1278). Should I change the column names and cache deletion in group deletion? 