### PR TITLE
get-all-details changes_since fix

### DIFF
--- a/otter/convergence/gathering.py
+++ b/otter/convergence/gathering.py
@@ -48,15 +48,16 @@ def get_all_server_details(changes_since=None, batch_size=100):
     url = append_segments('servers', 'detail')
     query = {'limit': batch_size}
     if changes_since is not None:
-        query['changes_since'] = '{0}Z'.format(changes_since.isoformat())
+        query['changes-since'] = '{0}Z'.format(changes_since.isoformat())
 
     last_link = []
 
     def get_server_details(query_params):
+        params = sorted(query_params.items())
         eff = retry_effect(
             service_request(ServiceType.CLOUD_SERVERS, 'GET',
                             "{}?{}".format(url,
-                                           urlencode(query_params, True))),
+                                           urlencode(params, True))),
             retry_times(5), exponential_backoff_interval(2))
         return eff.on(continue_)
 

--- a/otter/test/convergence/test_gathering.py
+++ b/otter/test/convergence/test_gathering.py
@@ -74,7 +74,7 @@ def svc_request_args(**params):
     """
     Return service request args with formatted changes_since argument in it
     """
-    changes_since = params.get('changes-since', None)
+    changes_since = params.pop('changes_since', None)
     if changes_since is not None:
         params['changes-since'] = changes_since.isoformat() + 'Z'
     return (ServiceType.CLOUD_SERVERS, 'GET',
@@ -195,7 +195,7 @@ class GetAllServerDetailsTests(SynchronousTestCase):
         svcreq = resolve_retry_stubs(eff)
         result = resolve_svcreq(
             svcreq, (fake_response, body),
-            *svc_request_args(**{'changes-since': since, 'limit': 10}))
+            *svc_request_args(changes_since=since, limit=10))
         self.assertEqual(result, self.servers)
 
     def test_retry(self):
@@ -228,7 +228,7 @@ class GetScalingGroupServersTests(SynchronousTestCase):
         body = {'servers': []}
         result = resolve_svcreq(
             eff, (fake_response, body),
-            *svc_request_args(**{'changes-since': since, 'limit': 100}))
+            *svc_request_args(changes_since=since, limit=100))
         self.assertEqual(result, {})
 
     def test_filters_no_metadata(self):


### PR DESCRIPTION
`get_all_server_details` was sending `changes_since` filter parameter instead of `changes-since` (note the hypen instead of underscore) due to which mimic was not returning deleted servers. Prod nova might have returned 400 but had tested this only with mimic.

Part of #1458