### PR TITLE
Store server JSON in NovaServer

### DIFF
--- a/otter/convergence/model.py
+++ b/otter/convergence/model.py
@@ -217,9 +217,10 @@ class NovaServer(object):
         the server is on the ServiceNet network
     :ivar str image_id: The ID of the image the server was launched with
     :ivar str flavor_id: The ID of the flavor the server was launched with
-
     :ivar PSet desired_lbs: An immutable mapping of load balancer IDs to lists
         of :class:`CLBDescription` instances.
+    :var dict json: JSON dict received fro mNova from which this server
+        is created
     """
 
     def __init__(self):

--- a/otter/convergence/model.py
+++ b/otter/convergence/model.py
@@ -10,7 +10,7 @@ from attr.validators import instance_of
 
 from characteristic import Attribute, attributes
 
-from pyrsistent import PSet, freeze, pmap, pset, pvector
+from pyrsistent import PMap, PSet, freeze, pmap, pset, pvector
 
 from sumtypes import constructor, sumtype
 
@@ -201,7 +201,8 @@ def _lbs_from_metadata(metadata):
              Attribute('desired_lbs', default_factory=pset, instance_of=PSet),
              Attribute('servicenet_address',
                        default_value='',
-                       instance_of=basestring)])
+                       instance_of=basestring),
+             Attribute('json', instance_of=PMap, default_factory=pmap)])
 class NovaServer(object):
     """
     Information about a server that was retrieved from Nova.
@@ -253,7 +254,8 @@ class NovaServer(object):
             flavor_id=server_json['flavor']['id'],
             links=freeze(server_json['links']),
             desired_lbs=_lbs_from_metadata(metadata),
-            servicenet_address=_servicenet_address(server_json))
+            servicenet_address=_servicenet_address(server_json),
+            json=freeze(server_json))
 
 
 def group_id_from_metadata(metadata):

--- a/otter/convergence/model.py
+++ b/otter/convergence/model.py
@@ -219,7 +219,7 @@ class NovaServer(object):
     :ivar str flavor_id: The ID of the flavor the server was launched with
     :ivar PSet desired_lbs: An immutable mapping of load balancer IDs to lists
         of :class:`CLBDescription` instances.
-    :var dict json: JSON dict received fro mNova from which this server
+    :var dict json: JSON dict received from Nova from which this server
         is created
     """
 

--- a/otter/test/convergence/test_gathering.py
+++ b/otter/test/convergence/test_gathering.py
@@ -35,7 +35,6 @@ from otter.convergence.model import (
     CLBNode,
     CLBNodeCondition,
     CLBNodeType,
-    NovaServer,
     RCv3Description,
     RCv3Node,
     ServerState)
@@ -43,7 +42,8 @@ from otter.test.utils import (
     patch,
     resolve_effect,
     resolve_retry_stubs,
-    resolve_stubs
+    resolve_stubs,
+    server
 )
 from otter.util.retry import (
     ShouldDelayAndRetry, exponential_backoff_interval, retry_times)
@@ -623,20 +623,13 @@ class GetAllConvergenceDataTests(SynchronousTestCase):
             get_rcv3_contents=_constant_as_eff(rcv3_nodes))
 
         expected_servers = [
-            NovaServer(id='a',
-                       state=ServerState.ACTIVE,
-                       image_id='image',
-                       flavor_id='flavor',
-                       created=0,
-                       servicenet_address='10.0.0.1',
-                       links=freeze([{'href': 'link1', 'rel': 'self'}])),
-            NovaServer(id='b',
-                       state=ServerState.ACTIVE,
-                       image_id='image',
-                       flavor_id='flavor',
-                       created=1,
-                       servicenet_address='10.0.0.2',
-                       links=freeze([{'href': 'link2', 'rel': 'self'}]))
+            server('a', ServerState.ACTIVE, servicenet_address='10.0.0.1',
+                   links=freeze([{'href': 'link1', 'rel': 'self'}]),
+                   json=freeze(self.servers[0])),
+            server('b', ServerState.ACTIVE, created=1,
+                   servicenet_address='10.0.0.2',
+                   links=freeze([{'href': 'link2', 'rel': 'self'}]),
+                   json=freeze(self.servers[1]))
         ]
         self.assertEqual(resolve_stubs(eff),
                          (expected_servers, clb_nodes + rcv3_nodes))

--- a/otter/test/convergence/test_model.py
+++ b/otter/test/convergence/test_model.py
@@ -381,7 +381,8 @@ class ToNovaServerTests(SynchronousTestCase):
                        flavor_id='valid_flavor',
                        created=self.createds[0][1],
                        servicenet_address='',
-                       links=freeze(self.links[0])))
+                       links=freeze(self.links[0]),
+                       json=freeze(self.servers[0])))
 
     def test_without_private(self):
         """
@@ -396,7 +397,8 @@ class ToNovaServerTests(SynchronousTestCase):
                        flavor_id='valid_flavor',
                        created=self.createds[0][1],
                        servicenet_address='',
-                       links=freeze(self.links[0])))
+                       links=freeze(self.links[0]),
+                       json=freeze(self.servers[0])))
 
     def test_with_servicenet(self):
         """
@@ -410,7 +412,8 @@ class ToNovaServerTests(SynchronousTestCase):
                        flavor_id='valid_flavor',
                        created=self.createds[1][1],
                        servicenet_address='10.0.0.1',
-                       links=freeze(self.links[1])))
+                       links=freeze(self.links[1]),
+                       json=freeze(self.servers[1])))
 
     def test_without_image_id(self):
         """
@@ -427,7 +430,8 @@ class ToNovaServerTests(SynchronousTestCase):
                            flavor_id='valid_flavor',
                            created=self.createds[0][1],
                            servicenet_address='',
-                           links=freeze(self.links[0])))
+                           links=freeze(self.links[0]),
+                           json=freeze(self.servers[0])))
         del self.servers[0]['image']
         self.assertEqual(
             NovaServer.from_server_details_json(self.servers[0]),
@@ -437,7 +441,8 @@ class ToNovaServerTests(SynchronousTestCase):
                        flavor_id='valid_flavor',
                        created=self.createds[0][1],
                        servicenet_address='',
-                       links=freeze(self.links[0])))
+                       links=freeze(self.links[0]),
+                       json=freeze(self.servers[0])))
 
     def test_with_lb_metadata(self):
         """
@@ -471,7 +476,8 @@ class ToNovaServerTests(SynchronousTestCase):
                            CLBDescription(lb_id='1', port=80),
                            CLBDescription(lb_id='1', port=90)]),
                        servicenet_address='',
-                       links=freeze(self.links[0])))
+                       links=freeze(self.links[0]),
+                       json=freeze(self.servers[0])))
 
     def test_lbs_from_metadata_ignores_unsupported_lb_types(self):
         """
@@ -490,7 +496,8 @@ class ToNovaServerTests(SynchronousTestCase):
                        created=self.createds[0][1],
                        desired_lbs=pset(),
                        servicenet_address='',
-                       links=freeze(self.links[0])))
+                       links=freeze(self.links[0]),
+                       json=freeze(self.servers[0])))
 
     def test_draining_from_metadata_trumps_active_build_nova_states(self):
         """
@@ -510,7 +517,8 @@ class ToNovaServerTests(SynchronousTestCase):
                            created=self.createds[0][1],
                            desired_lbs=pset(),
                            servicenet_address='',
-                           links=freeze(self.links[0])))
+                           links=freeze(self.links[0]),
+                           json=freeze(self.servers[0])))
 
     def test_draining_state_invalid_values(self):
         """
@@ -528,7 +536,8 @@ class ToNovaServerTests(SynchronousTestCase):
                        created=self.createds[0][1],
                        desired_lbs=pset(),
                        servicenet_address='',
-                       links=freeze(self.links[0])))
+                       links=freeze(self.links[0]),
+                       json=freeze(self.servers[0])))
 
     def test_error_and_deleted_nova_state_trumps_draining_from_metadata(self):
         """
@@ -548,7 +557,8 @@ class ToNovaServerTests(SynchronousTestCase):
                            created=self.createds[0][1],
                            desired_lbs=pset(),
                            servicenet_address='',
-                           links=freeze(self.links[0])))
+                           links=freeze(self.links[0]),
+                           json=freeze(self.servers[0])))
 
 
 class IPAddressTests(SynchronousTestCase):

--- a/otter/test/convergence/test_planning.py
+++ b/otter/test/convergence/test_planning.py
@@ -12,7 +12,6 @@ from otter.convergence.model import (
     DRAINING_METADATA,
     DesiredGroupState,
     ErrorReason,
-    NovaServer,
     RCv3Description,
     RCv3Node,
     ServerState)
@@ -27,6 +26,7 @@ from otter.convergence.steps import (
     DeleteServer,
     RemoveNodesFromCLB,
     SetMetadataItemOnServer)
+from otter.test.utils import server
 
 
 def copy_clb_desc(clb_desc, condition=CLBNodeCondition.ENABLED, weight=1):
@@ -488,13 +488,6 @@ class ConvergeLBStateTests(SynchronousTestCase):
                     address_configs=s(('1.1.1.1',
                                        CLBDescription(lb_id='5', port=8081))))
                 ]))
-
-
-def server(id, state, created=0, image_id='image', flavor_id='flavor',
-           **kwargs):
-    """Convenience for creating a :obj:`NovaServer`."""
-    return NovaServer(id=id, state=state, created=created, image_id=image_id,
-                      flavor_id=flavor_id, **kwargs)
 
 
 class DrainAndDeleteServerTests(SynchronousTestCase):

--- a/otter/test/utils.py
+++ b/otter/test/utils.py
@@ -35,6 +35,7 @@ from zope.interface import directlyProvides, implementer, interface
 from zope.interface.verify import verifyObject
 
 from otter.cloud_client import concretize_service_request
+from otter.convergence.model import NovaServer
 from otter.log.bound import BoundLog
 from otter.models.interface import IScalingGroup
 from otter.supervisor import ISupervisor
@@ -845,3 +846,11 @@ class TestStep(object):
 def noop(_):
     """Ignore input and return None."""
     pass
+
+
+def server(id, state, created=0, image_id='image', flavor_id='flavor',
+           json=None, **kwargs):
+    """Convenience for creating a :obj:`NovaServer`."""
+    return NovaServer(id=id, state=state, created=created, image_id=image_id,
+                      flavor_id=flavor_id,
+                      json=json or pmap({'id': id}), **kwargs)


### PR DESCRIPTION
This will be used when storing servers in cache at the succesful convergence cycle. See https://github.com/rackerlabs/otter/pull/1458/files#diff-5894116b577c37059087fcce5ce51693R175

Part of #1458.