### PR TITLE
LBSH tests OOB deletion of a CLB node

### DIFF
--- a/otter/integration/lib/cloud_load_balancer.py
+++ b/otter/integration/lib/cloud_load_balancer.py
@@ -299,6 +299,28 @@ class CloudLoadBalancer(object):
         d.addCallback(self.treq.content)
         return d
 
+    def delete_nodes(self, rcs, node_ids):
+        """
+        Delete one or more nodes from a load balancer.
+
+        :param rcs: a :class:`otter.integration.lib.resources.TestResources`
+            instance
+
+        :param list node_ids: A list of `int` node ids to delete.
+
+        :return: An empty string if successful.
+        """
+        d = self.treq.delete(
+            "{0}/loadbalancers/{1}/nodes".format(
+                str(rcs.endpoints["loadbalancers"]), self.clb_id),
+            params=[('id', node_id) for node_id in node_ids],
+            headers=headers(str(rcs.token)),
+            pool=self.pool
+        )
+        d.addCallback(check_success, [202])
+        d.addCallback(self.treq.content)
+        return d
+
 
 HasLength = MatchesPredicateWithParams(
     lambda items, length: len(items) == length,

--- a/otter/integration/lib/cloud_load_balancer.py
+++ b/otter/integration/lib/cloud_load_balancer.py
@@ -14,12 +14,26 @@ from twisted.internet import reactor
 from twisted.python.log import msg
 
 from otter.util.deferredutils import retry_and_timeout
-from otter.util.http import check_success, headers
+from otter.util.http import APIError, check_success, headers
 from otter.util.retry import (
     TransientRetryError,
     repeating_interval,
     terminal_errors_except
 )
+
+
+def _pending_update_to_transient(f):
+    """
+    A cloud load balancer locks on every update, so to ensure that the test
+    doesn't fail because of that, we want to retry POST/PUT/DELETE commands
+    issued by the test.  This is a utility function that checks if a treq
+    API failure is a 422 PENDING_UDPATE failure, and if so, re-raises a
+    TransientRetryError instead.
+    """
+    if f.check(APIError):
+        if f.value.code == 422 and 'PENDING_UPDATE' in f.value.body:
+            raise TransientRetryError()
+    return f
 
 
 @attributes([
@@ -74,7 +88,7 @@ class CloudLoadBalancer(object):
                 headers=headers(str(rcs.token)),
                 pool=self.pool,
             )
-            .addCallback(check_success, [200])
+            .addCallback(check_success, [200], _treq=self.treq)
             .addCallback(self.treq.json_content)
         )
 
@@ -152,7 +166,7 @@ class CloudLoadBalancer(object):
                                json.dumps(self.config()),
                                headers=headers(str(rcs.token)),
                                pool=self.pool)
-                .addCallback(check_success, [202])
+                .addCallback(check_success, [202], _treq=self.treq)
                 .addCallback(self.treq.json_content)
                 .addCallback(record_results))
 
@@ -175,7 +189,8 @@ class CloudLoadBalancer(object):
                 pool=self.pool
             ).addCallback(
                 check_success,
-                [202, 404] if success_codes is None else success_codes)
+                [202, 404] if success_codes is None else success_codes,
+                _treq=self.treq)
         ).addCallback(lambda _: rcs)
 
     def list_nodes(self, rcs):
@@ -208,7 +223,7 @@ class CloudLoadBalancer(object):
             headers=headers(str(rcs.token)),
             pool=self.pool
         )
-        d.addCallback(check_success, [200])
+        d.addCallback(check_success, [200], _treq=self.treq)
         d.addCallback(self.treq.json_content)
         return d
 
@@ -295,11 +310,11 @@ class CloudLoadBalancer(object):
             headers=headers(str(rcs.token)),
             pool=self.pool
         )
-        d.addCallback(check_success, [202])
+        d.addCallback(check_success, [202], _treq=self.treq)
         d.addCallback(self.treq.content)
         return d
 
-    def delete_nodes(self, rcs, node_ids):
+    def delete_nodes(self, rcs, node_ids, clock=None):
         """
         Delete one or more nodes from a load balancer.
 
@@ -310,16 +325,26 @@ class CloudLoadBalancer(object):
 
         :return: An empty string if successful.
         """
-        d = self.treq.delete(
-            "{0}/loadbalancers/{1}/nodes".format(
-                str(rcs.endpoints["loadbalancers"]), self.clb_id),
-            params=[('id', node_id) for node_id in node_ids],
-            headers=headers(str(rcs.token)),
-            pool=self.pool
+        def really_delete():
+            d = self.treq.delete(
+                "{0}/loadbalancers/{1}/nodes".format(
+                    str(rcs.endpoints["loadbalancers"]), self.clb_id),
+                params=[('id', node_id) for node_id in node_ids],
+                headers=headers(str(rcs.token)),
+                pool=self.pool
+            )
+            d.addCallback(check_success, [202], _treq=self.treq)
+            d.addCallbacks(self.treq.content, _pending_update_to_transient)
+            return d
+
+        return retry_and_timeout(
+            really_delete, 60,
+            can_retry=terminal_errors_except(TransientRetryError),
+            next_interval=repeating_interval(3),
+            clock=clock or reactor,
+            deferred_description="Trying to delete nodes {0}".format(
+                ", ".join(map(str, node_ids)))
         )
-        d.addCallback(check_success, [202])
-        d.addCallback(self.treq.content)
-        return d
 
 
 HasLength = MatchesPredicateWithParams(

--- a/otter/integration/lib/cloud_load_balancer.py
+++ b/otter/integration/lib/cloud_load_balancer.py
@@ -30,9 +30,9 @@ def _pending_update_to_transient(f):
     API failure is a 422 PENDING_UDPATE failure, and if so, re-raises a
     TransientRetryError instead.
     """
-    if f.check(APIError):
-        if f.value.code == 422 and 'PENDING_UPDATE' in f.value.body:
-            raise TransientRetryError()
+    f.trap(APIError)
+    if f.value.code == 422 and 'PENDING_UPDATE' in f.value.body:
+        raise TransientRetryError()
     return f
 
 

--- a/otter/integration/lib/test_cloud_load_balancer.py
+++ b/otter/integration/lib/test_cloud_load_balancer.py
@@ -68,6 +68,19 @@ class CLBTests(SynchronousTestCase):
         d = clb.update_node(self.rcs, 54321, weight=5)
         self.assertEqual('', self.successResultOf(d))
 
+    def test_delete_nodes(self):
+        """
+        Deleting one or more nodes calls the right endpoint and succeeds on
+        202.
+        """
+        self.expected_kwargs['params'] = [("id", 11111), ("id", 22222)]
+        clb = self.get_clb(
+            'delete', 'clburl/loadbalancers/12345/nodes',
+            ((), self.expected_kwargs),
+            Response(202), '')
+        d = clb.delete_nodes(self.rcs, (11111, 22222))
+        self.assertEqual('', self.successResultOf(d))
+
 
 class WaitForNodesTestCase(SynchronousTestCase):
     """

--- a/otter/integration/lib/test_cloud_load_balancer.py
+++ b/otter/integration/lib/test_cloud_load_balancer.py
@@ -119,6 +119,8 @@ class CLBTests(SynchronousTestCase):
 
         d = clb.delete_nodes(self.rcs, (11111, 22222), clock=clock)
 
+        # Note that the timeout is 60 seconds, which is in
+        # cloud_load_balancer's delete function implementation
         self.assertNoResult(d)
         clock.pump([3])
         self.assertNoResult(d)

--- a/otter/integration/lib/test_nova.py
+++ b/otter/integration/lib/test_nova.py
@@ -16,6 +16,7 @@ class Response(object):
     """Fake response object"""
     def __init__(self, code):
         self.code = code
+        self.headers = {}
 
 
 def get_fake_treq(test_case, method, url, expected_args_and_kwargs, response):

--- a/otter/integration/tests/test_convergence.py
+++ b/otter/integration/tests/test_convergence.py
@@ -91,6 +91,10 @@ class TestHelper(object):
         if self.clbs:
             kwargs['use_lbs'] = [clb.scaling_group_spec() for clb in self.clbs]
 
+        kwargs.setdefault("image_ref", image_ref)
+        kwargs.setdefault("flavor_ref", flavor_ref)
+        kwargs.setdefault("min_entities", 0)
+
         server_name_prefix = "{}-{}".format(
             random_string(), reactor.seconds())
         if "server_name_prefix" in kwargs:
@@ -1475,6 +1479,53 @@ class ConvergenceTestsWith1CLB(unittest.TestCase):
                 timeout=600
             )
         )
+
+    @tag("LBSH")
+    @inlineCallbacks
+    def test_oob_deleted_clb_node(self):
+        """
+        If an autoscaled server is removed from the CLB out of band its
+        supposed to be on, Otter will put it back.
+
+        1. Create a scaling group with 1 CLB and 1 server
+        2. Wait for server to be active
+        3. Delete server from the CLB
+        4. Converge
+        5. Assert that the server is put back on the CLB.
+        """
+        clb = self.helper.clbs[0]
+
+        nodes = yield clb.list_nodes(self.rcs)
+        self.assertEqual(len(nodes['nodes']), 0,
+                         "There should be no nodes on the CLB yet.")
+
+        group, _ = self.helper.create_group(min_entities=1)
+        yield self.helper.start_group_and_wait(group, self.rcs)
+
+        nodes = yield clb.list_nodes(self.rcs)
+        self.assertEqual(
+            len(nodes['nodes']), 1,
+            "There should be 1 node on the CLB now that the group is active.")
+        the_node = nodes["nodes"][0]
+
+        yield clb.delete_nodes(self.rcs, [the_node['id']])
+
+        nodes = yield clb.list_nodes(self.rcs)
+        self.assertEqual(len(nodes['nodes']), 0,
+                         "There should no nodes on the CLB after deletion.")
+
+        yield group.trigger_convergence(self.rcs)
+
+        yield clb.wait_for_nodes(
+            self.rcs,
+            MatchesAll(
+                HasLength(1),
+                ContainsAllIPs([the_node["address"]])
+            ),
+            timeout=600
+        )
+
+
 # Run the ConvergenceTestsNoLBs in a configuration with 1 CLB
 copy_test_methods(
     ConvergenceTestsNoLBs, ConvergenceTestsWith1CLB,


### PR DESCRIPTION
Otter should put it back on the next convergence cycle.

Note that if we are running these against production and the LB is in PENDING_UDPATE, we want to retry the delete operation, since we don't want the test to fail just on that alone.

Fixes #1481 

This depends upon a bugfix in mimic ~~(forthcoming)~~ (merged, but version bump not in ci yet), so please don't merge yet.