### PR TITLE
servers cache table schema fix

### DIFF
--- a/schema/setup/control_50_servers_cache.cql
+++ b/schema/setup/control_50_servers_cache.cql
@@ -6,7 +6,7 @@ CREATE TABLE servers_cache (
     last_update timestamp,
     server_id ascii,
     server_blob ascii,
-    PRIMARY KEY((tenant_id, group_id), last_update, server_id)
+    PRIMARY KEY(("tenantId", "groupId"), last_update, server_id)
 ) WITH CLUSTERING ORDER BY (last_update DESC, server_id ASC) AND
 compaction = {
     'class' : 'SizeTieredCompactionStrategy',


### PR DESCRIPTION
Had changed column names to tenantId/groupId to be consistent with other tables but forgot to change it in primary key definition.