### PR TITLE
don't blow up when GetStat returns None

### DIFF
--- a/otter/convergence/service.py
+++ b/otter/convergence/service.py
@@ -404,7 +404,10 @@ def converge_all_groups(currently_converging, my_buckets, all_buckets,
             # deleted, and then the deletion happens, and then our GetStat
             # happens. This basically means it happens when one convergence is
             # starting as another one for the same group is ending.
-            if stat is not None:
+            if stat is None:
+                return msg('converge-divergent-flag-disappeared',
+                           znode=dirty_flag)
+            else:
                 return Effect(TenantScope(
                     converge_one_group(currently_converging,
                                        tenant_id, group_id, stat.version,

--- a/otter/convergence/service.py
+++ b/otter/convergence/service.py
@@ -398,11 +398,12 @@ def converge_all_groups(currently_converging, my_buckets, all_buckets,
 
     def converge(tenant_id, group_id, dirty_flag):
         def got_stat(stat):
-            # If the node disappeared, ignore it. `stat` will be None here only
-            # after the group is removed from currently_converging, but before
-            # the divergent flag is deleted. This happens when we're "noticing"
-            # a divergent flag just we're also finishing up a convergence
-            # process for the same group.
+            # If the node disappeared, ignore it. `stat` will be None here if
+            # the divergent flag was discovered only after the group is removed
+            # from currently_converging, but before the divergent flag is
+            # deleted, and then the deletion happens, and then our GetStat
+            # happens. This basically means it happens when one convergence is
+            # starting as another one for the same group is ending.
             if stat is not None:
                 return Effect(TenantScope(
                     converge_one_group(currently_converging,

--- a/otter/log/spec.py
+++ b/otter/log/spec.py
@@ -12,6 +12,9 @@ msg_types = {
                        "to CLB {clb_id}"),
     "converge-all-groups": "Attempting to converge all dirty groups",
     "converge-all-groups-error": "Error while converging all groups",
+    "converge-divergent-flag-disappeared":
+        "Divergent flag {znode} disappeared when trying to start convergence. "
+        "This should be harmless.",
     "converge-fatal-error": (
         "Fatal error while converging group {scaling_group_id}."),
     "converge-non-fatal-error": (

--- a/otter/test/convergence/test_service.py
+++ b/otter/test/convergence/test_service.py
@@ -456,6 +456,39 @@ class ConvergeAllGroupsTests(SynchronousTestCase):
             3600, converge_one_group=converge_one_group)
         self.assertEqual(sync_perform(_get_dispatcher(), result), None)
 
+    def test_ignore_disappearing_divergent_flag(self):
+        """
+        When the divergent flag disappears just as we're starting to converge,
+        the group does not get converged and None is returned as its result.
+
+        This happens when a concurrent convergence iteration is just finishing
+        up.
+        """
+        eff = self._converge_all_groups(['00_g1'])
+
+        def get_bound_sequence(tid, gid):
+            # since this GetStat is going to return None, no more effects will
+            # be run. This is the crux of what we're testing.
+            return [
+                (GetStat(path='/groups/divergent/{}_{}'.format(tid, gid)),
+                 lambda i: None)]
+
+        sequence = SequenceDispatcher([
+            (ReadReference(ref=self.currently_converging),
+             lambda i: pset()),
+            (Log('converge-all-groups',
+                 dict(group_infos=[self.group_infos[0]],
+                      currently_converging=[])),
+             lambda i: None),
+            unwrap_wrapped_effect(
+                BoundFields, dict(fields={'tenant_id': '00',
+                                          'scaling_group_id': 'g1'}),
+                get_bound_sequence('00', 'g1')),
+        ])
+        dispatcher = test_dispatcher(sequence)
+        with sequence.consume():
+            self.assertEqual(sync_perform(dispatcher, eff), [None])
+
 
 class GetMyDivergentGroupsTests(SynchronousTestCase):
 

--- a/otter/test/convergence/test_service.py
+++ b/otter/test/convergence/test_service.py
@@ -469,9 +469,12 @@ class ConvergeAllGroupsTests(SynchronousTestCase):
         def get_bound_sequence(tid, gid):
             # since this GetStat is going to return None, no more effects will
             # be run. This is the crux of what we're testing.
+            znode = '/groups/divergent/{}_{}'.format(tid, gid)
             return [
-                (GetStat(path='/groups/divergent/{}_{}'.format(tid, gid)),
-                 lambda i: None)]
+                (GetStat(path=znode), lambda i: None),
+                (Log('converge-divergent-flag-disappeared',
+                     fields={'znode': znode}),
+                 noop)]
 
         sequence = SequenceDispatcher([
             (ReadReference(ref=self.currently_converging),


### PR DESCRIPTION
The `GetStat` will return None (indicating the node has been deleted) sometimes, and currently causes an exception about NoneType not having a `version` attribute.

It's safe to ignore this error because it indicates that we were in the process of finishing up convergence of this group. This is because the start of convergence looks like this:

- list divergent flags
- filter out ones that are in `currently_converging`
- for each divergent flag:
  - stat individual znode of flag to get the `version`
  - add group associated with flag to `currently_converging`
  - ...

and the end of convergence (for an individual group) looks like this:

- ...
- delete from `currently_converging`
- delete divergent flag

So, if we list & filter out divergent flags in between those last two steps, and then the deletion happens, by the time we get to "stat individual znode of flag to  get the `version`", it will return None and current code throws an exception when accessing the `version`.