### PR TITLE
metrics: If convergence-tenants is specified, only fetch metrics for  those tenants

### DIFF
--- a/otter/auth.py
+++ b/otter/auth.py
@@ -504,6 +504,8 @@ class NoSuchEndpoint(Exception):
     Exception to be raised when the service catalog does not contain an
     endpoint for the given service in the given region.
     """
+    def __str__(self):
+        return repr(self)
 
 
 def public_endpoint_url(service_catalog, service_name, region):

--- a/otter/metrics.py
+++ b/otter/metrics.py
@@ -55,7 +55,7 @@ def get_specific_scaling_groups(client, tenant_ids):
     defer.returnValue(r for r in results
                       if r.get('created_at') is not None and
                       r.get('desired') is not None and
-                      r.get('status') != 'DISABLED')
+                      r.get('status') not in ('DISABLED', 'ERROR'))
 
 
 @defer.inlineCallbacks
@@ -277,9 +277,7 @@ def collect_metrics(reactor, config, client=None, authenticator=None,
 
     :return: :class:`Deferred` with None
     """
-    convergence_tids = None
-    if config.get('convergence-tenants', []):
-        convergence_tids = config['convergence-tenants']
+    convergence_tids = config.get('convergence-tenants', None)
     _client = client or connect_cass_servers(reactor, config['cassandra'])
     authenticator = authenticator or generate_authenticator(reactor,
                                                             config['identity'])
@@ -289,7 +287,7 @@ def collect_metrics(reactor, config, client=None, authenticator=None,
                                        service_configs)
 
     # calculate metrics
-    if convergence_tids:
+    if convergence_tids is not None:
         cass_groups = yield get_specific_scaling_groups(
             _client, tenant_ids=convergence_tids)
     else:

--- a/otter/test/test_metrics.py
+++ b/otter/test/test_metrics.py
@@ -65,7 +65,8 @@ class GetSpecificScalingGroupsTests(SynchronousTestCase):
             {'desired': 'some', 'status': 'ACTIVE'},  # no created_at
             {'created_at': '0', 'status': 'ACTIVE'},  # no desired
             {'created_at': '0', 'desired': 'some'},   # no status
-            {'created_at': '0', 'desired': 'some', 'status': 'DISABLED'}]
+            {'created_at': '0', 'desired': 'some', 'status': 'DISABLED'},
+            {'created_at': '0', 'desired': 'some', 'status': 'ERROR'}]
         expected_query = QUERY_GROUPS_OF_TENANTS.format(tids="'foo', 'bar'")
         exec_args = {(expected_query, freeze({})): rows}
 

--- a/otter/test/test_metrics.py
+++ b/otter/test/test_metrics.py
@@ -390,7 +390,7 @@ class CollectMetricsTests(SynchronousTestCase):
                        'cloudLoadBalancers': 'clb', 'rackconnect': 'rc'}
 
         self.dispatcher = base_dispatcher
-        self.get_full_dispatcher = lambda r, auth, log, cfgs: self.dispatcher
+        self.get_legacy_dispatcher = lambda r, auth, log, cfgs: self.dispatcher
 
     def _fake_perform(self, dispatcher, effect):
         """
@@ -408,7 +408,7 @@ class CollectMetricsTests(SynchronousTestCase):
         _reactor = mock.Mock()
         d = collect_metrics(_reactor, self.config,
                             perform=self._fake_perform,
-                            get_full_dispatcher=self.get_full_dispatcher)
+                            get_legacy_dispatcher=self.get_legacy_dispatcher)
         self.assertIsNone(self.successResultOf(d))
 
         self.connect_cass_servers.assert_called_once_with(_reactor, 'c')
@@ -428,7 +428,7 @@ class CollectMetricsTests(SynchronousTestCase):
         client = mock.Mock(spec=['disconnect'])
         d = collect_metrics(mock.Mock(), self.config, client=client,
                             perform=self._fake_perform,
-                            get_full_dispatcher=self.get_full_dispatcher)
+                            get_legacy_dispatcher=self.get_legacy_dispatcher)
         self.assertIsNone(self.successResultOf(d))
         self.assertFalse(self.connect_cass_servers.called)
         self.assertFalse(client.disconnect.called)
@@ -440,7 +440,7 @@ class CollectMetricsTests(SynchronousTestCase):
         _reactor, auth = mock.Mock(), mock.Mock()
         d = collect_metrics(_reactor, self.config, authenticator=auth,
                             perform=self._fake_perform,
-                            get_full_dispatcher=self.get_full_dispatcher)
+                            get_legacy_dispatcher=self.get_legacy_dispatcher)
         self.assertIsNone(self.successResultOf(d))
         self.get_all_metrics.assert_called_once_with(
             self.dispatcher, self.groups, _print=False)


### PR DESCRIPTION
Fixes #931. If `convergence-tenants` is in the config file, only those tenants will be used.

I decided to just write a new function called `get_specific_scaling_groups`, instead of modifying `get_scaling_groups`, because that function is huge and scary. The new one doesn't limit by batch size so if we add TONS of convergence tenants to the config file we may run into performance issues down the line.

Also:

- fixes a bug in metrics where I never updated it to use `get_legacy_dispatcher` instead of `get_full_dispatcher` (and mocks in tests prevented the tests from failing ;_;)
- added a `__str__` to `NoSuchEndpoint` in `otter.auth` just 'cause I noticed it didn't have one while I was running the script to test it