### PR TITLE
Convergence test clb log

### DIFF
--- a/otter/integration/lib/cloud_load_balancer.py
+++ b/otter/integration/lib/cloud_load_balancer.py
@@ -11,7 +11,7 @@ from testtools.matchers import MatchesPredicateWithParams
 import treq
 
 from twisted.internet import reactor
-from twisted.python.log import msg
+from twisted.python.log import msg, err
 
 from otter.util.deferredutils import retry_and_timeout
 from otter.util.http import check_success, headers
@@ -127,7 +127,7 @@ class CloudLoadBalancer(object):
         :param TestResources rcs: The resources used to make appropriate API
             calls with.
         """
-        return self.delete(rcs)
+        return self.delete(rcs).addErrback(err)
 
     def start(self, rcs, test):
         """Creates the cloud load balancer and launches it in the cloud.

--- a/otter/integration/lib/cloud_load_balancer.py
+++ b/otter/integration/lib/cloud_load_balancer.py
@@ -11,7 +11,7 @@ from testtools.matchers import MatchesPredicateWithParams
 import treq
 
 from twisted.internet import reactor
-from twisted.python.log import msg, err
+from twisted.python.log import msg
 
 from otter.util.deferredutils import retry_and_timeout
 from otter.util.http import check_success, headers
@@ -127,7 +127,10 @@ class CloudLoadBalancer(object):
         :param TestResources rcs: The resources used to make appropriate API
             calls with.
         """
-        return self.delete(rcs).addErrback(err)
+        # TODO: Ideally .addErrback(err) should do the job but doing it
+        # causes the error to get propogated to trial after logging it
+        return self.delete(rcs).addErrback(
+            lambda f: msg("error deleting clb: {}".format(f)))
 
     def start(self, rcs, test):
         """Creates the cloud load balancer and launches it in the cloud.


### PR DESCRIPTION
`test_delete_all_loadbalancers_and_scale_up` test deletes CLB as part of the test. These tests delete the created CLB as part of cleanup irrelevant of the fact that test deleted it or not. So, it is expected that cleanup might try to delete an already deleted CLB. Prod CLB seems to be returning 400 instead of 404 in this case due to which error gets propagated to trial and the test is reported as failure. This change logs the failure and allows the test to pass.