### PR TITLE
Test delete server waits until server is deleted

### DIFF
--- a/otter/integration/lib/test_nova.py
+++ b/otter/integration/lib/test_nova.py
@@ -105,9 +105,6 @@ class NovaServerTestCase(SynchronousTestCase):
                                  Response(204), "delete response")
         d = server.delete(self.rcs)
         self.assertNoResult(d)
-        server.treq = get_fake_treq(
-            self, 'delete', 'novaurl/servers/server_id',
-            ((), self.expected_kwargs), (Response(204), 'del resp'))
         self.clock.pump([5] * 24)
         self.failureResultOf(d)
 

--- a/otter/integration/lib/test_nova.py
+++ b/otter/integration/lib/test_nova.py
@@ -18,7 +18,8 @@ class Response(object):
         self.code = code
 
 
-def get_fake_treq(test_case, method, url, expected_args_and_kwargs, response):
+def get_fake_treq(test_case, method, url, expected_args_and_kwargs, response,
+                  _treq=None):
     """
     Return a fake treq object that would return the given response given
     the correct request made.
@@ -41,7 +42,7 @@ def get_fake_treq(test_case, method, url, expected_args_and_kwargs, response):
             test_case.assertEqual(resp, response_object)
             return succeed(json.loads(str_response_body))
 
-    _treq = FakeTreq()
+    _treq = _treq or FakeTreq()
 
     setattr(_treq, method.lower(), requester)
 
@@ -85,8 +86,12 @@ class NovaServerTestCase(SynchronousTestCase):
         server = self.get_server('delete', 'novaurl/servers/server_id',
                                  ((), self.expected_kwargs),
                                  Response(204), "delete response")
+        get_fake_treq(
+            self, 'get', 'novaurl/servers/server_id',
+            ((), self.expected_kwargs), (Response(404), 'resp'), server.treq)
         d = server.delete(self.rcs)
-        self.assertEqual('delete response', self.successResultOf(d))
+        #self.assertNoResult(d)
+        self.assertIsNone(self.successResultOf(d))
 
     def test_list_metadata(self):
         """


### PR DESCRIPTION
This is required because prod Nova takes time to delete servers and many OOB tests expect otter to react based on server being deleted. With this merged, we can run all prod convergence tests in https://as-jenkins.rax.io/job/otter-trial-ord-convergence-tests