### PR TITLE
quick hack to log some info when the lock is held too long

### DIFF
--- a/otter/controller.py
+++ b/otter/controller.py
@@ -189,7 +189,10 @@ def delete_group(log, trans_id, group, force):
             # Delete only if desired is 0 which must be done with a lock to
             # ensure desired is not getting modified by another thread/node
             # when executing policy
-            d = group.modify_state(check_and_delete)
+            d = group.modify_state(
+                check_and_delete,
+                modify_state_log=group.log.bind(
+                    modify_state_reason='delete_group'))
     else:
         if force:
             d = empty_group(log, trans_id, group)
@@ -244,7 +247,8 @@ def empty_group(log, trans_id, group):
                 log,
                 trans_id,
                 group_info['groupConfiguration'],
-                launch_config=group_info['launchConfiguration']))
+                launch_config=group_info['launchConfiguration']),
+            modify_state_log=group.log.bind(modify_state_reason='empty_group'))
         return d
 
     d.addCallback(modify_state)

--- a/otter/controller.py
+++ b/otter/controller.py
@@ -191,8 +191,7 @@ def delete_group(log, trans_id, group, force):
             # when executing policy
             d = group.modify_state(
                 check_and_delete,
-                modify_state_log=group.log.bind(
-                    modify_state_reason='delete_group'))
+                modify_state_reason='delete_group')
     else:
         if force:
             d = empty_group(log, trans_id, group)
@@ -248,7 +247,7 @@ def empty_group(log, trans_id, group):
                 trans_id,
                 group_info['groupConfiguration'],
                 launch_config=group_info['launchConfiguration']),
-            modify_state_log=group.log.bind(modify_state_reason='empty_group'))
+            modify_state_reason='empty_group')
         return d
 
     d.addCallback(modify_state)

--- a/otter/models/cass.py
+++ b/otter/models/cass.py
@@ -807,11 +807,11 @@ class CassScalingGroup(object):
 
         return d.addCallback(_unmarshal_state)
 
-    def modify_state(self, modifier_callable, modify_state_reason=None,
-                     *args, **kwargs):
+    def modify_state(self, modifier_callable, *args, **kwargs):
         """
         see :meth:`otter.models.interface.IScalingGroup.modify_state`
         """
+        modify_state_reason = kwargs.pop('modify_state_reason', None)
         log = self.log.bind(
             system='CassScalingGroup.modify_state',
             modify_state_reason=modify_state_reason)

--- a/otter/models/cass.py
+++ b/otter/models/cass.py
@@ -807,13 +807,14 @@ class CassScalingGroup(object):
 
         return d.addCallback(_unmarshal_state)
 
-    def modify_state(self, modifier_callable, modify_state_log=None,
+    def modify_state(self, modifier_callable, modify_state_reason=None,
                      *args, **kwargs):
         """
         see :meth:`otter.models.interface.IScalingGroup.modify_state`
         """
-        log = modify_state_log if modify_state_log is not None else self.log
-        log = self.log.bind(system='CassScalingGroup.modify_state')
+        log = self.log.bind(
+            system='CassScalingGroup.modify_state',
+            modify_state_reason=modify_state_reason)
         consistency = DEFAULT_CONSISTENCY
 
         @self.with_timestamp

--- a/otter/models/intents.py
+++ b/otter/models/intents.py
@@ -19,7 +19,13 @@ class ModifyGroupState(object):
 @deferred_performer
 def perform_modify_group_state(dispatcher, mgs_intent):
     """Perform a :obj:`ModifyGroupState`."""
-    return mgs_intent.scaling_group.modify_state(mgs_intent.modifier)
+    group = mgs_intent.scaling_group
+    # TODO: Ideally we'd get the bound log from any BoundLog wrapper intent
+    # here, but we'd need an Intent specifically for that
+    return group.modify_state(
+        mgs_intent.modifier,
+        modify_state_log=group.log.bind(
+            modify_state_reason='ModifyGroupState intent'))
 
 
 @attributes(['tenant_id', 'group_id'])

--- a/otter/models/intents.py
+++ b/otter/models/intents.py
@@ -20,12 +20,10 @@ class ModifyGroupState(object):
 def perform_modify_group_state(dispatcher, mgs_intent):
     """Perform a :obj:`ModifyGroupState`."""
     group = mgs_intent.scaling_group
-    # TODO: Ideally we'd get the bound log from any BoundLog wrapper intent
-    # here, but we'd need an Intent specifically for that
+    # TODO: put modify_state_reason on intent
     return group.modify_state(
         mgs_intent.modifier,
-        modify_state_log=group.log.bind(
-            modify_state_reason='ModifyGroupState intent'))
+        modify_state_reason='ModifyGroupState intent')
 
 
 @attributes(['tenant_id', 'group_id'])

--- a/otter/rest/configs.py
+++ b/otter/rest/configs.py
@@ -129,8 +129,7 @@ class OtterConfig(object):
         deferred.addCallback(
             lambda _: rec.modify_state(
                 _get_launch_and_obey_config_change,
-                modify_state_log=rec.log.bind(
-                    modify_state_reason='edit_config_for_scaling_group')))
+                modify_state_reason='edit_config_for_scaling_group'))
         return deferred
 
 

--- a/otter/rest/configs.py
+++ b/otter/rest/configs.py
@@ -127,7 +127,10 @@ class OtterConfig(object):
             self.log, self.tenant_id, self.group_id)
         deferred = rec.update_config(data)
         deferred.addCallback(
-            lambda _: rec.modify_state(_get_launch_and_obey_config_change))
+            lambda _: rec.modify_state(
+                _get_launch_and_obey_config_change,
+                modify_state_log=rec.log.bind(
+                    modify_state_reason='edit_config_for_scaling_group')))
         return deferred
 
 

--- a/otter/rest/groups.py
+++ b/otter/rest/groups.py
@@ -388,8 +388,7 @@ class OtterGroups(object):
             d = group.modify_state(partial(
                 controller.obey_config_change, self.log,
                 transaction_id(request), config, launch_config=launch),
-                modify_state_log=group.log.bind(
-                    modify_state_reason='create_new_scaling_group'))
+                modify_state_reason='create_new_scaling_group')
             return d.addCallback(lambda _: result)
 
         deferred.addCallback(_do_obey_config_change)
@@ -728,6 +727,5 @@ class OtterServers(object):
                     transaction_id(request), server_id,
                     extract_bool_arg(request, 'replace', True),
                     extract_bool_arg(request, 'purge', True)),
-            modify_state_log=group.log.bind(
-                modify_state_reason='delete_server'))
+            modify_state_reason='delete_server')
         return d

--- a/otter/rest/groups.py
+++ b/otter/rest/groups.py
@@ -387,7 +387,9 @@ class OtterGroups(object):
                 self.log, self.tenant_id, group_id)
             d = group.modify_state(partial(
                 controller.obey_config_change, self.log,
-                transaction_id(request), config, launch_config=launch))
+                transaction_id(request), config, launch_config=launch),
+                modify_state_log=group.log.bind(
+                    modify_state_reason='create_new_scaling_group'))
             return d.addCallback(lambda _: result)
 
         deferred.addCallback(_do_obey_config_change)
@@ -725,5 +727,7 @@ class OtterServers(object):
                     self.log.bind(server_id=server_id),
                     transaction_id(request), server_id,
                     extract_bool_arg(request, 'replace', True),
-                    extract_bool_arg(request, 'purge', True)))
+                    extract_bool_arg(request, 'purge', True)),
+            modify_state_log=group.log.bind(
+                modify_state_reason='delete_server'))
         return d

--- a/otter/rest/policies.py
+++ b/otter/rest/policies.py
@@ -375,8 +375,7 @@ class OtterPolicy(object):
             partial(controller.maybe_execute_scaling_policy,
                     self.log, transaction_id(request),
                     policy_id=self.policy_id),
-            modify_state_log=group.log.bind(
-                modify_state_reason='execute_policy'))
+            modify_state_reason='execute_policy')
         d.addCallback(lambda _: "{}")  # Return value TBD
         return d
 

--- a/otter/rest/policies.py
+++ b/otter/rest/policies.py
@@ -369,10 +369,14 @@ class OtterPolicy(object):
 
             {}
         """
-        group = self.store.get_scaling_group(self.log, self.tenant_id, self.scaling_group_id)
-        d = group.modify_state(partial(controller.maybe_execute_scaling_policy,
-                                       self.log, transaction_id(request),
-                                       policy_id=self.policy_id))
+        group = self.store.get_scaling_group(self.log, self.tenant_id,
+                                             self.scaling_group_id)
+        d = group.modify_state(
+            partial(controller.maybe_execute_scaling_policy,
+                    self.log, transaction_id(request),
+                    policy_id=self.policy_id),
+            modify_state_log=group.log.bind(
+                modify_state_reason='execute_policy'))
         d.addCallback(lambda _: "{}")  # Return value TBD
         return d
 

--- a/otter/rest/webhooks.py
+++ b/otter/rest/webhooks.py
@@ -368,10 +368,14 @@ class OtterExecute(object):
                                       scaling_group_id=group_id,
                                       policy_id=policy_id)
             logl[0] = bound_log
-            group = self.store.get_scaling_group(bound_log, tenant_id, group_id)
-            return group.modify_state(partial(controller.maybe_execute_scaling_policy,
-                                              bound_log, transaction_id(request),
-                                              policy_id=policy_id))
+            group = self.store.get_scaling_group(bound_log, tenant_id,
+                                                 group_id)
+            return group.modify_state(
+                partial(controller.maybe_execute_scaling_policy,
+                        bound_log, transaction_id(request),
+                        policy_id=policy_id),
+                modify_state_log=group.log.bind(
+                    modify_state_reason='execute_webhook'))
 
         d.addCallback(execute_policy)
         d.addErrback(log_informational_webhook_failure)

--- a/otter/rest/webhooks.py
+++ b/otter/rest/webhooks.py
@@ -374,8 +374,7 @@ class OtterExecute(object):
                 partial(controller.maybe_execute_scaling_policy,
                         bound_log, transaction_id(request),
                         policy_id=policy_id),
-                modify_state_log=group.log.bind(
-                    modify_state_reason='execute_webhook'))
+                modify_state_reason='execute_webhook')
 
         d.addCallback(execute_policy)
         d.addErrback(log_informational_webhook_failure)

--- a/otter/scheduler.py
+++ b/otter/scheduler.py
@@ -204,8 +204,7 @@ def execute_event(store, log, event, deleted_policy_ids):
         partial(maybe_execute_scaling_policy,
                 log, generate_transaction_id(),
                 policy_id=policy_id, version=event['version']),
-        modify_state_log=group.log.bind(
-            modify_state_reason='scheduler.execute_event'))
+        modify_state_reason='scheduler.execute_event')
     d.addErrback(ignore_and_log, CannotExecutePolicyError,
                  log, 'Scheduler cannot execute policy {policy_id}')
 

--- a/otter/supervisor.py
+++ b/otter/supervisor.py
@@ -493,8 +493,7 @@ class _Job(object):
 
         d = self.scaling_group.modify_state(
             handle_failure,
-            modify_state_log=self.scaling_group.log.bind(
-                modify_state_reason='supervisor job failed: removing job'))
+            modify_state_reason='supervisor job failed: removing job')
 
         def ignore_error_if_group_deleted(f):
             f.trap(NoSuchScalingGroupError)
@@ -534,8 +533,7 @@ class _Job(object):
 
         d = self.scaling_group.modify_state(
             handle_success,
-            modify_state_log=self.scaling_group.log.bind(
-                modify_state_reason='supervisor job succeeded: adding active'))
+            modify_state_reason='supervisor job succeeded: adding active')
 
         def delete_if_group_deleted(f):
             f.trap(NoSuchScalingGroupError)

--- a/otter/supervisor.py
+++ b/otter/supervisor.py
@@ -491,7 +491,10 @@ class _Job(object):
             self.log.err(f, 'Launching server failed', **_log_capacity(state))
             return state
 
-        d = self.scaling_group.modify_state(handle_failure)
+        d = self.scaling_group.modify_state(
+            handle_failure,
+            modify_state_log=self.scaling_group.log.bind(
+                modify_state_reason='supervisor job failed: removing job'))
 
         def ignore_error_if_group_deleted(f):
             f.trap(NoSuchScalingGroupError)
@@ -529,7 +532,10 @@ class _Job(object):
                                **_log_capacity(state))
             return state
 
-        d = self.scaling_group.modify_state(handle_success)
+        d = self.scaling_group.modify_state(
+            handle_success,
+            modify_state_log=self.scaling_group.log.bind(
+                modify_state_reason='supervisor job succeeded: adding active'))
 
         def delete_if_group_deleted(f):
             f.trap(NoSuchScalingGroupError)

--- a/otter/test/models/test_cass_models.py
+++ b/otter/test/models/test_cass_models.py
@@ -893,8 +893,10 @@ class CassScalingGroupTests(CassScalingGroupTestCase):
         self.group.modify_state(modifier)
 
         log.bind.assert_called_once_with(
+            modify_state_reason=None,
             system='CassScalingGroup.modify_state')
-        log.bind().bind.assert_called_once_with(category='locking')
+        log.bind().bind.assert_called_once_with(
+            category='locking', lock_reason='modify_state')
 
     def test_modify_state_propagates_modifier_error_and_does_not_save(self):
         """
@@ -2052,7 +2054,8 @@ class CassScalingGroupTests(CassScalingGroupTestCase):
 
         log.bind.assert_called_once_with(
             system='CassScalingGroup.delete_group')
-        log.bind().bind.assert_called_once_with(category='locking')
+        log.bind().bind.assert_called_once_with(
+            category='locking', lock_reason='delete_group')
 
     @mock.patch('otter.models.cass.CassScalingGroup.view_state')
     @mock.patch('otter.models.cass.CassScalingGroup._naive_list_all_webhooks')

--- a/otter/test/models/test_cass_models.py
+++ b/otter/test/models/test_cass_models.py
@@ -895,7 +895,6 @@ class CassScalingGroupTests(CassScalingGroupTestCase):
         log.bind.assert_called_once_with(
             system='CassScalingGroup.modify_state')
         log.bind().bind.assert_called_once_with(category='locking')
-        self.assertEqual(log.bind().bind().msg.call_count, 4)
 
     def test_modify_state_propagates_modifier_error_and_does_not_save(self):
         """
@@ -2054,7 +2053,6 @@ class CassScalingGroupTests(CassScalingGroupTestCase):
         log.bind.assert_called_once_with(
             system='CassScalingGroup.delete_group')
         log.bind().bind.assert_called_once_with(category='locking')
-        self.assertEqual(log.bind().bind().msg.call_count, 4)
 
     @mock.patch('otter.models.cass.CassScalingGroup.view_state')
     @mock.patch('otter.models.cass.CassScalingGroup._naive_list_all_webhooks')

--- a/otter/test/rest/request.py
+++ b/otter/test/rest/request.py
@@ -292,7 +292,7 @@ class RestAPITestMixin(RequestTestMixin):
         # mock out modify state
         self.mock_state = mock.MagicMock(spec=[])  # so nothing can call it
 
-        def _mock_modify_state(modifier, *args, **kwargs):
+        def _mock_modify_state(modifier, modify_state_reason=None, *args, **kwargs):
             return defer.maybeDeferred(modifier, self.mock_group, self.mock_state, *args, **kwargs)
 
         self.mock_group.modify_state.side_effect = _mock_modify_state

--- a/otter/test/rest/request.py
+++ b/otter/test/rest/request.py
@@ -292,8 +292,10 @@ class RestAPITestMixin(RequestTestMixin):
         # mock out modify state
         self.mock_state = mock.MagicMock(spec=[])  # so nothing can call it
 
-        def _mock_modify_state(modifier, modify_state_reason=None, *args, **kwargs):
-            return defer.maybeDeferred(modifier, self.mock_group, self.mock_state, *args, **kwargs)
+        def _mock_modify_state(modifier, modify_state_reason=None,
+                               *args, **kwargs):
+            return defer.maybeDeferred(
+                modifier, self.mock_group, self.mock_state, *args, **kwargs)
 
         self.mock_group.modify_state.side_effect = _mock_modify_state
         self.root = Otter(self.mock_store, 'ord').app.resource()

--- a/otter/test/rest/test_configs.py
+++ b/otter/test/rest/test_configs.py
@@ -205,7 +205,8 @@ class GroupConfigTestCase(RestAPITestMixin, SynchronousTestCase):
             'metadata': {}
         }
 
-        self.mock_group.modify_state.assert_called_once_with(mock.ANY)
+        self.mock_group.modify_state.assert_called_once_with(
+            mock.ANY, modify_state_reason='edit_config_for_scaling_group')
         mock_controller.obey_config_change.assert_called_once_with(
             mock.ANY, "transaction-id", expected_config, self.mock_group,
             self.mock_state, 'launch')

--- a/otter/test/rest/test_groups.py
+++ b/otter/test/rest/test_groups.py
@@ -655,7 +655,8 @@ class AllGroupsEndpointTestCase(RestAPITestMixin, SynchronousTestCase):
             manifest)
         self._test_successful_create(manifest)
 
-        self.mock_group.modify_state.assert_called_once_with(mock.ANY)
+        self.mock_group.modify_state.assert_called_once_with(
+            mock.ANY, modify_state_reason='create_new_scaling_group')
         self.mock_controller.obey_config_change.assert_called_once_with(
             mock.ANY, "transaction-id", expected_config, self.mock_group,
             self.mock_state, launch_config=launch)

--- a/otter/test/test_scheduler.py
+++ b/otter/test/test_scheduler.py
@@ -502,7 +502,8 @@ class ExecuteEventTests(SchedulerTests):
         def _set_new_state(new_state):
             self.new_state = new_state
 
-        def _mock_modify_state(modifier, *args, **kwargs):
+        def _mock_modify_state(modifier, modify_state_reason=None,
+                               *args, **kwargs):
             d = modifier(self.mock_group, self.mock_state, *args, **kwargs)
             return d.addCallback(_set_new_state)
 
@@ -552,7 +553,7 @@ class ExecuteEventTests(SchedulerTests):
         """
         del_pol_ids = set()
         self.mock_group.modify_state.side_effect = \
-            lambda *_: defer.fail(NoSuchScalingGroupError(1, 2))
+            lambda *_, **__: defer.fail(NoSuchScalingGroupError(1, 2))
 
         d = execute_event(self.mock_store, self.log, self.event, del_pol_ids)
 
@@ -568,7 +569,7 @@ class ExecuteEventTests(SchedulerTests):
         """
         del_pol_ids = set()
         self.mock_group.modify_state.side_effect = (
-            lambda *_: defer.fail(NoSuchPolicyError(1, 2, 3)))
+            lambda *_, **__: defer.fail(NoSuchPolicyError(1, 2, 3)))
 
         d = execute_event(self.mock_store, self.log, self.event, del_pol_ids)
 

--- a/otter/test/test_supervisor.py
+++ b/otter/test/test_supervisor.py
@@ -1017,7 +1017,8 @@ class PrivateJobHelperTestCase(SynchronousTestCase):
         server is deleted
         """
         self.group.modify_state.side_effect = (
-            lambda *args: fail(NoSuchScalingGroupError('tenant', 'group')))
+            lambda *args, **kw:
+                fail(NoSuchScalingGroupError('tenant', 'group')))
         d = Deferred()
         self.del_job.return_value.start.return_value = d
 
@@ -1036,7 +1037,8 @@ class PrivateJobHelperTestCase(SynchronousTestCase):
         audit logged as a "server.deletable" event.
         """
         self.group.modify_state.side_effect = (
-            lambda *args: fail(NoSuchScalingGroupError('tenant', 'group')))
+            lambda *args, **kw:
+                fail(NoSuchScalingGroupError('tenant', 'group')))
 
         self.job.start(self.mock_launch)
         self.completion_deferred.callback({'id': 'yay'})
@@ -1058,7 +1060,8 @@ class PrivateJobHelperTestCase(SynchronousTestCase):
         failure can be ignored (not logged)
         """
         self.group.modify_state.side_effect = (
-            lambda *args: fail(NoSuchScalingGroupError('tenant', 'group')))
+            lambda *args, **kw:
+                fail(NoSuchScalingGroupError('tenant', 'group')))
 
         self.job.start('launch')
         self.completion_deferred.callback({'id': 'active'})
@@ -1070,7 +1073,7 @@ class PrivateJobHelperTestCase(SynchronousTestCase):
         is logged
         """
         self.group.modify_state.side_effect = (
-            lambda *args: fail(DummyException('e')))
+            lambda *args, **kw: fail(DummyException('e')))
 
         self.job.start(self.mock_launch)
         self.completion_deferred.callback({'id': 'active'})

--- a/otter/test/test_util.py
+++ b/otter/test/test_util.py
@@ -634,7 +634,8 @@ class WithLockTests(SynchronousTestCase):
 
         self.reactor.advance(10)
         f = self.failureResultOf(d, TimedOutError)
-        self.assertEqual(f.value.message, 'Lock release timed out after 9 seconds.')
+        self.assertEqual(f.value.message,
+                         'Lock release timed out after 9 seconds.')
 
     def test_held_too_long(self):
         """When the lock is held for some time, a log message is emitted."""

--- a/otter/test/test_util.py
+++ b/otter/test/test_util.py
@@ -540,7 +540,7 @@ class WithLockTests(SynchronousTestCase):
         self.reactor.advance(120)
         self.assertNotIn(
             self.too_long_message,
-            (call[1][0] for call in self.log.msg.mock_calls) )
+            (call[1][0] for call in self.log.msg.mock_calls))
 
     def test_acquire_release_no_log(self):
         """

--- a/otter/test/test_util.py
+++ b/otter/test/test_util.py
@@ -636,6 +636,17 @@ class WithLockTests(SynchronousTestCase):
         f = self.failureResultOf(d, TimedOutError)
         self.assertEqual(f.value.message, 'Lock release timed out after 9 seconds.')
 
+    def test_held_too_long(self):
+        """When the lock is held for some time, a log message is emitted."""
+        d = with_lock(self.reactor, self.lock, self.method, self.log)
+        self.assertNoResult(d)
+        self.acquire_d.callback(None)
+        self.method.assert_called_once_with()
+        self.reactor.advance(120)
+        self.log.msg.assert_called_with(
+            "Lock held for more than 120 seconds!", isError=True,
+            lock_status='Acquired', **self.log_fields)
+
 
 class DelayTests(SynchronousTestCase):
     """

--- a/otter/test/test_util.py
+++ b/otter/test/test_util.py
@@ -611,7 +611,8 @@ class WithLockTests(SynchronousTestCase):
 
         self.reactor.advance(10)
         f = self.failureResultOf(d, TimedOutError)
-        self.assertEqual(f.value.message, 'Lock acquisition timed out after 9 seconds.')
+        self.assertEqual(f.value.message,
+                         'Lock acquisition timed out after 9 seconds.')
         self.log.msg.assert_called_with(
             'Lock acquisition failed in 10.0 seconds', lock_status='Failed',
             **self.log_fields)

--- a/otter/test/utils.py
+++ b/otter/test/utils.py
@@ -634,6 +634,7 @@ def mock_group(state, tenant_id='tenant', group_id='group'):
             return d
 
     group.modify_state.side_effect = fake_modify_state
+    group.log = mock_log()
     return group
 
 

--- a/otter/test/utils.py
+++ b/otter/test/utils.py
@@ -624,7 +624,7 @@ def mock_group(state, tenant_id='tenant', group_id='group'):
     group.pause_modify_state = False
     group.modify_state_values = []
 
-    def fake_modify_state(f, *args, **kwargs):
+    def fake_modify_state(f, modify_state_reason=None, *args, **kwargs):
         d = maybeDeferred(f, group, state, *args, **kwargs)
         d.addCallback(lambda r: group.modify_state_values.append(r))
         if group.pause_modify_state:

--- a/otter/util/deferredutils.py
+++ b/otter/util/deferredutils.py
@@ -1,17 +1,15 @@
 """
 Deferred utilities
 """
-
-import traceback
-
-from twisted.internet import defer
-
-from otter.util.retry import retry
+from collections import defaultdict
+from functools import wraps
 
 from pyrsistent import freeze
 
-from functools import wraps
-from collections import defaultdict
+from twisted.internet import defer
+
+from otter.log import log as default_log
+from otter.util.retry import retry
 
 
 def unwrap_first_error(possible_first_error):
@@ -233,53 +231,48 @@ def log_with_time(result, reactor, log, start, msg, time_kwarg=None):
     return result
 
 
-def with_lock(reactor, lock, func, log=None, acquire_timeout=None,
+def with_lock(reactor, lock, func, log=default_log, acquire_timeout=None,
               release_timeout=None, held_too_long=120):
     """
     Context manager for any lock object that contains acquire() and release()
     methods
     """
-    if log:
-        log = log.bind(lock_status="Acquiring",
-                       lock=lock,
-                       locked_func=func)
-        log.msg('Starting lock acquisition')
+    held = [True]
+    log = log.bind(lock_status="Acquiring",
+                   lock=lock,
+                   locked_func=func)
+    log.msg('Starting lock acquisition')
     d = defer.maybeDeferred(lock.acquire)
     if acquire_timeout is not None:
         timeout_deferred(d, acquire_timeout, reactor, 'Lock acquisition')
-    if log:
-        d.addCallback(log_with_time, reactor, log.bind(lock_status='Acquired'),
-                      reactor.seconds(), 'Lock acquisition', 'acquire_time')
-        d.addErrback(log_with_time, reactor, log.bind(lock_status='Failed'),
-                     reactor.seconds(), 'Lock acquisition failed')
-
-    held = [True]
+    d.addCallback(log_with_time, reactor, log.bind(lock_status='Acquired'),
+                  reactor.seconds(), 'Lock acquisition', 'acquire_time')
+    d.addErrback(log_with_time, reactor, log.bind(lock_status='Failed'),
+                 reactor.seconds(), 'Lock acquisition failed')
 
     def release_lock(result, log):
-        if log:
-            log.msg('Starting lock release', lock_status="Releasing")
+        log.msg('Starting lock release', lock_status="Releasing")
         d = defer.maybeDeferred(lock.release)
         if release_timeout is not None:
             timeout_deferred(d, release_timeout, reactor, 'Lock release')
-        if log:
-            d.addCallback(
-                log_with_time, reactor, log.bind(lock_status="Released"),
-                reactor.seconds(),
-                'Lock release', 'release_time')
+        d.addCallback(
+            log_with_time, reactor, log.bind(lock_status="Released"),
+            reactor.seconds(),
+            'Lock release', 'release_time')
 
         def finished_release(_):
             held[0] = False
             return result
+
         return d.addCallback(finished_release)
 
-    def check_still_acquired():
+    def check_still_acquired(log):
         if held[0]:
             log.err(Exception("Lock held too long!"))
 
     def lock_acquired(acquire_result, log):
-        if log:
-            log = log.bind(lock_status="Acquired")
-            reactor.callLater(held_too_long, check_still_acquired)
+        log = log.bind(lock_status="Acquired")
+        reactor.callLater(held_too_long, check_still_acquired, log)
         d = defer.maybeDeferred(func).addBoth(release_lock, log)
         return d
 

--- a/otter/util/deferredutils.py
+++ b/otter/util/deferredutils.py
@@ -242,17 +242,16 @@ def with_lock(reactor, lock, func, log=None, acquire_timeout=None,
     if log:
         log = log.bind(lock_status="Acquiring",
                        lock=lock,
-                       locked_func=func,
-                       log_acquisition_tb=''.join(traceback.format_stack()))
+                       locked_func=func)
         log.msg('Starting lock acquisition')
     d = defer.maybeDeferred(lock.acquire)
     if acquire_timeout is not None:
         timeout_deferred(d, acquire_timeout, reactor, 'Lock acquisition')
     if log:
-        d.addCallback(log_with_time, reactor, log, reactor.seconds(),
-                      'Lock acquisition', 'acquire_time')
-        d.addErrback(log_with_time, reactor, log, reactor.seconds(),
-                     'Lock acquisition failed')
+        d.addCallback(log_with_time, reactor, log.bind(lock_status='Acquired'),
+                      reactor.seconds(), 'Lock acquisition', 'acquire_time')
+        d.addErrback(log_with_time, reactor, log.bind(lock_status='Failed'),
+                     reactor.seconds(), 'Lock acquisition failed')
 
     held = [True]
 

--- a/otter/util/deferredutils.py
+++ b/otter/util/deferredutils.py
@@ -268,7 +268,8 @@ def with_lock(reactor, lock, func, log=default_log, acquire_timeout=None,
 
     def check_still_acquired(log):
         if held[0]:
-            log.err(Exception("Lock held too long!"))
+            log.msg("Lock held for more than %s seconds!" % (held_too_long,),
+                    isError=True)
 
     def lock_acquired(acquire_result, log):
         log = log.bind(lock_status="Acquired")


### PR DESCRIPTION
does a couple things
- `otter.util.deferredutils.with_lock` now logs extra fields:
  - lock_status
  - lock
  - locked_func
- it also runs a delayed call for 120 seconds after acquiring a lock that will log a message *if* the lock is still acquired.
- updated all callers of `with_lock` to bind a `lock_reason` key into the log, so we know who's acquiring locks. Since with_log uses this bound log for the new 120-second-timeout, it will give us an idea of which lock-user is holding the lock too long.
- `with_lock` now defaults the `log` argument to the default otter log instead of just not logging. This was mostly just so I could get rid of the millions of `if` statements we had to placate the linter which was complaining about function complexity.
- modify_state now takes a `modify_state_reason` to bind into the log as `modify_state_reason`. Since `modify_state` is by far the most common acquirer of locks, this will help us further determine which `modify_state` caller might be keeping a lock for too long.

Also, caveat:
- I deleted some really horrible assertions about `log.bind().bind()` in `test_cass_models.py` because I can't even