### PR TITLE
Don't log BadVersionError when marking clean as an error

### DIFF
--- a/otter/log/spec.py
+++ b/otter/log/spec.py
@@ -24,6 +24,9 @@ msg_types = {
     "execute-convergence-results": (
         "Got result of {worst_status} after executing convergence"),
     "launch-servers": "Launching {num_servers} servers",
+    "mark-clean-skipped": (
+        "Not marking group {scaling_group_id} clean because another "
+        "convergence was requested."),
     "mark-clean-success": "Marked group {scaling_group_id} clean",
     "mark-clean-failure": "Failed to mark group {scaling_group_id} clean",
     "mark-dirty-success": "Marked group {scaling_group_id} dirty",

--- a/otter/test/convergence/test_service.py
+++ b/otter/test/convergence/test_service.py
@@ -317,7 +317,22 @@ class ConvergeOneGroupTests(SynchronousTestCase):
             (DeleteNode(path='/groups/divergent/tenant-id_g1',
                         version=self.version),
              lambda i: raise_(BadVersionError())),
-            (LogErr(CheckFailureValue(BadVersionError()), 'mark-clean-failure',
+            (Log('mark-clean-skipped',
+                 dict(path='/groups/divergent/tenant-id_g1',
+                      dirty_version=self.version)), lambda i: None)
+        ])
+        self._verify_sequence(sequence)
+
+    def test_delete_node_other_error(self):
+        """When marking clean raises arbitrary errors, an error is logged."""
+        sequence = SequenceDispatcher([
+            (('ec', self.tenant_id, self.group_id, 3600),
+             lambda i: StepResult.SUCCESS),
+            (DeleteNode(path='/groups/divergent/tenant-id_g1',
+                        version=self.version),
+             lambda i: raise_(ZeroDivisionError())),
+            (LogErr(CheckFailureValue(ZeroDivisionError()),
+                    'mark-clean-failure',
                     dict(path='/groups/divergent/tenant-id_g1',
                          dirty_version=self.version)), lambda i: None)
         ])


### PR DESCRIPTION
BadVersionError is expected any time multiple convergences are requested, and we don't want to be alerted of this. 