### PR TITLE
Replaced unwrap_wrapped_effect with a new nested_sequence function

### DIFF
--- a/otter/test/convergence/test_service.py
+++ b/otter/test/convergence/test_service.py
@@ -429,15 +429,15 @@ class ConvergeAllGroupsTests(SynchronousTestCase):
 
             (BoundFields(mock.ANY, dict(tenant_id='01',
                                         scaling_group_id='g2')),
-             lambda i: i.effect),
-            (GetStat(path='/groups/divergent/01_g2'),
-             lambda i: ZNodeStatStub(version=5)),
-            (TenantScope(
-                Effect(('converge', '01', 'g2', 5, 3600)),
-                '01'),
-             lambda tscope: tscope.effect),
-            (('converge', '01', 'g2', 5, 3600),
-             lambda i: 'converged two!'),
+             nested_sequence([
+                (GetStat(path='/groups/divergent/01_g2'),
+                 lambda i: ZNodeStatStub(version=5)),
+                (TenantScope(mock.ANY, '01'),
+                 nested_sequence([
+                    (('converge', '01', 'g2', 5, 3600),
+                     lambda i: 'converged two!'),
+                 ])),
+             ]))
         ])
         dispatcher = ComposedDispatcher([sequence, test_dispatcher()])
 

--- a/otter/test/convergence/test_service.py
+++ b/otter/test/convergence/test_service.py
@@ -384,13 +384,14 @@ class ConvergeAllGroupsTests(SynchronousTestCase):
         eff = self._converge_all_groups(['00_g1', '01_g2'])
 
         def get_bound_sequence(tid, gid):
-            tscope = TenantScope(Effect(('converge', tid, gid, 1, 3600)), tid)
             return [
                 (GetStat(path='/groups/divergent/{}_{}'.format(tid, gid)),
                  lambda i: ZNodeStatStub(version=1)),
-                (tscope, lambda i: i.effect),
-                (('converge', tid, gid, 1, 3600),
-                 lambda i: 'converged {}!'.format(tid))]
+                (TenantScope(mock.ANY, tid),
+                 nested_sequence([
+                     (('converge', tid, gid, 1, 3600),
+                      lambda i: 'converged {}!'.format(tid))])),
+            ]
 
         sequence = SequenceDispatcher([
             (ReadReference(ref=self.currently_converging),

--- a/otter/test/test_controller.py
+++ b/otter/test/test_controller.py
@@ -37,10 +37,10 @@ from otter.test.utils import (
     matches,
     mock_group as util_mock_group,
     mock_log,
+    nested_sequence,
     patch,
     raise_,
-    test_dispatcher,
-    unwrap_wrapped_effect)
+    test_dispatcher)
 from otter.util.config import set_config_data
 from otter.util.fp import assoc_obj
 from otter.util.retry import (
@@ -1443,11 +1443,13 @@ class ConvergenceRemoveServerTests(SynchronousTestCase):
         Return a :class:`SequenceDispatcher` tuple such that a TenantScope
         is wrapped over a Retry which is wrapped over the given intent.
         """
-        return unwrap_wrapped_effect(
-            TenantScope, {'tenant_id': self.group.tenant_id},
-            [unwrap_wrapped_effect(
-                Retry, {'should_retry': _should_retry_params},
-                [(intent, performer)])])
+        return (
+            TenantScope(mock.ANY, self.group.tenant_id),
+            nested_sequence([
+                (Retry(effect=mock.ANY, should_retry=_should_retry_params),
+                 nested_sequence([(intent, performer)]))
+             ])
+         )
 
     def _remove(self, replace, purge, seq_dispatcher):
         eff = controller.convergence_remove_server_from_group(

--- a/otter/test/utils.py
+++ b/otter/test/utils.py
@@ -697,7 +697,7 @@ def resolve_stubs(eff):
     return eff_resolve_stubs(base_dispatcher, eff)
 
 
-def perform_sequence(seq, eff, fallback_dispatcher=None):
+def perform_sequence(seq, eff, fallback_dispatcher=base_dispatcher):
     """
     Create a :obj:`SequenceDispatcher` with the given ``seq``, and perform
     ``eff`` with it.
@@ -715,7 +715,7 @@ def perform_sequence(seq, eff, fallback_dispatcher=None):
 
 
 def nested_sequence(seq, get_effect=attrgetter('effect'),
-                    fallback_dispatcher=None):
+                    fallback_dispatcher=base_dispatcher):
     """
     Return a function of Intent -> a that performs an effect retrieved from the
     intent (by accessing its `effect` attribute, by default) with the given
@@ -748,7 +748,7 @@ def nested_sequence(seq, get_effect=attrgetter('effect'),
         get_effect)
 
 
-def nested_parallel(seq, fallback_dispatcher=None):
+def nested_parallel(seq, fallback_dispatcher=base_dispatcher):
     """
     Return a two-tuple for use in a :obj:`SequenceDispatcher` which ensures
     that all the intents in ``seq`` are performed in parallel.

--- a/otter/test/utils.py
+++ b/otter/test/utils.py
@@ -12,7 +12,6 @@ from effect import (
     ComposedDispatcher, ParallelEffects, TypeDispatcher,
     base_dispatcher, sync_perform, sync_performer)
 from effect.async import perform_parallel_async
-from effect.fold import sequence
 from effect.testing import (
     SequenceDispatcher,
     resolve_effect as eff_resolve_effect,
@@ -744,21 +743,9 @@ def nested_sequence(seq, get_effect=attrgetter('effect'),
         sequence dispatcher.
     """
     return compose(
-        partial(perform_sequence, seq, fallback_dispatcher=fallback_dispatcher),
+        partial(perform_sequence, seq,
+                fallback_dispatcher=fallback_dispatcher),
         get_effect)
-
-
-def nested_parallel(seq, fallback_dispatcher=base_dispatcher):
-    """
-    Return a two-tuple for use in a :obj:`SequenceDispatcher` which ensures
-    that all the intents in ``seq`` are performed in parallel.
-
-    :param seq: sequence of intents like :obj:`SequenceDispatcher` takes
-    :param fallback_dispatcher: an optional dispatcher to compose onto the
-        sequence dispatcher.
-    """
-    return (ParallelEffects(effects=mock.ANY),
-            nested_sequence(seq, get_effect=lambda i: sequence(i.effects)))
 
 
 def test_dispatcher(disp=None):


### PR DESCRIPTION
Cons:
- more verbose

Pros:
- a little bit clearer: you don't have to pass an intent *class* and kwargs any more; you're in control of creating the expected intent (meaning you pretty much always have to use mock.ANY yourself)
- more general: doesn't require the wrapper-intent to have an "effect" attribute -- in fact, it can work even work with things like ParallelEffects which have "effects". This is done by accepting a function to of wrapper_intent -> Effect. I'll add a `nested_parallel` function that takes advantage of this in another PR.

I also noticed a few spots in our tests where we weren't really ensuring an effect was being run within the context of another effect, and made them use nested_sequence.
