### PR TITLE
Nested parallel

### DIFF
--- a/otter/test/convergence/test_service.py
+++ b/otter/test/convergence/test_service.py
@@ -736,11 +736,11 @@ class ExecuteConvergenceTests(SynchronousTestCase):
         except ZeroDivisionError:
             exc_info = sys.exc_info()
 
-        step = TestStep(Effect(Constant(
-            (StepResult.RETRY, [
+        step = TestStep(Effect("the step"))
+        step_result = (StepResult.RETRY, [
                 ErrorReason.Exception(exc_info),
                 ErrorReason.String('foo'),
-                ErrorReason.Structured({'foo': 'bar'})]))))
+                ErrorReason.Structured({'foo': 'bar'})])
 
         def plan(*args, **kwargs):
             return pbag([step])
@@ -761,22 +761,20 @@ class ExecuteConvergenceTests(SynchronousTestCase):
                          'foo',
                          {'foo': 'bar'}]))],
             'worst_status': 'RETRY'}
-        sequence = SequenceDispatcher([
-            (self.gsgi, lambda i: (self.group, self.manifest)),
+        sequence = [
+            nested_parallel([
+                (self.gsgi, lambda i: (self.group, self.manifest)),
+            ]),
+            (ParallelEffects([]), noop),  # no loggable steps
             (Log(msg='execute-convergence', fields=mock.ANY), noop),
             (ModifyGroupState(scaling_group=self.group, modifier=mock.ANY),
              noop),
+            nested_parallel([("the step", lambda i: step_result)]),
             (Log(msg='execute-convergence-results', fields=expected_fields),
              noop),
-        ])
+        ]
 
-        dispatcher = ComposedDispatcher([
-            base_dispatcher,
-            TypeDispatcher({ParallelEffects: perform_parallel_async}),
-            sequence])
-
-        with sequence.consume():
-            self.assertEqual(sync_perform(dispatcher, eff), StepResult.RETRY)
+        self.assertEqual(perform_sequence(sequence, eff), StepResult.RETRY)
 
     def test_log_steps(self):
         """The steps to be executed are logged to cloud feeds."""

--- a/otter/test/convergence/test_service.py
+++ b/otter/test/convergence/test_service.py
@@ -525,9 +525,6 @@ class GetMyDivergentGroupsTests(SynchronousTestCase):
 
 def _get_dispatcher():
     return ComposedDispatcher([
-        TypeDispatcher({
-            ParallelEffects: perform_parallel_async,
-        }),
         reference_dispatcher,
         base_dispatcher,
     ])

--- a/otter/test/test_testutils.py
+++ b/otter/test/test_testutils.py
@@ -1,13 +1,17 @@
 """
 Tests for :obj:`otter.test.utils`.
 """
+from effect import (
+    ComposedDispatcher, Effect,
+    base_dispatcher, parallel, sync_performer)
+
 from pyrsistent import pvector
 
 from twisted.trial.unittest import SynchronousTestCase
 
 from zope.interface import Attribute, Interface
 
-from otter.test.utils import iMock
+from otter.test.utils import iMock, nested_parallel, perform_sequence
 
 
 class _ITest1(Interface):
@@ -152,3 +156,41 @@ class IMockTests(SynchronousTestCase):
 
         im = iMock(_ITest1, another_attribute='what')
         self.assertEqual(im.another_attribute, 'what')
+
+
+class NestedParallelTests(SynchronousTestCase):
+    """Tests for :func:`nested_parallel`."""
+
+    def test_nested_parallel(self):
+        """
+        Ensures that all parallel effects are found in the given intents, in
+        order, and returns the results associated with those intents.
+        """
+        seq = [
+            nested_parallel([
+                (1, lambda i: "one!"),
+                (2, lambda i: "two!"),
+                (3, lambda i: "three!"),
+            ])
+        ]
+        p = parallel([Effect(1), Effect(2), Effect(3)])
+        self.assertEqual(perform_sequence(seq, p), ['one!', 'two!', 'three!'])
+
+    def test_fallback(self):
+        """
+        Accepts a ``fallback`` dispatcher that will be used when the sequence
+        doesn't contain an intent.
+        """
+        def dispatch_2(intent):
+            if intent == 2:
+                return sync_performer(lambda d, i: "two!")
+        fallback = ComposedDispatcher([dispatch_2, base_dispatcher])
+        seq = [
+            nested_parallel([
+                (1, lambda i: 'one!'),
+                (3, lambda i: 'three!'),
+                ],
+                fallback_dispatcher=fallback),
+        ]
+        p = parallel([Effect(1), Effect(2), Effect(3)])
+        self.assertEqual(perform_sequence(seq, p), ['one!', 'two!', 'three!'])

--- a/otter/test/utils.py
+++ b/otter/test/utils.py
@@ -748,6 +748,23 @@ def nested_sequence(seq, get_effect=attrgetter('effect'),
         get_effect)
 
 
+def nested_parallel(parallel, fallback_dispatcher=base_dispatcher):
+    """
+    Return a two-tuple for use in a :obj:`SequenceDispatcher` which ensures
+    that all the intents in ``parallel`` are performed in parallel. Note that
+    the items in ``parallel`` must match the order that they're given to the
+    :func:`effect.parallel` function, since the order of inputs affects the
+    order of results.
+
+    :param parallel: sequence of (intent, (intent -> result) function), like
+        what :obj:`SequenceDispatcher` accepts.
+    :param fallback_dispatcher: an optional dispatcher to compose onto the
+        sequence dispatcher.
+    """
+    return (ParallelEffects(effects=mock.ANY),
+            nested_sequence(seq, get_effect=lambda i: sequence(i.effects)))
+
+
 def test_dispatcher(disp=None):
     disps = [
         base_dispatcher,

--- a/otter/test/utils.py
+++ b/otter/test/utils.py
@@ -12,6 +12,7 @@ from effect import (
     ComposedDispatcher, ParallelEffects, TypeDispatcher,
     base_dispatcher, sync_perform, sync_performer)
 from effect.async import perform_parallel_async
+from effect.fold import sequence
 from effect.testing import (
     SequenceDispatcher,
     resolve_effect as eff_resolve_effect,
@@ -761,8 +762,9 @@ def nested_parallel(parallel, fallback_dispatcher=base_dispatcher):
     :param fallback_dispatcher: an optional dispatcher to compose onto the
         sequence dispatcher.
     """
-    return (ParallelEffects(effects=mock.ANY),
-            nested_sequence(seq, get_effect=lambda i: sequence(i.effects)))
+    return (
+        ParallelEffects(effects=mock.ANY),
+        nested_sequence(parallel, get_effect=lambda i: sequence(i.effects)))
 
 
 def test_dispatcher(disp=None):

--- a/otter/test/utils.py
+++ b/otter/test/utils.py
@@ -764,7 +764,9 @@ def nested_parallel(parallel, fallback_dispatcher=base_dispatcher):
     """
     return (
         ParallelEffects(effects=mock.ANY),
-        nested_sequence(parallel, get_effect=lambda i: sequence(i.effects)))
+        nested_sequence(parallel,
+                        get_effect=lambda i: sequence(i.effects),
+                        fallback_dispatcher=fallback_dispatcher))
 
 
 def test_dispatcher(disp=None):

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,8 +11,8 @@ jsonfig==0.1.1
 testtools==0.9.32
 croniter==0.3.5
 txkazoo==0.0.6b2
-effect==0.1a18
-txeffect==0.1a1
+effect==0.9
+txeffect==0.9
 characteristic==14.3.0
 attrs==15.0.0
 toolz==0.7.1


### PR DESCRIPTION
This introduces a `nested_parallel` function which returns a SequenceDispatcher entry (both the intent and the handler), and accepts an intent/handler sequence representing the parallel effects to be performed.

This means our tests can actually ensure that parallel things are run in parallel, whereas right now our tests would pass if we got rid of all of our `parallel()` calls in service.py.

I didn't update all the tests to use it. ExecuteConvergenceTests are going to be a bit tricky and they have some weird cases, and I think they'd be better off refactored more holistically. 
