### PR TITLE
Fix NoSuchScalingGroup when deleting group

### DIFF
--- a/otter/models/cass.py
+++ b/otter/models/cass.py
@@ -1292,7 +1292,8 @@ class CassScalingGroup(object):
             return b.execute(self.connection)
 
         def _maybe_delete(state):
-            if len(state.active) + len(state.pending) > 0:
+            if (state.status != ScalingGroupStatus.DELETING and
+                    len(state.active) + len(state.pending) > 0):
                 raise GroupNotEmptyError(self.tenant_id, self.uuid)
 
             d = self._naive_list_all_webhooks()

--- a/otter/test/models/test_cass_models.py
+++ b/otter/test/models/test_cass_models.py
@@ -1918,7 +1918,7 @@ class CassScalingGroupTests(CassScalingGroupTestCase):
         self.failureResultOf(self.group.delete_group(), GroupNotEmptyError)
 
         # nothing else called except view
-        self.assertTrue(mock_view_state.called)
+        mock_view_state.assert_called_once_with(get_deleting=True)
         self.assertFalse(self.connection.execute.called)
         self.flushLoggedErrors(GroupNotEmptyError)
         # locks znode is not deleted


### PR DESCRIPTION
Because the group has a status of DELETING, `view_state` filters the groups out.  However, `delete_group` calls `view_state` to determine if the group really exists before deleting it, and to determine whether the group has servers in it.

Fixed so that if the group is in DELETING state, `view_state` will not filter it out.  And if there are still servers in the DELETING group (because convergence won't bother to update the active cache before deleting the group), do not refuse to delete.

Have verified on the dev vm that there are no more deleting groups remaining in the DB, and that after running the trial tests the servers are still cleaned up from mimic.