### PR TITLE
Load balancer type validation fix

### DIFF
--- a/autoscale_cloudroast/test_repo/autoscale/functional/launch_config/test_launch_config_negative.py
+++ b/autoscale_cloudroast/test_repo/autoscale/functional/launch_config/test_launch_config_negative.py
@@ -216,6 +216,28 @@ class LaunchConfigNegtaiveTest(AutoscaleFixture):
             msg='Updating a group to have CLBs but no ServiceNet was '
             'successsful with response {0}'.format(status))
 
+    def test_create_scaling_group_with_CLB_with_invalid_types(self):
+        """
+        Scaling group creation fails with a 400 when a launch config has a
+        load balancers with an invalid types.
+        """
+        invalids = ['cloudloadbalancer', 'rackconnectv3', '', 'NotReal']
+
+        for invalid in invalids:
+            create_group_response = self.autoscale_client.create_scaling_group(
+                gc_name='test_empty_clb_type',
+                gc_cooldown=self.gc_cooldown,
+                gc_min_entities=self.gc_min_entities,
+                lc_image_ref=self.lc_image_ref,
+                lc_flavor_ref=self.lc_flavor_ref,
+                lc_load_balancers=[{'loadBalancerId': '1234', 'port': 80,
+                                    'type': invalid}])
+            self.assertEquals(
+                create_group_response.status_code, 400,
+                msg=('Create group with CLBs with a type "{0}" was '
+                     ' successsful with response {1}'
+                     .format(invalid, create_group_response.status_code)))
+
     def _create_group(self):
         """
         Create a group.

--- a/otter/json_schema/group_schemas.py
+++ b/otter/json_schema/group_schemas.py
@@ -117,7 +117,7 @@ _rcv3_lb = {
             "description": (
                 "What type of a load balancer is in use"),
             "required": True,
-            "pattern": "^\s*RackConnectV3\s*$"
+            "pattern": "^RackConnectV3$"
         }
     },
     "additionalProperties": False
@@ -151,7 +151,7 @@ _clb_lb = {
             "description": (
                 "What type of a load balancer is in use"),
             "required": False,
-            "pattern": "^\s*CloudLoadBalancer\s*$"
+            "pattern": "^CloudLoadBalancer$"
         }
     },
     "additionalProperties": False

--- a/otter/json_schema/group_schemas.py
+++ b/otter/json_schema/group_schemas.py
@@ -117,7 +117,7 @@ _rcv3_lb = {
             "description": (
                 "What type of a load balancer is in use"),
             "required": True,
-            "oneOf": ["RackConnectV3"]
+            "pattern": "^\s*RackConnectV3\s*$"
         }
     },
     "additionalProperties": False
@@ -132,7 +132,7 @@ _clb_lb = {
         # Cloud load balancer id's are NOT uuid's, just ints.  But accept
         # strings also for backwards compatibility reasons.
         "loadBalancerId": {
-            "type": ["integer", "string"],
+            "type": ["integer", {"type": "string", "pattern": "^\S+$"}],
             "description": (
                 "The ID of the load balancer to which new "
                 "servers will be added."),
@@ -151,7 +151,7 @@ _clb_lb = {
             "description": (
                 "What type of a load balancer is in use"),
             "required": False,
-            "oneOf": ["CloudLoadBalancer"]
+            "pattern": "^\s*CloudLoadBalancer\s*$"
         }
     },
     "additionalProperties": False

--- a/otter/test/json_schema/test_schemas.py
+++ b/otter/test/json_schema/test_schemas.py
@@ -196,12 +196,7 @@ class ServerLaunchConfigTestCase(SynchronousTestCase):
         optionally a type.  RCv3 needs the type but not the port.
         The type needs to be valid.
         """
-        base = {
-            "type": "launch_server",
-            "args": {
-                "server": {}
-            }
-        }
+        base = group_examples.launch_server_config()[0]
         invalids = [
             {'loadBalancerId': '', 'port': 80},
             {'loadBalancerId': 3, 'port': '80'},
@@ -222,7 +217,7 @@ class ServerLaunchConfigTestCase(SynchronousTestCase):
         ]
         for invalid in invalids:
             base["args"]["loadBalancers"] = [invalid]
-            # the type fails ot valdiate because of 'not of type'
+            # the type fails ot validiate because of 'not of type'
             self.assertRaisesRegexp(ValidationError, 'not of type', validate,
                                     base, group_schemas.launch_server)
             # because the type schema fails to validate, the config schema
@@ -235,14 +230,9 @@ class ServerLaunchConfigTestCase(SynchronousTestCase):
         If more than 5 load balancers are provided, the launch config fails to
         validate.
         """
-        invalid = {
-            "type": "launch_server",
-            "args": {
-                "server": {},
-                "loadBalancers": [{'loadBalancerId': i, 'port': 80}
-                                  for i in range(6)]
-            }
-        }
+        invalid = group_examples.launch_server_config()[0]
+        invalid['args']["loadBalancers"] = [{'loadBalancerId': i, 'port': 80}
+                                            for i in range(6)]
 
         # the type fails ot valdiate because the load balancer list is too long
         self.assertRaisesRegexp(ValidationError, 'is too long',
@@ -257,16 +247,11 @@ class ServerLaunchConfigTestCase(SynchronousTestCase):
         If the same load balancer config appears twice, the launch config
         fails to validate.
         """
-        invalid = {
-            "type": "launch_server",
-            "args": {
-                "server": {},
-                "loadBalancers": [
-                    {'loadBalancerId': 1, 'port': 80},
-                    {'loadBalancerId': 1, 'port': 80}
-                ]
-            }
-        }
+        invalid = group_examples.launch_server_config()[0]
+        invalid['args']["loadBalancers"] = [
+            {'loadBalancerId': 1, 'port': 80},
+            {'loadBalancerId': 1, 'port': 80}
+        ]
         # the type fails ot valdiate because of the load balancers are not
         # unique
         self.assertRaisesRegexp(ValidationError, 'non-unique elements',
@@ -281,10 +266,11 @@ class ServerLaunchConfigTestCase(SynchronousTestCase):
         If random attributes to args are provided, the launch config fails to
         validate
         """
+        server = group_examples.launch_server_config()[0]['args']['server']
         invalid = {
             "type": "launch_server",
             "args": {
-                "server": {},
+                "server": server,
                 "hat": "top"
             }
         }

--- a/otter/test/json_schema/test_schemas.py
+++ b/otter/test/json_schema/test_schemas.py
@@ -208,11 +208,17 @@ class ServerLaunchConfigTestCase(SynchronousTestCase):
             {'loadBalancerId': 3, 'type': 'CloudLoadBalancer'},
             {'loadBalancerId': 3, 'port': '80', 'type': 'blah blah'},
             {'loadBalancerId': 3, 'type': 'RackConnectV3'},
-            {'loadBalancerId': 'd6d3aa7c-dfa5-4e61-96ee-1d54ac1075d2', 'type': 'CloudLoadBalancer'},
-            {'loadBalancerId': 'd6d3aa7c-dfa5-4e61-96ee-1d54ac1075d2', 'type': 'RackConnectV3',
-             'port': 80},
+            {'loadBalancerId': 'd6d3aa7c-dfa5-4e61-96ee-1d54ac1075d2',
+             'type': 'CloudLoadBalancer'},
+            {'loadBalancerId': 'd6d3aa7c-dfa5-4e61-96ee-1d54ac1075d2',
+             'type': 'RackConnectV3', 'port': 80},
             {'loadBalancerId': 'd6d3aa7c-dfa5-4e61-96ee-1d54ac1075d2'},
-            {'loadBalancerId': 'd6d3aa7c-dfa5-4e61-96ee-1d54ac1075d2', 'type': ''},
+            {'loadBalancerId': 'd6d3aa7c-dfa5-4e61-96ee-1d54ac1075d2',
+             'type': ''},
+            {'loadBalancerId': 'd6d3aa7c-dfa5-4e61-96ee-1d54ac1075d2',
+             'type': None},
+            {'loadBalancerId': '112345', 'type': '', 'port': 80},
+            {'loadBalancerId': '112345', 'type': None, 'port': 80},
         ]
         for invalid in invalids:
             base["args"]["loadBalancers"] = [invalid]


### PR DESCRIPTION
We weren't really ensuring that random types couldn't be passed in as a load balancer type, because our unit tests were passing since the example given in the unit test would always fail because the server args were invalid, not because the lb args were invalid.

Fix that, and the schema validation.  Also add a functional test for this.