### PR TITLE
Intermittent cafe failure when scaling up over 25

### DIFF
--- a/autoscale_cloudroast/test_repo/autoscale/system/policies/test_system_execute_updated_policies.py
+++ b/autoscale_cloudroast/test_repo/autoscale/system/policies/test_system_execute_updated_policies.py
@@ -120,6 +120,10 @@ class ExecuteUpdatedPoliciesTest(AutoscaleFixture):
             msg='Executing the updated policy with desired capacity failed '
             'with {0} for group {1}'
             .format(upd_policy_to_desired_capacity_execute, self.group.id))
+        # We don't want to time-scale this one because of throttling if this
+        # is a convergence tenant - there are 26 servers, and convergence can
+        # only build 3 per cycle.  This might take longer than
+        # the worker would.
         self.check_for_expected_number_of_building_servers(
             group_id=self.group.id,
             expected_servers=26, time_scale=False)

--- a/autoscale_cloudroast/test_repo/autoscale/system/policies/test_system_execute_updated_policies.py
+++ b/autoscale_cloudroast/test_repo/autoscale/system/policies/test_system_execute_updated_policies.py
@@ -122,7 +122,7 @@ class ExecuteUpdatedPoliciesTest(AutoscaleFixture):
             .format(upd_policy_to_desired_capacity_execute, self.group.id))
         self.check_for_expected_number_of_building_servers(
             group_id=self.group.id,
-            expected_servers=26)
+            expected_servers=26, time_scale=False)
 
     @tags(speed='slow', convergence='yes')
     def test_update_scale_up_to_scale_down(self):


### PR DESCRIPTION
Against mimic.

The test `...system.policies.test_system_execute_updated_policies.ExecuteUpdatedPoliciesTest.test_update_policy_desired_capacity_over_25` sometimes fails after 30 seconds with the error that there are 26 servers as the desired capacity, but only 21 servers on the mimic account.  Likely this is due to throttling - we should probably increase the timeout on this test specifically.