### PR TITLE
execute convergence refactor

### DIFF
--- a/otter/test/convergence/test_service.py
+++ b/otter/test/convergence/test_service.py
@@ -719,7 +719,7 @@ class ExecuteConvergenceTests(SynchronousTestCase):
             (Func(time.time), lambda i: 500),
             (Log('execute-convergence',
                  dict(servers=tuple(self.servers), lb_nodes=(), steps=steps,
-                      now=500, desired=dgs, active=[])), lambda i: None),
+                      now=500, desired=dgs)), lambda i: None),
             ({'dgs': get_desired_group_state(self.group_id, self.lc, 2),
               'servers': tuple(self.servers),
               'lb_nodes': (),
@@ -796,9 +796,9 @@ class ExecuteConvergenceTests(SynchronousTestCase):
             'worst_status': 'RETRY'}
         sequence = SequenceDispatcher([
             (self.gsgi, lambda i: (self.group, self.manifest)),
-            (Log(msg='execute-convergence', fields=mock.ANY), noop),
             (ModifyGroupState(scaling_group=self.group, modifier=mock.ANY),
              noop),
+            (Log(msg='execute-convergence', fields=mock.ANY), noop),
             (Log(msg='execute-convergence-results', fields=expected_fields),
              noop),
         ])
@@ -827,13 +827,13 @@ class ExecuteConvergenceTests(SynchronousTestCase):
 
         sequence = SequenceDispatcher([
             (self.gsgi, lambda i: (self.group, self.manifest)),
+            (ModifyGroupState(scaling_group=self.group, modifier=mock.ANY),
+             noop),
             (Log('convergence-create-servers',
                  fields={'num_servers': 1, 'server_config': {'foo': 'bar'},
                          'cloud_feed': True}),
              noop),
             (Log('execute-convergence', fields=mock.ANY), noop),
-            (ModifyGroupState(scaling_group=self.group, modifier=mock.ANY),
-             noop),
             (Log('execute-convergence-results', fields=mock.ANY), noop),
         ])
 
@@ -946,9 +946,9 @@ class ExecuteConvergenceTests(SynchronousTestCase):
 
         sequence = SequenceDispatcher([
             (self.gsgi, lambda i: self.gsgi_result),
-            (Log(msg='execute-convergence', fields=mock.ANY), noop),
             (ModifyGroupState(scaling_group=self.group, modifier=mock.ANY),
              noop),
+            (Log(msg='execute-convergence', fields=mock.ANY), noop),
             (Log(msg='execute-convergence-results', fields=mock.ANY), noop),
             (UpdateGroupStatus(scaling_group=self.group,
                                status=ScalingGroupStatus.ERROR),
@@ -982,9 +982,9 @@ class ExecuteConvergenceTests(SynchronousTestCase):
 
         sequence = SequenceDispatcher([
             (self.gsgi, lambda i: self.gsgi_result),
-            (Log(msg='execute-convergence', fields=mock.ANY), noop),
             (ModifyGroupState(scaling_group=self.group, modifier=mock.ANY),
              noop),
+            (Log(msg='execute-convergence', fields=mock.ANY), noop),
             (Log(msg='execute-convergence-results', fields=mock.ANY), noop),
             (UpdateGroupStatus(scaling_group=self.group,
                                status=ScalingGroupStatus.ACTIVE),
@@ -995,7 +995,7 @@ class ExecuteConvergenceTests(SynchronousTestCase):
         dispatcher = ComposedDispatcher([sequence, test_dispatcher()])
         with sequence.consume():
             self.assertEqual(sync_perform(dispatcher, eff),
-                             (StepResult.SUCCESS, ScalingGroupStatus.ERROR))
+                             (StepResult.SUCCESS, ScalingGroupStatus.ACTIVE))
 
     def test_reactivate_group_on_success_with_no_steps(self):
         """
@@ -1012,9 +1012,9 @@ class ExecuteConvergenceTests(SynchronousTestCase):
 
         sequence = SequenceDispatcher([
             (self.gsgi, lambda i: self.gsgi_result),
-            (Log(msg='execute-convergence', fields=mock.ANY), noop),
             (ModifyGroupState(scaling_group=self.group, modifier=mock.ANY),
              noop),
+            (Log(msg='execute-convergence', fields=mock.ANY), noop),
             (Log(msg='execute-convergence-results', fields=mock.ANY), noop),
             (UpdateGroupStatus(scaling_group=self.group,
                                status=ScalingGroupStatus.ACTIVE),
@@ -1025,7 +1025,7 @@ class ExecuteConvergenceTests(SynchronousTestCase):
         dispatcher = ComposedDispatcher([sequence, test_dispatcher()])
         with sequence.consume():
             self.assertEqual(sync_perform(dispatcher, eff),
-                             (StepResult.SUCCESS, ScalingGroupStatus.ERROR))
+                             (StepResult.SUCCESS, ScalingGroupStatus.ACTIVE))
 
 
 class DetermineActiveTests(SynchronousTestCase):


### PR DESCRIPTION
Pure refactor except following changes:

- updating active cache while gathering
- not logging "active" along with "execute-convergence"
- return ACTIVE status from `execute_convergence` when group succeeds