### PR TITLE
metrics service is optional

### DIFF
--- a/otter/constants.py
+++ b/otter/constants.py
@@ -39,12 +39,13 @@ def get_service_configs(config):
         ServiceType.RACKCONNECT_V3: {
             'name': config['rackconnect'],
             'region': config['region'],
-        },
-        ServiceType.CLOUD_METRICS_INGEST: {
-            'name': config['metrics']['service'],
-            'region': config['metrics']['region'],
         }
     }
+
+    metrics = config.get('metrics')
+    if metrics is not None:
+        configs[ServiceType.CLOUD_METRICS_INGEST] = {
+            'name': metrics['service'], 'region': metrics['region']}
 
     cf = config.get('cloudfeeds')
     if cf is not None:

--- a/otter/test/test_constants.py
+++ b/otter/test/test_constants.py
@@ -59,3 +59,11 @@ class GetServiceMappingTests(SynchronousTestCase):
         del self.config['cloudfeeds']
         self.assertNotIn(ServiceType.CLOUD_FEEDS,
                          get_service_configs(self.config))
+
+    def test_metrics_optional(self):
+        """
+        Does not return metrics service if the config is not there
+        """
+        del self.config['metrics']
+        self.assertNotIn(ServiceType.CLOUD_METRICS_INGEST,
+                         get_service_configs(self.config))


### PR DESCRIPTION
metrics service uses code from otter but otter does not need to depend on it. This way metrics can be separate role in https://github.com/rackerlabs/autoscaling-chef/pull/745