### PR TITLE
Server cache model change

### DIFF
--- a/otter/models/cass.py
+++ b/otter/models/cass.py
@@ -1763,6 +1763,18 @@ class CassScalingGroupServersCache(object):
         else:
             return cql_eff(batch(queries), params)
 
+    def update_server_in_lbs(self, last_update, server_id, server_in_lbs):
+        """
+        See :method:`IScalingGroupServersCache.update_server_in_lbs
+        """
+        query = ('UPDATE {cf} SET server_in_lbs=:server_in_lbs '
+                 'WHERE "tenantId"=:tenantId AND "groupId"=:groupId '
+                 'AND last_update=:last_update AND server_id=:server_id')
+        params = merge(
+            self.params, {"last_update": last_update, "server_id": server_id,
+                          "server_in_lbs": server_in_lbs})
+        return cql_eff(query.format(cf=self.table), params)
+
     def delete_servers(self):
         """
         See :method:`IScalingGroupServersCache.delete_servers`

--- a/otter/models/cass.py
+++ b/otter/models/cass.py
@@ -59,6 +59,10 @@ from otter.util.retry import repeating_interval, retry, retry_times
 
 LOCK_PATH = '/locks'
 
+DEFAULT_CONSISTENCY = ConsistencyLevel.QUORUM
+
+QUERY_LIMIT = 10000
+
 
 @attributes(['query', 'params', 'consistency_level'])
 class CQLQueryExecute(object):
@@ -87,7 +91,7 @@ def get_cql_dispatcher(connection):
     })
 
 
-def cql_eff(query, params={}, consistency_level=ConsistencyLevel.ONE):
+def cql_eff(query, params={}, consistency_level=DEFAULT_CONSISTENCY):
     """
     Return Effect of CQLQueryExecute intent
     """
@@ -305,11 +309,6 @@ def _paginated_list(tenant_id, group_id=None, policy_id=None, limit=100,
 
     cql_parts.append(" LIMIT :limit;")
     return (''.join(cql_parts), params)
-
-
-DEFAULT_CONSISTENCY = ConsistencyLevel.QUORUM
-
-QUERY_LIMIT = 10000
 
 
 def _build_policies(policies, policies_table, event_table, queries, data,

--- a/otter/models/cass.py
+++ b/otter/models/cass.py
@@ -23,7 +23,9 @@ from pyrsistent import freeze
 
 from silverberg.client import ConsistencyLevel
 
+from toolz.curried import filter, map
 from toolz.dicttoolz import keymap, merge
+from toolz.functoolz import compose
 
 from twisted.internet import defer
 
@@ -1726,11 +1728,11 @@ class CassScalingGroupServersCache(object):
         self.params = {"tenantId": self.tenantId, "groupId": self.groupId}
 
     @do
-    def get_servers(self):
+    def get_servers(self, only_as_active):
         """
         See :method:`IScalingGroupServersCache.get_servers`
         """
-        query = ('SELECT server_blob, last_update FROM {cf} '
+        query = ('SELECT server_blob, server_as_active, last_update FROM {cf} '
                  'WHERE "tenantId"=:tenantId AND "groupId"=:groupId '
                  'ORDER BY last_update DESC;')
         rows = yield cql_eff(query.format(cf=self.table), self.params)
@@ -1738,8 +1740,13 @@ class CassScalingGroupServersCache(object):
             yield do_return(([], None))
         last_update = rows[0]['last_update']
         rows = takewhile(lambda r: r['last_update'] == last_update, rows)
-        yield do_return(([json.loads(r['server_blob']) for r in rows],
-                         last_update))
+
+        def _dict(r): return json.loads(r['server_blob'])
+        rfunc = (
+            compose(map(_dict), filter(lambda r: r['server_as_active']))
+            if only_as_active else map(_dict))
+
+        yield do_return((list(rfunc(rows)), last_update))
 
     def insert_servers(self, last_update, servers, clear_others):
         """
@@ -1748,13 +1755,15 @@ class CassScalingGroupServersCache(object):
         if len(servers) == 0:
             return Effect(Constant(None))
         query = ('INSERT INTO {cf} ("tenantId", "groupId", last_update, '
-                 'server_id, server_blob) '
+                 'server_id, server_blob, server_as_active) '
                  'VALUES(:tenantId, :groupId, :last_update, :server_id{i}, '
-                 ':server_blob{i});')
+                 ':server_blob{i}, :server_as_active{i});')
         params = merge(self.params, {"last_update": last_update})
         queries = []
         for i, server in enumerate(servers):
             params['server_id{}'.format(i)] = server['id']
+            params['server_as_active{}'.format(i)] = server.pop(
+                '_is_as_active', False)
             params['server_blob{}'.format(i)] = json.dumps(server)
             queries.append(query.format(cf=self.table, i=i))
         if clear_others:
@@ -1762,22 +1771,6 @@ class CassScalingGroupServersCache(object):
                 lambda _: cql_eff(batch(queries), params))
         else:
             return cql_eff(batch(queries), params)
-
-    def set_servers_as_active(self, last_update, server_ids):
-        """
-        See :method:`IScalingGroupServersCache.set_servers_as_active
-        """
-        if len(server_ids) == 0:
-            return Effect(Constant(None))
-        query = ('UPDATE {cf} SET server_as_active=true '
-                 'WHERE "tenantId"=:tenantId AND "groupId"=:groupId '
-                 'AND last_update=:last_update AND server_id=:server_id{i};')
-        params = merge(self.params, {"last_update": last_update})
-        queries = []
-        for i, server_id in enumerate(server_ids):
-            params['server_id{}'.format(i)] = server_id
-            queries.append(query.format(cf=self.table, i=i))
-        return cql_eff(batch(queries), params)
 
     def delete_servers(self):
         """

--- a/otter/models/interface.py
+++ b/otter/models/interface.py
@@ -644,13 +644,12 @@ class IScalingGroupServersCache(Interface):
         :return: Effect of None
         """
 
-    def update_server_in_lbs(last_update, server_id, server_in_lbs):
+    def set_servers_as_active(last_update, server_ids):
         """
-        Update the fact that server has been added to add LBs
+        Update the fact that given servers have become AS active
 
         :param datetime last_udpate: Update time of the cache
-        :param str server_id: ID of server
-        :param bool server_in_lbs: Has server been added to all LBs?
+        :param list server_ids: Server IDs which have become AS active
 
         :return: Effect of None
         """

--- a/otter/models/interface.py
+++ b/otter/models/interface.py
@@ -621,10 +621,12 @@ class IScalingGroupServersCache(Interface):
     tenant_id = Attribute("Rackspace Tenant ID of the owner of this group.")
     group_id = Attribute("UUID of the scaling group - immutable.")
 
-    def get_servers():
+    def get_servers(only_as_active):
         """
         Return latest cache of servers in a group along with last time the
         cache was updated.
+
+        :param bool only_as_active: Should it return only otter active servers?
 
         :return: Effect of (servers, last update time) tuple where servers
             is list of dict and last update time is datetime object. Will
@@ -637,19 +639,12 @@ class IScalingGroupServersCache(Interface):
         Update the servers cache of the group with last update time
 
         :param datetime last_update: Update time of the cache
-        :param list servers: List of server dicts
+        :param list servers: List of server dicts with optional "_is_as_active"
+            field with boolean value to represent if this server has become
+            active from autoscale's perpective. This field will be popped
+            before storing the blob
         :param bool clear_others: Should any other cache from a different
             update_time be deleted?
-
-        :return: Effect of None
-        """
-
-    def set_servers_as_active(last_update, server_ids):
-        """
-        Update the fact that given servers have become AS active
-
-        :param datetime last_udpate: Update time of the cache
-        :param list server_ids: Server IDs which have become AS active
 
         :return: Effect of None
         """

--- a/otter/models/interface.py
+++ b/otter/models/interface.py
@@ -625,6 +625,7 @@ class IScalingGroupServersCache(Interface):
         """
         Return latest cache of servers in a group along with last time the
         cache was updated.
+
         :return: Effect of (servers, last update time) tuple where servers
             is list of dict and last update time is datetime object. Will
             return last_update time as None if cache is empty
@@ -634,10 +635,23 @@ class IScalingGroupServersCache(Interface):
     def insert_servers(last_update, servers, clear_others):
         """
         Update the servers cache of the group with last update time
+
         :param datetime last_update: Update time of the cache
         :param list servers: List of server dicts
         :param bool clear_others: Should any other cache from a different
             update_time be deleted?
+
+        :return: Effect of None
+        """
+
+    def update_server_in_lbs(last_update, server_id, server_in_lbs):
+        """
+        Update the fact that server has been added to add LBs
+
+        :param datetime last_udpate: Update time of the cache
+        :param str server_id: ID of server
+        :param bool server_in_lbs: Has server been added to all LBs?
+
         :return: Effect of None
         """
 

--- a/otter/test/models/test_cass_models.py
+++ b/otter/test/models/test_cass_models.py
@@ -3797,6 +3797,19 @@ class CassGroupServersCacheTests(SynchronousTestCase):
             self.cache.insert_servers(self.dt, [], False),
             Effect(Constant(None)))
 
+    def test_update_server_in_lbs(self):
+        """
+        `update_server_in_lbs` updates the `server_in_lbs` field
+        """
+        self.assertEqual(
+            self.cache.update_server_in_lbs(self.dt, 'sid', True),
+            cql_eff(
+                ('UPDATE servers_cache SET server_in_lbs=:server_in_lbs '
+                 'WHERE "tenantId"=:tenantId AND "groupId"=:groupId '
+                 'AND last_update=:last_update AND server_id=:server_id'),
+                {"tenantId": "tid", "groupId": "gid", "last_update": self.dt,
+                 "server_id": "sid", "server_in_lbs": True}))
+
     def test_delete_servers(self):
         """
         `delete_servers` issues query to delete the whole cache

--- a/otter/test/models/test_cass_models.py
+++ b/otter/test/models/test_cass_models.py
@@ -3797,18 +3797,23 @@ class CassGroupServersCacheTests(SynchronousTestCase):
             self.cache.insert_servers(self.dt, [], False),
             Effect(Constant(None)))
 
-    def test_update_server_in_lbs(self):
+    def test_set_servers_as_active(self):
         """
-        `update_server_in_lbs` updates the `server_in_lbs` field
+        `set_servers_as_active` updates the `server_as_actve` field
         """
         self.assertEqual(
-            self.cache.update_server_in_lbs(self.dt, 'sid', True),
+            self.cache.set_servers_as_active(self.dt, ['s1', 's2']),
             cql_eff(
-                ('UPDATE servers_cache SET server_in_lbs=:server_in_lbs '
+                ('BEGIN BATCH '
+                 'UPDATE servers_cache SET server_as_active=true '
                  'WHERE "tenantId"=:tenantId AND "groupId"=:groupId '
-                 'AND last_update=:last_update AND server_id=:server_id'),
+                 'AND last_update=:last_update AND server_id=:server_id0; '
+                 'UPDATE servers_cache SET server_as_active=true '
+                 'WHERE "tenantId"=:tenantId AND "groupId"=:groupId '
+                 'AND last_update=:last_update AND server_id=:server_id1; '
+                 'APPLY BATCH;'),
                 {"tenantId": "tid", "groupId": "gid", "last_update": self.dt,
-                 "server_id": "sid", "server_in_lbs": True}))
+                 "server_id0": "s1", "server_id1": "s2"}))
 
     def test_delete_servers(self):
         """

--- a/otter/test/models/test_cass_models.py
+++ b/otter/test/models/test_cass_models.py
@@ -3767,23 +3767,23 @@ class CassGroupServersCacheTests(SynchronousTestCase):
         dt_earlier = datetime(2010, 10, 15, 10, 0, 0)
         self._test_get_servers(
             False,
-            [{"server_blob": '{"a": "b"}', "last_update": dt_earlier,
+            [{"server_blob": '{"a": "b"}', "last_update": self.dt,
               "server_as_active": False},
-             {"server_blob": '{"d": "e"}', "last_update": dt_earlier,
+             {"server_blob": '{"d": "e"}', "last_update": self.dt,
               "server_as_active": False},
-             {"server_blob": '{"c": "f"}', "last_update": self.dt,
+             {"server_blob": '{"c": "f"}', "last_update": dt_earlier,
               "server_as_active": False}],
-            ([{"a": "b"}, {"d": "e"}], dt_earlier))
+            ([{"a": "b"}, {"d": "e"}], self.dt))
         # Test with only_as_active as True
         self._test_get_servers(
             True,
-            [{"server_blob": '{"a": "b"}', "last_update": dt_earlier,
+            [{"server_blob": '{"a": "b"}', "last_update": self.dt,
               "server_as_active": False},
-             {"server_blob": '{"d": "e"}', "last_update": dt_earlier,
+             {"server_blob": '{"d": "e"}', "last_update": self.dt,
               "server_as_active": True},
-             {"server_blob": '{"c": "f"}', "last_update": self.dt,
+             {"server_blob": '{"c": "f"}', "last_update": dt_earlier,
               "server_as_active": True}],
-            ([{"d": "e"}], dt_earlier))
+            ([{"d": "e"}], self.dt))
 
     def _test_insert_servers(self, eff):
         query = (

--- a/otter/test/models/test_cass_models.py
+++ b/otter/test/models/test_cass_models.py
@@ -3741,8 +3741,10 @@ class CassGroupServersCacheTests(SynchronousTestCase):
             [{"server_blob": '{"a": "b"}', "last_update": self.dt,
               "server_as_active": False},
              {"server_blob": '{"d": "e"}', "last_update": self.dt,
-              "server_as_active": False}],
-            ([{"a": "b"}, {"d": "e"}], self.dt))
+              "server_as_active": False},
+             {"server_blob": '{"2": "a"}', "last_update": self.dt,
+              "server_as_active": True}],
+            ([{"a": "b"}, {"d": "e"}, {"2": "a"}], self.dt))
 
     def test_get_servers_as_active(self):
         """
@@ -3772,6 +3774,16 @@ class CassGroupServersCacheTests(SynchronousTestCase):
              {"server_blob": '{"c": "f"}', "last_update": self.dt,
               "server_as_active": False}],
             ([{"a": "b"}, {"d": "e"}], dt_earlier))
+        # Test with only_as_active as True
+        self._test_get_servers(
+            True,
+            [{"server_blob": '{"a": "b"}', "last_update": dt_earlier,
+              "server_as_active": False},
+             {"server_blob": '{"d": "e"}', "last_update": dt_earlier,
+              "server_as_active": True},
+             {"server_blob": '{"c": "f"}', "last_update": self.dt,
+              "server_as_active": True}],
+            ([{"d": "e"}], dt_earlier))
 
     def _test_insert_servers(self, eff):
         query = (

--- a/schema/setup/control_50_servers_cache.cql
+++ b/schema/setup/control_50_servers_cache.cql
@@ -6,7 +6,7 @@ CREATE TABLE servers_cache (
     last_update timestamp,
     server_id ascii,
     server_blob ascii,
-    server_in_lbs boolean,  -- Is server in all LBs as per group?
+    server_as_active boolean,  -- Is this autoscale ACTIVE server?
     PRIMARY KEY(("tenantId", "groupId"), last_update, server_id)
 ) WITH CLUSTERING ORDER BY (last_update DESC, server_id ASC) AND
 compaction = {

--- a/schema/setup/control_50_servers_cache.cql
+++ b/schema/setup/control_50_servers_cache.cql
@@ -6,6 +6,7 @@ CREATE TABLE servers_cache (
     last_update timestamp,
     server_id ascii,
     server_blob ascii,
+    server_in_lbs boolean,  -- Is server in all LBs as per group?
     PRIMARY KEY(("tenantId", "groupId"), last_update, server_id)
 ) WITH CLUSTERING ORDER BY (last_update DESC, server_id ASC) AND
 compaction = {


### PR DESCRIPTION
Change needed for #1558

- Changed model and added API to store `server_as_active` boolean along with server which will be
set to true when the server is known to have become AS active, i.e. been added in all LBs in the group
- Defaulted consistency level to `DEFAULT_CONSISTENCY` in `cql_eff`