### PR TITLE
When deleting a CLB in the trial tests, retry

### DIFF
--- a/otter/integration/lib/cloud_load_balancer.py
+++ b/otter/integration/lib/cloud_load_balancer.py
@@ -4,6 +4,8 @@ from __future__ import print_function
 
 import json
 
+from functools import wraps, partial
+
 from characteristic import Attribute, attributes
 
 from testtools.matchers import MatchesPredicateWithParams
@@ -11,6 +13,7 @@ from testtools.matchers import MatchesPredicateWithParams
 import treq
 
 from twisted.internet import reactor
+from twisted.internet.defer import inlineCallbacks
 from twisted.python.log import msg
 
 from otter.util.deferredutils import retry_and_timeout
@@ -34,6 +37,26 @@ def _pending_update_to_transient(f):
     if f.value.code == 422 and 'PENDING_UPDATE' in f.value.body:
         raise TransientRetryError()
     return f
+
+
+def _retry(reason, timeout=60, period=3, clock=reactor):
+    """
+    Helper that decorates a function to retry it until success it succeeds or
+    times out.  Assumes the function will raise :class:`TransientRetryError`
+    if it can be retried.
+    """
+    def decorator(f):
+        @wraps(f)
+        def retrier(*args, **kwargs):
+            return retry_and_timeout(
+                partial(f, *args, **kwargs), timeout,
+                can_retry=terminal_errors_except(TransientRetryError),
+                next_interval=repeating_interval(period),
+                clock=clock,
+                deferred_description=reason
+            )
+        return retrier
+    return decorator
 
 
 @attributes([
@@ -99,9 +122,10 @@ class CloudLoadBalancer(object):
         )
 
     def wait_for_state(
-        self, rcs, state_desired, timeout, period=10, clock=None
+        self, rcs, state_desired, timeout, period=10, clock=reactor
     ):
-        """Waits for the cloud load balancer to reach a certain state.  After
+        """
+        Wait for the cloud load balancer to reach a certain state.  After
         a timeout, a `TimeoutError` exception will occur.
 
         :param TestResources rcs: The resources used to make appropriate API
@@ -126,20 +150,13 @@ class CloudLoadBalancer(object):
 
             raise TransientRetryError()
 
+        @_retry("Waiting for cloud load balancer to reach state {}".format(
+                state_desired),
+                timeout=timeout, period=period, clock=clock)
         def poll():
             return self.get_state(rcs).addCallback(check)
 
-        return retry_and_timeout(
-            poll, timeout,
-            can_retry=terminal_errors_except(TransientRetryError),
-            next_interval=repeating_interval(period),
-            clock=clock or reactor,
-            deferred_description=(
-                "Waiting for cloud load balancer to reach state {}".format(
-                    state_desired
-                )
-            )
-        )
+        return poll()
 
     def stop(self, rcs):
         """Stops and deletes the cloud load balancer.
@@ -230,7 +247,7 @@ class CloudLoadBalancer(object):
         d.addCallback(self.treq.json_content)
         return d
 
-    def wait_for_nodes(self, rcs, matcher, timeout, period=10, clock=None):
+    def wait_for_nodes(self, rcs, matcher, timeout, period=10, clock=reactor):
         """
         Wait for the nodes on the load balancer to reflect a certain state,
         specified by matcher.
@@ -269,20 +286,15 @@ class CloudLoadBalancer(object):
                     .format(self.clb_id, mismatch.describe()))
                 raise TransientRetryError(mismatch.describe())
 
+        @_retry("Waiting for nodes to reach state {0}".format(str(matcher)),
+                timeout=timeout, period=period, clock=clock)
         def poll():
             return self.list_nodes(rcs).addCallback(check)
 
-        return retry_and_timeout(
-            poll, timeout,
-            can_retry=terminal_errors_except(TransientRetryError),
-            next_interval=repeating_interval(period),
-            clock=clock or reactor,
-            deferred_description="Waiting for nodes to reach state {0}".format(
-                str(matcher))
-        )
+        return poll()
 
     def update_node(self, rcs, node_id, weight=None, condition=None,
-                    type=None, clock=None):
+                    type=None, clock=reactor):
         """
         Update a node's attributes.  At least one of the optional parameters
         must be provided.
@@ -304,6 +316,7 @@ class CloudLoadBalancer(object):
         data = [("weight", weight), ("condition", condition), ("type", type)]
         data = {k: v for k, v in data if v is not None}
 
+        @_retry("Trying to change node {0}".format(node_id), clock=clock)
         def really_change():
             d = self.treq.put(
                 "{0}/nodes/{1}".format(self.endpoint(rcs), node_id),
@@ -315,15 +328,9 @@ class CloudLoadBalancer(object):
             d.addCallbacks(self.treq.content, _pending_update_to_transient)
             return d
 
-        return retry_and_timeout(
-            really_change, 60,
-            can_retry=terminal_errors_except(TransientRetryError),
-            next_interval=repeating_interval(3),
-            clock=clock or reactor,
-            deferred_description="Trying to change node {0}".format(node_id)
-        )
+        return really_change()
 
-    def delete_nodes(self, rcs, node_ids, clock=None):
+    def delete_nodes(self, rcs, node_ids, clock=reactor):
         """
         Delete one or more nodes from a load balancer.
 
@@ -334,6 +341,9 @@ class CloudLoadBalancer(object):
 
         :return: An empty string if successful.
         """
+        @_retry("Trying to delete nodes {0}".format(
+                ", ".join(map(str, node_ids))),
+                clock=clock)
         def really_delete():
             d = self.treq.delete(
                 "{0}/nodes".format(self.endpoint(rcs)),
@@ -345,16 +355,9 @@ class CloudLoadBalancer(object):
             d.addCallbacks(self.treq.content, _pending_update_to_transient)
             return d
 
-        return retry_and_timeout(
-            really_delete, 60,
-            can_retry=terminal_errors_except(TransientRetryError),
-            next_interval=repeating_interval(3),
-            clock=clock or reactor,
-            deferred_description="Trying to delete nodes {0}".format(
-                ", ".join(map(str, node_ids)))
-        )
+        return really_delete()
 
-    def add_nodes(self, rcs, node_list, clock=None):
+    def add_nodes(self, rcs, node_list, clock=reactor):
         """
         Add one or more nodes to a cloud load balancer
 
@@ -367,6 +370,7 @@ class CloudLoadBalancer(object):
             lists the nodes
 
         """
+        @_retry("Trying to add nodes.", clock=clock)
         def really_add():
             d = self.treq.post(
                 "{0}/nodes".format(self.endpoint(rcs)),
@@ -379,13 +383,7 @@ class CloudLoadBalancer(object):
                            _pending_update_to_transient)
             return d
 
-        return retry_and_timeout(
-            really_add, 60,
-            can_retry=terminal_errors_except(TransientRetryError),
-            next_interval=repeating_interval(3),
-            clock=clock or reactor,
-            deferred_description="Trying to add nodes"
-        )
+        return really_add()
 
 
 HasLength = MatchesPredicateWithParams(

--- a/otter/integration/lib/cloud_load_balancer.py
+++ b/otter/integration/lib/cloud_load_balancer.py
@@ -4,7 +4,7 @@ from __future__ import print_function
 
 import json
 
-from functools import wraps, partial
+from functools import partial, wraps
 
 from characteristic import Attribute, attributes
 

--- a/otter/integration/lib/test_cloud_load_balancer.py
+++ b/otter/integration/lib/test_cloud_load_balancer.py
@@ -262,6 +262,9 @@ class CLBTests(SynchronousTestCase):
                 return succeed(get_response)
 
             def content(cls, resp):
+                # If the get_response is not a 200, then, it would be
+                # considered an error and hence treq.content would be called.
+                # Otherwise, treq.content is only called for the del response.
                 if get_response == Response(200):
                     self.assertEqual(resp, del_response)
                 else:

--- a/otter/integration/lib/test_nova.py
+++ b/otter/integration/lib/test_nova.py
@@ -14,9 +14,10 @@ from otter.util.http import headers
 
 class Response(object):
     """Fake response object"""
-    def __init__(self, code, headers={}):
+    def __init__(self, code, headers={}, strbody=""):
         self.code = code
         self.headers = headers
+        self.strbody = strbody
 
 
 def get_fake_treq(test_case, method, url, expected_args_and_kwargs, response):

--- a/otter/integration/tests/test_convergence.py
+++ b/otter/integration/tests/test_convergence.py
@@ -1022,7 +1022,7 @@ def _delete_a_clb_and_scale(rcs, helper, group, scale_by, delete_clb=None):
     if delete_clb is not None:
         d = delete_clb(helper.clbs[0](rcs))
     else:
-        d = helper.clbs[0].delete(rcs, success_codes=[202])
+        d = helper.clbs[0].delete(rcs)
 
     policy = ScalingPolicy(scale_by=scale_by, scaling_group=group)
     d.addCallback(lambda _: policy.start(rcs, helper.test_case))


### PR DESCRIPTION
Fixes #1562.

Because it might be in pending update, and we don't want the tests to fail.  Also, if it's deleted, a 404 is NOT returned for real.  It goes into PENDING_DELETE state for a while, then into DELETED state.

All of these states mean that the CLB is immutable, and a 400 is returned when trying to delete (the error says that the CLB is immutable, but not which state it's in).  Which means we need to GET the CLB to figure out if we succeeded or need to retry.