### PR TITLE
Refactor CLB node removal to cloud_client

### DIFF
--- a/otter/cloud_client.py
+++ b/otter/cloud_client.py
@@ -568,11 +568,12 @@ def remove_clb_nodes(lb_id, node_ids):
     This function will handle the case where *some* of the nodes are valid and
     some aren't, by retrying deleting only the valid ones.
     """
+    node_ids = map(str, node_ids)
     eff = service_request(
         ServiceType.CLOUD_LOAD_BALANCERS,
         'DELETE',
         append_segments('loadbalancers', lb_id, 'nodes'),
-        params={'id': [str(node_id) for node_id in node_ids]},
+        params={'id': node_ids},
         success_pred=has_code(202))
 
     def check_invalid_nodes(exc_info):
@@ -583,8 +584,8 @@ def remove_clb_nodes(lb_id, node_ids):
                 body, ["validationErrors", "messages", 0])
             match = _CLB_NODE_REMOVED_PATTERN.match(message)
             if match:
-                removed = map(int, concat([group.split(',')
-                                           for group in match.groups()]))
+                removed = concat([group.split(',')
+                                  for group in match.groups()])
                 return remove_clb_nodes(lb_id, set(node_ids) - set(removed))
         six.reraise(*exc_info)
 

--- a/otter/cloud_client.py
+++ b/otter/cloud_client.py
@@ -329,6 +329,7 @@ def get_cloud_client_dispatcher(reactor, authenticator, log, service_configs):
 _CLB_PENDING_UPDATE_PATTERN = re.compile(
     "^Load Balancer '\d+' has a status of 'PENDING_UPDATE' and is considered "
     "immutable\.$")
+_CLB_NOT_ACTIVE_PATTERN = re.compile("^LoadBalancer is not ACTIVE$")
 _CLB_DELETED_PATTERN = re.compile(
     "^(Load Balancer '\d+' has a status of 'PENDING_DELETE' and is|"
     "The load balancer is deleted and) considered immutable\.$")
@@ -403,6 +404,14 @@ class NoSuchCLBNodeError(Exception):
     """
     Error to be raised when attempting to modify a CLB node that no longer
     exists.
+    """
+
+
+@attributes([Attribute('lb_id', instance_of=six.text_type)])
+class CLBNotActiveError(Exception):
+    """
+    Error to be raised when a CLB is not ACTIVE (and we have no more
+    information about what its actual state is).
     """
 
 
@@ -641,6 +650,7 @@ def _process_clb_api_error(api_error_code, json_body, lb_id):
         _expand_clb_matches(
             [(422, _CLB_DELETED_PATTERN, CLBDeletedError),
              (422, _CLB_PENDING_UPDATE_PATTERN, CLBPendingUpdateError),
+             (422, _CLB_NOT_ACTIVE_PATTERN, CLBNotActiveError),
              (404, _CLB_NO_SUCH_LB_PATTERN, NoSuchCLBError)],
             lb_id))
     return _match_errors(mappings, api_error_code, json_body)

--- a/otter/cloud_client.py
+++ b/otter/cloud_client.py
@@ -20,6 +20,7 @@ from effect import (
 import six
 
 from toolz.dicttoolz import get_in
+from toolz.itertoolz import concat
 
 from twisted.internet.defer import DeferredLock
 from twisted.internet.task import deferLater
@@ -29,7 +30,8 @@ from txeffect import deferred_performer, perform as twisted_perform
 from otter.auth import Authenticate, InvalidateToken, public_endpoint_url
 from otter.constants import ServiceType
 from otter.util.config import config_value
-from otter.util.http import APIError, append_segments
+from otter.util.fp import predicate_any
+from otter.util.http import APIError, append_segments, try_json_with_keys
 from otter.util.http import headers as otter_headers
 from otter.util.pure_http import (
     add_bind_root,
@@ -597,6 +599,116 @@ def _process_clb_api_error(api_error_code, json_body, lb_id):
              (404, _CLB_NO_SUCH_LB_PATTERN, NoSuchCLBError)],
             lb_id))
     return _match_errors(mappings, api_error_code, json_body)
+
+
+_CLB_PENDING_UPDATE_PATTERN = re.compile(
+    "^Load Balancer '\d+' has a status of 'PENDING_UPDATE' and is considered "
+    "immutable.$")
+_CLB_DELETED_PATTERN = re.compile(
+    "^(Load Balancer '\d+' has a status of 'PENDING_DELETE' and is|"
+    "The load balancer is deleted and) considered immutable.$")
+_CLB_NODE_REMOVED_PATTERN = re.compile(
+    "^Node ids ((?:\d+,)*(?:\d+)) are not a part of your loadbalancer\s*$")
+
+
+def _check_clb_422(*regex_matches):
+    """
+    A success predicate that succeeds if the status code is 422 and the content
+    matches the regex.  Used for detecting duplicate nodes on add to CLB, and
+    the load balancer being deleted or pending delete on remove from CLB.
+
+    It's unfortunate this involves parsing the body.
+    """
+    def check_response(response, content):
+        """
+        Check that the given response has a 422 code and its body matches the
+        regex.
+
+        Expects the content to be JSON, so whatever uses this should make sure
+        that the service request is called with ``json_response=True``,
+        which it should be by default.
+        """
+        if response.code == 422:
+            message = try_json_with_keys(content, ('message',))
+            return any([regex.search(message or '')
+                        for regex in regex_matches])
+        return False
+
+    return check_response
+
+
+def _clb_check_bulk_delete(lb_id, attempted_nodes, result):
+    """
+    Check if the CLB bulk deletion command failed with a 400, and if so,
+    returns the next step to try and remove the remaining nodes. This is
+    necessary because CLB bulk deletes are atomic-ish.
+
+    This seems to be the only case in which this API endpoint returns a 400.
+
+    All other cases are considered unambiguous successes.
+
+    :param result: The result of the :class:`ServiceRequest`. This should be a
+        2-tuple of the response object and the (parsed) body.
+    :ivar str lb_id: The cloud load balancer ID to remove nodes from.
+    :param attempted_nodes: The node IDs that were attempted to be removed.
+
+    This assumes that the result body is already parsed into JSON.
+    """
+    response, body = result
+    if response.code == 400:
+        message = get_in(["validationErrors", "messages", 0], body)
+        match = _CLB_NODE_REMOVED_PATTERN.match(message)
+        if match:
+            removed = concat([group.split(',') for group in match.groups()])
+            return remove_clb_nodes(lb_id, set(attempted_nodes) - set(removed))
+
+
+def remove_clb_nodes(lb_id, node_ids):
+    """
+    Remove multiple nodes from a load balancer.
+
+    :param str lb_id: A load balancer ID.
+    :param node_ids: iterable of node IDs.
+    :return: Effect of None.
+
+    Succeed unconditionally on 202 and 413 (over limit, so try again later).
+
+    Succeed conditionally on 422 if the load balancer is in PENDING_UPDATE
+    state, which happens because CLB locks for a few seconds and cannot be
+    changed again after an update - can be fixed next convergence cycle.
+
+    Succeed conditionally on 422 if the load balancer is in PENDING_DELETE
+    state, or already deleted, which means we don't have to remove any nodes.
+    """
+    eff = service_request(
+        ServiceType.CLOUD_LOAD_BALANCERS,
+        'DELETE',
+        append_segments('loadbalancers', lb_id, 'nodes'),
+        params={'id': [str(node_id) for node_id in node_ids]},
+        success_pred=predicate_any(
+            has_code(202, 413, 400),
+            _check_clb_422(_CLB_PENDING_UPDATE_PATTERN, _CLB_DELETED_PATTERN)))
+    # 400 means that there are some nodes that are no longer on the
+    # load balancer.  Parse them out and try again.
+    return eff.on(partial(_clb_check_bulk_delete, lb_id, node_ids))
+
+    # eff = service_request(
+    #     ServiceType.CLOUD_LOAD_BALANCERS,
+    #     'POST',
+    #     append_segments('loadbalancers', lb_id, 'nodes'),
+    #     data={'nodes': nodes},
+    #     success_pred=has_code(202))
+    #
+    # @_only_json_api_errors
+    # def _parse_known_errors(code, json_body):
+    #     mappings = _expand_clb_matches(
+    #         [(422, _CLB_DUPLICATE_NODES_PATTERN, CLBDuplicateNodesError),
+    #          (413, _CLB_NODE_LIMIT_PATTERN, CLBNodeLimitError)],
+    #         lb_id)
+    #     _match_errors(mappings, code, json_body)
+    #     _process_clb_api_error(code, json_body, lb_id)
+    #
+    # return eff.on(error=_parse_known_errors)
 
 
 # ----- Nova requests and error parsing -----

--- a/otter/cloud_client.py
+++ b/otter/cloud_client.py
@@ -582,11 +582,13 @@ def remove_clb_nodes(lb_id, node_ids):
         if code == 400:
             message = try_json_with_keys(
                 body, ["validationErrors", "messages", 0])
-            match = _CLB_NODE_REMOVED_PATTERN.match(message)
-            if match:
-                removed = concat([group.split(',')
-                                  for group in match.groups()])
-                return remove_clb_nodes(lb_id, set(node_ids) - set(removed))
+            if message is not None:
+                match = _CLB_NODE_REMOVED_PATTERN.match(message)
+                if match:
+                    removed = concat([group.split(',')
+                                      for group in match.groups()])
+                    return remove_clb_nodes(lb_id,
+                                            set(node_ids) - set(removed))
         six.reraise(*exc_info)
 
     return eff.on(

--- a/otter/test/convergence/test_steps.py
+++ b/otter/test/convergence/test_steps.py
@@ -522,6 +522,10 @@ class StepAsEffectTests(SynchronousTestCase):
         :obj:`RemoveNodesFromCLB`, on receiving a 400, parses out the nodes
         that are no longer on the load balancer, and retries the bulk delete
         with those nodes removed.
+
+        TODO: this has been left in as a regression test - this can probably be
+        removed the next time it's touched, as this functionality happens
+        in cloud_client now and there is a similar test there.
         """
         lb_id = "12345"
         node_ids = [str(i) for i in range(5)]

--- a/otter/test/test_cloud_client.py
+++ b/otter/test/test_cloud_client.py
@@ -54,6 +54,7 @@ from otter.cloud_client import (
     get_cloud_client_dispatcher,
     get_server_details,
     perform_tenant_scope,
+    remove_clb_nodes,
     service_request,
     set_nova_metadata_item)
 from otter.constants import ServiceType
@@ -61,7 +62,8 @@ from otter.test.utils import (
     StubResponse,
     resolve_effect,
     stub_pure_response,
-    nested_sequence)
+    nested_sequence,
+    perform_sequence)
 from otter.test.worker.test_launch_server_v1 import fake_service_catalog
 from otter.util.config import set_config_data
 from otter.util.http import APIError, headers
@@ -718,6 +720,66 @@ class CLBClientTests(SynchronousTestCase):
 
         # all the common failures
         self.assert_parses_common_clb_errors(expected.intent, eff)
+
+    def expected_node_removal_req(self, nodes=(1, 2)):
+        return service_request(
+            ServiceType.CLOUD_LOAD_BALANCERS,
+            'DELETE',
+            'loadbalancers/{}/nodes'.format(self.lb_id),
+            params={'id': map(str, nodes)},
+            success_pred=has_code(202))
+
+    def test_remove_clb_nodes_success(self):
+        """
+        A DELETE request is sent, and the Effect returns None if 202 is
+        returned.
+        """
+        eff = remove_clb_nodes(self.lb_id, [1, 2])
+        seq = [
+            (self.expected_node_removal_req().intent,
+             service_request_eqf(stub_pure_response({}, 202))),
+        ]
+        result = perform_sequence(seq, eff)
+        self.assertIs(result, None)
+
+    def test_remove_clb_nodes_non_202(self):
+        """Any random HTTP response code is bubbled up as an APIError."""
+        eff = remove_clb_nodes(self.lb_id, [1, 2])
+        seq = [
+            (self.expected_node_removal_req().intent,
+             service_request_eqf(stub_pure_response({}, 200))),
+        ]
+        self.assertRaises(APIError, perform_sequence, seq, eff)
+
+    def test_remove_clb_nodes_random_400(self):
+        """Random 400s are bubbled up as an APIError."""
+        eff = remove_clb_nodes(self.lb_id, [1, 2])
+        response = stub_pure_response(
+            {'validationErrors': {'messages': ['bar']}}, 400)
+        seq = [
+            (self.expected_node_removal_req().intent,
+             service_request_eqf(response)),
+        ]
+        self.assertRaises(APIError, perform_sequence, seq, eff)
+
+    def test_remove_clb_nodes_retry_on_some_invalid_nodes(self):
+        """
+        When CLB returns an error indicating that some of the nodes are
+        invalid, the request is retried without the offending nodes.
+        """
+        eff = remove_clb_nodes(self.lb_id, [1, 2, 3, 4])
+        response = stub_pure_response(
+            {'validationErrors': {'messages': [
+                 'Node ids 1,3 are not a part of your loadbalancer']}},
+            400)
+        response2 = stub_pure_response({}, 202)
+        seq = [
+            (self.expected_node_removal_req([1, 2, 3, 4]).intent,
+             service_request_eqf(response)),
+            (self.expected_node_removal_req([2, 4]).intent,
+             service_request_eqf(response2))
+        ]
+        self.assertIs(perform_sequence(seq, eff), None)
 
 
 def _perform_one_request(intent, effect, response_code, response_body):

--- a/otter/test/test_cloud_client.py
+++ b/otter/test/test_cloud_client.py
@@ -30,6 +30,7 @@ from otter.cloud_client import (
     CLBDeletedError,
     CLBDuplicateNodesError,
     CLBNodeLimitError,
+    CLBNotActiveError,
     CLBPendingUpdateError,
     CLBRateLimitError,
     CreateServerConfigurationError,
@@ -554,7 +555,8 @@ class CLBClientTests(SynchronousTestCase):
              "considered immutable.", 422, CLBDeletedError),
             ("The load balancer is deleted and considered immutable.",
              422, CLBDeletedError),
-            ("Load balancer not found.", 404, NoSuchCLBError)
+            ("Load balancer not found.", 404, NoSuchCLBError),
+            ("LoadBalancer is not ACTIVE", 422, CLBNotActiveError),
         ]
 
         for msg, code, err in json_responses_and_errs:

--- a/otter/test/test_cloud_client.py
+++ b/otter/test/test_cloud_client.py
@@ -745,6 +745,15 @@ class CLBClientTests(SynchronousTestCase):
         result = perform_sequence(seq, eff)
         self.assertIs(result, None)
 
+    def test_remove_clb_nodes_handles_standard_clb_errors(self):
+        """
+        Common CLB errors about it being in a deleted state, pending update,
+        etc. are handled.
+        """
+        eff = remove_clb_nodes(self.lb_id, [1, 2])
+        self.assert_parses_common_clb_errors(
+            self.expected_node_removal_req().intent, eff)
+
     def test_remove_clb_nodes_non_202(self):
         """Any random HTTP response code is bubbled up as an APIError."""
         eff = remove_clb_nodes(self.lb_id, [1, 2])


### PR DESCRIPTION
- moves the core logic (including retry when some nodes are invalid) into cloud_client.py
- refactored it all to use the same error-handling that the rest of cloud_client.py uses, simplifying the code in the process
- the RemoveNodesFromCLB step now interprets exceptions instead of HTTP codes

This is a preliminary step before implementing #1551 and #1559, which are *not* implemented in this branch, since this PR is getting big enough.

I'm going to disappear for several days after this so if there are any issues with the PR then please feel free to make the change directly in this branch. I'm also unassigning #1551 and #1559 from myself. sorry :-(