### PR TITLE
Normalize results logging

### DIFF
--- a/otter/convergence/errors.py
+++ b/otter/convergence/errors.py
@@ -49,8 +49,10 @@ class structure_reason(object):
         return {
             'exception': serialize_to_jsonable(exc_info[1]),
             'traceback': ''.join(traceback.format_exception(*exc_info))}
+
     def String(string):
         # So that the "reasons" are all the same structure, so that it can be
         # mapped if using elasticsearch
         return {'string': string}
+
     Structured = identity

--- a/otter/convergence/errors.py
+++ b/otter/convergence/errors.py
@@ -49,5 +49,8 @@ class structure_reason(object):
         return {
             'exception': serialize_to_jsonable(exc_info[1]),
             'traceback': ''.join(traceback.format_exception(*exc_info))}
+    def String(string):
+        # So that the "reasons" are all the same structure, so that it can be
+        # mapped if using elasticsearch
+        return {'string': string}
     Structured = identity
-    String = identity

--- a/otter/convergence/service.py
+++ b/otter/convergence/service.py
@@ -107,11 +107,13 @@ def _execute_steps(steps):
         priority = sorted(results,
                           key=lambda (status, reasons): severity.index(status))
         worst_status = priority[0][0]
-        results_to_log = zip(
-            steps,
-            [(result, map(structure_reason, reasons))
-             for result, reasons in results])
-
+        results_to_log = [
+            {'step': step,
+             'result': result,
+             'reasons': map(structure_reason, reasons)}
+            for step, (result, reasons) in
+            zip(steps, results)
+        ]
         reasons = reduce(operator.add,
                          (x[1] for x in results if x[0] == worst_status))
     else:

--- a/otter/test/convergence/test_errors.py
+++ b/otter/test/convergence/test_errors.py
@@ -50,8 +50,9 @@ class StructureReasonsTests(SynchronousTestCase):
         )
 
     def test_string(self):
-        """String values get unwrapped."""
-        self.assertEqual(structure_reason(ErrorReason.String('foo')), 'foo')
+        """String values get wrapped in a dictionary.unwrapped."""
+        self.assertEqual(structure_reason(ErrorReason.String('foo')),
+                         {'string': 'foo'})
 
     def test_structured(self):
         """Structured values get unwrapped."""

--- a/otter/test/convergence/test_service.py
+++ b/otter/test/convergence/test_service.py
@@ -722,7 +722,9 @@ class ExecuteConvergenceTests(SynchronousTestCase):
               'now': 500},
              lambda i: None),
             (Log('execute-convergence-results',
-                 {'results': [(steps[0], (StepResult.SUCCESS, []))],
+                 {'results': [{'step': steps[0],
+                               'result': StepResult.SUCCESS,
+                               'reasons': []}],
                   'worst_status': 'SUCCESS'}), lambda i: None)
         ])
         dispatcher = ComposedDispatcher([sequence, self._get_dispatcher()])
@@ -784,11 +786,16 @@ class ExecuteConvergenceTests(SynchronousTestCase):
         tb_msg = ''.join(traceback.format_exception(*exc_info))
         expected_fields = {
             'results': [
-                (step, (StepResult.RETRY,
-                        [{'exception': exc_msg,
-                          'traceback': tb_msg},
-                         'foo',
-                         {'foo': 'bar'}]))],
+                {
+                    'step': step,
+                    'result': StepResult.RETRY,
+                    'reasons': [
+                        {'exception': exc_msg, 'traceback': tb_msg},
+                        {'string': 'foo'},
+                        {'foo': 'bar'}
+                    ]
+                }
+            ],
             'worst_status': 'RETRY'}
         sequence = SequenceDispatcher([
             (self.gsgi, lambda i: (self.group, self.manifest)),


### PR DESCRIPTION
Fixes #1572.

Unfortunately this wraps the string in a dictionary too, which is verbose, but makes everything a list of the same type.

And unfortunately reading the logs means that things won't necessarily be in sorted order (step, then result, then reasons) - so results will look like:

```
"results": [
  {
    "reasons": [
      {
        "string": "waiting for server to become active"
      }
    ], 
    "result": "<StepResult=RETRY>", 
    "step": "<CreateServer(server_config=pmap({'server': pmap({u'flavorRef': u'performance1-1', 'metadata': pmap({'rax:autoscale:group:id': u'04393cb2-0c7d-4fff-9c04-370365719d55', 'rax:auto_scaling_group_id': u'04393cb2-0c7d-4fff-9c04-370365719d55'}), u'networks': pvector([pmap({u'uuid': u'11111111-1111-1111-1111-111111111111'})]), u'imageRef': u'22b7790b-a629-4a3a-b557-1039dad513ad', u'name': u'fcc39090-1436222831.19'})}))>"
  }, 
  {
    "reasons": [
      {
        "string": "waiting for server to become active"
      }
    ], 
    "result": "<StepResult=RETRY>", 
    "step": "<CreateServer(server_config=pmap({'server': pmap({u'flavorRef': u'performance1-1', 'metadata': pmap({'rax:autoscale:group:id': u'04393cb2-0c7d-4fff-9c04-370365719d55', 'rax:auto_scaling_group_id': u'04393cb2-0c7d-4fff-9c04-370365719d55'}), u'networks': pvector([pmap({u'uuid': u'11111111-1111-1111-1111-111111111111'})]), u'imageRef': u'22b7790b-a629-4a3a-b557-1039dad513ad', u'name': u'fcc39090-1436222831.19'})}))>"
  }, 
  {
    "reasons": [
      {
        "string": "waiting for server to become active"
      }
    ], 
    "result": "<StepResult=RETRY>", 
    "step": "<CreateServer(server_config=pmap({'server': pmap({u'flavorRef': u'performance1-1', 'metadata': pmap({'rax:autoscale:group:id': u'04393cb2-0c7d-4fff-9c04-370365719d55', 'rax:auto_scaling_group_id': u'04393cb2-0c7d-4fff-9c04-370365719d55'}), u'networks': pvector([pmap({u'uuid': u'11111111-1111-1111-1111-111111111111'})]), u'imageRef': u'22b7790b-a629-4a3a-b557-1039dad513ad', u'name': u'fcc39090-1436222831.19'})}))>"
  }, 
  {
    "reasons": [
      {
        "string": "waiting for server to become active"
      }
    ], 
    "result": "<StepResult=RETRY>", 
    "step": "<CreateServer(server_config=pmap({'server': pmap({u'flavorRef': u'performance1-1', 'metadata': pmap({'rax:autoscale:group:id': u'04393cb2-0c7d-4fff-9c04-370365719d55', 'rax:auto_scaling_group_id': u'04393cb2-0c7d-4fff-9c04-370365719d55'}), u'networks': pvector([pmap({u'uuid': u'11111111-1111-1111-1111-111111111111'})]), u'imageRef': u'22b7790b-a629-4a3a-b557-1039dad513ad', u'name': u'fcc39090-1436222831.19'})}))>"
  }
]
```