### PR TITLE
REST group state active from servers cache table

### DIFF
--- a/otter/convergence/service.py
+++ b/otter/convergence/service.py
@@ -224,13 +224,12 @@ def convergence_succeeded(scaling_group, group_state, servers, now):
                                        status=ScalingGroupStatus.ACTIVE))
         yield cf_msg('group-status-active',
                      status=ScalingGroupStatus.ACTIVE.name)
-    else:
-        # update servers cache with latest servers
-        yield Effect(
-            UpdateServersCache(
-                scaling_group.tenant_id, scaling_group.uuid, now,
-                [merge(thaw(s.json), {"_is_as_active": True})
-                 for s in servers if s.state != ServerState.DELETED]))
+    # update servers cache with latest servers
+    yield Effect(
+        UpdateServersCache(
+            scaling_group.tenant_id, scaling_group.uuid, now,
+            [merge(thaw(s.json), {"_is_as_active": True})
+                for s in servers if s.state != ServerState.DELETED]))
     yield do_return(ScalingGroupStatus.ACTIVE)
 
 

--- a/otter/convergence/service.py
+++ b/otter/convergence/service.py
@@ -23,6 +23,8 @@ from pyrsistent import thaw
 
 import six
 
+from toolz.dicttoolz import merge
+
 from twisted.application.service import MultiService
 
 from txeffect import exc_info_to_failure, perform
@@ -39,8 +41,7 @@ from otter.convergence.planning import plan
 from otter.log.cloudfeeds import cf_err, cf_msg
 from otter.log.intents import err, msg, with_log
 from otter.models.intents import (
-    DeleteGroup, GetScalingGroupInfo, ModifyGroupStateActive,
-    UpdateGroupStatus, UpdateServersCache)
+    DeleteGroup, GetScalingGroupInfo, UpdateGroupStatus, UpdateServersCache)
 from otter.models.interface import NoSuchScalingGroupError, ScalingGroupStatus
 from otter.util.timestamp import datetime_to_epoch
 from otter.util.zk import CreateOrSet, DeleteNode, GetChildren, GetStat
@@ -78,29 +79,20 @@ def is_autoscale_active(server, lb_nodes):
                              if node.matches(server)]))
 
 
-def update_old_cache(group, active):
-    active = {server.id: server_to_json(server) for server in active}
-    return Effect(ModifyGroupStateActive(group, active))
-
-
 def update_cache(group, servers, lb_nodes, now):
     """
     :param group: scaling group
     :param list servers: list of NovaServer objects
     """
-    active = []
     server_dicts = []
     for server in servers:
         sd = thaw(server.json)
         if is_autoscale_active(server, lb_nodes):
             sd["_is_as_active"] = True
-            active.append(server)
         server_dicts.append(sd)
 
-    set_eff = Effect(
+    return Effect(
         UpdateServersCache(group.tenant_id, group.uuid, now, server_dicts))
-
-    return parallel([update_old_cache(group, active), set_eff])
 
 
 @do
@@ -237,8 +229,8 @@ def convergence_succeeded(scaling_group, group_state, servers, now):
         yield Effect(
             UpdateServersCache(
                 scaling_group.tenant_id, scaling_group.uuid, now,
-                [thaw(s.json) for s in servers
-                 if s.state != ServerState.DELETED]))
+                [merge(thaw(s.json), {"_is_as_active": True})
+                 for s in servers if s.state != ServerState.DELETED]))
     yield do_return(ScalingGroupStatus.ACTIVE)
 
 

--- a/otter/effect_dispatcher.py
+++ b/otter/effect_dispatcher.py
@@ -62,6 +62,17 @@ def get_full_dispatcher(reactor, authenticator, log, service_configs,
     ])
 
 
+def get_working_cql_dispatcher(reactor, cass_client):
+    """
+    Get dispatcher with CQLQueryExecute performer along with any other
+    dependent performers to make it work
+    """
+    return ComposedDispatcher([
+        get_simple_dispatcher(reactor),
+        get_cql_dispatcher(cass_client)
+    ])
+
+
 def get_legacy_dispatcher(reactor, authenticator, log, service_configs):
     """
     Return a dispatcher that can perform effects that are needed by the old

--- a/otter/models/intents.py
+++ b/otter/models/intents.py
@@ -11,28 +11,6 @@ from twisted.internet.defer import inlineCallbacks, returnValue
 from txeffect import deferred_performer
 
 from otter.models.cass import CassScalingGroupServersCache
-from otter.util.fp import assoc_obj
-
-
-@attr.s
-class ModifyGroupStateActive(object):
-    """
-    Intent to update group state's active list
-    """
-    group = attr.ib()
-    active = attr.ib()
-
-
-@deferred_performer
-def perform_modify_group_state_active(dispatcher, mgs_intent):
-    """Perform a :obj:`ModifyGroupStateActive`."""
-
-    def update_group_active(group, old_state):
-        return assoc_obj(old_state, active=mgs_intent.active)
-
-    return mgs_intent.group.modify_state(
-        update_group_active,
-        modify_state_reason='updating active')
 
 
 @attributes(['tenant_id', 'group_id'])
@@ -106,7 +84,6 @@ def perform_update_servers_cache(disp, intent):
 def get_model_dispatcher(log, store):
     """Get a dispatcher that can handle all the model-related intents."""
     return TypeDispatcher({
-        ModifyGroupStateActive: perform_modify_group_state_active,
         GetScalingGroupInfo:
             partial(perform_get_scaling_group_info, log, store),
         DeleteGroup: partial(perform_delete_group, log, store),

--- a/otter/rest/groups.py
+++ b/otter/rest/groups.py
@@ -57,6 +57,8 @@ def format_state_dict(state, active=None):
     response.
 
     :param state: a :class:`otter.models.interface.GroupState` object
+    :param dict active: Active servers used when provided
+        instead of state.active
 
     :return: a ``dict`` that looks like what should be respond by the API
         response when getting state
@@ -472,6 +474,10 @@ class OtterGroup(object):
         self.group_id = group_id
 
     def with_active_cache(self, get_func, *args, **kwargs):
+        """
+        Return result of `get_func` and active cache from servers table
+        if this is convergence enabled tenant
+        """
         if tenant_is_enabled(self.tenant_id, config_value):
             cache_d = get_active_cache(self.store.connection,
                                        self.tenant_id, self.group_id)

--- a/otter/rest/groups.py
+++ b/otter/rest/groups.py
@@ -6,17 +6,22 @@ import json
 
 from functools import partial
 
-from twisted.internet.defer import succeed, gatherResults
+from twisted.internet import reactor
+from twisted.internet.defer import gatherResults, succeed
+
+from txeffect import perform
 
 from otter import controller
 from otter.convergence.composition import tenant_is_enabled
 from otter.convergence.service import get_convergence_starter
+from otter.effect_dispatcher import get_working_cql_dispatcher
 from otter.json_schema.group_schemas import (
     MAX_ENTITIES,
     validate_launch_config_servicenet,
 )
 from otter.json_schema.rest_schemas import create_group_request
 from otter.log import log
+from otter.models.cass import CassScalingGroupServersCache
 from otter.rest.bobby import get_bobby
 from otter.rest.configs import (
     OtterConfig,
@@ -443,6 +448,9 @@ class OtterGroups(object):
 
 
 def get_active_cache(connection, tenant_id, group_id):
+    """
+    Get active servers from servers cache table
+    """
     eff = CassScalingGroupServersCache(tenant_id, group_id).get_servers(True)
     disp = get_working_cql_dispatcher(reactor, connection)
     d = perform(disp, eff)

--- a/otter/test/convergence/test_service.py
+++ b/otter/test/convergence/test_service.py
@@ -37,7 +37,6 @@ from otter.log.intents import BoundFields, Log, LogErr
 from otter.models.intents import (
     DeleteGroup,
     GetScalingGroupInfo,
-    ModifyGroupStateActive,
     UpdateGroupStatus,
     UpdateServersCache)
 from otter.models.interface import (
@@ -644,11 +643,8 @@ class ExecuteConvergenceTests(SynchronousTestCase):
                 (("gacd", self.tenant_id, self.group_id, self.now),
                  lambda i: (self.servers, ()))
             ]),
-            nested_parallel([
-                (ModifyGroupStateActive(self.group, self.state_active), noop),
-                (UpdateServersCache(
-                    self.tenant_id, self.group_id, self.now, self.cache), noop)
-            ])
+            (UpdateServersCache(
+                self.tenant_id, self.group_id, self.now, self.cache), noop)
         ]
 
     def _invoke(self, plan=None):
@@ -670,7 +666,8 @@ class ExecuteConvergenceTests(SynchronousTestCase):
             (Log('execute-convergence-results',
                  {'results': [], 'worst_status': 'SUCCESS'}), noop),
             (UpdateServersCache("tenant-id", "group-id", self.now,
-                                [{"id": "a"}, {"id": "b"}]), noop)
+                                [{"id": "a", "_is_as_active": True},
+                                 {"id": "b", "_is_as_active": True}]), noop)
         ]
         self.state_active = {
             'a': {'id': 'a', 'links': [{'href': 'link1', 'rel': 'self'}]},
@@ -723,9 +720,9 @@ class ExecuteConvergenceTests(SynchronousTestCase):
                                'reasons': []}],
                   'worst_status': 'SUCCESS'}), noop),
             # Note that servers arg is non-deleted servers
-            (UpdateServersCache(
-                "tenant-id", "group-id", self.now,
-                [{'id': 'a'}, {'id': 'b'}]), noop)
+            (UpdateServersCache("tenant-id", "group-id", self.now,
+                                [{"id": "a", "_is_as_active": True},
+                                 {"id": "b", "_is_as_active": True}]), noop)
         ]
 
         # all the servers updated in cache in beginning

--- a/otter/test/convergence/test_service.py
+++ b/otter/test/convergence/test_service.py
@@ -955,7 +955,10 @@ class ExecuteConvergenceTests(SynchronousTestCase):
                                status=ScalingGroupStatus.ACTIVE),
              noop),
             (Log('group-status-active',
-                 dict(cloud_feed=True, status='ACTIVE')), noop)
+                 dict(cloud_feed=True, status='ACTIVE')), noop),
+            (UpdateServersCache("tenant-id", "group-id", self.now,
+                                [{"id": "a", "_is_as_active": True},
+                                 {"id": "b", "_is_as_active": True}]), noop)
         ]
         self.assertEqual(
             perform_sequence(self.get_seq() + sequence, self._invoke(plan)),
@@ -977,7 +980,10 @@ class ExecuteConvergenceTests(SynchronousTestCase):
                                status=ScalingGroupStatus.ACTIVE),
              noop),
             (Log('group-status-active',
-                 dict(cloud_feed=True, status='ACTIVE')), noop)
+                 dict(cloud_feed=True, status='ACTIVE')), noop),
+            (UpdateServersCache("tenant-id", "group-id", self.now,
+                                [{"id": "a", "_is_as_active": True},
+                                 {"id": "b", "_is_as_active": True}]), noop)
         ]
         self.state_active = {
             'a': {'id': 'a', 'links': [{'href': 'link1', 'rel': 'self'}]},

--- a/otter/test/models/test_intents.py
+++ b/otter/test/models/test_intents.py
@@ -9,24 +9,11 @@ from twisted.internet.defer import succeed
 from twisted.trial.unittest import SynchronousTestCase
 
 from otter.models.intents import (
-    DeleteGroup, GetScalingGroupInfo, ModifyGroupStateActive,
-    UpdateGroupStatus, UpdateServersCache, get_model_dispatcher)
+    DeleteGroup, GetScalingGroupInfo, UpdateGroupStatus, UpdateServersCache,
+    get_model_dispatcher)
 from otter.models.interface import (
-    GroupState, IScalingGroupCollection, ScalingGroupStatus)
+    IScalingGroupCollection, ScalingGroupStatus)
 from otter.test.utils import EffectServersCache, iMock, mock_group, mock_log
-
-
-class ModifyGroupStateTests(SynchronousTestCase):
-    """Tests for :func:`perform_modify_group_state`."""
-    def test_perform(self):
-        state = GroupState('tid', 'gid', 'g', 'active', 'pending', False,
-                           False, False, 'st')
-        group = mock_group(state)
-        mgs = ModifyGroupStateActive(group, 'new active')
-        dispatcher = get_model_dispatcher(mock_log(), None)
-        result = sync_perform(dispatcher, Effect(mgs))
-        self.assertIsNone(result)
-        self.assertEqual(group.modify_state_values[0].active, 'new active')
 
 
 class ScalingGroupIntentsTests(SynchronousTestCase):

--- a/otter/test/rest/test_groups.py
+++ b/otter/test/rest/test_groups.py
@@ -1204,7 +1204,7 @@ class GroupStateTestCase(RestAPITestMixin, SynchronousTestCase):
         self.mock_store.get_scaling_group.assert_called_once_with(
             mock.ANY, '11111', 'one')
         self.mock_group.view_state.assert_called_once_with()
-        mock_format.assert_called_once_with('group_state')
+        mock_format.assert_called_once_with('group_state', None)
 
     @mock.patch('otter.rest.groups.get_active_cache',
                 return_value=defer.succeed({'s1': {'links': 'l'}}))

--- a/otter/test/rest/test_groups.py
+++ b/otter/test/rest/test_groups.py
@@ -102,14 +102,12 @@ class FormatterHelpers(SynchronousTestCase):
             'status': 'ACTIVE',
         })
 
-    @mock.patch('otter.rest.groups.config_value')
-    def test_format_state_dict_with_convergence(self, config_value):
+    def test_format_state_dict_with_active(self):
         """
-        When convergence is enabled for a tenant, the returned desiredCapacity
+        If active is passed then the returned desiredCapacity
         is based on the stored `desired` in the group state, and the pending
-        capacity is desired from the desired and active servers.
+        capacity is got from the desired and active list provided
         """
-        config_value.side_effect = {'convergence-tenants': ['11111']}.get
         active = {
             '1': {'name': 'n1', 'links': ['links1'], 'created': 't'},
             '2': {'name': 'n2', 'links': ['links2'], 'created': 't'},
@@ -118,22 +116,16 @@ class FormatterHelpers(SynchronousTestCase):
             '11111',
             'one',
             'test',
-            active,
-            {},  # Ignored!
+            None, # active ignored
+            None, # pending Ignored!
             None,
             {},
             True,
             ScalingGroupStatus.ACTIVE,
             desired=10)
-        result = format_state_dict(state)
+        result = format_state_dict(state, active)
         self.assertEqual(result['desiredCapacity'], 10)
         self.assertEqual(result['pendingCapacity'], 7)
-
-        # And a non-convergence tenant still gets old-style data
-        state.tenant_id = '11112'
-        result = format_state_dict(state)
-        self.assertEqual(result['desiredCapacity'], 3)
-        self.assertEqual(result['pendingCapacity'], 0)
 
     @mock.patch('otter.rest.groups.config_value')
     def test_format_state_different_status(self, config_value):
@@ -141,7 +133,6 @@ class FormatterHelpers(SynchronousTestCase):
         When a group's status is something other than ACTIVE, it's reflected in
         the output.
         """
-        config_value.side_effect = {'convergence-tenants': ['11111']}.get
         active = {
             '1': {'name': 'n1', 'links': ['links1'], 'created': 't'},
             '2': {'name': 'n2', 'links': ['links2'], 'created': 't'},
@@ -150,14 +141,14 @@ class FormatterHelpers(SynchronousTestCase):
             '11111',
             'one',
             'test',
-            active,
-            {},  # Ignored!
+            None, # active ignored
+            None, # pending Ignored!
             None,
             {},
             True,
             ScalingGroupStatus.ERROR,
             desired=10)
-        result = format_state_dict(state)
+        result = format_state_dict(state, active)
         self.assertEqual(result['status'], 'ERROR')
 
 
@@ -316,7 +307,8 @@ class AllGroupsEndpointTestCase(RestAPITestMixin, SynchronousTestCase):
         self.mock_store.list_scaling_group_states.assert_called_once_with(
             mock.ANY, '11111', limit=100)
 
-        mock_format.assert_has_calls([mock.call(state) for state in states])
+        mock_format.assert_has_calls(
+            [mock.call(state, None) for state in states])
         self.assertEqual(len(mock_format.mock_calls), 2)
 
     @mock.patch('otter.rest.groups.get_autoscale_links',
@@ -350,6 +342,31 @@ class AllGroupsEndpointTestCase(RestAPITestMixin, SynchronousTestCase):
             }],
             "groups_links": []
         })
+
+    @mock.patch('otter.rest.groups.get_active_cache')
+    def test_list_group_convergence(self, mock_gac):
+        """
+        ``list_all_scaling_groups`` returns state that has active servers
+        taken from servers cache table
+        """
+        set_config_data({'convergence-tenants': ['11111'], 'url_root': 'root'})
+        self.addCleanup(set_config_data, None)
+
+        mock_gac.return_value = defer.succeed({'s1': {'links': 'l'}})
+        self.mock_store.connection = 'connection'
+
+        self.mock_store.list_scaling_group_states.return_value = defer.succeed(
+            [GroupState('11111', 'one', '1', None, None, None, {}, False,
+                        ScalingGroupStatus.ACTIVE, desired=2)]
+        )
+
+        body = self.assert_status_code(200)
+        resp = json.loads(body)
+        self.assertEqual(resp['groups'][0]['state']['activeCapacity'], 1)
+        self.assertEqual(resp['groups'][0]['state']['pendingCapacity'], 1)
+        self.assertEqual(resp['groups'][0]['state']['active'],
+                         [{'id': 's1', 'links': 'l'}])
+        mock_gac.assert_called_once_with('connection', '11111', 'one')
 
     def test_list_group_passes_limit_query(self):
         """
@@ -900,6 +917,37 @@ class OneGroupTestCase(RestAPITestMixin, SynchronousTestCase):
         self.mock_group.view_manifest.assert_called_once_with(
             with_webhooks=False)
 
+    @mock.patch('otter.rest.groups.get_active_cache')
+    def test_view_manifest_convergence(self, mock_gac):
+        """
+        Viewing the manifest of group of convergence enabled tenant
+        returns state based on servers cache
+        """
+        set_config_data({'convergence-tenants': ['11111'], 'url_root': 'root'})
+        self.addCleanup(set_config_data, None)
+
+        manifest = {
+            'groupConfiguration': config_examples()[0],
+            'launchConfiguration': launch_examples()[0],
+            'id': 'one',
+            'state': GroupState('11111', 'one', 'g', None, None, None, {}, False,
+                                ScalingGroupStatus.ACTIVE, desired=3),
+            'scalingPolicies': [dict(id="5", **policy_examples()[0])]
+        }
+        self.mock_group.view_manifest.return_value = defer.succeed(manifest)
+
+        self.mock_store.connection = 'connection'
+        mock_gac.return_value = defer.succeed({'s1': {'links': 's1l'}})
+
+        response_body = self.assert_status_code(200, method="GET")
+        resp = json.loads(response_body)
+
+        self.assertEqual(resp['group']['state']['pendingCapacity'], 2)
+        self.assertEqual(resp['group']['state']['activeCapacity'], 1)
+        self.assertEqual(resp['group']['state']['active'],
+                         [{'id': 's1', 'links': 's1l'}])
+        mock_gac.assert_called_once_with('connection', '11111', 'one')
+
     def test_view_manifest_with_webhooks(self):
         """
         `view_manifest` gives webhooks information in policies if query args
@@ -1126,6 +1174,28 @@ class GroupStateTestCase(RestAPITestMixin, SynchronousTestCase):
             mock.ANY, '11111', 'one')
         self.mock_group.view_state.assert_called_once_with()
         mock_format.assert_called_once_with('group_state')
+
+    @mock.patch('otter.rest.groups.get_active_cache',
+                return_value=defer.succeed({'s1': {'links': 'l'}}))
+    def test_view_state_convergence(self, mock_gac):
+        """
+        Viewing the state of an existant group that belongs to convergence
+        enabled tenant returns the active list from servers cache table
+        """
+        set_config_data({'convergence-tenants': ['11111'], 'url_root': 'root'})
+        self.addCleanup(set_config_data, None)
+
+        self.mock_group.view_state.return_value = defer.succeed(
+            GroupState("11111", "one", 'g', None, None, False, False, False,
+                       ScalingGroupStatus.ACTIVE, desired=4))
+        self.mock_store.connection = 'connection'
+        response_body = self.assert_status_code(200, method="GET")
+        resp = json.loads(response_body)
+
+        self.assertEqual(resp['group']['activeCapacity'], 1)
+        self.assertEqual(resp['group']['pendingCapacity'], 3)
+        self.assertEqual(resp['group']['active'], [{'id': 's1', 'links': 'l'}])
+        mock_gac.assert_called_once_with('connection', '11111', 'one')
 
 
 class GroupPauseTestCase(RestAPITestMixin, SynchronousTestCase):

--- a/scripts/load_cql.py
+++ b/scripts/load_cql.py
@@ -12,8 +12,6 @@ import sys
 from cql.apivalues import ProgrammingError
 from cql.connection import connect
 
-from effect import ComposedDispatcher
-
 from silverberg.client import CQLClient, ConsistencyLevel
 
 from twisted.internet import task
@@ -24,7 +22,7 @@ from txeffect import perform
 
 from otter.effect_dispatcher import get_working_cql_dispatcher
 from otter.metrics import get_scaling_groups
-from otter.models.cass import CassScalingGroupCollection, get_cql_dispatcher
+from otter.models.cass import CassScalingGroupCollection
 from otter.test.resources import CQLGenerator
 from otter.util.cqlbatch import batch
 

--- a/scripts/load_cql.py
+++ b/scripts/load_cql.py
@@ -22,7 +22,7 @@ from twisted.internet.endpoints import clientFromString
 
 from txeffect import perform
 
-from otter.effect_dispatcher import get_simple_dispatcher
+from otter.effect_dispatcher import get_working_cql_dispatcher
 from otter.metrics import get_scaling_groups
 from otter.models.cass import CassScalingGroupCollection, get_cql_dispatcher
 from otter.test.resources import CQLGenerator
@@ -161,7 +161,7 @@ def webhook_index(reactor, conn):
     """
     store = CassScalingGroupCollection(None, None, 3)
     eff = store.get_webhook_index_only()
-    return perform(get_dispatcher(reactor, conn), eff)
+    return perform(get_working_cql_dispatcher(reactor, conn), eff)
 
 
 def webhook_migrate(reactor, conn):
@@ -170,18 +170,7 @@ def webhook_migrate(reactor, conn):
     """
     store = CassScalingGroupCollection(None, None, 3)
     eff = store.get_webhook_index_only().on(store.add_webhook_keys)
-    return perform(get_dispatcher(reactor, conn), eff)
-
-
-def get_dispatcher(reactor, connection):
-    """
-    Get dispatcher with CQLQueryExecute performer with any other
-    necessary performers
-    """
-    return ComposedDispatcher([
-        get_simple_dispatcher(reactor),
-        get_cql_dispatcher(connection)
-    ])
+    return perform(get_working_cql_dispatcher(reactor, conn), eff)
 
 
 @inlineCallbacks


### PR DESCRIPTION
For convergence tenants, getting group state active servers in rest layer from servers cache table instead of from scaling_group table. Removed updating old group state cache during convergence gathering. 