### PR TITLE
Small fix to CF dispatcher

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -62,7 +62,6 @@
     "cloudfeeds": {
         "service": "cloudFeeds",
         "tenant_id": "identity_admin_tenant",
-        "region": "CF region to log to",
         "url": "http://cfurl.net/not/in/service/catalog"
     },
     "converger": {

--- a/config.example.json
+++ b/config.example.json
@@ -59,8 +59,12 @@
         "ttl": 432000,
         "interval": 60
     },
-    "cloudfeeds": {"service": "cloudFeeds", "tenant_id": "tenant",
-                   "url": "http://cfurl.net/"},
+    "cloudfeeds": {
+        "service": "cloudFeeds",
+        "tenant_id": "identity_admin_tenant",
+        "region": "CF region to log to",
+        "url": "http://cfurl.net/not/in/service/catalog"
+    },
     "converger": {
         "build_timeout": 3600,
         "interval": 30

--- a/otter/log/cloudfeeds.py
+++ b/otter/log/cloudfeeds.py
@@ -16,7 +16,7 @@ from txeffect import perform
 
 from otter.cloud_client import TenantScope, service_request
 from otter.constants import ServiceType
-from otter.effect_dispatcher import get_full_dispatcher
+from otter.effect_dispatcher import get_legacy_dispatcher
 from otter.log import log as otter_log
 from otter.log.formatters import (
     ErrorFormattingWrapper, LogLevel, PEP3101FormattingWrapper)
@@ -136,6 +136,7 @@ def prepare_request(req_fmt, event, error, timestamp, region, _id):
     request['entry']['content']['event']['eventTime'] = timestamp
     request['entry']['content']['event']['product'].update(event)
     request['entry']['content']['event']['id'] = _id
+    request['entry']['content']['event']['tenantId'] = event['tenant_id']
     return request
 
 
@@ -164,7 +165,7 @@ def add_event(event, tenant_id, region, log):
 
 @attributes(['reactor', 'authenticator', 'tenant_id', 'region',
              'service_configs', 'log', 'get_disp', 'add_event'],
-            defaults={'log': otter_log, 'get_disp': get_full_dispatcher,
+            defaults={'log': otter_log, 'get_disp': get_legacy_dispatcher,
                       'add_event': add_event})
 class CloudFeedsObserver(object):
     """

--- a/otter/log/cloudfeeds.py
+++ b/otter/log/cloudfeeds.py
@@ -136,7 +136,6 @@ def prepare_request(req_fmt, event, error, timestamp, region, _id):
     request['entry']['content']['event']['eventTime'] = timestamp
     request['entry']['content']['event']['product'].update(event)
     request['entry']['content']['event']['id'] = _id
-    request['entry']['content']['event']['tenantId'] = event['tenant_id']
     return request
 
 


### PR DESCRIPTION
Cloudfeeds was calling `get_full_dispatcher` with the wrong number of arguments, but it really only needs to make `cloud_client` calls, so switch dispatchers to `get_legacy_dispatcher`.

Wondering if we should rename `get_legacy_dispatcher`, since it's just a dispatcher that makes cloud client calls in addition to the simple dispatcher?