### PR TITLE
Propagate tenant id to cloud feeds event

### DIFF
--- a/otter/test/log/test_cloudfeeds.py
+++ b/otter/test/log/test_cloudfeeds.py
@@ -157,6 +157,10 @@ class SanitizeEventTests(SynchronousTestCase):
         self.event['message'] = ('some exception', )
         self.assertRaises(UnsuitableMessage, sanitize_event, self.event)
 
+        self.event['level'] = LogLevel.INFO
+        del self.event['tenant_id']
+        self.assertRaises(UnsuitableMessage, sanitize_event, self.event)
+
 
 class EventTests(SynchronousTestCase):
     """


### PR DESCRIPTION
Since the event has to have the tenant we are logging the event for.