### PR TITLE
Treat CLB immutability consistently in error handling

### DIFF
--- a/otter/cloud_client.py
+++ b/otter/cloud_client.py
@@ -333,6 +333,9 @@ _CLB_NOT_ACTIVE_PATTERN = re.compile("^LoadBalancer is not ACTIVE$")
 _CLB_DELETED_PATTERN = re.compile(
     "^(Load Balancer '\d+' has a status of 'PENDING_DELETE' and is|"
     "The load balancer is deleted and) considered immutable\.$")
+_CLB_BUILDING_PATTERN = re.compile(
+    "^Load Balancer '\d+' has a status of 'BUILD' and is considered "
+    "immutable\.$")
 _CLB_NO_SUCH_NODE_PATTERN = re.compile(
     "^Node with id #\d+ not found for loadbalancer #\d+$")
 _CLB_NO_SUCH_LB_PATTERN = re.compile(
@@ -650,6 +653,7 @@ def _process_clb_api_error(api_error_code, json_body, lb_id):
         _expand_clb_matches(
             [(422, _CLB_DELETED_PATTERN, CLBDeletedError),
              (422, _CLB_PENDING_UPDATE_PATTERN, CLBPendingUpdateError),
+             (422, _CLB_BUILDING_PATTERN, CLBPendingUpdateError),
              (422, _CLB_NOT_ACTIVE_PATTERN, CLBNotActiveError),
              (404, _CLB_NO_SUCH_LB_PATTERN, NoSuchCLBError)],
             lb_id))

--- a/otter/cloud_client.py
+++ b/otter/cloud_client.py
@@ -377,8 +377,11 @@ class ExceptionWithMessage(Exception):
 @attributes([Attribute('lb_id', instance_of=six.text_type)])
 class CLBImmutableError(Exception):
     """
-    Error to be raised when the CLB is in PENDING_UPDATE status and is
-    immutable (temporarily).
+    Error to be raised when the CLB is in some status that causes is to be
+    temporarily immutable.
+
+    This exception is _not_ used when the status is PENDING_DELETE. See
+    :obj:`CLBDeletedError`.
     """
 
 

--- a/otter/test/convergence/test_steps.py
+++ b/otter/test/convergence/test_steps.py
@@ -16,7 +16,7 @@ from otter.cloud_client import (
     CLBDeletedError,
     CLBDuplicateNodesError,
     CLBNodeLimitError,
-    CLBPendingUpdateError,
+    CLBImmutableError,
     CLBRateLimitError,
     CreateServerConfigurationError,
     CreateServerOverQuoteError,
@@ -449,7 +449,7 @@ class StepAsEffectTests(SynchronousTestCase):
         there was an API error and the error is unknown but not a 4xx.
         """
         non_terminals = (CLBDuplicateNodesError(lb_id=u"12345"),
-                         CLBPendingUpdateError(lb_id=u"12345"),
+                         CLBImmutableError(lb_id=u"12345"),
                          CLBRateLimitError(lb_id=u"12345"),
                          APIError(code=500, body="oops!"),
                          TypeError("You did something wrong in your code."))
@@ -571,7 +571,7 @@ class StepAsEffectTests(SynchronousTestCase):
         or if the request was rate-limited, or if there was an API error and
         the error is unknown but not a 4xx.
         """
-        non_terminals = (CLBPendingUpdateError(lb_id=u"12345"),
+        non_terminals = (CLBImmutableError(lb_id=u"12345"),
                          CLBRateLimitError(lb_id=u"12345"),
                          APIError(code=500, body="oops!"),
                          TypeError("You did something wrong in your code."))

--- a/otter/test/test_cloud_client.py
+++ b/otter/test/test_cloud_client.py
@@ -549,6 +549,8 @@ class CLBClientTests(SynchronousTestCase):
         :class:`APIError`
         """
         json_responses_and_errs = [
+            ("Load Balancer '{0}' has a status of 'BUILD' and is "
+             "considered immutable.", 422, CLBPendingUpdateError),
             ("Load Balancer '{0}' has a status of 'PENDING_UPDATE' and is "
              "considered immutable.", 422, CLBPendingUpdateError),
             ("Load Balancer '{0}' has a status of 'PENDING_DELETE' and is "

--- a/otter/test/test_cloud_client.py
+++ b/otter/test/test_cloud_client.py
@@ -31,7 +31,7 @@ from otter.cloud_client import (
     CLBDuplicateNodesError,
     CLBNodeLimitError,
     CLBNotActiveError,
-    CLBPendingUpdateError,
+    CLBImmutableError,
     CLBRateLimitError,
     CreateServerConfigurationError,
     CreateServerOverQuoteError,
@@ -544,15 +544,17 @@ class CLBClientTests(SynchronousTestCase):
     def assert_parses_common_clb_errors(self, intent, eff):
         """
         Assert that the effect produced performs the common CLB error parsing:
-        :class:`CLBPendingUpdateError`, :class:`CLBDescription`,
+        :class:`CLBImmutableError`, :class:`CLBDescription`,
         :class:`NoSuchCLBError`, :class:`CLBRateLimitError`,
         :class:`APIError`
         """
         json_responses_and_errs = [
             ("Load Balancer '{0}' has a status of 'BUILD' and is "
-             "considered immutable.", 422, CLBPendingUpdateError),
+             "considered immutable.", 422, CLBImmutableError),
             ("Load Balancer '{0}' has a status of 'PENDING_UPDATE' and is "
-             "considered immutable.", 422, CLBPendingUpdateError),
+             "considered immutable.", 422, CLBImmutableError),
+            ("Load Balancer '{0}' has a status of 'unexpected status' and is "
+             "considered immutable.", 422, CLBImmutableError),
             ("Load Balancer '{0}' has a status of 'PENDING_DELETE' and is "
              "considered immutable.", 422, CLBDeletedError),
             ("The load balancer is deleted and considered immutable.",


### PR DESCRIPTION
Fixes #1559

Instead of adding yet another exception type, I generalized CLBPendingUpdateError to CLBImmutableError and made our regex match that message no matter what status it is.

We still treat 'DELETED' specially, in that we raise CLBDeletedError in that case.