### PR TITLE
CLB trial tests retry on 413

### DIFF
--- a/otter/integration/lib/autoscale.py
+++ b/otter/integration/lib/autoscale.py
@@ -281,8 +281,8 @@ class ScalingGroup(object):
             This provides useful information to complete the request, like
             which endpoint to use to make the API request.
         """
-
-        return self.delete_scaling_group(rcs)
+        if getattr(self, 'group_id', None):
+            return self.delete_scaling_group(rcs)
 
     def delete_scaling_group(self, rcs):
         """Unconditionally delete the scaling group.  You may call this only

--- a/otter/integration/tests/test_lbsh.py
+++ b/otter/integration/tests/test_lbsh.py
@@ -266,9 +266,8 @@ class TestLoadBalancerSelfHealing(unittest.TestCase):
         """
         clb = self.helper.clbs[0]
 
-        nodes = yield clb.list_nodes(self.rcs)
-        self.assertEqual(len(nodes['nodes']), 0,
-                         "There should be no nodes on the CLB yet.")
+        yield clb.wait_for_nodes(self.rcs, HasLength(0),
+                                 timeout=timeout_default)
 
         # create the other two non-autoscaled servers - just wait until they
         # have servicenet addresses - don't bother waiting for them to be


### PR DESCRIPTION
Handle 413 from CLB, and extend the timeouts for retrying because of transient errors.