### PR TITLE
Metrics get scaling groups fix

### DIFF
--- a/otter/metrics.py
+++ b/otter/metrics.py
@@ -31,7 +31,7 @@ from txeffect import exc_info_to_failure, perform
 from otter.auth import generate_authenticator
 from otter.cloud_client import TenantScope, service_request
 from otter.constants import ServiceType, get_service_configs
-from otter.convergence.gathering import get_scaling_group_servers
+from otter.convergence.gathering import get_all_scaling_group_servers
 from otter.effect_dispatcher import get_legacy_dispatcher
 from otter.log import log as otter_log
 from otter.util.fp import predicate_all
@@ -173,7 +173,7 @@ def get_all_metrics_effects(cass_groups, log, _print=False):
     tenanted_groups = groupby(lambda g: g['tenantId'], cass_groups)
     effs = []
     for tenant_id, groups in tenanted_groups.iteritems():
-        eff = get_scaling_group_servers(
+        eff = get_all_scaling_group_servers(
             server_predicate=lambda s: s['status'] in ('ACTIVE', 'BUILD'))
         eff = Effect(TenantScope(eff, tenant_id))
         eff = eff.on(partial(get_tenant_metrics, tenant_id, groups,

--- a/otter/test/test_metrics.py
+++ b/otter/test/test_metrics.py
@@ -263,8 +263,8 @@ class GetAllMetricsEffectsTests(SynchronousTestCase):
         """
         Metrics are returned based on the requests done to get server info.
         """
-        # Maybe this could use a parameterized "get_scaling_group_servers" call
-        # to avoid needing to stub the nova responses, but it seems okay.
+        # Maybe this could use a parameterized "get_all_scaling_group_servers"
+        # call to avoid needing to stub the nova responses, but it seems okay.
         servers_t1 = {
             'g1': ([_server('g1', 'ACTIVE')] * 3
                    + [_server('g1', 'BUILD')] * 2),
@@ -283,7 +283,7 @@ class GetAllMetricsEffectsTests(SynchronousTestCase):
         effs = get_all_metrics_effects(groups, mock_log())
         # All the effs are wrapped in TenantScopes to indicate the tenant
         # of ServiceRequests made under them. We use that tenant to get the
-        # stubbed result of get_scaling_group_servers.
+        # stubbed result of get_all_scaling_group_servers.
         results = [
             resolve_effect(eff, tenant_servers[eff.intent.tenant_id])
             for eff in effs]

--- a/otter/test/test_metrics.py
+++ b/otter/test/test_metrics.py
@@ -266,8 +266,8 @@ class GetAllMetricsEffectsTests(SynchronousTestCase):
         # Maybe this could use a parameterized "get_all_scaling_group_servers"
         # call to avoid needing to stub the nova responses, but it seems okay.
         servers_t1 = {
-            'g1': ([_server('g1', 'ACTIVE')] * 3
-                   + [_server('g1', 'BUILD')] * 2),
+            'g1': ([_server('g1', 'ACTIVE')] * 3 +
+                   [_server('g1', 'BUILD')] * 2),
             'g2': [_server('g2', 'ACTIVE')]}
 
         servers_t2 = {


### PR DESCRIPTION
`get_scaling_group_servers` got changed to something and was replaced by `get_all_scaling_group_servers` but metrics was not updated with this change. 