### PR TITLE
Fix sending events to CF multiple times

### DIFF
--- a/otter/cloud_client.py
+++ b/otter/cloud_client.py
@@ -850,3 +850,20 @@ _nova_standard_errors = [
     (413, ('overLimit', 'message'), None, NovaRateLimitError),
     (500, ('computeFault', 'message'), None, NovaComputeFaultError)
 ]
+
+
+# ----- Cloud feeds requests -----
+def publish_to_cloudfeeds(event, log=None):
+    """
+    Publish an event dictionary to cloudfeeds.
+    """
+    return service_request(
+        ServiceType.CLOUD_FEEDS, 'POST',
+        append_segments('autoscale', 'events'),
+        # note: if we actually wanted a JSON response instead of XML,
+        # we'd have to pass the header:
+        # 'accept': ['application/vnd.rackspace.atom+json'],
+        headers={
+            'content-type': ['application/vnd.rackspace.atom+json']},
+        data=event, log=log, success_pred=has_code(201),
+        json_response=False)

--- a/otter/log/cloudfeeds.py
+++ b/otter/log/cloudfeeds.py
@@ -14,16 +14,14 @@ from toolz.dicttoolz import keyfilter
 
 from txeffect import perform
 
-from otter.cloud_client import TenantScope, service_request
-from otter.constants import ServiceType
+from otter.cloud_client import TenantScope, publish_to_cloudfeeds
 from otter.effect_dispatcher import get_legacy_dispatcher
 from otter.log import log as otter_log
 from otter.log.formatters import (
     ErrorFormattingWrapper, LogLevel, PEP3101FormattingWrapper)
 from otter.log.intents import err as err_effect, msg as msg_effect
 from otter.log.spec import SpecificationObserverWrapper
-from otter.util.http import APIError, append_segments
-from otter.util.pure_http import has_code
+from otter.util.http import APIError
 from otter.util.retry import (
     compose_retries,
     exponential_backoff_interval,
@@ -159,16 +157,7 @@ def add_event(event, admin_tenant_id, region, log):
 
     def _send_event(req):
         eff = retry_effect(
-            service_request(
-                ServiceType.CLOUD_FEEDS, 'POST',
-                append_segments('autoscale', 'events'),
-                # note: if we actually wanted a JSON response instead of XML,
-                # we'd have to pass the header:
-                # 'accept': ['application/vnd.rackspace.atom+json'],
-                headers={
-                    'content-type': ['application/vnd.rackspace.atom+json']},
-                data=req, log=log, success_pred=has_code(201),
-                json_response=False),
+            publish_to_cloudfeeds(req, log=log),
             compose_retries(
                 lambda f: (not f.check(APIError) or
                            f.value.code < 400 or

--- a/otter/test/utils.py
+++ b/otter/test/utils.py
@@ -730,7 +730,7 @@ def retry_sequence(expected_retry_intent, performers,
                 return Effect(Constant(
                     actual_retry_intent.should_retry.can_retry(failure)))
 
-        new_retry_intent = Effect(Retry(
+        new_retry_effect = Effect(Retry(
             effect=actual_retry_intent.effect,
             should_retry=should_retry))
 
@@ -742,7 +742,7 @@ def retry_sequence(expected_retry_intent, performers,
         seq = [(expected_retry_intent.effect.intent, performer)
                for performer in performers]
 
-        return perform_sequence(seq, new_retry_intent,
+        return perform_sequence(seq, new_retry_effect,
                                 ComposedDispatcher(_dispatchers))
 
     return (expected_retry_intent, perform_retry_without_delay)


### PR DESCRIPTION
This addresses both the issue where we send an invalid CF event multiple times, and where we send a valid CF event multiple times.

Fixes #1584.