### PR TITLE
Make pure_http requests use effectful bound logs

### DIFF
--- a/otter/log/intents.py
+++ b/otter/log/intents.py
@@ -45,12 +45,9 @@ class LogErr(object):
 
 
 @attr.s
-class GetLog(object):
+class GetFields(object):
     """
-    Intent to get a BoundLog from the effectful context.
-
-    This is useful to pass a log object to "legacy" code using BoundLogs
-    directly.
+    Intent to get the fields bound in the effectful context.
     """
 
 
@@ -87,8 +84,8 @@ def err(failure, msg, **fields):
 
 
 def get_log():
-    """Return Effect(GetLog())."""
-    return Effect(GetLog())
+    """Return Effect(GetFields())."""
+    return Effect(GetFields())
 
 
 def perform_logging(log, fields, log_func, disp, intent, box):
@@ -116,15 +113,6 @@ def bound_log(log, all_fields, disp, intent, box):
     perform(new_disp, intent.effect.on(box.succeed, box.fail))
 
 
-@sync_performer
-def perform_get_log(log, fields, disp, intent):
-    """
-    Perform a GetLog intent by returning a BoundLog with all the Effectfully
-    bound fields.
-    """
-    return log.bind(**fields)
-
-
 def get_log_dispatcher(log, fields):
     """
     Get dispatcher containing performers for logging intents that
@@ -134,5 +122,5 @@ def get_log_dispatcher(log, fields):
         BoundFields: partial(perform_logging, log, fields, bound_log),
         Log: partial(perform_logging, log, fields, log_msg),
         LogErr: partial(perform_logging, log, fields, log_err),
-        GetLog: partial(perform_get_log, log, fields),
+        GetFields: sync_performer(lambda d, i: fields),
     })

--- a/otter/log/intents.py
+++ b/otter/log/intents.py
@@ -83,7 +83,7 @@ def err(failure, msg, **fields):
     return Effect(LogErr(failure, msg, fields))
 
 
-def get_log():
+def get_fields():
     """Return Effect(GetFields())."""
     return Effect(GetFields())
 

--- a/otter/test/log/test_intents.py
+++ b/otter/test/log/test_intents.py
@@ -15,12 +15,11 @@ from twisted.trial.unittest import SynchronousTestCase
 
 from otter.log.intents import (
     err,
-    get_log,
+    get_fields,
     get_log_dispatcher,
     msg,
     with_log)
-from otter.test.utils import (
-    CheckFailureValue, IsBoundWith, matches, mock_log)
+from otter.test.utils import CheckFailureValue, mock_log
 
 
 class LogDispatcherTests(SynchronousTestCase):
@@ -166,6 +165,6 @@ class LogDispatcherTests(SynchronousTestCase):
 
     def test_get_fields(self):
         """GetFields results in the fields bound in the effectful context."""
-        eff = with_log(get_log(), ab=12, cd='foo')
+        eff = with_log(get_fields(), ab=12, cd='foo')
         fields = sync_perform(self.disp, eff)
         self.assertEqual(fields, {'f1': 'v', 'ab': 12, 'cd': 'foo'})

--- a/otter/test/log/test_intents.py
+++ b/otter/test/log/test_intents.py
@@ -15,10 +15,12 @@ from twisted.trial.unittest import SynchronousTestCase
 
 from otter.log.intents import (
     err,
+    get_log,
     get_log_dispatcher,
     msg,
     with_log)
-from otter.test.utils import CheckFailureValue, mock_log
+from otter.test.utils import (
+    CheckFailureValue, IsBoundWith, matches, mock_log)
 
 
 class LogDispatcherTests(SynchronousTestCase):
@@ -161,3 +163,10 @@ class LogDispatcherTests(SynchronousTestCase):
         self.assertEqual(sync_perform(self.disp, with_log(e, o='f')), "def")
         self.log.msg.assert_called_once_with(
             'foo', i='a', f1='v', m='d', o='f')
+
+    def test_get_log(self):
+        eff = with_log(get_log(), ab=12, cd='foo')
+        log = sync_perform(self.disp, eff)
+        self.assertEqual(
+            log,
+            matches(IsBoundWith(f1='v', ab=12, cd='foo')))

--- a/otter/test/log/test_intents.py
+++ b/otter/test/log/test_intents.py
@@ -164,9 +164,8 @@ class LogDispatcherTests(SynchronousTestCase):
         self.log.msg.assert_called_once_with(
             'foo', i='a', f1='v', m='d', o='f')
 
-    def test_get_log(self):
+    def test_get_fields(self):
+        """GetFields results in the fields bound in the effectful context."""
         eff = with_log(get_log(), ab=12, cd='foo')
-        log = sync_perform(self.disp, eff)
-        self.assertEqual(
-            log,
-            matches(IsBoundWith(f1='v', ab=12, cd='foo')))
+        fields = sync_perform(self.disp, eff)
+        self.assertEqual(fields, {'f1': 'v', 'ab': 12, 'cd': 'foo'})

--- a/otter/test/util/test_pure_http.py
+++ b/otter/test/util/test_pure_http.py
@@ -3,7 +3,7 @@
 import json
 from itertools import starmap
 
-from effect import Constant, Effect, Func
+from effect import ComposedDispatcher, Constant, Effect, Func
 from effect.testing import Stub
 
 from testtools import TestCase
@@ -13,8 +13,11 @@ from twisted.trial.unittest import SynchronousTestCase
 from txeffect import perform
 
 from otter.effect_dispatcher import get_simple_dispatcher
+from otter.log import log as default_log
+from otter.log.intents import get_log_dispatcher, with_log
 from otter.test.utils import (
-    StubResponse, StubTreq, resolve_stubs, stub_pure_response)
+    IsBoundWith, StubResponse, StubTreq, matches, mock_log,
+    resolve_stubs, stub_pure_response)
 from otter.util.http import APIError
 from otter.util.pure_http import (
     Request,
@@ -50,7 +53,8 @@ class RequestEffectTests(SynchronousTestCase):
         The Request effect dispatches a request to treq, and returns a
         two-tuple of the Twisted Response object and the content as bytes.
         """
-        req = ('GET', 'http://google.com/', None, None, None, {'log': None})
+        req = ('GET', 'http://google.com/', None, None, None,
+               {'log': default_log})
         response = StubResponse(200, {})
         treq = StubTreq(reqs=[(req, response)],
                         contents=[(response, "content")])
@@ -76,6 +80,54 @@ class RequestEffectTests(SynchronousTestCase):
         dispatcher = get_simple_dispatcher(None)
         self.assertEqual(
             self.successResultOf(perform(dispatcher, Effect(req))),
+            (response, "content"))
+
+    def test_log_effectful_fields(self):
+        """
+        The log passed to treq is bound with the fields from BoundFields.
+        """
+        log = mock_log().bind(duplicate='should be overridden')
+        expected_log = matches(IsBoundWith(duplicate='effectful',
+                                           bound='stuff'))
+        req = ('GET', 'http://google.com/', None, None, None,
+               {'log': expected_log})
+        response = StubResponse(200, {})
+        treq = StubTreq(reqs=[(req, response)],
+                        contents=[(response, "content")])
+        req = Request(method="get", url="http://google.com/", log=log)
+        req.treq = treq
+        req_eff = Effect(req)
+        bound_log_eff = with_log(req_eff, bound='stuff', duplicate='effectful')
+        dispatcher = ComposedDispatcher([
+            get_simple_dispatcher(None),
+            get_log_dispatcher(log, {})])
+        self.assertEqual(
+            self.successResultOf(perform(dispatcher, bound_log_eff)),
+            (response, "content"))
+
+    def test_log_none_effectful_fields(self):
+        """
+        When log is not passed, but there are log fields from BoundFields,
+        the log passed to treq has those fields.
+        """
+        log = mock_log()
+        # we have to include system='otter' in the expected log here because
+        # the code falls back to otter.log.log, which has the system key bound.
+        expected_log = matches(IsBoundWith(bound='stuff', system='otter'))
+        req = ('GET', 'http://google.com/', None, None, None,
+               {'log': expected_log})
+        response = StubResponse(200, {})
+        treq = StubTreq(reqs=[(req, response)],
+                        contents=[(response, "content")])
+        req = Request(method="get", url="http://google.com/")
+        req.treq = treq
+        req_eff = Effect(req)
+        bound_log_eff = with_log(req_eff, bound='stuff')
+        dispatcher = ComposedDispatcher([
+            get_simple_dispatcher(None),
+            get_log_dispatcher(log, {})])
+        self.assertEqual(
+            self.successResultOf(perform(dispatcher, bound_log_eff)),
             (response, "content"))
 
 


### PR DESCRIPTION
Fixes #1598

The problem is that the new effectful log-binding system in otter.log.intents only works "with itself", when `intents.msg()` and `intents.err()` are used. To remedy this I added a `GetFields` / `get_fields` intent, which returns the bound fields as a dictionary, and then used that intent in the `pure_http.Request` performer to get those effect-bound fields and bind them into the log we pass to logging_treq.