### PR TITLE
Coerce lb ids and node ids and server ids to be unicode

### DIFF
--- a/otter/cloud_client.py
+++ b/otter/cloud_client.py
@@ -633,9 +633,9 @@ def _expand_clb_matches(matches_tuples, lb_id, node_id=None):
 
     and maybe the partial will include the node ID too if it's provided.
     """
-    params = {"lb_id": lb_id}
+    params = {"lb_id": six.text_type(lb_id)}
     if node_id is not None:
-        params["node_id"] = node_id
+        params["node_id"] = six.text_type(node_id)
 
     return [(m[0], ("message",), m[1], partial(m[2], **params))
             for m in matches_tuples]
@@ -657,7 +657,7 @@ def _process_clb_api_error(api_error_code, json_body, lb_id):
         # overLimit is different than the other CLB messages because it's
         # produced by repose
         [(413, ("overLimit", "message"), _CLB_OVER_LIMIT_PATTERN,
-          partial(CLBRateLimitError, lb_id=lb_id))] +
+          partial(CLBRateLimitError, lb_id=six.text_type(lb_id)))] +
         _expand_clb_matches(
             [(422, _CLB_DELETED_PATTERN, CLBDeletedError),
              (410, _CLB_MARKED_DELETED_PATTERN, CLBDeletedError),
@@ -760,9 +760,10 @@ def set_nova_metadata_item(server_id, key, value):
     def _parse_known_errors(code, json_body):
         other_errors = [
             (404, ('itemNotFound', 'message'), None,
-             partial(NoSuchServerError, server_id=server_id)),
+             partial(NoSuchServerError, server_id=six.text_type(server_id))),
             (403, ('forbidden', 'message'), _MAX_METADATA_PATTERN,
-             partial(ServerMetadataOverLimitError, server_id=server_id)),
+             partial(ServerMetadataOverLimitError,
+                     server_id=six.text_type(server_id))),
         ]
         _match_errors(_nova_standard_errors + other_errors, code, json_body)
 
@@ -790,7 +791,7 @@ def get_server_details(server_id):
     def _parse_known_errors(code, json_body):
         other_errors = [
             (404, ('itemNotFound', 'message'), None,
-             partial(NoSuchServerError, server_id=server_id)),
+             partial(NoSuchServerError, server_id=six.text_type(server_id))),
         ]
         _match_errors(_nova_standard_errors + other_errors, code, json_body)
 

--- a/otter/test/test_cloud_client.py
+++ b/otter/test/test_cloud_client.py
@@ -539,7 +539,7 @@ class CLBClientTests(SynchronousTestCase):
     @property
     def lb_id(self):
         """What is my LB ID"""
-        return u"123456"
+        return "123456"
 
     def assert_parses_common_clb_errors(self, intent, eff):
         """
@@ -573,7 +573,8 @@ class CLBClientTests(SynchronousTestCase):
                 sync_perform(
                     EQFDispatcher([(intent, service_request_eqf(resp))]),
                     eff)
-            self.assertEqual(cm.exception, err(msg, lb_id=self.lb_id))
+            self.assertEqual(cm.exception,
+                             err(msg, lb_id=six.text_type(self.lb_id)))
 
         # OverLimit Retry is different because it's produced by repose
         over_limit = stub_pure_response(
@@ -592,7 +593,8 @@ class CLBClientTests(SynchronousTestCase):
                 eff)
         self.assertEqual(
             cm.exception,
-            CLBRateLimitError("OverLimit Retry...", lb_id=self.lb_id))
+            CLBRateLimitError("OverLimit Retry...",
+                              lb_id=six.text_type(self.lb_id)))
 
         # Ignored errors
         bad_resps = [
@@ -638,7 +640,7 @@ class CLBClientTests(SynchronousTestCase):
 
         Parse the common CLB errors, and :class:`NoSuchCLBNodeError`.
         """
-        eff = change_clb_node(lb_id=self.lb_id, node_id=u'1234',
+        eff = change_clb_node(lb_id=self.lb_id, node_id='1234',
                               condition="DRAINING", weight=50)
         expected = service_request(
             ServiceType.CLOUD_LOAD_BALANCERS,
@@ -667,7 +669,8 @@ class CLBClientTests(SynchronousTestCase):
             sync_perform(dispatcher, eff)
         self.assertEqual(
             cm.exception,
-            NoSuchCLBNodeError(msg, lb_id=self.lb_id, node_id=u'1234'))
+            NoSuchCLBNodeError(msg, lb_id=six.text_type(self.lb_id),
+                               node_id=u'1234'))
 
         # all the common failures
         self.assert_parses_common_clb_errors(expected.intent, eff)
@@ -710,7 +713,7 @@ class CLBClientTests(SynchronousTestCase):
             sync_perform(dispatcher, eff)
         self.assertEqual(
             cm.exception,
-            CLBDuplicateNodesError(msg, lb_id=self.lb_id))
+            CLBDuplicateNodesError(msg, lb_id=six.text_type(self.lb_id)))
 
         # CLBNodeLimitError failure
         msg = "Nodes must not exceed 25 per load balancer."
@@ -723,7 +726,7 @@ class CLBClientTests(SynchronousTestCase):
             sync_perform(dispatcher, eff)
         self.assertEqual(
             cm.exception,
-            CLBNodeLimitError(msg, lb_id=self.lb_id))
+            CLBNodeLimitError(msg, lb_id=six.text_type(self.lb_id)))
 
         # all the common failures
         self.assert_parses_common_clb_errors(expected.intent, eff)


### PR DESCRIPTION
Been seeing errors like this when running trial tests against production when removing nodes from a CLB:

```
Traceback (most recent call last):
  File "/opt/otter/.ve/local/lib/python2.7/site-packages/effect/_base.py", line 83, in guard
    return (False, f(*args, **kwargs))
  File "/opt/otter/otter/convergence/steps.py", line 82, in handler
    six.reraise(*exc_info)
  File "/opt/otter/.ve/local/lib/python2.7/site-packages/effect/_base.py", line 83, in guard
    return (False, f(*args, **kwargs))
  File "/opt/otter/.ve/local/lib/python2.7/site-packages/effect/_base.py", line 174, in catcher
    return callable(exc_info)
  File "/opt/otter/otter/cloud_client.py", line 481, in try_parsing
    f(api_error.code, body)
  File "/opt/otter/otter/cloud_client.py", line 612, in <lambda>
    lambda c, b: _process_clb_api_error(c, b, lb_id))
  File "/opt/otter/otter/cloud_client.py", line 662, in _process_clb_api_error
    return _match_errors(mappings, api_error_code, json_body)
  File "/opt/otter/otter/cloud_client.py", line 459, in _match_errors
    raise make_exc(message)
  File "<characteristic generated init 997c1139407d4c568d8a9dde7a042899f2a4f06c>", line 14, in characteristic_init
    raise TypeError("Attribute 'lb_id' must be an instance of 'unicode'.")
TypeError: Attribute 'lb_id' must be an instance of 'unicode'.
```

There are several places the LB id can come from (steps, retrying after removing already removed nodes), and I'm not sure which instance of it has the wrong encoding, so just coerce everything into unicode.