### PR TITLE
make model intent performers also merge effectful logs

### DIFF
--- a/otter/log/intents.py
+++ b/otter/log/intents.py
@@ -118,8 +118,10 @@ def bound_log(log, all_fields, disp, intent, box):
 
 def merge_effectful_fields(dispatcher, log):
     """
-    An *implicitly* side-effecting function which returns a log object based on
-    binding fields in the effectful log context into the passed-in log.
+    Return a log object based on bound fields in the effectful log context and
+    the passed-in log. The effectful context takes precedence.
+
+    If log is None then the default otter log will be used.
 
     Intended for use in legacy-ish intent performers that need a BoundLog.
     """

--- a/otter/models/intents.py
+++ b/otter/models/intents.py
@@ -10,6 +10,7 @@ from twisted.internet.defer import inlineCallbacks, returnValue
 
 from txeffect import deferred_performer
 
+from otter.log.intents import merge_effectful_fields
 from otter.models.cass import CassScalingGroupServersCache
 
 
@@ -29,6 +30,7 @@ def perform_get_scaling_group_info(log, store, dispatcher, intent):
     :param dispatcher: dispatcher provided by perform
     :param GetScalingGroupInfo intent: the intent
     """
+    log = merge_effectful_fields(dispatcher, log)
     group = store.get_scaling_group(log, intent.tenant_id, intent.group_id)
     manifest = yield group.view_manifest(with_policies=False,
                                          with_webhooks=False,
@@ -48,6 +50,7 @@ def perform_delete_group(log, store, dispatcher, intent):
     """
     Perform `DeleteGroup`
     """
+    log = merge_effectful_fields(dispatcher, log)
     group = store.get_scaling_group(log, intent.tenant_id, intent.group_id)
     return group.delete_group()
 

--- a/otter/test/log/test_intents.py
+++ b/otter/test/log/test_intents.py
@@ -13,13 +13,15 @@ import mock
 
 from twisted.trial.unittest import SynchronousTestCase
 
+from otter.log import log as default_log
 from otter.log.intents import (
     err,
     get_fields,
     get_log_dispatcher,
+    merge_effectful_fields,
     msg,
     with_log)
-from otter.test.utils import CheckFailureValue, mock_log
+from otter.test.utils import CheckFailureValue, IsBoundWith, matches, mock_log
 
 
 class LogDispatcherTests(SynchronousTestCase):
@@ -168,3 +170,36 @@ class LogDispatcherTests(SynchronousTestCase):
         eff = with_log(get_fields(), ab=12, cd='foo')
         fields = sync_perform(self.disp, eff)
         self.assertEqual(fields, {'f1': 'v', 'ab': 12, 'cd': 'foo'})
+
+    def test_merge_effectful_fields_no_context(self):
+        """
+        The given log is returned unmodified when there's no effectful context.
+        """
+        log = mock_log()
+        result = merge_effectful_fields(base_dispatcher, log)
+        self.assertIs(result, log)
+
+    def test_merge_effectful_fields_no_log_no_context(self):
+        """
+        The default otter log is returned when no log is passed and there is no
+        effectful context.
+        """
+        result = merge_effectful_fields(base_dispatcher, None)
+        self.assertIs(result, default_log)
+
+    def test_merge_effectful_fields_no_log_with_context(self):
+        """
+        A log is returned with fields from the default otter log and the
+        context when no log is passed.
+        """
+        result = merge_effectful_fields(self.disp, None)
+        self.assertEqual(result, matches(IsBoundWith(f1='v', system='otter')))
+
+    def test_merge_effectful_fields_log_and_context(self):
+        """
+        A log is returned with fields from both the passed-in log and the
+        effectful context, with the latter taking precedence.
+        """
+        log = self.log.bind(f1='v2', passed_log=True)
+        result = merge_effectful_fields(self.disp, log)
+        self.assertEqual(result, matches(IsBoundWith(passed_log=True, f1='v')))

--- a/otter/test/models/test_intents.py
+++ b/otter/test/models/test_intents.py
@@ -71,7 +71,7 @@ class ScalingGroupIntentsTests(SynchronousTestCase):
     def test_get_scaling_group_info_log_context(self):
         """
         When run in an effectful log context, the fields are bound to the log
-        passed to get_scaling_group.
+        passed to delete_group.
         """
         manifest = {}
 

--- a/otter/util/pure_http.py
+++ b/otter/util/pure_http.py
@@ -8,7 +8,7 @@ from functools import partial, wraps
 
 from characteristic import attributes
 
-from effect import Effect, NoPerformerFoundError, sync_perform
+from effect import Effect
 
 from toolz.dicttoolz import merge
 from toolz.functoolz import memoize
@@ -17,8 +17,7 @@ from twisted.internet.defer import inlineCallbacks, returnValue
 
 from txeffect import deferred_performer
 
-from otter.log import log as default_log
-from otter.log.intents import get_fields
+from otter.log.intents import merge_effectful_fields
 from otter.util import logging_treq
 from otter.util.http import APIError
 
@@ -50,15 +49,7 @@ def perform_request(dispatcher, intent):
 
     :return: A two-tuple of (HTTP Response, content as bytes)
     """
-    log = intent.log if intent.log is not None else default_log
-    try:
-        eff_fields = sync_perform(dispatcher, get_fields())
-    except NoPerformerFoundError:
-        # There's no BoundLog wrapping this intent; no effectful log fields to
-        # extract
-        pass
-    else:
-        log = log.bind(**eff_fields)
+    log = merge_effectful_fields(dispatcher, intent.log)
     response = yield intent.treq.request(intent.method.upper(), intent.url,
                                          headers=intent.headers,
                                          data=intent.data,


### PR DESCRIPTION
This should fix the logs we see in #otter-logs that look like this:

```
(%{tenant_id}/%{scaling_group_id}) NoSuchScalingGroupError('No such scaling group f23148ac-be66-4a6f-a0ef-fe1da19cbb86 for tenant 851153',)
```

so that they actually have tenant_id and scaling_group_id set.

Same problem as #1600, with the same solution. I've refactored the code to merge logs into a central place so all the performers can use it.

I also did a fair amount of bikeshedding on the model/test_intents.py code, because all the mutable instance-attributes were hurting my brain :confounded: 