### PR TITLE
Generate the CF UUID when logging

### DIFF
--- a/otter/log/cloudfeeds.py
+++ b/otter/log/cloudfeeds.py
@@ -49,9 +49,10 @@ log_cf_mapping = {
 }
 
 
-def _cf_log(log_effect, *args, **kwargs):
+def _cf_log_with_id(log_effect, *args, **kwargs):
     """
-    Helper helper function to log cloud feed event.
+    Helper helper function to generate a cloud feed ID before logging a
+    log cloud feed event.
     """
     def log_to_cf(uid):
         kwargs.update({'cloud_feed': True, 'cloud_feed_id': uid})
@@ -64,21 +65,21 @@ def cf_msg(msg, **fields):
     """
     Helper function to log cloud feeds event
     """
-    return _cf_log(msg_effect, msg, **fields)
+    return _cf_log_with_id(msg_effect, msg, **fields)
 
 
 def cf_err(msg, **fields):
     """
     Log cloud feed error event without failure
     """
-    return _cf_log(msg_effect, msg, isError=True, **fields)
+    return _cf_log_with_id(msg_effect, msg, isError=True, **fields)
 
 
 def cf_fail(failure, msg, **fields):
     """
     Log cloud feed error event with failure
     """
-    return _cf_log(err_effect, failure, msg, **fields)
+    return _cf_log_with_id(err_effect, failure, msg, **fields)
 
 
 def sanitize_event(event):

--- a/otter/log/cloudfeeds.py
+++ b/otter/log/cloudfeeds.py
@@ -4,7 +4,6 @@ Publishing events to Cloud feeds
 
 import uuid
 from copy import deepcopy
-from functools import partial
 
 from characteristic import attributes
 
@@ -50,25 +49,36 @@ log_cf_mapping = {
 }
 
 
+def _cf_log(log_effect, *args, **kwargs):
+    """
+    Helper helper function to log cloud feed event.
+    """
+    def log_to_cf(uid):
+        kwargs.update({'cloud_feed': True, 'cloud_feed_id': uid})
+        return log_effect(*args, **kwargs)
+
+    return Effect(Func(uuid.uuid4)).on(str).on(log_to_cf)
+
+
 def cf_msg(msg, **fields):
     """
     Helper function to log cloud feeds event
     """
-    return msg_effect(msg, cloud_feed=True, **fields)
+    return _cf_log(msg_effect, msg, **fields)
 
 
 def cf_err(msg, **fields):
     """
     Log cloud feed error event without failure
     """
-    return msg_effect(msg, isError=True, cloud_feed=True, **fields)
+    return _cf_log(msg_effect, msg, isError=True, **fields)
 
 
 def cf_fail(failure, msg, **fields):
     """
     Log cloud feed error event with failure
     """
-    return err_effect(failure, msg, cloud_feed=True, **fields)
+    return _cf_log(err_effect, failure, msg, **fields)
 
 
 def sanitize_event(event):
@@ -98,13 +108,14 @@ def sanitize_event(event):
            'exception' in cf_event['message']):
             raise UnsuitableMessage(cf_event['message'])
 
-    if 'tenant_id' not in event:
+    if 'tenant_id' not in event or 'cloud_feed_id' not in event:
         raise UnsuitableMessage(cf_event['message'])
 
     return (cf_event,
             error,
             epoch_to_utctimestr(event["time"]),
-            event['tenant_id'])
+            event['tenant_id'],
+            event['cloud_feed_id'])
 
 
 request_format = {
@@ -150,23 +161,19 @@ def add_event(event, admin_tenant_id, region, log):
     """
     Add event to cloud feeds
     """
-    event, error, timestamp, event_tenant_id = sanitize_event(event)
-    eff = Effect(Func(uuid.uuid4)).on(str).on(
-        partial(prepare_request, request_format, event,
-                error, timestamp, region, event_tenant_id))
+    event, error, timestamp, event_tenant_id, event_id = sanitize_event(event)
+    req = prepare_request(request_format, event, error, timestamp, region,
+                          event_tenant_id, event_id)
 
-    def _send_event(req):
-        eff = retry_effect(
-            publish_to_cloudfeeds(req, log=log),
-            compose_retries(
-                lambda f: (not f.check(APIError) or
-                           f.value.code < 400 or
-                           f.value.code >= 500),
-                retry_times(5)),
-            exponential_backoff_interval(2))
-        return Effect(TenantScope(tenant_id=admin_tenant_id, effect=eff))
-
-    return eff.on(_send_event)
+    eff = retry_effect(
+        publish_to_cloudfeeds(req, log=log),
+        compose_retries(
+            lambda f: (not f.check(APIError) or
+                       f.value.code < 400 or
+                       f.value.code >= 500),
+            retry_times(5)),
+        exponential_backoff_interval(2))
+    return Effect(TenantScope(tenant_id=admin_tenant_id, effect=eff))
 
 
 @attributes(['reactor', 'authenticator', 'tenant_id', 'region',

--- a/otter/test/convergence/test_logging.py
+++ b/otter/test/convergence/test_logging.py
@@ -1,5 +1,11 @@
+"""
+Tests for logging in convergence (that steps are correctly logged).
+"""
+
 from effect import sync_perform
 from effect.testing import SequenceDispatcher
+
+from mock import ANY
 
 from pyrsistent import freeze, pbag, pset
 
@@ -48,10 +54,10 @@ class LogStepsTests(SynchronousTestCase):
         self.assert_logs(creates, [
             Log('convergence-create-servers',
                 fields={'num_servers': 2, 'server_config': cfg,
-                        'cloud_feed': True}),
+                        'cloud_feed': True, 'cloud_feed_id': ANY}),
             Log('convergence-create-servers',
                 fields={'num_servers': 1, 'server_config': cfg2,
-                        'cloud_feed': True})
+                        'cloud_feed': True, 'cloud_feed_id': ANY})
             ])
 
     def test_delete_servers(self):
@@ -61,7 +67,8 @@ class LogStepsTests(SynchronousTestCase):
                         DeleteServer(server_id='3')])
         self.assert_logs(deletes, [
             Log('convergence-delete-servers',
-                fields={'servers': '1, 2, 3', 'cloud_feed': True})
+                fields={'servers': '1, 2, 3', 'cloud_feed': True,
+                        'cloud_feed_id': ANY})
         ])
 
     def test_add_nodes_to_clbs(self):
@@ -80,11 +87,11 @@ class LogStepsTests(SynchronousTestCase):
             Log('convergence-add-clb-nodes',
                 fields={'lb_id': 'lbid1',
                         'addresses': '10.0.0.1:1234, 10.0.0.2:1235',
-                        'cloud_feed': True}),
+                        'cloud_feed': True, 'cloud_feed_id': ANY}),
             Log('convergence-add-clb-nodes',
                 fields={'lb_id': 'lbid2',
                         'addresses': '10.0.0.1:4321',
-                        'cloud_feed': True})
+                        'cloud_feed': True, 'cloud_feed_id': ANY})
         ])
 
     def test_remove_nodes_from_clbs(self):
@@ -98,11 +105,11 @@ class LogStepsTests(SynchronousTestCase):
             Log('convergence-remove-clb-nodes',
                 fields={'lb_id': 'lbid1',
                         'nodes': ['a', 'b', 'c'],
-                        'cloud_feed': True}),
+                        'cloud_feed': True, 'cloud_feed_id': ANY}),
             Log('convergence-remove-clb-nodes',
                 fields={'lb_id': 'lbid2',
                         'nodes': ['d', 'e', 'f'],
-                        'cloud_feed': True}),
+                        'cloud_feed': True, 'cloud_feed_id': ANY}),
         ])
 
     def test_change_clb_node(self):
@@ -130,19 +137,19 @@ class LogStepsTests(SynchronousTestCase):
                 fields={
                     'lb_id': 'lbid1', 'nodes': 'node3',
                     'type': 'PRIMARY', 'condition': 'ENABLED', 'weight': 50,
-                    'cloud_feed': True,
+                    'cloud_feed': True, 'cloud_feed_id': ANY
                 }),
             Log('convergence-change-clb-nodes',
                 fields={
                     'lb_id': 'lbid1', 'nodes': 'node1, node2',
                     'type': 'PRIMARY', 'condition': 'DRAINING', 'weight': 50,
-                    'cloud_feed': True,
+                    'cloud_feed': True, 'cloud_feed_id': ANY
                 }),
             Log('convergence-change-clb-nodes',
                 fields={
                     'lb_id': 'lbid2', 'nodes': 'node4',
                     'type': 'PRIMARY', 'condition': 'ENABLED', 'weight': 50,
-                    'cloud_feed': True,
+                    'cloud_feed': True, 'cloud_feed_id': ANY
                 }),
         ])
 
@@ -160,16 +167,16 @@ class LogStepsTests(SynchronousTestCase):
         self.assert_logs(adds, [
             Log('convergence-add-rcv3-nodes',
                 fields={'lb_id': 'lb1', 'servers': 'node1, node2, nodea',
-                        'cloud_feed': True}),
+                        'cloud_feed': True, 'cloud_feed_id': ANY}),
             Log('convergence-add-rcv3-nodes',
                 fields={'lb_id': 'lb2', 'servers': 'node2, node3',
-                        'cloud_feed': True}),
+                        'cloud_feed': True, 'cloud_feed_id': ANY}),
             Log('convergence-add-rcv3-nodes',
                 fields={'lb_id': 'lb3', 'servers': 'node4',
-                        'cloud_feed': True}),
+                        'cloud_feed': True, 'cloud_feed_id': ANY}),
             Log('convergence-add-rcv3-nodes',
                 fields={'lb_id': 'lba', 'servers': 'nodea, nodeb',
-                        'cloud_feed': True})
+                        'cloud_feed': True, 'cloud_feed_id': ANY})
         ])
 
     def test_bulk_remove_from_rcv3(self):
@@ -186,16 +193,16 @@ class LogStepsTests(SynchronousTestCase):
         self.assert_logs(adds, [
             Log('convergence-remove-rcv3-nodes',
                 fields={'lb_id': 'lb1', 'servers': 'node1, node2, nodea',
-                        'cloud_feed': True}),
+                        'cloud_feed': True, 'cloud_feed_id': ANY}),
             Log('convergence-remove-rcv3-nodes',
                 fields={'lb_id': 'lb2', 'servers': 'node2, node3',
-                        'cloud_feed': True}),
+                        'cloud_feed': True, 'cloud_feed_id': ANY}),
             Log('convergence-remove-rcv3-nodes',
                 fields={'lb_id': 'lb3', 'servers': 'node4',
-                        'cloud_feed': True}),
+                        'cloud_feed': True, 'cloud_feed_id': ANY}),
             Log('convergence-remove-rcv3-nodes',
                 fields={'lb_id': 'lba', 'servers': 'nodea, nodeb',
-                        'cloud_feed': True})
+                        'cloud_feed': True, 'cloud_feed_id': ANY})
         ])
 
     def test_set_metadata_item_on_server(self):
@@ -209,8 +216,8 @@ class LogStepsTests(SynchronousTestCase):
         self.assert_logs(sets, [
             Log('convergence-set-server-metadata',
                 fields={'servers': 's1, s2', 'key': 'k1', 'value': 'v1',
-                        'cloud_feed': True}),
+                        'cloud_feed': True, 'cloud_feed_id': ANY}),
             Log('convergence-set-server-metadata',
                 fields={'servers': 's3', 'key': 'k2', 'value': 'v2',
-                        'cloud_feed': True})
+                        'cloud_feed': True, 'cloud_feed_id': ANY})
         ])

--- a/otter/test/convergence/test_service.py
+++ b/otter/test/convergence/test_service.py
@@ -807,7 +807,8 @@ class ExecuteConvergenceTests(SynchronousTestCase):
                 nested_parallel([
                     (Log('convergence-create-servers',
                          {'num_servers': 1, 'server_config': {'foo': 'bar'},
-                          'cloud_feed': True}), noop)
+                          'cloud_feed': True, 'cloud_feed_id': mock.ANY}),
+                     noop)
                 ])
             ]),
             (Log(msg='execute-convergence', fields=mock.ANY), noop),
@@ -925,7 +926,7 @@ class ExecuteConvergenceTests(SynchronousTestCase):
              noop),
             (Log('group-status-error',
                  dict(isError=True, cloud_feed=True,
-                      status='ERROR',
+                      cloud_feed_id=mock.ANY, status='ERROR',
                       reasons='Cloud Load Balancer does not exist: nolb1; '
                               'Cloud Load Balancer does not exist: nolb2')),
              noop)
@@ -955,7 +956,9 @@ class ExecuteConvergenceTests(SynchronousTestCase):
                                status=ScalingGroupStatus.ACTIVE),
              noop),
             (Log('group-status-active',
-                 dict(cloud_feed=True, status='ACTIVE')), noop),
+                 dict(cloud_feed=True, cloud_feed_id=mock.ANY,
+                      status='ACTIVE')),
+             noop),
             (UpdateServersCache("tenant-id", "group-id", self.now,
                                 [{"id": "a", "_is_as_active": True},
                                  {"id": "b", "_is_as_active": True}]), noop)
@@ -980,7 +983,9 @@ class ExecuteConvergenceTests(SynchronousTestCase):
                                status=ScalingGroupStatus.ACTIVE),
              noop),
             (Log('group-status-active',
-                 dict(cloud_feed=True, status='ACTIVE')), noop),
+                 dict(cloud_feed=True, cloud_feed_id=mock.ANY,
+                      status='ACTIVE')),
+             noop),
             (UpdateServersCache("tenant-id", "group-id", self.now,
                                 [{"id": "a", "_is_as_active": True},
                                  {"id": "b", "_is_as_active": True}]), noop)

--- a/otter/test/log/test_cloudfeeds.py
+++ b/otter/test/log/test_cloudfeeds.py
@@ -63,7 +63,7 @@ class CFHelperTests(SynchronousTestCase):
                                  a=2, b=3)),
                 lambda _: 'logged')
         ]
-        self.assertEqual(perform_sequence(cf_msg('message', a=2, b=3), seq),
+        self.assertEqual(perform_sequence(seq, cf_msg('message', a=2, b=3)),
                          'logged')
 
     def test_cf_err(self):
@@ -77,7 +77,7 @@ class CFHelperTests(SynchronousTestCase):
                                  cloud_feed_id='uuid', a=2, b=3)),
                 lambda _: 'logged')
         ]
-        self.assertEqual(perform_sequence(cf_err('message', a=2, b=3), seq),
+        self.assertEqual(perform_sequence(seq, cf_err('message', a=2, b=3)),
                          'logged')
 
     def test_cf_fail(self):
@@ -92,7 +92,7 @@ class CFHelperTests(SynchronousTestCase):
                 lambda _: 'logged')
         ]
         self.assertEqual(
-            perform_sequence(cf_fail(f, 'message', a=2, b=3), seq),
+            perform_sequence(seq, cf_fail(f, 'message', a=2, b=3)),
             'logged')
 
 

--- a/otter/test/log/test_cloudfeeds.py
+++ b/otter/test/log/test_cloudfeeds.py
@@ -271,10 +271,11 @@ class EventTests(SynchronousTestCase):
     def test_add_event_succeeds_if_request_succeeds(self):
         """
         Adding an event succeeds without retrying if the service request
-        succeeds.
+        succeeds.  Testing what response code causes a service request to
+        succeeds is beyond the scope of this test.
         """
         body = "<some xml>"
-        resp = stub_pure_response(body, 202)
+        resp = stub_pure_response(body, 201)
         response = [lambda _: (resp, body)]
         self.assertEqual(self._perform_add_event(response), (resp, body))
 


### PR DESCRIPTION
So that our logs by default have the cloud feeds ID in them, so that if something goes wrong, or a message got mangled or dropped, we can find them in our logs.

Fixes #1144.
Fixes #1603.