### PR TITLE
stop setting the `build_config` servermill option to `core`

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -84,7 +84,6 @@ format containing id and links is returned.
                     "flavorRef": "2",
                     "OS-DCF:diskConfig": "AUTO",
                     "metadata": {
-                      "build_config": "core",
                       "meta_key_1": "meta_value_1",
                       "meta_key_2": "meta_value_2"
                     },
@@ -159,7 +158,6 @@ format containing id and links is returned.
                         }
                       ],
                       "metadata": {
-                        "build_config": "core",
                         "meta_key_1": "meta_value_1",
                         "meta_key_2": "meta_value_2"
                       }
@@ -251,7 +249,6 @@ the body of the response in JSON format.
                         }
                       ],
                       "metadata": {
-                        "build_config": "core",
                         "meta_key_1": "meta_value_1",
                         "meta_key_2": "meta_value_2"
                       }

--- a/autoscale_cloudcafe/autoscale/client.py
+++ b/autoscale_cloudcafe/autoscale/client.py
@@ -112,12 +112,6 @@ class AutoscalingAPIClient(AutoMarshallingRestClient):
         '/{tenantId}/groups'
         """
         url = '%s/groups' % (self.url)
-        # Option "core" - Creates rack user only. See servermill build config
-        # option
-        if lc_metadata:
-            lc_metadata['build_config'] = 'core'
-        else:
-            lc_metadata = dict(build_config='core')
 
         # Setting network type for servers to be private by default so that
         # when testing against production, by default public IPs are not

--- a/doc/apiary.txt
+++ b/doc/apiary.txt
@@ -76,7 +76,6 @@ POST /{tenantId}/groups
         "flavorRef": "2",
         "OS-DCF:diskConfig": "AUTO",
         "metadata": {
-          "build_config": "core",
           "meta_key_1": "meta_value_1",
           "meta_key_2": "meta_value_2"
         },
@@ -149,7 +148,6 @@ POST /{tenantId}/groups
             }
           ],
           "metadata": {
-            "build_config": "core",
             "meta_key_1": "meta_value_1",
             "meta_key_2": "meta_value_2"
           }

--- a/docbook/src/docbkx/samples/LaunchConfiguration.json
+++ b/docbook/src/docbkx/samples/LaunchConfiguration.json
@@ -12,7 +12,6 @@
         "flavorRef": "performance1-2",
         "OS-DCF:diskConfig": "AUTO",
         "metadata": {
-          "build_config": "core",
           "meta_key_1": "meta_value_1",
           "meta_key_2": "meta_value_2"
         },

--- a/docbook/src/docbkx/samples/LaunchConfigurationBFV.json
+++ b/docbook/src/docbkx/samples/LaunchConfigurationBFV.json
@@ -6,7 +6,6 @@
         "flavorRef": "performance1-2",
         "OS-DCF:diskConfig": "AUTO",
         "metadata": {
-          "build_config": "core",
           "meta_key_1": "meta_value_1",
           "meta_key_2": "meta_value_2"
         },

--- a/otter/rest/groups.py
+++ b/otter/rest/groups.py
@@ -246,7 +246,6 @@ class OtterGroups(object):
                     "flavorRef": "2",
                     "OS-DCF:diskConfig": "AUTO",
                     "metadata": {
-                      "build_config": "core",
                       "meta_key_1": "meta_value_1",
                       "meta_key_2": "meta_value_2"
                     },
@@ -324,7 +323,6 @@ class OtterGroups(object):
                         }
                       ],
                       "metadata": {
-                        "build_config": "core",
                         "meta_key_1": "meta_value_1",
                         "meta_key_2": "meta_value_2"
                       }


### PR DESCRIPTION
This is what's spamming us with support tickets. Apparently `core` is an invalid option for us to use on the public net so it's not having any effect anyway.

It was also mentioned in all of our documentation and examples for some reason (probably because it got copied from our tests?) and so I went through and removed it from every place that mentioned it.