### PR TITLE
unify CLBDeletedError and NoSuchCLBError

### DIFF
--- a/otter/cloud_client.py
+++ b/otter/cloud_client.py
@@ -389,23 +389,14 @@ class CLBImmutableError(Exception):
     temporarily immutable.
 
     This exception is _not_ used when the status is PENDING_DELETE. See
-    :obj:`CLBDeletedError`.
-    """
-
-
-@attributes([Attribute('lb_id', instance_of=six.text_type)])
-class CLBDeletedError(Exception):
-    """
-    Error to be raised when the CLB has been deleted or is being deleted.
-    This is distinct from it not existing.
+    :obj:`NoSuchCLBError`.
     """
 
 
 @attributes([Attribute('lb_id', instance_of=six.text_type)])
 class NoSuchCLBError(Exception):
     """
-    Error to be raised when the CLB never existed in the first place (or it
-    has been deleted so long that there is no longer a record of it).
+    Error to be raised when the CLB does not exist or is being deleted.
     """
 
 
@@ -514,7 +505,7 @@ def add_clb_nodes(lb_id, nodes):
 
     :return: :class:`ServiceRequest` effect
 
-    :raises: :class:`CLBImmutableError`, :class:`CLBDeletedError`,
+    :raises: :class:`CLBImmutableError`,
         :class:`NoSuchCLBError`, :class:`CLBDuplicateNodesError`,
         :class:`APIError`
     """
@@ -552,7 +543,7 @@ def change_clb_node(lb_id, node_id, condition, weight):
 
     :return: :class:`ServiceRequest` effect
 
-    :raises: :class:`CLBImmutableError`, :class:`CLBDeletedError`,
+    :raises: :class:`CLBImmutableError`,
         :class:`NoSuchCLBError`, :class:`NoSuchCLBNodeError`, :class:`APIError`
     """
     eff = service_request(
@@ -650,7 +641,7 @@ def _process_clb_api_error(api_error_code, json_body, lb_id):
     :param dict json_body: The error message, parsed as a JSON dict.
     :param string lb_id: The load balancer ID
 
-    :raises: :class:`CLBImmutableError`, :class:`CLBDeletedError`,
+    :raises: :class:`CLBImmutableError`,
         :class:`NoSuchCLBError`, :class:`APIError` by itself
     """
     mappings = (
@@ -659,8 +650,8 @@ def _process_clb_api_error(api_error_code, json_body, lb_id):
         [(413, ("overLimit", "message"), _CLB_OVER_LIMIT_PATTERN,
           partial(CLBRateLimitError, lb_id=six.text_type(lb_id)))] +
         _expand_clb_matches(
-            [(422, _CLB_DELETED_PATTERN, CLBDeletedError),
-             (410, _CLB_MARKED_DELETED_PATTERN, CLBDeletedError),
+            [(422, _CLB_DELETED_PATTERN, NoSuchCLBError),
+             (410, _CLB_MARKED_DELETED_PATTERN, NoSuchCLBError),
              (422, _CLB_IMMUTABLE_PATTERN, CLBImmutableError),
              (422, _CLB_NOT_ACTIVE_PATTERN, CLBNotActiveError),
              (404, _CLB_NO_SUCH_LB_PATTERN, NoSuchCLBError)],

--- a/otter/convergence/errors.py
+++ b/otter/convergence/errors.py
@@ -7,7 +7,6 @@ from sumtypes import match
 from toolz.functoolz import identity
 
 from otter.cloud_client import (
-    CLBDeletedError,
     CreateServerConfigurationError,
     NoSuchCLBError
 )
@@ -39,12 +38,6 @@ def _present_exception(exception):
 @_present_exception.register(NoSuchCLBError)
 def _present_no_such_clb_error(exception):
     return "Cloud Load Balancer does not exist: {0}".format(exception.lb_id)
-
-
-@_present_exception.register(CLBDeletedError)
-def _present_clb_deleted_error(exception):
-    return "Cloud Load Balancer is currently being deleted: {0}".format(
-        exception.lb_id)
 
 
 @_present_exception.register(CreateServerConfigurationError)

--- a/otter/convergence/steps.py
+++ b/otter/convergence/steps.py
@@ -16,7 +16,6 @@ from twisted.python.constants import NamedConstant
 from zope.interface import Interface, implementer
 
 from otter.cloud_client import (
-    CLBDeletedError,
     CLBNodeLimitError,
     CreateServerConfigurationError,
     CreateServerOverQuoteError,
@@ -279,8 +278,7 @@ class AddNodesToCLB(object):
             success=_success_reporter(
                 'must re-gather after adding to CLB in order to update '
                 'the active cache'),
-            error=_failure_reporter(CLBDeletedError, CLBNodeLimitError,
-                                    NoSuchCLBError))
+            error=_failure_reporter(CLBNodeLimitError, NoSuchCLBError))
 
 
 @implementer(IStep)
@@ -300,8 +298,7 @@ class RemoveNodesFromCLB(object):
         # Since we're deleting a node, we'll ignore any errors which indicate
         # that the node doesn't exist.
         return eff.on(
-            error=_ignore_errors(
-                CLBDeletedError, NoSuchCLBError, NoSuchCLBNodeError)
+            error=_ignore_errors(NoSuchCLBError, NoSuchCLBNodeError)
         ).on(
             success=lambda r: (StepResult.SUCCESS, []),
             error=_failure_reporter())

--- a/otter/test/convergence/test_errors.py
+++ b/otter/test/convergence/test_errors.py
@@ -3,7 +3,6 @@ import traceback
 from twisted.trial.unittest import SynchronousTestCase
 
 from otter.cloud_client import (
-    CLBDeletedError,
     CreateServerConfigurationError,
     NoSuchCLBError
 )
@@ -29,8 +28,6 @@ class PresentReasonsTests(SynchronousTestCase):
         excs = {
             NoSuchCLBError(lb_id=u'lbid1'):
                 'Cloud Load Balancer does not exist: lbid1',
-            CLBDeletedError(lb_id=u'lbid2'):
-                'Cloud Load Balancer is currently being deleted: lbid2',
             CreateServerConfigurationError("Your server is wrong"):
                 'Server launch configuration is invalid: Your server is wrong'
         }

--- a/otter/test/convergence/test_steps.py
+++ b/otter/test/convergence/test_steps.py
@@ -13,10 +13,9 @@ from testtools.matchers import ContainsAll
 from twisted.trial.unittest import SynchronousTestCase
 
 from otter.cloud_client import (
-    CLBDeletedError,
     CLBDuplicateNodesError,
-    CLBNodeLimitError,
     CLBImmutableError,
+    CLBNodeLimitError,
     CLBRateLimitError,
     CreateServerConfigurationError,
     CreateServerOverQuoteError,
@@ -26,7 +25,8 @@ from otter.cloud_client import (
     NovaRateLimitError,
     ServerMetadataOverLimitError,
     has_code,
-    service_request)
+    service_request,
+)
 from otter.constants import ServiceType
 from otter.convergence.model import (
     CLBDescription,
@@ -469,8 +469,7 @@ class StepAsEffectTests(SynchronousTestCase):
         if there is any other 4xx error, then
         the error is propagated up and the result is a failure.
         """
-        terminals = (CLBDeletedError(lb_id=u"12345"),
-                     CLBNodeLimitError(lb_id=u"12345"),
+        terminals = (CLBNodeLimitError(lb_id=u"12345"),
                      NoSuchCLBError(lb_id=u"12345"),
                      APIError(code=403, body="You're out of luck."),
                      APIError(code=422, body="Oh look another 422."))
@@ -609,8 +608,7 @@ class StepAsEffectTests(SynchronousTestCase):
         :obj:`AddNodesToCLB` succeeds if the CLB is not in existence (has been
         deleted or is not found).
         """
-        successes = (CLBDeletedError(lb_id=u"12345"),
-                     NoSuchCLBError(lb_id=u"12345"))
+        successes = [NoSuchCLBError(lb_id=u"12345")]
         eff = RemoveNodesFromCLB(lb_id='12345',
                                  node_ids=pset(['1', '2'])).as_effect()
 

--- a/otter/test/test_cloud_client.py
+++ b/otter/test/test_cloud_client.py
@@ -27,11 +27,10 @@ from txeffect import perform
 
 from otter.auth import Authenticate, InvalidateToken
 from otter.cloud_client import (
-    CLBDeletedError,
     CLBDuplicateNodesError,
+    CLBImmutableError,
     CLBNodeLimitError,
     CLBNotActiveError,
-    CLBImmutableError,
     CLBRateLimitError,
     CreateServerConfigurationError,
     CreateServerOverQuoteError,
@@ -565,12 +564,12 @@ class CLBClientTests(SynchronousTestCase):
             ("Load Balancer '{0}' has a status of 'unexpected status' and is "
              "considered immutable.", 422, CLBImmutableError),
             ("Load Balancer '{0}' has a status of 'PENDING_DELETE' and is "
-             "considered immutable.", 422, CLBDeletedError),
+             "considered immutable.", 422, NoSuchCLBError),
             ("The load balancer is deleted and considered immutable.",
-             422, CLBDeletedError),
+             422, NoSuchCLBError),
             ("Load balancer not found.", 404, NoSuchCLBError),
             ("LoadBalancer is not ACTIVE", 422, CLBNotActiveError),
-            ("The loadbalancer is marked as deleted.", 410, CLBDeletedError),
+            ("The loadbalancer is marked as deleted.", 410, NoSuchCLBError),
         ]
 
         for msg, code, err in json_responses_and_errs:


### PR DESCRIPTION
Just deletes CLBDeletedError and replaces it with NoSuchCLBError, since we always treat them the same.