### PR TITLE
introduce a CLBNotFoundError superclass to CLBDeletedError and NoSuchCLBError

### DIFF
--- a/otter/cloud_client.py
+++ b/otter/cloud_client.py
@@ -394,15 +394,20 @@ class CLBImmutableError(Exception):
 
 
 @attributes([Attribute('lb_id', instance_of=six.text_type)])
-class CLBDeletedError(Exception):
+class CLBNotFoundError(Exception):
+    """A CLB doesn't exist. Superclass of other, more specific exceptions."""
+    message = attr.ib(default='')
+    lb_id = attr.ib()
+
+
+class CLBDeletedError(CLBNotFoundError):
     """
     Error to be raised when the CLB has been deleted or is being deleted.
     This is distinct from it not existing.
     """
 
 
-@attributes([Attribute('lb_id', instance_of=six.text_type)])
-class NoSuchCLBError(Exception):
+class NoSuchCLBError(CLBNotFoundError):
     """
     Error to be raised when the CLB never existed in the first place (or it
     has been deleted so long that there is no longer a record of it).

--- a/otter/cloud_client.py
+++ b/otter/cloud_client.py
@@ -396,8 +396,6 @@ class CLBImmutableError(Exception):
 @attributes([Attribute('lb_id', instance_of=six.text_type)])
 class CLBNotFoundError(Exception):
     """A CLB doesn't exist. Superclass of other, more specific exceptions."""
-    message = attr.ib(default='')
-    lb_id = attr.ib()
 
 
 class CLBDeletedError(CLBNotFoundError):

--- a/otter/convergence/steps.py
+++ b/otter/convergence/steps.py
@@ -20,6 +20,7 @@ from otter.cloud_client import (
     CLBNotFoundError,
     CreateServerConfigurationError,
     CreateServerOverQuoteError,
+    NoSuchCLBNodeError,
     add_clb_nodes,
     create_server,
     has_code,
@@ -297,7 +298,7 @@ class RemoveNodesFromCLB(object):
         # Since we're deleting a node, we'll ignore any errors which indicate
         # that the node doesn't exist.
         return eff.on(
-            error=_ignore_errors(CLBNotFoundError)
+            error=_ignore_errors(CLBNotFoundError, NoSuchCLBNodeError)
         ).on(
             success=lambda r: (StepResult.SUCCESS, []),
             error=_failure_reporter())

--- a/otter/convergence/steps.py
+++ b/otter/convergence/steps.py
@@ -100,9 +100,9 @@ def _failure_reporter(*terminal_err_types):
         err_type, error, traceback = exc_tuple
 
         terminal_error = (
-            err_type in terminal_err_types or
-            (err_type == APIError and 400 <= error.code < 500)
-        )
+            any(issubclass(err_type, etype)
+                for etype in terminal_err_types) or
+            err_type == APIError and 400 <= error.code < 500)
 
         if terminal_error:
             return StepResult.FAILURE, [ErrorReason.Exception(exc_tuple)]

--- a/otter/convergence/steps.py
+++ b/otter/convergence/steps.py
@@ -16,11 +16,10 @@ from twisted.python.constants import NamedConstant
 from zope.interface import Interface, implementer
 
 from otter.cloud_client import (
-    CLBDeletedError,
+    CLBNotFoundError,
     CLBNodeLimitError,
     CreateServerConfigurationError,
     CreateServerOverQuoteError,
-    NoSuchCLBError,
     NoSuchCLBNodeError,
     add_clb_nodes,
     create_server,
@@ -279,8 +278,8 @@ class AddNodesToCLB(object):
             success=_success_reporter(
                 'must re-gather after adding to CLB in order to update '
                 'the active cache'),
-            error=_failure_reporter(CLBDeletedError, CLBNodeLimitError,
-                                    NoSuchCLBError))
+            error=_failure_reporter(CLBNotFoundError, CLBNodeLimitError))
+
 
 
 @implementer(IStep)
@@ -300,8 +299,7 @@ class RemoveNodesFromCLB(object):
         # Since we're deleting a node, we'll ignore any errors which indicate
         # that the node doesn't exist.
         return eff.on(
-            error=_ignore_errors(
-                CLBDeletedError, NoSuchCLBError, NoSuchCLBNodeError)
+            error=_ignore_errors(CLBNotFoundError)
         ).on(
             success=lambda r: (StepResult.SUCCESS, []),
             error=_failure_reporter())

--- a/otter/convergence/steps.py
+++ b/otter/convergence/steps.py
@@ -16,11 +16,10 @@ from twisted.python.constants import NamedConstant
 from zope.interface import Interface, implementer
 
 from otter.cloud_client import (
-    CLBNotFoundError,
     CLBNodeLimitError,
+    CLBNotFoundError,
     CreateServerConfigurationError,
     CreateServerOverQuoteError,
-    NoSuchCLBNodeError,
     add_clb_nodes,
     create_server,
     has_code,
@@ -279,7 +278,6 @@ class AddNodesToCLB(object):
                 'must re-gather after adding to CLB in order to update '
                 'the active cache'),
             error=_failure_reporter(CLBNotFoundError, CLBNodeLimitError))
-
 
 
 @implementer(IStep)

--- a/otter/test/convergence/test_steps.py
+++ b/otter/test/convergence/test_steps.py
@@ -13,6 +13,7 @@ from testtools.matchers import ContainsAll
 from twisted.trial.unittest import SynchronousTestCase
 
 from otter.cloud_client import (
+    CLBDeletedError,
     CLBDuplicateNodesError,
     CLBImmutableError,
     CLBNodeLimitError,
@@ -469,6 +470,7 @@ class StepAsEffectTests(SynchronousTestCase):
         the error is propagated up and the result is a failure.
         """
         terminals = (CLBNotFoundError(lb_id=u"12345"),
+                     CLBDeletedError(lb_id=u"12345"),
                      CLBNodeLimitError(lb_id=u"12345"),
                      APIError(code=403, body="You're out of luck."),
                      APIError(code=422, body="Oh look another 422."))

--- a/otter/test/convergence/test_steps.py
+++ b/otter/test/convergence/test_steps.py
@@ -21,6 +21,7 @@ from otter.cloud_client import (
     CLBRateLimitError,
     CreateServerConfigurationError,
     CreateServerOverQuoteError,
+    NoSuchCLBError,
     NoSuchServerError,
     NovaComputeFaultError,
     NovaRateLimitError,
@@ -471,6 +472,7 @@ class StepAsEffectTests(SynchronousTestCase):
         """
         terminals = (CLBNotFoundError(lb_id=u"12345"),
                      CLBDeletedError(lb_id=u"12345"),
+                     NoSuchCLBError(lb_id=u"12345"),
                      CLBNodeLimitError(lb_id=u"12345"),
                      APIError(code=403, body="You're out of luck."),
                      APIError(code=422, body="Oh look another 422."))

--- a/otter/test/convergence/test_steps.py
+++ b/otter/test/convergence/test_steps.py
@@ -14,9 +14,9 @@ from twisted.trial.unittest import SynchronousTestCase
 
 from otter.cloud_client import (
     CLBDuplicateNodesError,
+    CLBImmutableError,
     CLBNodeLimitError,
     CLBNotFoundError,
-    CLBImmutableError,
     CLBRateLimitError,
     CreateServerConfigurationError,
     CreateServerOverQuoteError,

--- a/otter/test/convergence/test_steps.py
+++ b/otter/test/convergence/test_steps.py
@@ -13,14 +13,13 @@ from testtools.matchers import ContainsAll
 from twisted.trial.unittest import SynchronousTestCase
 
 from otter.cloud_client import (
-    CLBDeletedError,
     CLBDuplicateNodesError,
     CLBNodeLimitError,
+    CLBNotFoundError,
     CLBImmutableError,
     CLBRateLimitError,
     CreateServerConfigurationError,
     CreateServerOverQuoteError,
-    NoSuchCLBError,
     NoSuchServerError,
     NovaComputeFaultError,
     NovaRateLimitError,
@@ -469,9 +468,8 @@ class StepAsEffectTests(SynchronousTestCase):
         if there is any other 4xx error, then
         the error is propagated up and the result is a failure.
         """
-        terminals = (CLBDeletedError(lb_id=u"12345"),
+        terminals = (CLBNotFoundError(lb_id=u"12345"),
                      CLBNodeLimitError(lb_id=u"12345"),
-                     NoSuchCLBError(lb_id=u"12345"),
                      APIError(code=403, body="You're out of luck."),
                      APIError(code=422, body="Oh look another 422."))
         eff = self._add_one_node_to_clb()
@@ -609,8 +607,7 @@ class StepAsEffectTests(SynchronousTestCase):
         :obj:`AddNodesToCLB` succeeds if the CLB is not in existence (has been
         deleted or is not found).
         """
-        successes = (CLBDeletedError(lb_id=u"12345"),
-                     NoSuchCLBError(lb_id=u"12345"))
+        successes = [CLBNotFoundError(lb_id=u'12345')]
         eff = RemoveNodesFromCLB(lb_id='12345',
                                  node_ids=pset(['1', '2'])).as_effect()
 

--- a/otter/test/convergence/test_steps.py
+++ b/otter/test/convergence/test_steps.py
@@ -611,7 +611,9 @@ class StepAsEffectTests(SynchronousTestCase):
         :obj:`AddNodesToCLB` succeeds if the CLB is not in existence (has been
         deleted or is not found).
         """
-        successes = [CLBNotFoundError(lb_id=u'12345')]
+        successes = [CLBNotFoundError(lb_id=u'12345'),
+                     CLBDeletedError(lb_id=u'12345'),
+                     NoSuchCLBError(lb_id=u'12345')]
         eff = RemoveNodesFromCLB(lb_id='12345',
                                  node_ids=pset(['1', '2'])).as_effect()
 


### PR DESCRIPTION
This makes it simpler to handle "there is no CLB" as one error.