### PR TITLE
Upgrade to Twisted 15.2.1

### DIFF
--- a/otter/log/cloudfeeds.py
+++ b/otter/log/cloudfeeds.py
@@ -17,7 +17,11 @@ from otter.cloud_client import TenantScope, publish_to_cloudfeeds
 from otter.effect_dispatcher import get_legacy_dispatcher
 from otter.log import log as otter_log
 from otter.log.formatters import (
-    ErrorFormattingWrapper, LogLevel, PEP3101FormattingWrapper)
+    ErrorFormattingWrapper,
+    LogLevel,
+    PEP3101FormattingWrapper,
+    copying_wrapper
+)
 from otter.log.intents import err as err_effect, msg as msg_effect
 from otter.log.spec import SpecificationObserverWrapper
 from otter.util.http import APIError
@@ -219,6 +223,7 @@ def get_cf_observer(reactor, authenticator, tenant_id, region,
     cf_observer = CloudFeedsObserver(
         reactor=reactor, authenticator=authenticator, tenant_id=tenant_id,
         region=region, service_configs=service_configs)
-    return SpecificationObserverWrapper(
+    return copying_wrapper(
+        SpecificationObserverWrapper(
             PEP3101FormattingWrapper(
-                ErrorFormattingWrapper(cf_observer)))
+                ErrorFormattingWrapper(cf_observer))))

--- a/otter/log/formatters.py
+++ b/otter/log/formatters.py
@@ -269,7 +269,6 @@ def throttling_wrapper(observer):
         return True
 
     def emit(event):
-        event = event.copy()
         template = _get_matching_template(event)
         if template is not None:
             event_counts[template] += 1
@@ -281,4 +280,14 @@ def throttling_wrapper(observer):
         else:
             return observer(event)
 
+    return emit
+
+
+def copying_wrapper(observer):
+    """
+    An observer that copies the event-dict, so if there is more than one
+    observer chain that mutates events, we don't get any errors.
+    """
+    def emit(event_dict):
+        return observer(event_dict.copy())
     return emit

--- a/otter/log/setup.py
+++ b/otter/log/setup.py
@@ -12,6 +12,7 @@ from otter.log.formatters import (
     StreamObserverWrapper,
     SystemFilterWrapper,
     throttling_wrapper,
+    copying_wrapper,
 )
 from otter.log.spec import SpecificationObserverWrapper
 
@@ -20,17 +21,18 @@ def make_observer_chain(ultimate_observer, indent):
     """
     Return our feature observers wrapped our the ultimate_observer
     """
-    return throttling_wrapper(
-        SpecificationObserverWrapper(
-            PEP3101FormattingWrapper(
-                SystemFilterWrapper(
-                    ErrorFormattingWrapper(
-                        ObserverWrapper(
-                            JSONObserverWrapper(
-                                ultimate_observer,
-                                sort_keys=True,
-                                indent=indent or None),
-                            hostname=socket.gethostname()))))))
+    return copying_wrapper(
+        throttling_wrapper(
+            SpecificationObserverWrapper(
+                PEP3101FormattingWrapper(
+                    SystemFilterWrapper(
+                        ErrorFormattingWrapper(
+                            ObserverWrapper(
+                                JSONObserverWrapper(
+                                    ultimate_observer,
+                                    sort_keys=True,
+                                    indent=indent or None),
+                                hostname=socket.gethostname())))))))
 
 
 def observer_factory():

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 klein==15.0.0
-twisted==15.0.0
+twisted==15.2.1
 service_identity==14.0.0
 jsonschema==2.4.0
 iso8601==0.1.8


### PR DESCRIPTION
This adds a new formatter that copies the event dictionary to all our observer chains.

All our trial tests succeed under twisted 15.2.1.

Will run cafe tests on jenkins.

This adds a couple of new fields to our logs, mostly having to do with twisted noting that we are using the legacy logging system:

- `"log_system": ends up being the same as our `otter_facility`
- `"log_time": "<epoch>"`
- `"log_text": "..."` - This ends up being the same as message
- `"log_format": "{log_text}"` - it's always this value
- `"format": "%(log_legacy)s"` - its' always this value
- `"log_legacy": "<twisted.logger._stdlib.StringifiableFromEvent object at 0x....>"`
- `"log_level": "<LogLevel=...>"`

I don't think any of those new fields conflict with our logging stuff, so it should probably be ok.

Fixes #1580.
Part of #1619.

Ran master on 15.0.0 and compared the logs with this branch on 15.2.1, both with and without CF setup.

Looked at logs with the script in https://github.com/rackerlabs/otter/pull/1595#issuecomment-122376658, and the numbers all seemed to match up more or less, modulo a couple of extra get states from the tests.  And nothing particularly seemed to stand out when I grepped for Traceback.