### PR TITLE
switch the defaults in config.sh-template to those suitable for using mimic on the devvm

### DIFF
--- a/otter/integration/config.sh-template
+++ b/otter/integration/config.sh-template
@@ -50,11 +50,12 @@ export AS_NOVA_SC_KEY=cloudServersOpenStack
 # different key in the service catalog.
 export AS_CLB_SC_KEY=cloudLoadBalancers
 
-# Uncomment this if you are running tests against Mimic.
+# Comment this out if you aren't running tests against Mimic.
 export AS_USING_MIMIC=true
 
-# Uncomment this to change the default value of the otter build timeout for
-# testing
+# The number of seconds to wait for servers to build. When using mimic this
+# can be very low (like 30 seconds). Comment this out to use the normal
+# production value (which is much, much higher than 30 seconds).
 export AS_BUILD_TIMEOUT_SECONDS=30
 
 # This is a test tenant that is enabled for convergence in Otter.  This will

--- a/otter/integration/config.sh-template
+++ b/otter/integration/config.sh-template
@@ -1,18 +1,19 @@
 #!/bin/sh
 #
 # To run the integration tests, you'll need to have various environment
-# settings established.
+# settings established. The defaults in this file are set to run against
+# Mimic, so you should just need to "source config.sh-template" before
+# running the trial tests.
 
-# This is the username used to authenticate against Identity.
+# These are the credentials used to authenticate against Identity.
+# Mimic will accept any username/password.
 export AS_USERNAME=joe_user
-
-# This is the password used to authenticate against Identity.
 export AS_PASSWORD=joes_password
 
-# This is the Identity V2 API endpoint.
-export AS_IDENTITY=https://identity.api.rackspacecloud.com/v2.0
+# This is the public Identity V2 API endpoint.
+# export AS_IDENTITY=https://identity.api.rackspacecloud.com/v2.0
 # To run agains mimic, use the following default endpoint:
-# export AS_IDENTITY=http://localhost:8900/identity/v2.0
+export AS_IDENTITY=http://localhost:8900/identity/v2.0
 
 # When creating servers, use this flavor.
 export AS_FLAVOR_REF=2
@@ -21,9 +22,8 @@ export AS_FLAVOR_REF=2
 export AS_IMAGE_REF=cca73d10-8953-4949-a2f2-1e5444a4130d
 
 # When creating servers, use this region.  Beware; this is case sensitive.
-export AS_REGION=IAD
 # Mimic defaults to using ORD as the region
-#export AS_REGION=ORD
+export AS_REGION=ORD
 
 # This is the test tenant ID that is enabled for convergence in otter.
 export AS_CONVERGENCE_TENANT=000000
@@ -51,11 +51,11 @@ export AS_NOVA_SC_KEY=cloudServersOpenStack
 export AS_CLB_SC_KEY=cloudLoadBalancers
 
 # Uncomment this if you are running tests against Mimic.
-# export AS_USING_MIMIC=true
+export AS_USING_MIMIC=true
 
 # Uncomment this to change the default value of the otter build timeout for
 # testing
-# export AS_BUILD_TIMEOUT_SECONDS=30
+export AS_BUILD_TIMEOUT_SECONDS=30
 
 # This is a test tenant that is enabled for convergence in Otter.  This will
 # only be used for testing against mimic, to test otter reaction to auth


### PR DESCRIPTION
this way we don't need to create a custom config.sh to run the tests