### PR TITLE
fix unhandled noscalinggroup error

### DIFF
--- a/otter/rest/groups.py
+++ b/otter/rest/groups.py
@@ -487,7 +487,8 @@ class OtterGroup(object):
                 self.group_id)
         else:
             cache_d = succeed(None)
-        return gatherResults([get_func(*args, **kwargs), cache_d])
+        return gatherResults([get_func(*args, **kwargs), cache_d],
+                             consumeErrors=True)
 
     @app.route('/', methods=['GET'])
     @with_transaction_id()


### PR DESCRIPTION
Fixes #1625.

Earlier, get_func deferred in gatherResults errored which was propogated above in different deferred. The originial get_func deferred was not handled and resulted in "unhandled error" message. Adding
`consumeError=True` avoids this.