### PR TITLE
Don't use deepcopy in assoc_obj

### DIFF
--- a/otter/test/util/test_fp.py
+++ b/otter/test/util/test_fp.py
@@ -4,7 +4,8 @@ from pyrsistent import pmap
 
 from twisted.trial.unittest import SynchronousTestCase
 
-from otter.util.fp import predicate_all, predicate_any, set_in
+from otter.util.fp import (
+    assoc_obj, predicate_all, predicate_any, set_in)
 
 
 class PredicateAllTests(SynchronousTestCase):
@@ -130,3 +131,23 @@ class SetInTests(SynchronousTestCase):
         """
         self.assertEquals(set_in({}, (1, 2, 3), 4),
                           pmap({1: pmap({2: pmap({3: 4})})}))
+
+
+class AssocObjTests(SynchronousTestCase):
+    """Tests for :func:`assoc_obj`."""
+
+    def test_assoc(self):
+        """
+        Creates a new object that's a copy of the old one, with the
+        specified attributes rebound. Existing attributes are identical.
+        """
+        class Foo(object):
+            def __init__(self):
+                self.l = [1, 2]
+                self.name = "foo"
+
+        o = Foo()
+        new = assoc_obj(o, name="bar")
+        self.assertEqual(o.name, "foo")
+        self.assertEqual(new.name, "bar")
+        self.assertIs(o.l, new.l)

--- a/otter/util/fp.py
+++ b/otter/util/fp.py
@@ -84,7 +84,10 @@ def predicate_any(*preds):
 
 
 def assoc_obj(o, **k):
-    """Update attributes on an object, returning a new one."""
+    """
+    Update attributes on an object, returning a new one (after performing a
+    shallow copy).
+    """
     new_o = copy(o)
     new_o.__dict__.update(k)
     return new_o

--- a/otter/util/fp.py
+++ b/otter/util/fp.py
@@ -2,7 +2,7 @@
 
 """Functional programming utilities."""
 
-from copy import deepcopy
+from copy import copy
 
 from pyrsistent import freeze, pmap
 
@@ -85,7 +85,7 @@ def predicate_any(*preds):
 
 def assoc_obj(o, **k):
     """Update attributes on an object, returning a new one."""
-    new_o = deepcopy(o)
+    new_o = copy(o)
     new_o.__dict__.update(k)
     return new_o
 


### PR DESCRIPTION
assoc_obj should use shallow copying since if there are things like twisted constants in an object they become uncomparable when copied.

