### PR TITLE
Add a CLBNode.from_node_json method

### DIFF
--- a/otter/convergence/gathering.py
+++ b/otter/convergence/gathering.py
@@ -16,10 +16,8 @@ from otter.auth import NoSuchEndpoint
 from otter.cloud_client import service_request
 from otter.constants import ServiceType
 from otter.convergence.model import (
-    CLBDescription,
     CLBNode,
     CLBNodeCondition,
-    CLBNodeType,
     NovaServer,
     RCv3Description,
     RCv3Node,

--- a/otter/convergence/gathering.py
+++ b/otter/convergence/gathering.py
@@ -203,15 +203,7 @@ def get_clb_contents():
 
     def fetch_drained_feeds((ids, all_lb_nodes)):
         nodes = [
-            CLBNode(
-                node_id=str(node['id']),
-                address=node['address'],
-                description=CLBDescription(
-                    lb_id=str(_id),
-                    port=node['port'],
-                    weight=node.get('weight', 1),
-                    condition=CLBNodeCondition.lookupByName(node['condition']),
-                    type=CLBNodeType.lookupByName(node['type'])))
+            CLBNode.from_node_json(_id, node)
             for _id, nodes in zip(ids, all_lb_nodes) for node in nodes]
         draining = [n for n in nodes
                     if n.description.condition == CLBNodeCondition.DRAINING]

--- a/otter/convergence/model.py
+++ b/otter/convergence/model.py
@@ -497,6 +497,22 @@ class CLBNode(object):
         """
         return self.description.condition != CLBNodeCondition.DISABLED
 
+    @classmethod
+    def from_node_json(cls, lb_id, json):
+        """
+        Create an instance of this class based on node JSON data from the CLB
+        API.
+        """
+        return cls(
+            node_id=str(json['id']),
+            address=json['address'],
+            description=CLBDescription(
+                lb_id=str(lb_id),
+                port=json['port'],
+                weight=json.get('weight', 1),
+                condition=CLBNodeCondition.lookupByName(json['condition']),
+                type=CLBNodeType.lookupByName(json['type'])))
+
 
 @implementer(ILBDescription)
 @attributes([Attribute("lb_id", instance_of=basestring)])

--- a/otter/test/convergence/test_model.py
+++ b/otter/test/convergence/test_model.py
@@ -230,6 +230,43 @@ class CLBNodeTests(SynchronousTestCase):
                        address='10.1.1.1', drained_at=0.0, connections=1)
         self.assertFalse(node.is_active())
 
+    def test_from_node_json_no_weight(self):
+        """
+        A node's JSON representation can be parsed to a :obj:`CLBNode` object
+        with a `CLBDescription`. When weight is not specified it defaults to 1.
+        """
+        node_json = {'id': 'node1', 'address': '1.2.3.4', 'port': 20,
+                     'condition': 'DRAINING', 'type': 'SECONDARY'}
+        node = CLBNode.from_node_json(123, node_json)
+        self.assertEqual(
+            node,
+            CLBNode(node_id='node1', address='1.2.3.4',
+                    connections=None, drained_at=0.0,
+                    description=CLBDescription(
+                        lb_id='123', port=20,
+                        weight=1,
+                        condition=CLBNodeCondition.DRAINING,
+                        type=CLBNodeType.SECONDARY)))
+
+    def test_from_node_json_with_weight(self):
+        """
+        A node's JSON representation can be parsed to a :obj:`CLBNode` object
+        with a `CLBDescription`. When weight is not specified it defaults to 1.
+        """
+        node_json = {'id': 'node1', 'address': '1.2.3.4', 'port': 20,
+                     'condition': 'DRAINING', 'type': 'SECONDARY',
+                     'weight': 50}
+        node = CLBNode.from_node_json(123, node_json)
+        self.assertEqual(
+            node,
+            CLBNode(node_id='node1', address='1.2.3.4',
+                    connections=None, drained_at=0.0,
+                    description=CLBDescription(
+                        lb_id='123', port=20,
+                        weight=50,
+                        condition=CLBNodeCondition.DRAINING,
+                        type=CLBNodeType.SECONDARY)))
+
 
 class ServiceMetadataTests(SynchronousTestCase):
     """


### PR DESCRIPTION
Moves the json-parsing code from gathering.py to the CLBNode class.