### PR TITLE
Revert "Bump twisted version to one with a twisted logger"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 klein==15.0.0
-twisted==15.2.1
+twisted==15.0.0
 service_identity==14.0.0
 jsonschema==2.4.0
 iso8601==0.1.8


### PR DESCRIPTION
This reverts commit bda05dbc5149f95dbe36c503d19fbc595613a2a9.

This was the conclusion of the conversation in https://github.com/rackerlabs/otter/pull/1621 post-merge.