### PR TITLE
servers cache queries use timestamp

### DIFF
--- a/otter/models/cass.py
+++ b/otter/models/cass.py
@@ -1795,9 +1795,10 @@ class CassScalingGroupServersCache(object):
         if clear_others:
             return self.delete_servers().on(
                 lambda _: cql_eff(
-                    batch(queries, self.clock.seconds()), params))
+                    batch(queries, self.clock.seconds() * 1000000), params))
         else:
-            return cql_eff(batch(queries, self.clock.seconds()), params)
+            return cql_eff(batch(queries, self.clock.seconds() * 1000000),
+                           params)
 
     def delete_servers(self):
         """
@@ -1805,7 +1806,8 @@ class CassScalingGroupServersCache(object):
         """
         query = (_cql_delete_all_in_group.format(cf=self.table, name='') +
                  " USING TIMESTAMP :ts")
-        return cql_eff(query, merge(self.params, {"ts": self.clock.seconds()}))
+        return cql_eff(
+            query, merge(self.params, {"ts": self.clock.seconds() * 1000000}))
 
 
 @implementer(IAdmin)

--- a/otter/models/cass.py
+++ b/otter/models/cass.py
@@ -694,9 +694,7 @@ class CassScalingGroup(object):
         """
         @functools.wraps(func)
         def wrapper(*args):
-            d = defer.maybeDeferred(get_client_ts, self.reactor)
-            d.addCallback(lambda ts: func(ts, *args))
-            return d
+            return func(get_client_ts(self.reactor), *args)
         return wrapper
 
     def view_manifest(self, with_policies=True, with_webhooks=False,

--- a/otter/test/models/test_cass_models.py
+++ b/otter/test/models/test_cass_models.py
@@ -3846,7 +3846,7 @@ class CassGroupServersCacheTests(SynchronousTestCase):
 
     def _test_insert_servers(self, eff):
         query = (
-            'BEGIN BATCH USING TIMESTAMP 2.5 '
+            'BEGIN BATCH USING TIMESTAMP 2500000.0 '
             'INSERT INTO servers_cache ("tenantId", "groupId", last_update, '
             'server_id, server_blob, server_as_active) '
             'VALUES(:tenantId, :groupId, :last_update, :server_id0, '
@@ -3901,7 +3901,7 @@ class CassGroupServersCacheTests(SynchronousTestCase):
             cql_eff(('DELETE FROM servers_cache WHERE '
                      '"tenantId" = :tenantId AND "groupId" = :groupId '
                      'USING TIMESTAMP :ts'),
-                    merge(self.params, {"ts": 2.5})))
+                    merge(self.params, {"ts": 2500000.0})))
 
 
 class CassAdminTestCase(SynchronousTestCase):

--- a/otter/test/models/test_cass_models.py
+++ b/otter/test/models/test_cass_models.py
@@ -499,9 +499,9 @@ class CassScalingGroupTests(CassScalingGroupTestCase):
             self.b = b
             return 45
 
-        d = f(2, 3)
+        r = f(2, 3)
         # Wrapped function's return is same
-        self.assertEqual(self.successResultOf(d), 45)
+        self.assertEqual(r, 45)
         # Timestamp and arguments are passed correctly
         self.assertEqual(self.ts, 23566783)
         self.assertEqual(self.a, 2)


### PR DESCRIPTION
Fixes #1627.

Since delete and insert are really close in time, there is chance that delete can take precedence over insert. We avoid this by sending timestamp from client which should be serial between the queries. Thanks to @cyli for suggesting this.

It would be nice to provide real reactor to `CassScalingGroupServersCache` but it seems difficult in current code base since that class's object is created in gathering on the fly. 