### PR TITLE
Propagate treq request ID as a header

### DIFF
--- a/otter/test/test_logging_treq.py
+++ b/otter/test/test_logging_treq.py
@@ -91,7 +91,7 @@ class LoggingTreqTest(SynchronousTestCase):
     def test_url_params(self):
         """`params` is logged as `url_params`."""
         params = {'key': 'val'}
-        d = logging_treq.request('get', self.url, headers={}, data='',
+        d = logging_treq.request('get', self.url, data='',
                                  log=self.log, params=params, clock=self.clock)
         self.clock.advance(5)
         self.treq.request.return_value.callback(self.response)
@@ -105,7 +105,7 @@ class LoggingTreqTest(SynchronousTestCase):
         """
         On failed call to request, failure is returned and request logged
         """
-        d = logging_treq.request('patch', self.url, headers={}, data='',
+        d = logging_treq.request('patch', self.url, data='',
                                  log=self.log, clock=self.clock)
         self.treq.request.assert_called_once_with(
             method='patch', url=self.url,
@@ -122,7 +122,7 @@ class LoggingTreqTest(SynchronousTestCase):
         """
         A request times out after 45 seconds, and the failure is logged
         """
-        d = logging_treq.request('patch', self.url, headers={}, data='',
+        d = logging_treq.request('patch', self.url, data='',
                                  log=self.log, clock=self.clock)
         self.treq.request.assert_called_once_with(
             method='patch', url=self.url,

--- a/otter/test/test_logging_treq.py
+++ b/otter/test/test_logging_treq.py
@@ -38,7 +38,8 @@ class LoggingTreqTest(SynchronousTestCase):
         self.response = mock.MagicMock(code=204, headers={'1': '2'})
 
         patch(self, 'otter.util.logging_treq.treq', self.treq)
-
+        patch(self, 'otter.util.logging_treq.uuid4',
+              mock.MagicMock(spec=[], return_value='uuid'))
         self.url = 'myurl'
 
     def _assert_success_logging(self, method, status, request_time,
@@ -48,12 +49,12 @@ class LoggingTreqTest(SynchronousTestCase):
         """
         self.assertEqual(self.log.msg.mock_calls, [
             mock.call(mock.ANY, url=self.url, system="treq.request",
-                      method=method, treq_request_id=mock.ANY,
+                      method=method, treq_request_id='uuid',
                       url_params=url_params),
             mock.call(
                 mock.ANY, url=self.url, status_code=status, headers={'1': '2'},
                 system="treq.request", request_time=request_time,
-                method=method, treq_request_id=mock.ANY, url_params=url_params)
+                method=method, treq_request_id='uuid', url_params=url_params)
         ])
 
     def _assert_failure_logging(self, method, exception_type, request_time):
@@ -62,12 +63,12 @@ class LoggingTreqTest(SynchronousTestCase):
         """
         self.assertEqual(self.log.msg.mock_calls, [
             mock.call(mock.ANY, url=self.url, system="treq.request",
-                      method=method, treq_request_id=mock.ANY,
+                      method=method, treq_request_id='uuid',
                       url_params=None),
             mock.call(
                 mock.ANY, url=self.url, reason=CheckFailure(exception_type),
                 system="treq.request", request_time=request_time,
-                method=method, treq_request_id=mock.ANY, url_params=None)
+                method=method, treq_request_id='uuid', url_params=None)
         ])
 
     def test_request(self):
@@ -77,7 +78,8 @@ class LoggingTreqTest(SynchronousTestCase):
         d = logging_treq.request('patch', self.url, headers={}, data='',
                                  log=self.log, clock=self.clock)
         self.treq.request.assert_called_once_with(
-            method='patch', url=self.url, headers={}, data='')
+            method='patch', url=self.url,
+            headers={'x-otter-request-id': ['uuid']}, data='')
         self.assertNoResult(d)
 
         self.clock.advance(5)
@@ -94,7 +96,8 @@ class LoggingTreqTest(SynchronousTestCase):
         self.clock.advance(5)
         self.treq.request.return_value.callback(self.response)
         self.treq.request.assert_called_once_with(
-            method='get', url=self.url, headers={}, data='', params=params)
+            method='get', url=self.url,
+            headers={'x-otter-request-id': ['uuid']}, data='', params=params)
         self.assertIs(self.successResultOf(d), self.response)
         self._assert_success_logging('get', 204, 5, url_params=params)
 
@@ -105,7 +108,8 @@ class LoggingTreqTest(SynchronousTestCase):
         d = logging_treq.request('patch', self.url, headers={}, data='',
                                  log=self.log, clock=self.clock)
         self.treq.request.assert_called_once_with(
-            method='patch', url=self.url, headers={}, data='')
+            method='patch', url=self.url,
+            headers={'x-otter-request-id': ['uuid']}, data='')
         self.assertNoResult(d)
 
         self.clock.advance(5)
@@ -121,7 +125,8 @@ class LoggingTreqTest(SynchronousTestCase):
         d = logging_treq.request('patch', self.url, headers={}, data='',
                                  log=self.log, clock=self.clock)
         self.treq.request.assert_called_once_with(
-            method='patch', url=self.url, headers={}, data='')
+            method='patch', url=self.url,
+            headers={'x-otter-request-id': ['uuid']}, data='')
         self.assertNoResult(d)
 
         self.clock.advance(45)
@@ -137,7 +142,8 @@ class LoggingTreqTest(SynchronousTestCase):
                              clock=self.clock)
 
         treq_function = getattr(self.treq, method)
-        treq_function.assert_called_once_with(url=self.url, headers={}, data='')
+        treq_function.assert_called_once_with(
+            url=self.url, headers={'x-otter-request-id': ['uuid']}, data='')
 
         self.assertNoResult(d)
 
@@ -156,7 +162,8 @@ class LoggingTreqTest(SynchronousTestCase):
                              clock=self.clock)
 
         treq_function = getattr(self.treq, method)
-        treq_function.assert_called_once_with(url=self.url, headers={}, data='')
+        treq_function.assert_called_once_with(
+            url=self.url, headers={'x-otter-request-id': ['uuid']}, data='')
         self.assertNoResult(d)
 
         self.clock.advance(5)
@@ -174,7 +181,8 @@ class LoggingTreqTest(SynchronousTestCase):
                              clock=self.clock)
 
         treq_function = getattr(self.treq, method)
-        treq_function.assert_called_once_with(url=self.url, headers={}, data='')
+        treq_function.assert_called_once_with(
+            url=self.url, headers={'x-otter-request-id': ['uuid']}, data='')
         self.assertNoResult(d)
 
         self.clock.advance(45)

--- a/otter/test/test_logging_treq.py
+++ b/otter/test/test_logging_treq.py
@@ -43,38 +43,33 @@ class LoggingTreqTest(SynchronousTestCase):
         self.url = 'myurl'
 
     def _assert_success_logging(self, method, status, request_time,
-                                url_params=None, headers=None,
-                                request_id='uuid'):
+                                url_params=None):
         """
         msg expected to be made on a successful request are logged
         """
-        if headers is None:
-            headers = {'1': '2'}
-
         self.assertEqual(self.log.msg.mock_calls, [
             mock.call(mock.ANY, url=self.url, system="treq.request",
-                      method=method, treq_request_id=request_id,
+                      method=method, treq_request_id='uuid',
                       url_params=url_params),
             mock.call(
-                mock.ANY, url=self.url, status_code=status, headers=headers,
+                mock.ANY, url=self.url, status_code=status, headers={'1': '2'},
                 system="treq.request", request_time=request_time,
-                method=method, treq_request_id=request_id,
+                method=method, treq_request_id='uuid',
                 url_params=url_params)
         ])
 
-    def _assert_failure_logging(self, method, exception_type, request_time,
-                                request_id='uuid'):
+    def _assert_failure_logging(self, method, exception_type, request_time):
         """
         msg expected to be made on a failed request are logged
         """
         self.assertEqual(self.log.msg.mock_calls, [
             mock.call(mock.ANY, url=self.url, system="treq.request",
-                      method=method, treq_request_id=request_id,
+                      method=method, treq_request_id='uuid',
                       url_params=None),
             mock.call(
                 mock.ANY, url=self.url, reason=CheckFailure(exception_type),
                 system="treq.request", request_time=request_time,
-                method=method, treq_request_id=request_id, url_params=None)
+                method=method, treq_request_id='uuid', url_params=None)
         ])
 
     def test_request(self):
@@ -107,38 +102,21 @@ class LoggingTreqTest(SynchronousTestCase):
         self.assertIs(self.successResultOf(d), self.response)
         self._assert_success_logging('get', 204, 5, url_params=params)
 
-    def test_headers_are_preserved(self):
+    def test_headers_are_preserved_except_request_id(self):
         """
         `headers` are passed through as is, with an `x-otter-request-id` added.
+        If the header `x-otter-request-id` is supplied in the existing headers,
+        it is replaced.
         """
         headers = {'header1': ['val1'], 'header2': ['val2'],
-                   'x-otter-almost-it': ['unchanged']}
+                   'x-otter-almost-it': ['unchanged'],
+                   'x-otter-request-id': ['different-value']}
         new_headers = headers.copy()
         new_headers['x-otter-request-id'] = ['uuid']
         logging_treq.request('get', self.url, headers=headers, log=self.log,
                              clock=self.clock)
         self.treq.request.assert_called_once_with(
             method='get', url=self.url, headers=new_headers)
-
-    def test_x_otter_request_id_header_is_preserved_success(self):
-        """
-        If the header `x-otter-request-id` is supplied in the existing headers,
-        it is not replaced and instead is used as the transaction ID in
-        success logging.
-        """
-        headers = {'header1': ['val1'], 'header2': ['val2'],
-                   'x-otter-request-id': ['different_value']}
-        d = logging_treq.request('get', self.url, headers=headers,
-                                 log=self.log, clock=self.clock)
-        self.assertNoResult(d)
-        self.clock.advance(5)
-        self.treq.request.return_value.callback(self.response)
-
-        self.treq.request.assert_called_once_with(
-            method='get', url=self.url, headers=headers)
-        self.assertIs(self.successResultOf(d), self.response)
-        self._assert_success_logging(
-            'get', 204, 5, request_id='different_value')
 
     def test_request_failure(self):
         """
@@ -156,22 +134,6 @@ class LoggingTreqTest(SynchronousTestCase):
 
         self.failureResultOf(d, DummyException)
         self._assert_failure_logging('patch', DummyException, 5)
-
-    def test_x_otter_request_id_header_is_preserved_failure(self):
-        """
-        If the header `x-otter-request-id` is supplied in the existing headers,
-        it is not replaced and instead is used as the transaction ID in
-        success logging.
-        """
-        headers = {'header1': ['val1'], 'header2': ['val2'],
-                   'x-otter-request-id': ['different_value']}
-        d = logging_treq.request('get', self.url, headers=headers,
-                                 log=self.log, clock=self.clock)
-        self.clock.advance(1)
-        self.treq.request.return_value.errback(Failure(DummyException('e')))
-        self.failureResultOf(d, DummyException)
-        self._assert_failure_logging(
-            'get', DummyException, 1, request_id='different_value')
 
     def test_request_timeout(self):
         """

--- a/otter/util/logging_treq.py
+++ b/otter/util/logging_treq.py
@@ -38,9 +38,6 @@ def _log_request(treq_call, url, **kwargs):
                    treq_request_id=treq_transaction)
     start_time = clock.seconds()
 
-    kwargs.setdefault('headers', {})
-    kwargs['headers'].setdefault('x-otter-request-id', [treq_transaction])
-
     log.msg("Request to {method} {url} starting.")
     d = treq_call(url=url, **kwargs)
 

--- a/otter/util/logging_treq.py
+++ b/otter/util/logging_treq.py
@@ -30,8 +30,8 @@ def _log_request(treq_call, url, **kwargs):
     method = kwargs.get('method', treq_call.__name__)
 
     kwargs.setdefault('headers', {})
-    treq_transaction = kwargs['headers'].setdefault('x-otter-request-id',
-                                                    [str(uuid4())])[0]
+    treq_transaction = str(uuid4())
+    kwargs['headers']['x-otter-request-id'] = [treq_transaction]
 
     log = log.bind(system='treq.request', url=url, method=method,
                    url_params=kwargs.get('params'),

--- a/otter/util/logging_treq.py
+++ b/otter/util/logging_treq.py
@@ -29,7 +29,10 @@ def _log_request(treq_call, url, **kwargs):
         log = default_log
     method = kwargs.get('method', treq_call.__name__)
 
-    treq_transaction = str(uuid4())
+    kwargs.setdefault('headers', {})
+    treq_transaction = kwargs['headers'].setdefault('x-otter-request-id',
+                                                    [str(uuid4())])[0]
+
     log = log.bind(system='treq.request', url=url, method=method,
                    url_params=kwargs.get('params'),
                    treq_request_id=treq_transaction)

--- a/otter/util/logging_treq.py
+++ b/otter/util/logging_treq.py
@@ -24,6 +24,7 @@ def _log_request(treq_call, url, **kwargs):
     """
     clock = kwargs.pop('clock', reactor)
     log = kwargs.pop('log', None)
+
     if not log:
         log = default_log
     method = kwargs.get('method', treq_call.__name__)
@@ -33,6 +34,9 @@ def _log_request(treq_call, url, **kwargs):
                    url_params=kwargs.get('params'),
                    treq_request_id=treq_transaction)
     start_time = clock.seconds()
+
+    kwargs.setdefault('headers', {})
+    kwargs['headers'].setdefault('x-otter-request-id', [treq_transaction])
 
     log.msg("Request to {method} {url} starting.")
     d = treq_call(url=url, **kwargs)


### PR DESCRIPTION
This addresses part of #843 and gives us a treq transaction ID to trace additional log messages from `cloud_client` logs, which will be done as part of #1635.