### PR TITLE
Log server create response

### DIFF
--- a/otter/cloud_client.py
+++ b/otter/cloud_client.py
@@ -29,6 +29,7 @@ from txeffect import deferred_performer, perform as twisted_perform
 
 from otter.auth import Authenticate, InvalidateToken, public_endpoint_url
 from otter.constants import ServiceType
+from otter.log.intents import msg as msg_effect
 from otter.util.config import config_value
 from otter.util.http import APIError, append_segments, try_json_with_keys
 from otter.util.http import headers as otter_headers
@@ -322,6 +323,38 @@ def get_cloud_client_dispatcher(reactor, authenticator, log, service_configs):
                              service_configs, throttler),
         _Throttle: _perform_throttle,
     })
+
+
+# ----- Logging responses -----
+
+
+def log_success_response(msg_type, response_body_filter):
+    """
+    :param str msg_type: A string representing the message type of the log
+        message
+    :param callable response_body_filter: A callable that takes a the response
+        body and returns a version of the body that should be logged - this
+        should not mutate the original response body.
+    :return: a function that accepts success result from a `ServiceRequest` and
+        log the response body.  This assumes a JSON response, which is a
+        tuple of (response, response_content).  (non-JSON responses do not
+        currently include the original response)
+    """
+    def _log_it(result):
+        resp, json_body = result
+        # So we can link it to any non-cloud_client logs
+        request_id = resp.request.headers.getRawHeaders(
+            'x-otter-request-id', [None])[0]
+
+        eff = msg_effect(
+            msg_type,
+            method=resp.request.method,
+            url=resp.request.absoluteURI,
+            response_body=json.dumps(response_body_filter(json_body)),
+            request_id=request_id)
+        return eff.on(lambda _: result)
+
+    return _log_it
 
 
 # ----- CLB requests and error parsing -----
@@ -845,9 +878,16 @@ def create_server(server_args):
 
         six.reraise(*api_error_exc_info)
 
+    def _remove_admin_pass_for_logging(response):
+        return {'server': {
+            k: v for k, v in response['server'].items() if k != "adminPass"
+        }}
+
     return (eff
             .on(error=catch(APIError, _parse_known_string_errors))
-            .on(error=_parse_known_json_errors))
+            .on(error=_parse_known_json_errors)
+            .on(log_success_response('request-create-server',
+                                     _remove_admin_pass_for_logging)))
 
 
 _nova_standard_errors = [

--- a/otter/log/spec.py
+++ b/otter/log/spec.py
@@ -33,6 +33,8 @@ msg_types = {
     "mark-dirty-failure": "Failed to mark group {scaling_group_id} dirty",
     "remove-server-clb": ("Removing server {server_id} with IP address "
                           "{ip_address} from CLB {clb_id}"),
+    "request-create-server": (
+        "Request to create a server succeeded with response: {response_body}"),
 
     # CF-published log messages
     "cf-add-failure": "Failed to add event to cloud feeds",

--- a/otter/test/test_cloud_client.py
+++ b/otter/test/test_cloud_client.py
@@ -63,10 +63,11 @@ from otter.constants import ServiceType
 from otter.log.intents import Log
 from otter.test.utils import (
     StubResponse,
-    resolve_effect,
-    stub_pure_response,
     nested_sequence,
-    perform_sequence)
+    perform_sequence,
+    resolve_effect,
+    stub_pure_response
+)
 from otter.test.worker.test_launch_server_v1 import fake_service_catalog
 from otter.util.config import set_config_data
 from otter.util.http import APIError, headers

--- a/otter/test/utils.py
+++ b/otter/test/utils.py
@@ -34,6 +34,7 @@ from twisted.application.service import Service
 from twisted.internet import defer
 from twisted.internet.defer import Deferred, maybeDeferred, succeed
 from twisted.python.failure import Failure
+from twisted.web.http_headers import Headers
 
 from zope.interface import directlyProvides, implementer, interface
 from zope.interface.verify import verifyObject
@@ -369,6 +370,15 @@ def mock_log(*args, **kwargs):
     return BoundLog(msg, err)
 
 
+class StubClientRequest(object):
+    """
+    A fake request object attached to a Twisted response object
+    """
+    method = "method"
+    absoluteURI = "original/request/URL"
+    headers = Headers({'x-otter-request-id': ['original-request-id']})
+
+
 class StubResponse(object):
     """
     A fake pre-built Twisted Web Response object.
@@ -376,6 +386,7 @@ class StubResponse(object):
     def __init__(self, code, headers, data=None):
         self.code = code
         self.headers = headers
+        self.request = StubClientRequest()
         # Data is not part of twisted response object
         self._data = data
 


### PR DESCRIPTION
First attempt at logging responses from `cloud_client`, as per #1635.  Also associating these logs by getting the request ID put into the request in #1637.

Does this look like a good place to put the logging?