### PR TITLE
Fix bug where if headers=None is passed, propagating the treq ID fails

### DIFF
--- a/otter/test/test_logging_treq.py
+++ b/otter/test/test_logging_treq.py
@@ -139,7 +139,7 @@ class LoggingTreqTest(SynchronousTestCase):
         """
         A request times out after 45 seconds, and the failure is logged
         """
-        d = logging_treq.request('patch', self.url, data='',
+        d = logging_treq.request('patch', self.url, data='', headers=None,
                                  log=self.log, clock=self.clock)
         self.treq.request.assert_called_once_with(
             method='patch', url=self.url,

--- a/otter/util/logging_treq.py
+++ b/otter/util/logging_treq.py
@@ -30,6 +30,9 @@ def _log_request(treq_call, url, **kwargs):
     method = kwargs.get('method', treq_call.__name__)
 
     kwargs.setdefault('headers', {})
+    if kwargs['headers'] is None:
+        kwargs['headers'] = {}
+
     treq_transaction = str(uuid4())
     kwargs['headers']['x-otter-request-id'] = [treq_transaction]
 


### PR DESCRIPTION
Because 'headers' DOES have a default value it's just None.