### PR TITLE
run all trial tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ SCRIPTSDIR=scripts
 PYDIRS=${CODEDIR} ${SCRIPTSDIR} autoscale_cloudcafe autoscale_cloudroast
 CQLSH ?= $(shell which cqlsh)
 DOCDIR=doc
-UNITTESTS ?= ${CODEDIR}
+UNITTESTS ?= ${CODEDIR}.test
 CASSANDRA_HOST ?= localhost
 export CASSANDRA_HOST
 CASSANDRA_PORT ?= 9160


### PR DESCRIPTION
by making otter.integration.tests a module. Changed the Makefile to make unittests from `otter.test`. This way we can run all trial tests by running `trial otter.integration.tests`