### PR TITLE
rest of group pause implementation

### DIFF
--- a/otter/controller.py
+++ b/otter/controller.py
@@ -119,7 +119,7 @@ def pause_scaling_group(log, transaction_id, scaling_group, dispatcher):
     :return: None
     """
     if not tenant_is_enabled(scaling_group.tenant_id, config_value):
-        raise NotImplementedError("Pause is not yet implemented")
+        raise NotImplementedError("Pause is not implemented for legay groups")
     return perform(dispatcher,
                    conv_pause_group_eff(scaling_group, transaction_id))
 

--- a/otter/controller.py
+++ b/otter/controller.py
@@ -204,10 +204,6 @@ def delete_group(log, trans_id, group, force):
     """
 
     def check_and_delete(_group, state):
-        if state.paused:
-            raise GroupPausedError(
-                _group.tenant_id, _group.uuid, "delete group",
-                "Please use ?force=true to delete paused group")
         if state.desired == 0:
             d = trigger_convergence_deletion(log, group)
             return d.addCallback(lambda _: state)

--- a/otter/integration/tests/test_pause.py
+++ b/otter/integration/tests/test_pause.py
@@ -165,23 +165,3 @@ class PauseTests(unittest.TestCase):
                 "pendingCapacity": Equals(0),
                 "activeCapacity": Equals(0),
                 "desiredCapacity": Equals(0)}))
-
-    @inlineCallbacks
-    def test_delete_paused_group(self):
-        """
-        Deleting a paused group with force=false results in 403
-        """
-        group, _ = self.helper.create_group()
-        yield group.start(self.rcs, self)
-        yield group.pause(self.rcs)
-        yield group.delete_scaling_group(self.rcs, "false", [403])
-
-    @inlineCallbacks
-    def test_force_delete_paused_group(self):
-        """
-        Deleting a paused froup with force=true succeeds
-        """
-        group, _ = self.helper.create_group()
-        yield group.start(self.rcs, self)
-        yield group.pause(self.rcs)
-        yield group.delete_scaling_group(self.rcs, "true")

--- a/otter/integration/tests/test_pause.py
+++ b/otter/integration/tests/test_pause.py
@@ -35,8 +35,6 @@ class PauseTests(unittest.TestCase):
     Tests for `../groups/groupId/pause` endpoint
     """
 
-    skip = "Until #1604 is implemented"
-
     def setUp(self):
         self.helper = TestHelper(self)
         self.rcs = TestResources()

--- a/otter/rest/application.py
+++ b/otter/rest/application.py
@@ -28,6 +28,8 @@ class Otter(object):
         self.health_check_function = health_check_function
         self.scheduler = None
         self.treq = _treq
+        # Effect dispatcher for all otter intents
+        self.dispatcher = None
 
     @app.route('/', methods=['GET'])
     def base(self, request):
@@ -57,15 +59,15 @@ class Otter(object):
         """
         group routes delegated to OtterGroups.
         """
-        return OtterGroups(self.store, tenant_id).app.resource()
+        return OtterGroups(
+            self.store, tenant_id, self.dispatcher).app.resource()
 
-    @app.route('/v1.0/execute/<string:capability_version>/<string:capability_hash>/')
-    def execute(self, request, capability_version, capability_hash):
+    @app.route('/v1.0/execute/<string:cap_version>/<string:cap_hash>/')
+    def execute(self, request, cap_version, cap_hash):
         """
         execute route handled by OtterExecute
         """
-        return OtterExecute(self.store, capability_version,
-                            capability_hash).app.resource()
+        return OtterExecute(self.store, cap_version, cap_hash).app.resource()
 
     @app.route('/v1.0/<string:tenant_id>/limits')
     def limits(self, request, tenant_id):

--- a/otter/rest/errors.py
+++ b/otter/rest/errors.py
@@ -4,17 +4,15 @@ Errors mapped to http status codes in the rest module
 
 from jsonschema import ValidationError
 
-from otter.controller import CannotExecutePolicyError
-from otter.supervisor import ServerNotFoundError, CannotDeleteServerBelowMinError
-
+from otter.controller import CannotExecutePolicyError, GroupPausedError
 from otter.models.interface import (
-    GroupNotEmptyError, NoSuchScalingGroupError,
-    NoSuchPolicyError, NoSuchWebhookError, ScalingGroupOverLimitError,
-    WebhooksOverLimitError, PoliciesOverLimitError)
-
-from otter.worker.validate_config import InvalidLaunchConfiguration
-
+    GroupNotEmptyError, NoSuchPolicyError, NoSuchScalingGroupError,
+    NoSuchWebhookError, PoliciesOverLimitError,
+    ScalingGroupOverLimitError, WebhooksOverLimitError)
 from otter.rest.decorators import InvalidJsonError, InvalidQueryArgument
+from otter.supervisor import (
+    CannotDeleteServerBelowMinError, ServerNotFoundError)
+from otter.worker.validate_config import InvalidLaunchConfiguration
 
 
 class InvalidMinEntities(Exception):
@@ -32,6 +30,7 @@ exception_codes = {
     NoSuchWebhookError: 404,
     ServerNotFoundError: 404,
     GroupNotEmptyError: 403,
+    GroupPausedError: 403,
     CannotDeleteServerBelowMinError: 403,
     CannotExecutePolicyError: 403,
     InvalidQueryArgument: 400,

--- a/otter/rest/groups.py
+++ b/otter/rest/groups.py
@@ -11,6 +11,7 @@ from twisted.internet.defer import gatherResults, succeed
 from txeffect import perform
 
 from otter import controller
+from otter.controller import GroupPausedError
 from otter.convergence.composition import tenant_is_enabled
 from otter.convergence.service import get_convergence_starter
 from otter.effect_dispatcher import get_working_cql_dispatcher
@@ -120,11 +121,12 @@ class OtterGroups(object):
     """
     app = OtterApp()
 
-    def __init__(self, store, tenant_id):
+    def __init__(self, store, tenant_id, dispatcher):
         self.log = log.bind(system='otter.rest.groups',
                             tenant_id=tenant_id)
         self.store = store
         self.tenant_id = tenant_id
+        self.dispatcher = dispatcher
 
     @app.route('/', methods=['GET'])
     @with_transaction_id()
@@ -449,7 +451,8 @@ class OtterGroups(object):
         Routes requiring a specific group_id are delegated to
         OtterGroup.
         """
-        return OtterGroup(self.store, self.tenant_id, group_id).app.resource()
+        return OtterGroup(self.store, self.tenant_id,
+                          group_id, self.dispatcher).app.resource()
 
 
 def get_active_cache(reactor, connection, tenant_id, group_id):
@@ -468,13 +471,14 @@ class OtterGroup(object):
     """
     app = OtterApp()
 
-    def __init__(self, store, tenant_id, group_id):
+    def __init__(self, store, tenant_id, group_id, dispatcher):
         self.log = log.bind(system='otter.rest.group',
                             tenant_id=tenant_id,
                             scaling_group_id=group_id)
         self.store = store
         self.tenant_id = tenant_id
         self.group_id = group_id
+        self.dispatcher = dispatcher
 
     def with_active_cache(self, get_func, *args, **kwargs):
         """
@@ -659,10 +663,20 @@ class OtterGroup(object):
         """
         Trigger convergence on given scaling group
         """
+
+        def is_group_paused(group, state):
+            if state.paused:
+                raise GroupPausedError(group.tenant_id, group.uuid, "converge")
+            return state
+
         if tenant_is_enabled(self.tenant_id, config_value):
+            group = self.store.get_scaling_group(
+                self.log, self.tenant_id, self.group_id)
             cs = get_convergence_starter()
-            return cs.start_convergence(self.log, self.tenant_id,
-                                        self.group_id)
+            d = group.modify_state(is_group_paused)
+            return d.addCallback(
+                lambda _: cs.start_convergence(self.log, self.tenant_id,
+                                               self.group_id))
         else:
             request.setResponseCode(404)
 
@@ -679,7 +693,7 @@ class OtterGroup(object):
         group = self.store.get_scaling_group(
             self.log, self.tenant_id, self.group_id)
         return controller.pause_scaling_group(
-            self.log, transaction_id(request), group)
+            self.log, transaction_id(request), group, self.dispatcher)
 
     @app.route('/resume/', methods=['POST'])
     @with_transaction_id()

--- a/otter/tap/api.py
+++ b/otter/tap/api.py
@@ -280,6 +280,8 @@ def makeService(config):
             scheduler = setup_scheduler(s, store, kz_client)
             health_checker.checks['scheduler'] = scheduler.health_check
             otter.scheduler = scheduler
+            # Give dispatcher to Otter REST object
+            otter.dispatcher = dispatcher
             # Set the client after starting
             # NOTE: There is small amount of time when the start is
             # not finished and the kz_client is not set in which case

--- a/otter/test/rest/request.py
+++ b/otter/test/rest/request.py
@@ -298,7 +298,8 @@ class RestAPITestMixin(RequestTestMixin):
                 modifier, self.mock_group, self.mock_state, *args, **kwargs)
 
         self.mock_group.modify_state.side_effect = _mock_modify_state
-        self.root = Otter(self.mock_store, 'ord').app.resource()
+        self.otter = Otter(self.mock_store, 'ord')
+        self.root = self.otter.app.resource()
 
         # set pagination limits as it'll be used by all rest interfaces
         set_config_data({'limits': {'pagination': 100}, 'url_root': ''})

--- a/otter/test/tap/test_api.py
+++ b/otter/test/tap/test_api.py
@@ -678,6 +678,9 @@ class APIMakeServiceTests(SynchronousTestCase):
 
         dispatcher = mock_setup_converger.call_args[0][2]
 
+        # Check dispatcher is set in otter object
+        self.assertIs(self.Otter.return_value.dispatcher, dispatcher)
+
         for intent in full_intents():
             self.assertIsNot(dispatcher(intent), None)
 

--- a/otter/test/test_controller.py
+++ b/otter/test/test_controller.py
@@ -5,6 +5,7 @@ from datetime import datetime, timedelta
 
 from effect import (
     ComposedDispatcher,
+    Effect,
     sync_perform)
 from effect.testing import SequenceDispatcher
 
@@ -24,7 +25,8 @@ from otter.cloud_client import (
 from otter.convergence.model import DRAINING_METADATA
 from otter.convergence.service import (
     ConvergenceStarter, get_convergence_starter, set_convergence_starter)
-from otter.models.intents import GetScalingGroupInfo
+from otter.log.intents import BoundFields, Log
+from otter.models.intents import GetScalingGroupInfo, ModifyGroupStatePaused
 from otter.models.interface import (
     GroupNotEmptyError, GroupState, IScalingGroup, NoSuchPolicyError,
     NoSuchScalingGroupError, ScalingGroupStatus)
@@ -37,8 +39,11 @@ from otter.test.utils import (
     matches,
     mock_group as util_mock_group,
     mock_log,
+    nested_parallel,
     nested_sequence,
+    noop,
     patch,
+    perform_sequence,
     raise_,
     test_dispatcher)
 from otter.util.config import set_config_data
@@ -46,7 +51,61 @@ from otter.util.fp import assoc_obj
 from otter.util.retry import (
     Retry, ShouldDelayAndRetry, exponential_backoff_interval, retry_times)
 from otter.util.timestamp import MIN
+from otter.util.zk import DeleteNode
 from otter.worker_intents import EvictServerFromScalingGroup
+
+
+class PauseGroupTests(SynchronousTestCase):
+    """
+    Tests for `conv_pause_group_eff`
+    """
+
+    def setUp(self):
+        self.group = util_mock_group(sample_group_state(), "tid", "gid")
+        self.log = mock_log()
+
+    def test_conv_pause_group_eff(self):
+        """
+        `conv_pause_group_eff` returns effect that modifies group state paused
+        and deletes divergent flag with bound log context
+        """
+        eff = controller.conv_pause_group_eff(self.group, "transid")
+        seq = [
+            (BoundFields(mock.ANY, dict(transaction_id="transid",
+                                        tenant_id="tid",
+                                        scaling_group_id="gid")),
+             nested_sequence([
+                 nested_parallel([
+                     (ModifyGroupStatePaused(self.group, True), noop),
+                     (DeleteNode(path="/groups/divergent/tid_gid", version=-1),
+                      noop),
+                     (Log("mark-clean-success", {}), noop)
+                 ])
+             ]))
+        ]
+        self.assertEqual(perform_sequence(seq, eff), None)
+
+    @mock.patch("otter.controller.conv_pause_group_eff",
+                return_value=Effect("pause"))
+    def test_pause_group_conv(self, mock_cpge):
+        """
+        `pause_scaling_group` performs effect got from conv_pause_group_eff
+        for convergence tenants
+        """
+        set_config_data({"convergence-tenants": ["tid"]})
+        self.addCleanup(set_config_data, None)
+        dispatcher = SequenceDispatcher([("pause", lambda i: "paused")])
+        d = controller.pause_scaling_group(
+            self.log, "transid", self.group, dispatcher)
+        self.assertEqual(self.successResultOf(d), "paused")
+
+    def test_pause_group_worker(self):
+        """
+        `pause_scaling_group` is not implemented for worker tenants
+        """
+        self.assertRaises(
+            NotImplementedError, controller.pause_scaling_group, self.log,
+            "transid", self.group, object())
 
 
 class CalculateDeltaTestCase(SynchronousTestCase):
@@ -844,19 +903,29 @@ class DeleteGroupTests(SynchronousTestCase):
         # converger not called
         self.assertFalse(self.mock_tcd.called)
 
-    def test_convergence_tenant_force(self):
+    def setup_conv(self):
+        set_config_data({'convergence-tenants': ['tid']})
+        self.addCleanup(set_config_data, {})
+        self.mock_tcd.return_value = defer.succeed('tcd')
+
+    def test_convergence_tenant_force(self, paused=False):
         """
         Updates DELETED status for convergence tenant and starts convergence
         """
-        set_config_data({'convergence-tenants': ['tid']})
-        self.addCleanup(set_config_data, {})
-
-        self.mock_tcd.return_value = defer.succeed('tcd')
+        self.setup_conv()
+        self.state.paused = paused
         d = controller.delete_group(self.log, 'transid', self.group, True)
         self.assertEqual(self.successResultOf(d), 'tcd')
         # delete_group() or modify_state() not called
         self.assertFalse(self.group.delete_group.called)
         self.assertFalse(self.group.modify_state.called)
+
+    def test_convergence_tenant_force_group_paused(self):
+        """
+        Updates DELETED status for convergence tenant and starts convergence
+        even if group is paused
+        """
+        self.test_convergence_tenant_force(True)
 
     def test_convergence_tenant_no_force(self):
         """
@@ -864,9 +933,7 @@ class DeleteGroupTests(SynchronousTestCase):
         convergence deletion only if desired=0. This desired check is done
         under lock using `modify_state`
         """
-        set_config_data({'convergence-tenants': ['tid']})
-        self.addCleanup(set_config_data, {})
-        self.mock_tcd.return_value = defer.succeed('tcd')
+        self.setup_conv()
         self.group.pause_modify_state = True
 
         d = controller.delete_group(self.log, 'transid', self.group, False)
@@ -885,21 +952,15 @@ class DeleteGroupTests(SynchronousTestCase):
         # delete_group() not called
         self.assertFalse(self.group.delete_group.called)
 
-    def test_convergence_tenant_no_force_with_servers(self):
+    def assert_raises_in_modify_state(self, excp_type):
         """
-        When deleting convergence group without force, `delete_group` raises
-        `GroupNotEmptyError` if desired > 0. This desired check is done
-        under lock using `modify_state`
+        Assert that given exception occurs inside modify_state
         """
-        set_config_data({'convergence-tenants': ['tid']})
-        self.addCleanup(set_config_data, {})
-        self.mock_tcd.return_value = defer.succeed('tcd')
-        self.state.desired = 1
         self.group.pause_modify_state = True
 
         d = controller.delete_group(self.log, 'transid', self.group, False)
 
-        # trigger_convergence has been called and no result because
+        # trigger_convergence has not been called and no result because
         # modify_state is paused
         self.assertNoResult(d)
         self.assertTrue(self.group.modify_state.called)
@@ -911,10 +972,30 @@ class DeleteGroupTests(SynchronousTestCase):
 
         # unpause modify_state
         self.group.modify_state_pause_d.callback(None)
-        self.failureResultOf(d, GroupNotEmptyError)
+        self.failureResultOf(d, excp_type)
 
         # delete_group() not called
         self.assertFalse(self.group.delete_group.called)
+
+    def test_convergence_tenant_no_force_with_servers(self):
+        """
+        When deleting convergence group without force, `delete_group` raises
+        `GroupNotEmptyError` if desired > 0. This desired check is done
+        under lock using `modify_state`
+        """
+        self.setup_conv()
+        self.state.desired = 1
+        self.assert_raises_in_modify_state(GroupNotEmptyError)
+
+    def test_convergence_tenant_no_force_group_paused(self):
+        """
+        When deleting convergence group without force, `delete_group` raises
+        `GroupPausedError` if group is paused. This check is done
+        under lock using `modify_state`
+        """
+        self.setup_conv()
+        self.state.paused = True
+        self.assert_raises_in_modify_state(controller.GroupPausedError)
 
 
 class EmptyGroupTests(SynchronousTestCase):
@@ -1029,7 +1110,10 @@ class MaybeExecuteScalingPolicyTestCase(SynchronousTestCase):
         """
         self.mocks = mock_controller_utilities(self)
         self.mock_log = mock.MagicMock()
-        self.mock_state = mock_group_state()
+        self.mock_state = GroupState(
+            "tid", "gid", "g", {"a": "a", "b": "b", "c": "c"},
+            {"d": "d", "e": "e"}, None, {}, False, ScalingGroupStatus.ACTIVE,
+            desired=5, now=mock.Mock(return_value="now"))
         self.group = mock_group()
 
     def test_maybe_execute_scaling_policy_no_such_policy(self):
@@ -1050,6 +1134,21 @@ class MaybeExecuteScalingPolicyTestCase(SynchronousTestCase):
 
         self.assertEqual(len(self.group.view_config.mock_calls), 0)
         self.assertEqual(len(self.group.view_launch_config.mock_calls), 0)
+
+    def test_group_paused(self):
+        """
+        Raises `GroupPausedError` if group is paused and does not do anything
+        else
+        """
+        self.mock_state.paused = True
+        self.assertRaises(
+            controller.GroupPausedError,
+            controller.maybe_execute_scaling_policy,
+            self.mock_log, 'transaction', self.group, self.mock_state, 'pol1')
+        # Nothing else is called
+        self.assertFalse(self.group.view_config.called)
+        self.assertFalse(self.group.view_launch_config.called)
+        self.assertEqual(self.mock_state.policy_touched, {})
 
     def test_execute_launch_config_success_on_positive_delta(self):
         """
@@ -1085,7 +1184,7 @@ class MaybeExecuteScalingPolicyTestCase(SynchronousTestCase):
             self.mocks['calculate_delta'].return_value)
 
         # state should have been updated
-        self.mock_state.mark_executed.assert_called_once_with('pol1')
+        self.assertEqual(self.mock_state.policy_touched["pol1"], "now")
 
     def test_execute_launch_config_failure_on_positive_delta(self):
         """
@@ -1119,7 +1218,7 @@ class MaybeExecuteScalingPolicyTestCase(SynchronousTestCase):
             self.mocks['calculate_delta'].return_value)
 
         # state should not have been updated
-        self.assertEqual(self.mock_state.mark_executed.call_count, 0)
+        self.assertEqual(self.mock_state.policy_touched, {})
 
     def test_maybe_execute_scaling_policy_cooldown_failure(self):
         """
@@ -1143,7 +1242,7 @@ class MaybeExecuteScalingPolicyTestCase(SynchronousTestCase):
         self.assertEqual(self.mocks['execute_launch_config'].call_count, 0)
 
         # state should not have been updated
-        self.assertEqual(self.mock_state.mark_executed.call_count, 0)
+        self.assertEqual(self.mock_state.policy_touched, {})
 
     def test_maybe_execute_scaling_policy_zero_delta(self):
         """
@@ -1193,7 +1292,7 @@ class MaybeExecuteScalingPolicyTestCase(SynchronousTestCase):
             len(self.mocks['execute_launch_config'].mock_calls), 0)
 
         # state should have been updated
-        self.mock_state.mark_executed.assert_called_once_with('pol1')
+        self.assertEqual(self.mock_state.policy_touched["pol1"], "now")
 
     def test_audit_log_events_logged_on_positive_delta(self):
         """
@@ -1206,11 +1305,12 @@ class MaybeExecuteScalingPolicyTestCase(SynchronousTestCase):
                                                     'pol1')
         self.assertEqual(self.successResultOf(d), self.mock_state)
         log.msg.assert_called_with(
-            'Starting {convergence_delta} new servers to satisfy desired capacity',
-            scaling_group_id=self.group.uuid, event_type="convergence.scale_up",
-            convergence_delta=5, desired_capacity=5, pending_capacity=2,
-            active_capacity=3, audit_log=True, policy_id=None,
-            webhook_id=None)
+            ('Starting {convergence_delta} new servers to satisfy '
+             'desired capacity'),
+            scaling_group_id=self.group.uuid,
+            event_type="convergence.scale_up", convergence_delta=5,
+            desired_capacity=5, pending_capacity=2, current_capacity=3,
+            audit_log=True, policy_id=None, webhook_id=None)
 
     def test_audit_log_events_logged_on_negative_delta(self):
         """
@@ -1224,9 +1324,10 @@ class MaybeExecuteScalingPolicyTestCase(SynchronousTestCase):
         self.assertEqual(self.successResultOf(d), self.mock_state)
         log.msg.assert_called_with(
             'Deleting 5 servers to satisfy desired capacity',
-            scaling_group_id=self.group.uuid, event_type="convergence.scale_down",
+            scaling_group_id=self.group.uuid,
+            event_type="convergence.scale_down",
             convergence_delta=-5, desired_capacity=5, pending_capacity=2,
-            active_capacity=3, audit_log=True, policy_id=None,
+            current_capacity=3, audit_log=True, policy_id=None,
             webhook_id=None)
 
 


### PR DESCRIPTION
Final PR of #1640. Please review this after merging #1643 and #1644. This does following:

- pausing the group by updating group state paused and deleting divergent flag
- returning 403 on REST APIs that should not execute on paused group