### PR TITLE
Skip test scaling

### DIFF
--- a/otter/integration/tests/test_scaling.py
+++ b/otter/integration/tests/test_scaling.py
@@ -18,6 +18,9 @@ from otter.integration.lib.identity import IdentityV2
 from otter.integration.lib.resources import TestResources
 
 
+skip = "This module needs maintenance before being run."
+
+
 username = os.environ['AS_USERNAME']
 password = os.environ['AS_PASSWORD']
 endpoint = os.environ['AS_IDENTITY']


### PR DESCRIPTION
Skip this test for now while we decide whether this should be fixed up or removed (since there is cloudcafe coverage for scaling up and down)