### PR TITLE
Add an argument to logging-treq to log responses for tests

### DIFF
--- a/otter/test/test_logging_treq.py
+++ b/otter/test/test_logging_treq.py
@@ -99,20 +99,6 @@ class LoggingTreqTest(SynchronousTestCase):
         self.assertIs(self.successResultOf(d), self.response)
         self._assert_success_logging('patch', 204, 5)
 
-    def test_request_with_response_logging(self):
-        """
-        On a successful request with response logging turned on, response is
-        returned and request with body is logged.
-        """
-        self.treq.request.return_value.callback(self.response)
-        self.treq.content.return_value = succeed("this is the body")
-
-        d = logging_treq.request('patch', self.url, headers={}, data='',
-                                 log=self.log, clock=self.clock,
-                                 log_response=True)
-        self.assertIs(self.successResultOf(d), self.response)
-        self._assert_success_logging('patch', 204, 0, body='this is the body')
-
     def test_url_params(self):
         """`params` is logged as `url_params`."""
         params = {'key': 'val'}
@@ -174,9 +160,24 @@ class LoggingTreqTest(SynchronousTestCase):
         self.failureResultOf(d, TimedOutError)
         self._assert_failure_logging('patch', TimedOutError, 45)
 
+    def test_request_with_response_logging(self):
+        """
+        On a successful request with response logging turned on, response is
+        returned and request with body is logged.
+        """
+        self.treq.request.return_value.callback(self.response)
+        self.treq.content.return_value = succeed("this is the body")
+
+        ltreq = logging_treq.LoggingTreq(log_response=True)
+        d = ltreq.request('patch', self.url, headers={}, data='',
+                          log=self.log, clock=self.clock)
+        self.assertIs(self.successResultOf(d), self.response)
+        self._assert_success_logging('patch', 204, 0, body='this is the body')
+
     def _test_method_success(self, method):
         """
-        On successful call to ``method``, response is returned and request logged
+        On successful call to ``method``, response is returned and request
+        logged.
         """
         request_function = getattr(logging_treq, method)
         d = request_function(url=self.url, headers={}, data='', log=self.log,

--- a/otter/util/logging_treq.py
+++ b/otter/util/logging_treq.py
@@ -2,7 +2,10 @@
 A wrapper around treq to log all requests along with the status code and time
 it took.
 """
+from functools import wraps
 from uuid import uuid4
+
+import attr
 
 import treq
 
@@ -12,143 +15,137 @@ from otter.log import log as default_log
 from otter.util.deferredutils import timeout_deferred
 
 
-def _log_request(treq_call, url, **kwargs):
+_treq_request_methods = ('get', 'head', 'post', 'put', 'delete',
+                         'patch', 'request')
+
+
+@attr.s
+class LoggingTreq(object):
     """
-    Log a treq request, including the time it took and the status code.
+    A class that wraps treq and calls all of its request methods and logs
+    the request and the response, including the time the request took to
+    finish.
 
-    :param callable f: a ``treq`` request method, such as ``treq.request``, or
-        ``treq.get``, ``treq.post``, etc.
-    :param log: If provided, an instance of BoundLog.
-        Defaults to ``otter.log.default_log`` if not provided.
-    :type log: BoundLog or None.
-
-    Supported non-treq keyword arguments::
-
-    - ``clock`` - a reactor to use for timing requests - will use the default
+    :ivar clock: - a reactor to use for timing requests - will use the default
         reactor if not provided.
-    - ``log`` - a BoundLog instance - will use the default BoundLog instance
+    :ivar log: - a BoundLog instance - will use the default BoundLog instance
         in :obj:`otter.log` if not provided.
-    - ``log_response`` - a boolean as to whether or not the response bodies
+    :ivar log_response: - a boolean as to whether or not the response bodies
         should be logged as bytes.  Defaults to False, because this can be
         dangerous as it may log secret information such as admin passwords.
-
-    Note that the `headers` are modified to include a treq-specific request ID.
     """
-    clock = kwargs.pop('clock', reactor)
-    log = kwargs.pop('log', None)
-    log_response = kwargs.pop('log_response', False)
+    clock = attr.ib(default=reactor)
+    log = attr.ib(default=default_log)
+    log_response = attr.ib(default=False)
+    pool = attr.ib(default=None)
 
-    if not log:
-        log = default_log
-    method = kwargs.get('method', treq_call.__name__)
+    def request(self, method, url, **kwargs):
+        """Wrapper around :py:func:`treq.request` that logs the request."""
+        return self.log_request(treq.request)(url, method=method, **kwargs)
 
-    kwargs.setdefault('headers', {})
-    if kwargs['headers'] is None:
-        kwargs['headers'] = {}
+    def head(self, url, headers=None, **kwargs):
+        """Wrapper around :py:func:`treq.head` that logs the request."""
+        return self.log_request(treq.head)(url, headers=headers, **kwargs)
 
-    treq_transaction = str(uuid4())
-    kwargs['headers']['x-otter-request-id'] = [treq_transaction]
+    def get(self, url, headers=None, **kwargs):
+        """Wrapper around :py:func:`treq.get` that logs the request."""
+        return self.log_request(treq.get)(url, headers=headers, **kwargs)
 
-    log = log.bind(system='treq.request', url=url, method=method,
-                   url_params=kwargs.get('params'),
-                   treq_request_id=treq_transaction)
-    start_time = clock.seconds()
+    def post(self, url, data=None, **kwargs):
+        """Wrapper around :py:func:`treq.post` that logs the request."""
+        return self.log_request(treq.post)(url, data=data, **kwargs)
 
-    log.msg("Request to {method} {url} starting.")
-    d = treq_call(url=url, **kwargs)
+    def put(self, url, data=None, **kwargs):
+        """Wrapper around :py:func:`treq.put` that logs the request."""
+        return self.log_request(treq.put)(url, data=data, **kwargs)
 
-    timeout_deferred(d, 45, clock)
+    def patch(self, url, data=None, **kwargs):
+        """Wrapper around :py:func:`treq.patch` that logs the request."""
+        return self.log_request(treq.patch)(url, data=data, **kwargs)
 
-    def log_request(response):
-        kwargs = {'request_time': clock.seconds() - start_time,
-                  'status_code': response.code,
-                  'headers': response.headers}
-        message = (
-            "Request to {method} {url} resulted in a {status_code} response "
-            "after {request_time} seconds.")
+    def delete(self, url, **kwargs):
+        """Wrapper around :py:func:`treq.delete` that logs the request."""
+        return self.log_request(treq.delete)(url, **kwargs)
 
-        if log_response:
-            return (
-                treq.content(response)
-                .addCallback(
-                    lambda b: log.msg(message, response_body=b, **kwargs))
-                .addCallback(lambda _: response))
+    def log_request(self, treq_call):
+        """
+        A decorator around a treq request that logs information.
 
-        log.msg(message, **kwargs)
-        return response
+        Supported non-treq keyword arguments::
 
-    def log_failure(failure):
-        request_time = clock.seconds() - start_time
-        log.msg("Request to {method} {url} failed after {request_time} "
-                "seconds.",
-                reason=failure, request_time=request_time)
-        return failure
+        - ``clock`` - a reactor to use for timing requests - will use the
+            default reactor if not provided.
+        - ``log`` - a BoundLog instance - will use the default BoundLog
+            instance in :obj:`otter.log` if not provided.
 
-    return d.addCallbacks(log_request, log_failure)
+        Note that the `headers` are modified to include a treq-specific request
+        ID.
+        """
+        @wraps(treq_call)
+        def wrapper(url, **kwargs):
+            clock = kwargs.pop('clock', self.clock)
+            log = kwargs.pop('log', self.log)
 
+            method = kwargs.get('method', treq_call.__name__)
 
-def request(method, url, **kwargs):
-    """
-    Wrapper around :meth:`treq.request` that logs the request.
+            kwargs.setdefault('headers', {})
+            if kwargs['headers'] is None:
+                kwargs['headers'] = {}
 
-    See :py:func:`treq.request`
-    """
-    return _log_request(treq.request, url, method=method, **kwargs)
+            treq_transaction = str(uuid4())
+            kwargs['headers']['x-otter-request-id'] = [treq_transaction]
 
+            log = log.bind(system='treq.request', url=url, method=method,
+                           url_params=kwargs.get('params'),
+                           treq_request_id=treq_transaction)
+            start_time = clock.seconds()
 
-def head(url, headers=None, **kwargs):
-    """
-    Wrapper around :meth:`treq.head` that logs the request.
+            log.msg("Request to {method} {url} starting.")
+            d = treq_call(url=url, **kwargs)
 
-    See :py:func:`treq.head`
-    """
-    return _log_request(treq.head, url, headers=headers, **kwargs)
+            timeout_deferred(d, 45, clock)
 
+            def log_request(response):
+                kwargs = {'request_time': clock.seconds() - start_time,
+                          'status_code': response.code,
+                          'headers': response.headers}
+                message = (
+                    "Request to {method} {url} resulted in a {status_code} "
+                    "response after {request_time} seconds.")
 
-def get(url, headers=None, **kwargs):
-    """
-    Wrapper around :meth:`treq.get` that logs the request.
+                if self.log_response:
+                    return (
+                        treq.content(response)
+                        .addCallback(
+                            lambda b: log.msg(message, response_body=b,
+                                              **kwargs))
+                        .addCallback(lambda _: response))
 
-    See :py:func:`treq.get`
-    """
-    return _log_request(treq.get, url, headers=headers, **kwargs)
+                log.msg(message, **kwargs)
+                return response
 
+            def log_failure(failure):
+                request_time = clock.seconds() - start_time
+                log.msg("Request to {method} {url} failed after "
+                        "{request_time} seconds.",
+                        reason=failure, request_time=request_time)
+                return failure
 
-def post(url, data=None, **kwargs):
-    """
-    Wrapper around :meth:`treq.post` that logs the request.
-
-    See :py:func:`treq.post`
-    """
-    return _log_request(treq.post, url, data=data, **kwargs)
-
-
-def put(url, data=None, **kwargs):
-    """
-    Wrapper around :meth:`treq.put` that logs the request.
-
-    See :py:func:`treq.put`
-    """
-    return _log_request(treq.put, url, data=data, **kwargs)
-
-
-def patch(url, data=None, **kwargs):
-    """
-    Wrapper around :meth:`treq.patch` that logs the request.
-
-    See :py:func:`treq.patch`
-    """
-    return _log_request(treq.patch, url, data=data, **kwargs)
+            return d.addCallbacks(log_request, log_failure)
+        return wrapper
 
 
-def delete(url, **kwargs):
-    """
-    Wrapper around :meth:`treq.delete` that logs the request.
+_logging_treq = LoggingTreq()
 
-    See :py:func:`treq.delete`
-    """
-    return _log_request(treq.delete, url, **kwargs)
 
+# these methods just wrap logging_treq
+request = _logging_treq.request
+head = _logging_treq.head
+get = _logging_treq.get
+post = _logging_treq.post
+put = _logging_treq.put
+patch = _logging_treq.patch
+delete = _logging_treq.delete
 
 json_content = treq.json_content
 content = treq.content


### PR DESCRIPTION
This is intended to be used only for the trial tests, because it doesn't do any filtering, and I didn't want to write a different logging treq just for the tests.

The otter codebase will just log responses in the `cloud_client.py`.

I moved most of the `logging_treq` logic into an object because I wanted to be able to pass around a treq with the log-type arguments already bound in the trial tests.