### PR TITLE
Add another file log observer for the trial tests

### DIFF
--- a/otter/integration/lib/trial_tools.py
+++ b/otter/integration/lib/trial_tools.py
@@ -112,13 +112,13 @@ def filter_logs(observer):
     Filter out logs like
     "Starting factory <twisted.web.client_HTTP11ClientFactory".
     """
-    def filter(eventdict):
+    def emit(eventdict):
         if ('message' not in eventdict or
                 all([not m.startswith("Starting factory") and
                      not m.startswith("Stopping factory")
                      for m in eventdict['message']])):
             observer(eventdict)
-    return filter
+    return emit
 
 
 def pretty_print_logs(observer):

--- a/otter/integration/lib/trial_tools.py
+++ b/otter/integration/lib/trial_tools.py
@@ -150,7 +150,7 @@ def setup_test_log_observer(testcase):
     file for the duration of the test.  Also cleans up the observer and the
     temp file object after the test is over.
     """
-    logfile = open(testcase.mktemp(), 'wb')
+    logfile = open("{0}.log".format(testcase.id()), 'ab')
     observer = copying_wrapper(
         PEP3101FormattingWrapper(
             ErrorFormattingWrapper(


### PR DESCRIPTION
There is currently no good way to replace the log observer that trial uses, because I think we'd have to get ahold of the current instance of the tests (I'm sure we can do this from a test module), obtain its observer, remove it from the global log publisher, and then replace it with our own.

For less grossness, I'm just adding a log observer at the start of every test that writes to a file, and closing it after the test.

So the `_trial_temp` directory will look like:

```
_trial_temp
\_ #                               <-- process number when running with -j#
   \_ test.log                     <-- where normal trial logs go
   \_ test_module_name.TestCaseName.test_method_name1.log
   \_ test_module_name.TestCaseName.test_method_name2.log
```

The logs we write are all in separate files, because for some reason the test name demarcation that appears in `test.log` doesn't seem to appear in our logs.

Part of #1619 