### PR TITLE
use uuid4() instead of uuid1() for converger run id

### DIFF
--- a/otter/convergence/service.py
+++ b/otter/convergence/service.py
@@ -595,7 +595,7 @@ class Converger(MultiService):
         """
         Return Effect wrapped with converger_run_id log field
         """
-        return Effect(Func(uuid.uuid1)).on(str).on(
+        return Effect(Func(uuid.uuid4)).on(str).on(
             lambda uid: with_log(eff, otter_service='converger',
                                  converger_run_id=uid))
 

--- a/otter/test/convergence/test_service.py
+++ b/otter/test/convergence/test_service.py
@@ -114,10 +114,10 @@ class ConvergerTests(SynchronousTestCase):
         return self.fake_partitioner
 
     def _log_sequence(self, intents):
-        uid = uuid.uuid1()
+        uid = uuid.uuid4()
         exp_uid = str(uid)
         return SequenceDispatcher([
-            (Func(uuid.uuid1), lambda i: uid),
+            (Func(uuid.uuid4), lambda i: uid),
             (BoundFields(effect=mock.ANY,
                          fields={'otter_service': 'converger',
                                  'converger_run_id': exp_uid}),


### PR DESCRIPTION
because that is more random making it more easier to debug with.