### PR TITLE
Inject a logging treq into all the trial integration test calls.

### DIFF
--- a/otter/integration/lib/trial_tools.py
+++ b/otter/integration/lib/trial_tools.py
@@ -39,6 +39,10 @@ from otter.integration.lib.nova import (
     wait_for_servers
 )
 
+from otter.log import log
+
+from otter.util.logging_treq import LoggingTreq
+
 
 username = os.environ['AS_USERNAME']
 password = os.environ['AS_PASSWORD']
@@ -115,9 +119,10 @@ class TestHelper(object):
         """
         self.test_case = test_case
         self.pool = HTTPConnectionPool(reactor, False)
+        self.treq = LoggingTreq(log=log, log_response=True)
         self.test_case.addCleanup(self.pool.closeCachedConnections)
 
-        self.clbs = [CloudLoadBalancer(pool=self.pool)
+        self.clbs = [CloudLoadBalancer(pool=self.pool, treq=self.treq)
                      for _ in range(num_clbs)]
 
     def create_group(self, **kwargs):
@@ -142,6 +147,7 @@ class TestHelper(object):
         return (
             ScalingGroup(
                 group_config=create_scaling_group_dict(**kwargs),
+                treq=self.treq,
                 pool=self.pool),
             server_name_prefix)
 

--- a/otter/integration/tests/test_lbsh.py
+++ b/otter/integration/tests/test_lbsh.py
@@ -113,7 +113,8 @@ class TestLoadBalancerSelfHealing(unittest.TestCase):
         # Create another loadbalancer not to be used in autoscale
         # The CLB will not be added to the helper, since when the helper
         # creates a group, it automatically adds the clb
-        clb_other = CloudLoadBalancer(pool=self.helper.pool)
+        clb_other = CloudLoadBalancer(pool=self.helper.pool,
+                                      treq=self.helper.treq)
 
         yield clb_other.start(self.rcs, self)
         yield clb_other.wait_for_state(
@@ -187,7 +188,8 @@ class TestLoadBalancerSelfHealing(unittest.TestCase):
         # Create another loadbalancer not to be used in autoscale
         # The CLB will not be added to the helper, since when the helper
         # creates a group, it automatically adds the clb
-        clb_other = CloudLoadBalancer(pool=self.helper.pool)
+        clb_other = CloudLoadBalancer(pool=self.helper.pool,
+                                      treq=self.helper.treq)
 
         yield clb_other.start(self.rcs, self)
         yield clb_other.wait_for_state(

--- a/otter/test/test_logging_treq.py
+++ b/otter/test/test_logging_treq.py
@@ -338,3 +338,18 @@ class LoggingTreqTest(SynchronousTestCase):
         On timed out call to delete, failure is returned and request logged
         """
         self._test_method_timeout('delete')
+
+    def test_contents(self):
+        """
+        ``content``, ``json_content``, and ``text_content`` are just directly
+        mapped to treq.
+        """
+        ltreq_instance = logging_treq.LoggingTreq()
+        for name in ('content', 'json_content', 'text_content'):
+            for obj in (ltreq_instance, logging_treq):
+                # patching won't change things that were defined at import time
+                expected = (getattr(self.treq, name), getattr(treq, name))
+                actual = getattr(obj, name)
+                self.assertIn(actual, expected,
+                              "{0}.{1} ({2}) is not treq.{1} ({3} or {4})"
+                              .format(obj.__name__, name, actual, *expected))

--- a/otter/test/test_logging_treq.py
+++ b/otter/test/test_logging_treq.py
@@ -339,17 +339,32 @@ class LoggingTreqTest(SynchronousTestCase):
         """
         self._test_method_timeout('delete')
 
-    def test_contents(self):
+    def test_module_contents_mapped_to_treq_contents(self):
         """
         ``content``, ``json_content``, and ``text_content`` are just directly
-        mapped to treq.
+        mapped to treq.  Not the patched treq, because the functions are
+        already assigned at import time, and thus patching treq won't
+        reassign these module attributes.
+        """
+        for name in ('content', 'json_content', 'text_content'):
+            expected = getattr(treq, name)
+            actual = getattr(logging_treq, name)
+            self.assertIs(actual, expected,
+                          "{0}.{1} ({2}) is not treq.{1} ({3})"
+                          .format(logging_treq.__name__, name, actual,
+                                  expected))
+
+    def test_new_logging_treq_contents_mapped_to_treq_contents(self):
+        """
+        ``content``, ``json_content``, and ``text_content`` of a newly created
+        LoggingTreq instance are just directly mapped to the patched treq
+        functions..
         """
         ltreq_instance = logging_treq.LoggingTreq()
         for name in ('content', 'json_content', 'text_content'):
-            for obj in (ltreq_instance, logging_treq):
-                # patching won't change things that were defined at import time
-                expected = (getattr(self.treq, name), getattr(treq, name))
-                actual = getattr(obj, name)
-                self.assertIn(actual, expected,
-                              "{0}.{1} ({2}) is not treq.{1} ({3} or {4})"
-                              .format(obj.__name__, name, actual, *expected))
+            expected = getattr(self.treq, name)
+            actual = getattr(ltreq_instance, name)
+            self.assertIs(actual, expected,
+                          "{0}.{1} ({2}) is not treq.{1} ({3})"
+                          .format(ltreq_instance.__name__, name, actual,
+                                  expected))

--- a/otter/util/logging_treq.py
+++ b/otter/util/logging_treq.py
@@ -37,7 +37,12 @@ class LoggingTreq(object):
     clock = attr.ib(default=reactor)
     log = attr.ib(default=default_log)
     log_response = attr.ib(default=False)
-    pool = attr.ib(default=None)
+
+    def __getattr__(self, name):
+        """
+        Handle anything else that should be on treq.
+        """
+        return getattr(treq, name)
 
     def request(self, method, url, **kwargs):
         """Wrapper around :py:func:`treq.request` that logs the request."""


### PR DESCRIPTION
Create a logging treq that also logs the response, and use this treq to do all the trial requests.

(except for auth, which is handled by the otter code, not the trial test code).

Part of #1619 