### PR TITLE
Resume group implementation

### DIFF
--- a/otter/integration/tests/test_pause.py
+++ b/otter/integration/tests/test_pause.py
@@ -23,7 +23,6 @@ from otter.integration.lib.trial_tools import (
     region,
     scheduler_interval,
     skip_if,
-    skip_me,
     sleep
 )
 

--- a/otter/integration/tests/test_pause.py
+++ b/otter/integration/tests/test_pause.py
@@ -31,7 +31,7 @@ from otter.integration.lib.trial_tools import (
 timeout_default = 600
 
 
-class PauseTests(unittest.TestCase):
+class PauseResumeTests(unittest.TestCase):
     """
     Tests for `../groups/groupId/pause` and `../groups/groupId/resume` endpoint
     """
@@ -94,7 +94,6 @@ class PauseTests(unittest.TestCase):
         yield self.helper.assert_group_state(group, one_building)
         returnValue(group)
 
-    @skip_me("Until resume is implemented: #1605")
     @skip_if(not_mimic, "This requires mimic for server build time")
     @inlineCallbacks
     def test_resume(self):
@@ -104,7 +103,7 @@ class PauseTests(unittest.TestCase):
         webhook or trigger convergence
         """
         group = yield self.test_pause_stops_convergence()
-        yield group.resume()
+        yield group.resume(self.rcs)
         yield self.helper.assert_group_state(
             group, ContainsDict({"paused": Equals(False)}))
         yield group.wait_for_state(

--- a/otter/rest/groups.py
+++ b/otter/rest/groups.py
@@ -708,7 +708,7 @@ class OtterGroup(object):
         group = self.store.get_scaling_group(
             self.log, self.tenant_id, self.group_id)
         return controller.resume_scaling_group(
-            self.log, transaction_id(request), group)
+            self.log, transaction_id(request), group, self.dispatcher)
 
     @app.route('/servers/', branch=True)
     def servers(self, request):

--- a/otter/test/rest/test_groups.py
+++ b/otter/test/rest/test_groups.py
@@ -1301,6 +1301,7 @@ class GroupResumeTestCase(RestAPITestMixin, SynchronousTestCase):
         """
         Resume should call the controller's ``resume_scaling_group`` function
         """
+        self.otter.dispatcher = "disp"
         mock_resume = patch(
             self, 'otter.rest.groups.controller.resume_scaling_group',
             return_value=defer.succeed(None))
@@ -1308,13 +1309,7 @@ class GroupResumeTestCase(RestAPITestMixin, SynchronousTestCase):
         self.assertEqual(response_body, "")
 
         mock_resume.assert_called_once_with(mock.ANY, 'transaction-id',
-                                            self.mock_group)
-
-    def test_resume_not_implemented(self):
-        """
-        Resume currently raises 501 not implemented
-        """
-        self.assert_status_code(501, method="POST")
+                                            self.mock_group, "disp")
 
 
 class GroupServersTests(RestAPITestMixin, SynchronousTestCase):


### PR DESCRIPTION
Closes #1605. This just changes group state `paused` and triggers convergence on the group. 