### PR TITLE
Update APIError and UpstreamError.

### DIFF
--- a/otter/test/test_cloud_client.py
+++ b/otter/test/test_cloud_client.py
@@ -649,7 +649,8 @@ class CLBClientTests(SynchronousTestCase):
                     eff)
             self.assertEqual(
                 cm.exception,
-                APIError(headers={}, code=resp[0].code, body=resp[1]))
+                APIError(headers={}, code=resp[0].code, body=resp[1],
+                         method='method', url='original/request/URL'))
 
     def test_change_clb_node(self):
         """

--- a/otter/test/test_util.py
+++ b/otter/test/test_util.py
@@ -268,7 +268,7 @@ class UpstreamErrorTests(SynchronousTestCase):
         body = json.dumps({"computeFault": {"message": "b"}})
         apie = APIError(404, body, {})
         err = UpstreamError(Failure(apie), 'nova', 'add', 'xkcd.com')
-        self.assertEqual(str(err), 'nova error: 404 - b')
+        self.assertEqual(str(err), 'nova error: 404 - b (add)')
         self.assertEqual(err.details, {
             'system': 'nova', 'operation': 'add', 'url': 'xkcd.com',
             'message': 'b', 'code': 404, 'body': body, 'headers': {}})
@@ -280,7 +280,7 @@ class UpstreamErrorTests(SynchronousTestCase):
         body = json.dumps({"message": "b"})
         apie = APIError(403, body, {'h1': 2})
         err = UpstreamError(Failure(apie), 'clb', 'remove', 'xkcd.com')
-        self.assertEqual(str(err), 'clb error: 403 - b')
+        self.assertEqual(str(err), 'clb error: 403 - b (remove)')
         self.assertEqual(err.details, {
             'system': 'clb', 'operation': 'remove', 'url': 'xkcd.com',
             'message': 'b', 'code': 403, 'body': body, 'headers': {'h1': 2}})
@@ -292,30 +292,34 @@ class UpstreamErrorTests(SynchronousTestCase):
         body = json.dumps({"identityFault": {"message": "ba"}})
         apie = APIError(410, body, {})
         err = UpstreamError(Failure(apie), 'identity', 'stuff', 'xkcd.com')
-        self.assertEqual(str(err), 'identity error: 410 - ba')
+        self.assertEqual(str(err), 'identity error: 410 - ba (stuff)')
         self.assertEqual(err.details, {
             'system': 'identity', 'operation': 'stuff', 'url': 'xkcd.com',
             'message': 'ba', 'code': 410, 'body': body, 'headers': {}})
 
     def test_apierror_unparsed(self):
         """
-        Wraps APIError from identity and uses default string if unable to parses
-        error body
+        Wraps APIError from identity and uses default string if unable to
+        parses error body
         """
         body = json.dumps({"identityFault": {"m": "ba"}})
         apie = APIError(410, body, {})
         err = UpstreamError(Failure(apie), 'identity', 'stuff', 'xkcd.com')
-        self.assertEqual(str(err), 'identity error: 410 - Could not parse API error body')
+        self.assertEqual(
+            str(err),
+            'identity error: 410 - Could not parse API error body (stuff)')
         self.assertEqual(err.details, {
             'system': 'identity', 'operation': 'stuff', 'url': 'xkcd.com',
-            'message': 'Could not parse API error body', 'code': 410, 'body': body, 'headers': {}})
+            'message': 'Could not parse API error body', 'code': 410,
+            'body': body, 'headers': {}})
 
     def test_non_apierror(self):
         """
         Wraps any other error and has message and details accordingly
         """
-        err = UpstreamError(Failure(ValueError('heh')), 'identity', 'stuff', 'xkcd.com')
-        self.assertEqual(str(err), 'identity error: heh')
+        err = UpstreamError(Failure(ValueError('heh')), 'identity',
+                                    'stuff', 'xkcd.com')
+        self.assertEqual(str(err), 'identity error: heh (stuff)')
         self.assertEqual(err.details, {
             'system': 'identity', 'operation': 'stuff', 'url': 'xkcd.com'})
 

--- a/otter/test/test_util.py
+++ b/otter/test/test_util.py
@@ -91,7 +91,8 @@ class HTTPUtilityTests(SynchronousTestCase):
         body, and HTTP headers, and will expose these in public attributes and
         have a reasonable string representation.
         """
-        e = APIError(404, "Not Found.", Headers({'header': ['value']}))
+        e = APIError(404, "Not Found.", Headers({'header': ['value']}),
+                     'GET', 'http://myurl.com')
 
         self.assertEqual(e.code, 404)
         self.assertEqual(e.body, "Not Found.")
@@ -99,22 +100,24 @@ class HTTPUtilityTests(SynchronousTestCase):
         self.assertEqual(
             str(e),
             ("API Error code=404, body='Not Found.', "
-             "headers=Headers({'header': ['value']})"))
+             "headers=Headers({'header': ['value']}) (GET http://myurl.com)"))
 
     def test_api_error_with_Nones(self):
         """
         An APIError will be instantiated with an HTTP Code, an HTTP response
         body, and HTTP headers, and will expose these in public attributes and
-        have a reasonable string representation even if the body and headers
-        are None.
+        have a reasonable string representation even if the body, headers,
+        method, and url are not provided.
         """
         e = APIError(404, None)
 
         self.assertEqual(e.code, 404)
         self.assertEqual(e.body, None)
         self.assertEqual(e.headers, None)
-        self.assertEqual(str(e),
-                         ("API Error code=404, body=None, headers=None"))
+        self.assertEqual(
+            str(e),
+            "API Error code=404, body=None, headers=None (no_method no_url)"
+        )
 
     def test_check_success(self):
         """

--- a/otter/test/test_util.py
+++ b/otter/test/test_util.py
@@ -300,7 +300,7 @@ class UpstreamErrorTests(SynchronousTestCase):
     def test_apierror_unparsed(self):
         """
         Wraps APIError from identity and uses default string if unable to
-        parses error body
+        parse error body
         """
         body = json.dumps({"identityFault": {"m": "ba"}})
         apie = APIError(410, body, {})

--- a/otter/test/test_util.py
+++ b/otter/test/test_util.py
@@ -318,7 +318,7 @@ class UpstreamErrorTests(SynchronousTestCase):
         Wraps any other error and has message and details accordingly
         """
         err = UpstreamError(Failure(ValueError('heh')), 'identity',
-                                    'stuff', 'xkcd.com')
+                            'stuff', 'xkcd.com')
         self.assertEqual(str(err), 'identity error: heh (stuff)')
         self.assertEqual(err.details, {
             'system': 'identity', 'operation': 'stuff', 'url': 'xkcd.com'})

--- a/otter/util/http.py
+++ b/otter/util/http.py
@@ -96,11 +96,17 @@ class UpstreamError(Exception):
         self.url = url
         msg = self.system + ' error: '
         if self.reason.check(APIError):
-            self.apierr_message = _extract_error_message(self.system, self.reason.value.body,
-                                                         'Could not parse API error body')
-            msg += '{} - {}'.format(self.reason.value.code, self.apierr_message)
+            if system in ('nova', 'clb', 'identity'):
+                self.apierr_message = _extract_error_message(
+                    self.system, self.reason.value.body,
+                    'Could not parse API error body')
+            else:
+                self.apierr_message = self.reason.value.body
+            msg += '{} - {}'.format(
+                self.reason.value.code, self.apierr_message)
         else:
             msg += str(self.reason.value)
+        msg += " ({0})".format(operation)
         super(UpstreamError, self).__init__(msg)
 
     @property

--- a/otter/util/http.py
+++ b/otter/util/http.py
@@ -170,8 +170,8 @@ def append_segments(uri, *segments):
     return uri
 
 
-@attributes(['code', 'body',
-             Attribute('headers', default_value=None)], apply_with_init=False)
+@attributes(['code', 'body', 'headers', 'method', 'url'],
+            apply_with_init=False)
 class APIError(Exception):
     """
     An error raised when a non-success response is returned by the API.
@@ -179,16 +179,21 @@ class APIError(Exception):
     :param int code: HTTP Response code for this error.
     :param str body: HTTP Response body for this error or None.
     :param Headers headers: HTTP Response headers for this error, or None
+    :param str method: The HTTP method for the request
+    :param str url: The url that was hit
     """
-    def __init__(self, code, body, headers=None):
+    def __init__(self, code, body, headers=None, method="no_method",
+                 url="no_url"):
         Exception.__init__(
             self,
-            'API Error code={0!r}, body={1!r}, headers={2!r}'.format(
-                code, body, headers))
+            'API Error code={0}, body={1!r}, headers={2!r} ({3} {4})'.format(
+                code, body, headers, method, url))
 
         self.code = code
         self.body = body
         self.headers = headers
+        self.url = url
+        self.method = method
 
 
 def check_success(response, success_codes, _treq=None):
@@ -209,7 +214,8 @@ def check_success(response, success_codes, _treq=None):
         _treq = treq
 
     def _raise_api_error(body):
-        raise APIError(response.code, body, response.headers)
+        raise APIError(response.code, body, response.headers,
+                       response.request.method, response.request.absoluteURI)
 
     if response.code not in success_codes:
         return _treq.content(response).addCallback(_raise_api_error)

--- a/otter/util/http.py
+++ b/otter/util/http.py
@@ -6,7 +6,7 @@ from itertools import chain
 from urllib import quote, urlencode
 from urlparse import parse_qs, urlsplit, urlunsplit
 
-from characteristic import Attribute, attributes
+from characteristic import attributes
 
 from toolz.dicttoolz import get_in
 

--- a/otter/util/pure_http.py
+++ b/otter/util/pure_http.py
@@ -98,7 +98,8 @@ def check_response(pred, result):
     if pred(response, content):
         return result
     else:
-        raise APIError(response.code, content, response.headers)
+        raise APIError(response.code, content, response.headers,
+                       response.request.method, response.request.absoluteURI)
 
 
 @memoize


### PR DESCRIPTION
This does two things:

1. Add the method and URL in the API error
1. Update UpstreamError to be slightly more permissive and to display the operation in the string representation.

Both of these are needed for a utility that will help debug APIErrors in the trial tests.  Both of these don't change the string representation much, just adds a little bit to the end, so shouldn't break our logs or dashboards.
