### PR TITLE
Reorganize giant comments in the service.py file into GHC-style "Notes"

### DIFF
--- a/otter/convergence/service.py
+++ b/otter/convergence/service.py
@@ -29,7 +29,6 @@ The top-level entry-points into this module are :obj:`ConvergenceStarter` and
 #   - Remove the group from `currently_converging`
 #   - If the iteration was successful, attempt to delete the divergent flag
 #     *only if its version has not changed*. See [Divergent flags] for why.
-#   -
 #
 # A lot of care is taken to avoid running iterations concurrently for the same
 # group -- see note [Divergent flags], which takes care of concurrency

--- a/otter/convergence/service.py
+++ b/otter/convergence/service.py
@@ -9,7 +9,7 @@ The top-level entry-points into this module are :obj:`ConvergenceStarter` and
 #
 # A very abstract version of our convergence cycle:
 # - CYCLE (every N seconds)
-# - find all of my divergent groups
+# - find all divergent flags for this node's groups
 # - for each group (that's not in `currently_converging`)
 #   - add to currently_converging
 #   - run a single convergence iteration


### PR DESCRIPTION
... note that I also bikeshedded an inner function to use `@do` notation to be more clear

While I was thinking about #1656 I looked for a nice simple explanation of convergence cycles and iterations, because I always forget the precise order of things. I couldn't find one, so I wrote one, and then I realize that service.py was filling up with giant comments. So I decided to take the lead from the GHC source code, which uses [a very simple system of organizing long "Notes"](https://ghc.haskell.org/trac/ghc/wiki/Commentary/CodingStyle#Commentsinthesourcecode) which are just top-level comments with tags `[Like this]` which other parts of the source code can reference. The patch should be pretty self-explanatory.