### PR TITLE
Nova server repr

### DIFF
--- a/otter/test/convergence/test_model.py
+++ b/otter/test/convergence/test_model.py
@@ -375,9 +375,10 @@ class AutoscaleMetadataTests(SynchronousTestCase):
                          expected)
 
 
-class ToNovaServerTests(SynchronousTestCase):
+class NovaServerTests(SynchronousTestCase):
     """
-    Tests for :func:`NovaServer.from_server_details_json`
+    Tests for :func:`NovaServer.from_server_details_json` and
+    ``repr(NovaServer)``.
     """
     def setUp(self):
         """
@@ -614,6 +615,36 @@ class ToNovaServerTests(SynchronousTestCase):
                        servicenet_address='',
                        links=freeze(self.links[0]),
                        json=freeze(self.servers[0])))
+
+    def test_repr_nova(self):
+        """
+        The repr of a Nova server includes thawed data structures and shortened
+        JSON.
+        """
+        server_json = self.servers[0]
+        # add a bunch more fields
+        server_json.update({
+            'metadata': {'some': 'stuff'},
+            'OS-EXT-STS:task_state': None,
+            'updated': self.createds[0][0],
+            'user': '12345',
+            'hostId': '12356773526246'
+        })
+        server = NovaServer.from_server_details_json(server_json)
+        expected_json = {
+            'status': server_json['status'],
+            'OS-EXT-STS:task_state': None,
+            'updated': self.createds[0][0],
+            'metadata': {'some': 'stuff'}
+        }
+        self.assertEqual(
+            repr(server),
+            "<NovaServer(id={0}, state={1}, created={2}, image_id={3}, "
+            "flavor_id={4}, links={5}, desired_lbs={6}, "
+            "servicenet_address={7}, json={8})>".format(*[repr(i) for i in [
+                'a', ServerState.ACTIVE, float(self.createds[0][1]),
+                'valid_image', 'valid_flavor', self.links[0], set(), '',
+                expected_json]]))
 
 
 class IPAddressTests(SynchronousTestCase):


### PR DESCRIPTION
Makes the NovaServer `repr` a little shorter and easier to read.
Fixes #1652.

Tested this on dev vm - the `servers` part of the execute-convergence logs now look like:

`"<NovaServer(id=u'test-server7015522524-id-7015522524', state=<ServerState=DELETED>, created=1439241282.299928, image_id=u'cca73d10-8953-4949-a2f2-1e5444a4130d', flavor_id=u'2', links=[{u'href': u'http://localhost:8900/mimicking/NovaApi-837c09/ORD/v2/000000/servers/test-server7015522524-id-7015522524', u'rel': u'self'}, {u'href': u'http://localhost:8900/mimicking/NovaApi-837c09/ORD/000000/servers/test-server7015522524-id-7015522524', u'rel': u'bookmark'}], desired_lbs=set([<CLBDescription(lb_id=u'31430', port=80, weight=1, condition=<CLBNodeCondition=ENABLED>, type=<CLBNodeType=PRIMARY>)>]), servicenet_address=u'10.180.245.166', json={u'status': u'DELETED', u'updated': u'2015-08-10T21:14:51.784378Z', u'OS-EXT-STS:task_state': None, u'name': u'6fc60544-1439241270.08-asc3dc2c16', u'metadata': {u'rax:autoscale:group:id': u'7366b343-7b1a-4f25-9979-6eabb3a98b21', u'rax:autoscale:lb:CloudLoadBalancer:31430': u'[{\"port\": 80}]', u'rax:auto_scaling_group_id': u'7366b343-7b1a-4f25-9979-6eabb3a98b21'}})>",  "<NovaServer(id=u'test-server9361275831-id-9361275831', state=<ServerState=DELETED>, created=1439241272.532468, image_id=u'cca73d10-8953-4949-a2f2-1e5444a4130d', flavor_id=u'2', links=[{u'href': u'http://localhost:8900/mimicking/NovaApi-837c09/ORD/v2/000000/servers/test-server9361275831-id-9361275831', u'rel': u'self'}, {u'href': u'http://localhost:8900/mimicking/NovaApi-837c09/ORD/000000/servers/test-server9361275831-id-9361275831', u'rel': u'bookmark'}], desired_lbs=set([<CLBDescription(lb_id=u'31430', port=80, weight=1, condition=<CLBNodeCondition=ENABLED>, type=<CLBNodeType=PRIMARY>)>]), servicenet_address=u'10.180.61.145', json={u'status': u'DELETED', u'updated': u'2015-08-10T21:14:51.783231Z', u'OS-EXT-STS:task_state': None, u'name': u'6fc60544-1439241270.08-as37fa0672', u'metadata': {u'rax:autoscale:group:id': u'7366b343-7b1a-4f25-9979-6eabb3a98b21', u'rax:autoscale:lb:CloudLoadBalancer:31430': u'[{\"port\": 80}]', u'rax:auto_scaling_group_id': u'7366b343-7b1a-4f25-9979-6eabb3a98b21'}})>"`