### PR TITLE
Use UpstreamError in the trial tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ SCRIPTSDIR=scripts
 PYDIRS=${CODEDIR} ${SCRIPTSDIR} autoscale_cloudcafe autoscale_cloudroast
 CQLSH ?= $(shell which cqlsh)
 DOCDIR=doc
-UNITTESTS ?= ${CODEDIR}.test
+UNITTESTS ?= ${CODEDIR}.test ${CODEDIR}.integration.lib
 CASSANDRA_HOST ?= localhost
 export CASSANDRA_HOST
 CASSANDRA_PORT ?= 9160

--- a/otter/integration/lib/identity.py
+++ b/otter/integration/lib/identity.py
@@ -2,6 +2,8 @@
 
 from characteristic import Attribute, attributes
 
+from otter.integration.lib.utils import diagnose
+
 
 @attributes([
     Attribute('auth'),
@@ -35,6 +37,7 @@ class IdentityV2(object):
     def __init__(self):
         self.access = None
 
+    @diagnose("Identity", "Authing test user")
     def authenticate_user(self, rcs, resources=None, region=None):
         """Authenticates against the Identity API.  Prior to success, the
         :attr:`access` member will be set to `None`.  After authentication

--- a/otter/integration/lib/mimic.py
+++ b/otter/integration/lib/mimic.py
@@ -10,6 +10,8 @@ import treq
 
 from twisted.internet.defer import inlineCallbacks, returnValue
 
+from otter.integration.lib.utils import diagnose
+
 from otter.util.http import check_success
 
 
@@ -55,6 +57,7 @@ def _sequenced_behaviors(test_case, pool, endpoint, criteria, behaviors,
     returnValue(behavior_id)
 
 
+@diagnose("mimic", "Deleting behavior")
 def _delete_behavior(pool, endpoint, behavior_id, _treq):
     """
     Given a behavior ID, delete it from mimic.
@@ -92,6 +95,7 @@ class MimicNova(object):
         the default library :mod:`treq` will be used.  Mainly to be used for
         injecting stubs during tests.
     """
+    @diagnose("mimic", "Changing a server's status")
     def change_server_statuses(self, rcs, ids_to_status):
         """
         Change the statuses of the given server IDs.  Changing the statuses of
@@ -114,6 +118,7 @@ class MimicNova(object):
             pool=self.pool
         ).addCallback(check_success, [201]).addCallback(self.treq.content)
 
+    @diagnose("mimic", "Injecting create server behavior")
     def sequenced_behaviors(self, rcs, criteria, behaviors,
                             event_description="creation"):
         """
@@ -141,6 +146,7 @@ class MimicNova(object):
                                        event_description),
             criteria, behaviors, self.treq)
 
+    @diagnose("mimic", "Deleting create server behavior")
     def delete_behavior(self, rcs, behavior_id, event_description="creation"):
         """
         Given a behavior ID, delete it from mimic.
@@ -176,6 +182,7 @@ class MimicIdentity(object):
         the default library :mod:`treq` will be used.  Mainly to be used for
         injecting stubs during tests.
     """
+    @diagnose("mimic", "Injecting auth behavior")
     def sequenced_behaviors(self, identity_endpoint, criteria, behaviors,
                             event_description="auth"):
         """
@@ -226,6 +233,7 @@ class MimicCLB(object):
         the default library :mod:`treq` will be used.  Mainly to be used for
         injecting stubs during tests.
     """
+    @diagnose("mimic", "Setting CLB status")
     def set_clb_attributes(self, rcs, clb_id, kvpairs):
         """
         Update the attributes of a clould load balancer based on the provided

--- a/otter/integration/lib/test_cloud_load_balancer.py
+++ b/otter/integration/lib/test_cloud_load_balancer.py
@@ -14,7 +14,7 @@ from otter.integration.lib.cloud_load_balancer import (
     HasLength)
 from otter.integration.lib.test_nova import Response, get_fake_treq
 from otter.util.deferredutils import TimedOutError
-from otter.util.http import APIError, headers
+from otter.util.http import UpstreamError, headers
 
 
 class _FakeRCS(object):
@@ -157,7 +157,7 @@ class CLBTests(SynchronousTestCase):
         clb = self.get_clb(
             *(expected_args + [Response(422), json.dumps(pending_delete)]))
         d = mutate_callable(clb, clock)
-        self.failureResultOf(d, APIError)
+        self.failureResultOf(d, UpstreamError)
 
     def test_update_node(self):
         """
@@ -348,7 +348,7 @@ class CLBTests(SynchronousTestCase):
         clb.clb_id = self.clb_id
 
         d = clb.delete(self.rcs, clock=clock)
-        self.failureResultOf(d, APIError)
+        self.failureResultOf(d, UpstreamError)
 
 
 class WaitForNodesTestCase(SynchronousTestCase):

--- a/otter/integration/lib/test_nova.py
+++ b/otter/integration/lib/test_nova.py
@@ -8,6 +8,7 @@ from twisted.internet.task import Clock
 from twisted.trial.unittest import SynchronousTestCase
 
 from otter.integration.lib import nova
+from otter.test.utils import StubClientRequest
 from otter.util.deferredutils import TimedOutError
 from otter.util.http import headers
 
@@ -18,6 +19,7 @@ class Response(object):
         self.code = code
         self.headers = headers
         self.strbody = strbody
+        self.request = StubClientRequest()
 
 
 def get_fake_treq(test_case, method, url, expected_args_and_kwargs, response):

--- a/otter/integration/lib/test_utils.py
+++ b/otter/integration/lib/test_utils.py
@@ -3,20 +3,26 @@ Tests for the utility functions for convergence black-box testing.
 """
 from pyrsistent import pmap, pset
 
+from twisted.internet.defer import FirstError, fail
+from twisted.internet.error import ConnectionRefusedError
+from twisted.python.failure import Failure
 from twisted.trial.unittest import SynchronousTestCase
-
-from utils import (
-    GroupState,
-    OvershootError,
-    UndershootError,
-    measure_progress
-)
 
 from otter.convergence.model import (
     DesiredGroupState,
     NovaServer,
     ServerState
 )
+
+from otter.integration.lib.utils import (
+    GroupState,
+    OvershootError,
+    UndershootError,
+    diagnose,
+    measure_progress
+)
+
+from otter.util.http import APIError, UpstreamError
 
 
 class MeasureProgressTests(SynchronousTestCase):
@@ -203,3 +209,73 @@ class MeasureProgressTests(SynchronousTestCase):
         progress = measure_progress(
             previous_state, current_state, desired_state)
         self.assertEqual(progress, 0)
+
+
+class DiagnoseTests(SynchronousTestCase):
+    """
+    Tests for :func:`diagnose`.
+    """
+    def test_diagnose_wraps_connection_and_api_errors(self):
+        """
+        :func:`diagnose` wraps only :class:`ConnectionRefusedError` and
+        :class:`APIError`
+        """
+        af = fail(APIError(200, {}))
+        f = self.failureResultOf(diagnose("system", "operation")(lambda: af)(),
+                                 UpstreamError)
+        self.assertTrue(f.value.reason.check(APIError))
+        self.assertEqual(f.value.system, "system")
+        self.assertEqual(f.value.operation, "operation")
+
+        cf = fail(ConnectionRefusedError('meh'))
+        f = self.failureResultOf(diagnose("system", "operation")(lambda: cf)(),
+                                 UpstreamError)
+        self.assertTrue(f.value.reason.check(ConnectionRefusedError))
+        self.assertEqual(f.value.system, "system")
+        self.assertEqual(f.value.operation, "operation")
+
+        of = fail(ValueError('not-wrapped'))
+        self.failureResultOf(diagnose("system", "operation")(lambda: of)(),
+                             ValueError)
+
+    def test_diagnose_unwraps_first_error_if_apierr_or_connection_error(self):
+        """
+        :func:`diagnose` unwraps :class:`FirstError`, no matter how deeply
+        nested, and wraps the underlying :class:`ConnectionRefusedError` and
+        :class:`APIError` in an :class:`UpstreamError`
+        """
+        def _wrap(exception):
+            return lambda: fail(
+                FirstError(
+                    Failure(FirstError(Failure(exception), 0)),
+                    0))
+
+        f = self.failureResultOf(
+            diagnose("system", "operation")(_wrap(APIError(200, {})))(),
+            UpstreamError)
+        self.assertTrue(f.value.reason.check(APIError))
+        self.assertEqual(f.value.system, "system")
+        self.assertEqual(f.value.operation, "operation")
+
+        f = self.failureResultOf(
+            diagnose("system", "operation")(
+                _wrap(ConnectionRefusedError('meh')))(),
+            UpstreamError)
+        self.assertTrue(f.value.reason.check(ConnectionRefusedError))
+        self.assertEqual(f.value.system, "system")
+        self.assertEqual(f.value.operation, "operation")
+
+    def test_diagnose_keeps_first_error_if_not_apierr_or_connection_err(self):
+        """
+        :func:`diagnose` keeps the original :class:`FirstError`, if
+        the ultimately underlying exception is not a
+        :class:`ConnectionRefusedError` or :class:`APIError`
+        """
+        err = FirstError(
+            Failure(FirstError(Failure(ValueError), 0)),
+            0
+        )
+        f = self.failureResultOf(
+            diagnose("system", "operation")(lambda: fail(err))(), FirstError)
+
+        self.assertIs(f.value, err)

--- a/otter/integration/tests/test_convergence.py
+++ b/otter/integration/tests/test_convergence.py
@@ -49,6 +49,7 @@ from otter.integration.lib.trial_tools import (
     skip_if,
     tag
 )
+from otter.integration.lib.utils import diagnose
 
 
 # if this is None, the test will be skipped
@@ -248,6 +249,7 @@ class TestConvergence(unittest.TestCase):
 
         return create_clb_first().addCallback(then_test)
 
+    @diagnose("Nova", "OOB-removing metadata from some servers")
     def _remove_metadata(self, ids, rcs):
         """Given a list of server IDs, use Nova to remove their metadata.
         This will strip them of their association with Autoscale.
@@ -350,6 +352,7 @@ def _oob_disable_then(helper, rcs, num_to_disable, disabler, then,
     returnValue(scaling_group)
 
 
+@diagnose("Nova", "OOB-deleting some servers")
 def _deleter(helper, rcs, server_ids):
     """
     A disabler function to be passed to :func:`_oob_disable_then` that deletes
@@ -358,6 +361,7 @@ def _deleter(helper, rcs, server_ids):
     return delete_servers(server_ids, rcs, pool=helper.pool, _treq=helper.treq)
 
 
+@diagnose("Mimic", "OOB-erroring some servers")
 def _errorer(helper, rcs, server_ids):
     """
     A disabler function to be passed to :func:`_oob_disable_then` that invokes


### PR DESCRIPTION
So we can more easily see what the trial tests were doing when they failed, so if we get an API error, we can see what caused it without having to guess by looking at the body.

the error messages now look like:

```
[ERROR]
Traceback (most recent call last):
  File "/opt/otter/.ve/local/lib/python2.7/site-packages/twisted/internet/defer.py", line 1105, in _inlineCallbacks
    result = result.throwExceptionIntoGenerator(g)
  File "/opt/otter/.ve/local/lib/python2.7/site-packages/twisted/python/failure.py", line 389, in throwExceptionIntoGenerator
    return g.throw(self.type, self.value, self.tb)
  File "/opt/otter/otter/integration/tests/test_convergence.py", line 1006, in test_recover_from_identity_auth_failures
    yield self.helper.start_group_and_wait(group, rcs, desired=5)
  File "/opt/otter/.ve/local/lib/python2.7/site-packages/twisted/internet/defer.py", line 1105, in _inlineCallbacks
    result = result.throwExceptionIntoGenerator(g)
  File "/opt/otter/.ve/local/lib/python2.7/site-packages/twisted/python/failure.py", line 389, in throwExceptionIntoGenerator
    return g.throw(self.type, self.value, self.tb)
  File "/opt/otter/otter/integration/lib/trial_tools.py", line 258, in start_group_and_wait
    timeout=600)
  File "/opt/otter/.ve/local/lib/python2.7/site-packages/twisted/internet/defer.py", line 578, in _runCallbacks
    current.result = callback(current.result, *args, **kw)
  File "/opt/otter/otter/integration/lib/utils.py", line 119, in wrap_failure
    raise UpstreamError(failure, system, message)
otter.util.http.UpstreamError: AS error: AS error: Connection was refused by other side: 111: Connection refused. (Getting scaling group state) (Wait for scaling group state to reach a particular point)
```

Giving us a sort of very ugly stack trace (failed during the get scaling group state part of waiting for state).

Fixes #1619.