### PR TITLE
Otter stops after scheduler finishes

### DIFF
--- a/otter/convergence/service.py
+++ b/otter/convergence/service.py
@@ -607,6 +607,10 @@ class Converger(MultiService):
         """
         ceff = Effect(GetChildren(CONVERGENCE_DIRTY_DIR)).on(
             partial(self._converge_all, my_buckets))
+        # Return deferred as 1-element tuple for testing only.
+        # Returning deferred would block otter from shutting down until
+        # it is fired which we don't need to do since convergence is itempotent
+        # and will be triggered in next start of otter
         return (perform(self._dispatcher, self._with_conv_runid(ceff)), )
 
     def divergent_changed(self, children):

--- a/otter/convergence/service.py
+++ b/otter/convergence/service.py
@@ -607,7 +607,7 @@ class Converger(MultiService):
         """
         ceff = Effect(GetChildren(CONVERGENCE_DIRTY_DIR)).on(
             partial(self._converge_all, my_buckets))
-        return perform(self._dispatcher, self._with_conv_runid(ceff))
+        return (perform(self._dispatcher, self._with_conv_runid(ceff)), )
 
     def divergent_changed(self, children):
         """

--- a/otter/test/convergence/test_service.py
+++ b/otter/test/convergence/test_service.py
@@ -153,7 +153,7 @@ class ConvergerTests(SynchronousTestCase):
         converger = self._converger(converge_all_groups, dispatcher=sequence)
 
         with sequence.consume():
-            result = self.fake_partitioner.got_buckets(my_buckets)
+            result, = self.fake_partitioner.got_buckets(my_buckets)
         self.assertEqual(self.successResultOf(result), 'foo')
 
     def test_buckets_acquired_errors(self):
@@ -179,7 +179,7 @@ class ConvergerTests(SynchronousTestCase):
         self._converger(converge_all_groups, dispatcher=sequence)
 
         with sequence.consume():
-            result = self.fake_partitioner.got_buckets([0])
+            result, = self.fake_partitioner.got_buckets([0])
         self.assertEqual(self.successResultOf(result), None)
 
     def test_divergent_changed_not_acquired(self):

--- a/otter/test/util/test_zkpartitioner.py
+++ b/otter/test/util/test_zkpartitioner.py
@@ -200,7 +200,7 @@ class PartitionerTests(SynchronousTestCase):
         self.partitioner.startService()
         d = self.partitioner.stopService()
         self.assertFalse(self.kz_partitioner.finish.called)
-        self.assertIsNone(d)
+        self.successResultOf(d)
 
     def test_stop_service_acquired(self):
         """
@@ -209,7 +209,8 @@ class PartitionerTests(SynchronousTestCase):
         self.kz_partitioner.acquired = True
         self.partitioner.startService()
         d = self.partitioner.stopService()
-        self.assertIs(self.kz_partitioner.finish.return_value, d)
+        self.assertIs(self.successResultOf(d),
+                      self.kz_partitioner.finish.return_value)
 
     def test_stop_service_stops_polling(self):
         """

--- a/otter/test/util/test_zkpartitioner.py
+++ b/otter/test/util/test_zkpartitioner.py
@@ -4,6 +4,7 @@ from kazoo.recipe.partitioner import PartitionState
 
 import mock
 
+from twisted.internet.defer import Deferred
 from twisted.internet.task import Clock
 from twisted.trial.unittest import SynchronousTestCase
 
@@ -129,6 +130,38 @@ class PartitionerTests(SynchronousTestCase):
         self.clock.advance(10)
         self.clock.advance(10)
         self.assertEqual(self.buckets_received, [[2, 3], [2, 3], [2, 3]])
+
+    def test_got_buckets_return(self):
+        """
+        `got_buckets` return value is propogated to timerservice that ensures
+        that the service stops after returned deferred is fired
+        """
+        self.kz_partitioner.acquired = True
+        self.kz_partitioner.__iter__.return_value = [2, 3]
+        self.buckets_got = None
+        d = Deferred()
+
+        def got_buckets(_buckets):
+            self.buckets_got = _buckets
+            return d
+
+        partitioner = Partitioner(
+            self.kz_client, 10, self.path, self.buckets, self.time_boundary,
+            self.log, got_buckets, clock=self.clock)
+        partitioner.startService()
+        self.log.msg.assert_called_once_with(
+            'Got buckets {buckets}',
+            buckets=[2, 3], old_buckets=[], path=self.path,
+            otter_msg_type='partition-acquired')
+        self.assertEqual(self.buckets_got, [2, 3])
+        self.clock.advance(10)
+        # Stopping service does not complete even after advancing clock
+        # since got_buckets deferred has not fired yet
+        sd = partitioner.stopService()
+        self.assertNoResult(sd)
+        # Service stops after deferred is fired
+        d.callback(None)
+        self.successResultOf(sd)
 
     def test_no_log_spam(self):
         """Bucket changes are not logged when the buckets don't change."""

--- a/otter/util/zkpartitioner.py
+++ b/otter/util/zkpartitioner.py
@@ -67,9 +67,10 @@ class Partitioner(MultiService):
 
     def stopService(self):
         """Release the buckets."""
-        MultiService.stopService(self)
+        d = MultiService.stopService(self)
         if self.partitioner.acquired:
-            return self.partitioner.finish()
+            d.addCallback(lambda _: self.partitioner.finish())
+        return d
 
     def reset_path(self, path):
         """Re-initialize the partitioner to use a new path."""
@@ -114,7 +115,7 @@ class Partitioner(MultiService):
                          old_buckets=self._old_buckets,
                          otter_msg_type='partition-acquired')
             self._old_buckets = buckets
-        self.got_buckets(buckets)
+        return self.got_buckets(buckets)
 
     def health_check(self):
         """

--- a/otter/util/zkpartitioner.py
+++ b/otter/util/zkpartitioner.py
@@ -7,7 +7,7 @@ from twisted.application.service import MultiService
 from twisted.internet.defer import succeed
 
 
-class Partitioner(MultiService):
+class Partitioner(MultiService, object):
     """
     A Twisted service which uses a Kazoo :obj:`SetPartitioner` to allocate
     logical ``buckets`` between nodes.
@@ -63,11 +63,11 @@ class Partitioner(MultiService):
         # TimerService may call `check_partition` before self.partitioner is
         # created.
         self.partitioner = self._new_partitioner()
-        MultiService.startService(self)
+        super(Partitioner, self).startService()
 
     def stopService(self):
         """Release the buckets."""
-        d = MultiService.stopService(self)
+        d = super(Partitioner, self).stopService()
         if self.partitioner.acquired:
             d.addCallback(lambda _: self.partitioner.finish())
         return d


### PR DESCRIPTION
Closes #1539.

In zkpartitioner.py `got_buckets` return value is propogated to `check_partition` return that ensures that partitioner service stops after `got_buckets` deferred is fired. This way scheduler will stop after its events are processed like before. 

Changed `ConvergerService` to return tuple with deferred instead of the deferred to allow it to stop right away. We don't want to block otter stopping when convergence cycle is going on since it idempotent and it will be started in next otter start.