### PR TITLE
Execute convergence split messages

### DIFF
--- a/otter/log/spec.py
+++ b/otter/log/spec.py
@@ -27,9 +27,10 @@ def split_execute_convergence(event, max_length=50000):
     :param int max_length: The maximum length of the entire JSON-formatted
         dictionary.
 
-    :return: `list` of `dict` representing the spit up event dicts.  If
-        the event does not need to be split, this list will only have one
-        element.
+    :return: `list` of `tuple` of (`dict`, `str`).  The `dict`s in the tuple
+        represents the spit up event dicts, and the `str` the format string
+        for each.  If the event does not need to be split, the list will only
+        have one tuple.
     """
     message = "Executing convergence"
     if _json_len(event) <= max_length:

--- a/otter/log/spec.py
+++ b/otter/log/spec.py
@@ -22,6 +22,14 @@ def split_execute_convergence(event, max_length=50000):
 
     Experimentally determined that probably logs cut off at around 75k,
     characters - we're going to limit it to 50k.
+
+    :param dict event: The 'execute-convergence' type event dictionary to split
+    :param int max_length: The maximum length of the entire JSON-formatted
+        dictionary.
+
+    :return: `list` of `dict` representing the spit up event dicts.  If
+        the event does not need to be split, this list will only have one
+        element.
     """
     message = "Executing convergence"
     if _json_len(event) <= max_length:

--- a/otter/log/spec.py
+++ b/otter/log/spec.py
@@ -122,7 +122,8 @@ msg_types = {
 
 def halve(l):
     """
-    Split a sequence in half, biased to the left.
+    Split a sequence in half, biased to the left (if the number of elements
+    is odd, the left sub-list has one more element than the right sub-list.)
 
     :param list l: The sequence to split
     :return: a `tuple` containing both halves of the sequence.
@@ -133,24 +134,33 @@ def halve(l):
 
 def split(render, elements, max_len, calculate_len=len):
     """
-    Render some elements of a list, where the length (as determined by
-    ``calculate_len``) of each rendered object is no longer than ``max_len``.
+    Split given elements into sub-lists, ensuring that length (as calculated by
+    ``calculate_len``) of each rendered sub-list is less than ``max_len``, and
+    transform each sublist using the ``render`` callable.
 
     Messages longer than the max that are rendered from individual elements
     will still be returned, so ``max_len`` mustn't be assumed to be a hard
     constraint.
 
-    :param callable render: A callable which takes a list of elements, and
-        produces an object string the list of elements be rendered to.
+    :param callable render: A callable that takes list of elements and returns
+        an object whose length is calculated by ``calculate_len``.  These
+        objects are what get returned, as opposed to the elements themselves.
     :param list elements: A list of elements that should be potentially split.
-    :param int max_len: Maximum length of the rendered object, as calculated
+        They should be renderable by ``render``.
+    :param int max_len: Maximum length of the rendered object (an object
+        produced by calling ``render(elements)``), as calculated
         by ``calculate_len``.
     :param callable calculate_len: A callable that takes the rendered object
-        and calculates the length.
+        (produced by calling ``render(elements)``) and calculates the length.
 
-    :return: a `list` of `list`s of elements, each of which, when rendered
-        and measured with the provided callables, should probably be less than
-        ``max_len``.
+    :return: a `list` of rendered elements such that::
+
+            all([calculate_len(rendered) <= max_len
+                 for rendered in return_value]) == True
+
+        To the best of this function's ability, anyway.  Each rendered object
+        in the return value will be the result of calling ``render`` on a
+        subset of ``elements``.
     """
     m = render(elements)
     if len(elements) > 1 and calculate_len(m) > max_len:

--- a/otter/log/spec.py
+++ b/otter/log/spec.py
@@ -123,20 +123,24 @@ def halve(l):
 
 def split(render, elements, max_len, calculate_len=len):
     """
-    Render some elements of a list, where each rendered message is no longer
-    than max.
+    Render some elements of a list, where the length (as determined by
+    ``calculate_len``) of each rendered object is no longer than ``max_len``.
 
     Messages longer than the max that are rendered from individual elements
     will still be returned, so ``max_len`` mustn't be assumed to be a hard
     constraint.
 
     :param callable render: A callable which takes a list of elements, and
-        produces a string the list should be rendered to.
+        produces an object string the list of elements be rendered to.
     :param list elements: A list of elements that should be potentially split.
-    :param int max_len: Maximum length of the rendered list
+    :param int max_len: Maximum length of the rendered object, as calculated
+        by ``calculate_len``.
+    :param callable calculate_len: A callable that takes the rendered object
+        and calculates the length.
 
-    :return: a `list` of `list`s of elements, each of which, when rendered with
-        the provided callable, should probably be less than ``max_len``.
+    :return: a `list` of `list`s of elements, each of which, when rendered
+        and measured with the provided callables, should probably be less than
+        ``max_len``.
     """
     m = render(elements)
     if len(elements) > 1 and calculate_len(m) > max_len:

--- a/otter/log/spec.py
+++ b/otter/log/spec.py
@@ -4,8 +4,9 @@ Format logs based on specification
 import json
 import math
 
-from toolz.dicttoolz import assoc, keyfilter
-from toolz.functoolz import compose, curry
+from toolz.curried import assoc
+from toolz.dicttoolz import keyfilter
+from toolz.functoolz import compose
 
 from twisted.python.failure import Failure
 
@@ -48,7 +49,7 @@ def split_execute_convergence(event, max_length=50000):
 
     for thing in large_things:
         split_up_events = split(
-            curry(assoc, base_event, thing), event[thing], max_length,
+            assoc(base_event, thing), event[thing], max_length,
             _json_len)
         events.extend([(e, message) for e in split_up_events])
         del event[thing]

--- a/otter/test/log/test_spec.py
+++ b/otter/test/log/test_spec.py
@@ -1,10 +1,15 @@
 """
 Tests for log_spec.py
 """
+import json
 
 from twisted.trial.unittest import SynchronousTestCase
 
-from otter.log.spec import SpecificationObserverWrapper, get_validated_event
+from otter.log.spec import (
+    SpecificationObserverWrapper,
+    get_validated_event,
+    split_execute_convergence
+)
 from otter.test.utils import CheckFailureValue, raise_
 
 
@@ -171,3 +176,104 @@ class GetValidatedEventTests(SynchronousTestCase):
               'otter_msg_type': 'foo-bar',
               'ab': 'cd',
               'split_message': '2 of 2'}])
+
+
+class ExecuteConvergenceSplitTests(SynchronousTestCase):
+    """
+    Tests for splitting "execute-convergence" type events
+    (e.g. :func:`split_execute_convergence`)
+    """
+    def test_split_out_servers_if_servers_longer(self):
+        """
+        If the 'servers' parameter is longer than the 'lb_nodes' parameter,
+        and the event is otherwise sufficiently small, 'servers' is the
+        param that gets split into another message.
+        """
+        event = {'hi': 'there', 'desired': 'desired', 'steps': ['steps'],
+                 'lb_nodes': ['1', '2', '3'], 'servers': ['1', '2', '3', '4']}
+        message = "Executing convergence"
+
+        # assume that removing 'lb_nodes' would make it the perfect length, but
+        # since 'servers' is bigger, it's the thing that gets removed.
+        length = len(
+            json.dumps({k: event[k] for k in event if k != 'lb_nodes'}))
+
+        result = split_execute_convergence(event.copy(), max_length=length)
+        expected = [
+            ({k: event[k] for k in event if k != 'servers'}, message),
+            ({k: event[k] for k in event
+              if k not in ('desired', 'steps', 'lb_nodes')}, message)
+        ]
+
+        self.assertEqual(result, expected)
+
+    def test_split_out_lb_nodes_if_lb_nodes_longer(self):
+        """
+        If the 'lb_nodes' parameter is longer than the 'servers' parameter,
+        and the event is otherwise sufficiently small, 'lb_nodes' is the
+        param that gets split into another message.
+        """
+        event = {'hi': 'there', 'desired': 'desired', 'steps': ['steps'],
+                 'lb_nodes': ['1', '2', '3', '4'], 'servers': ['1', '2', '3']}
+        message = "Executing convergence"
+
+        # assume that removing 'servers' would make it the perfect length, but
+        # since 'lb_nodes' is bigger, it's the thing that gets removed.
+        length = len(
+            json.dumps({k: event[k] for k in event if k != 'servers'}))
+
+        result = split_execute_convergence(event.copy(), max_length=length)
+        expected = [
+            ({k: event[k] for k in event if k != 'lb_nodes'}, message),
+            ({k: event[k] for k in event
+              if k not in ('desired', 'steps', 'servers')}, message)
+        ]
+
+        self.assertEqual(result, expected)
+
+    def test_split_out_both_servers_and_lb_nodes_if_too_long(self):
+        """
+        Both 'lb_nodes' and 'servers' are split out if the event is too long
+        to accomodate both.  The longest one is removed first.
+        """
+        event = {'hi': 'there', 'desired': 'desired', 'steps': ['steps'],
+                 'lb_nodes': ['1', '2', '3', '4'], 'servers': ['1', '2', '3']}
+        message = "Executing convergence"
+
+        short_event = {k: event[k] for k in event
+                       if k not in ('servers', 'lb_nodes')}
+        result = split_execute_convergence(
+            event.copy(),
+            max_length=len(json.dumps(short_event)) + 5)
+
+        expected = [
+            (short_event, message),
+            ({k: event[k] for k in event
+              if k not in ('desired', 'steps', 'servers')}, message),
+            ({k: event[k] for k in event
+              if k not in ('desired', 'steps', 'lb_nodes')}, message)
+        ]
+
+        self.assertEqual(result, expected)
+
+    def test_split_servers_into_multiple_if_servers_too_long(self):
+        """
+        Both 'servers' is too long to even fit in one event, split the servers
+        list, so there are more than 2 events returned.
+        """
+        def event(servers):
+            return {'hi': 'there', "servers": servers}
+
+        message = "Executing convergence"
+        result = split_execute_convergence(
+            dict(lb_nodes=[], **event([str(i) for i in range(5)])),
+            max_length=len(json.dumps(event(['0', '1']))))
+
+        expected = [
+            ({'hi': 'there', 'lb_nodes': []}, message),
+            (event(['0', '1']), message),
+            (event(['2']), message),
+            (event(['3', '4']), message),
+        ]
+
+        self.assertEqual(result, expected)

--- a/otter/test/log/test_spec.py
+++ b/otter/test/log/test_spec.py
@@ -225,9 +225,8 @@ class ExecuteConvergenceSplitTests(SynchronousTestCase):
 
         result = split_execute_convergence(event.copy(), max_length=length)
         expected = [
-            ({k: event[k] for k in event if k != 'lb_nodes'}, message),
-            ({k: event[k] for k in event
-              if k not in ('desired', 'steps', 'servers')}, message)
+            (dissoc(event, 'lb_nodes'), message),
+            (dissoc(event, 'desired', 'steps', 'servers'), message)
         ]
 
         self.assertEqual(result, expected)
@@ -249,10 +248,8 @@ class ExecuteConvergenceSplitTests(SynchronousTestCase):
 
         expected = [
             (short_event, message),
-            ({k: event[k] for k in event
-              if k not in ('desired', 'steps', 'servers')}, message),
-            ({k: event[k] for k in event
-              if k not in ('desired', 'steps', 'lb_nodes')}, message)
+            (dissoc(event, 'desired', 'steps', 'servers'), message),
+            (dissoc(event, 'desired', 'steps', 'lb_nodes'), message)
         ]
 
         self.assertEqual(result, expected)

--- a/otter/test/log/test_spec.py
+++ b/otter/test/log/test_spec.py
@@ -3,6 +3,8 @@ Tests for log_spec.py
 """
 import json
 
+from toolz.dicttoolz import dissoc
+
 from twisted.trial.unittest import SynchronousTestCase
 
 from otter.log.spec import (
@@ -200,9 +202,8 @@ class ExecuteConvergenceSplitTests(SynchronousTestCase):
 
         result = split_execute_convergence(event.copy(), max_length=length)
         expected = [
-            ({k: event[k] for k in event if k != 'servers'}, message),
-            ({k: event[k] for k in event
-              if k not in ('desired', 'steps', 'lb_nodes')}, message)
+            (dissoc(event, 'servers'), message),
+            (dissoc(event, 'desired', 'steps', 'lb_nodes'), message)
         ]
 
         self.assertEqual(result, expected)

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ effect==0.9
 txeffect==0.9
 characteristic==14.3.0
 attrs==15.0.0
-toolz==0.7.1
+toolz==0.7.4
 pyrsistent==0.10.3
 singledispatch==3.4.0.3
 six==1.9.0


### PR DESCRIPTION
Execute convergence messages are really big, so we're going to attempt to split them across multiple messages.

This is based on @radix's code here:  https://gist.github.com/radix/234255d8712dc9cba756

This does not guarantee that we won't have "execute-convergence" messages that exceed this length - such as if we have a truly huge number of steps or something.  But servers seems to be our main problem, and looking at some of the test output from dev vm logs, there might be quite a few nodes too if we're running a lot of tests/have a lot of CLBs and nodes.

~~This depends on #1671 being merged.~~ Merged.