### PR TITLE
RCv3 cafe convergence tests

### DIFF
--- a/autoscale_cloudcafe/autoscale/behaviors.py
+++ b/autoscale_cloudcafe/autoscale/behaviors.py
@@ -4,7 +4,6 @@ Behaviors for Autoscale
 import inspect
 import logging
 import time
-import unittest
 
 from datetime import datetime, timedelta
 from decimal import Decimal, ROUND_HALF_UP
@@ -56,7 +55,7 @@ class DefaultAsserter(object):
             self.fail(msg)
 
     def fail(self, msg):
-        raise unittest.AssertionError(msg)
+        raise AssertionError(msg)
 
 
 class AutoscaleBehaviors(BaseBehavior):

--- a/autoscale_cloudroast/test_repo/autoscale/system/integration/test_system_integration_rcv3.py
+++ b/autoscale_cloudroast/test_repo/autoscale/system/integration/test_system_integration_rcv3.py
@@ -154,7 +154,7 @@ class AutoscaleRackConnectFixture(AutoscaleFixture):
         if dummy_asserter.err:
             print("SetUpClass failed: background LB nodes")
 
-    @tags(speed='slow', type='rcv3', rcv3_mimic='pass')
+    @tags(speed='slow', type='rcv3', rcv3_mimic='pass', convergence='yes')
     def test_create_scaling_group_with_pool_on_cloud_network(self):
         """
         Test that it is possible to create a scaling group with 0 entities
@@ -167,7 +167,7 @@ class AutoscaleRackConnectFixture(AutoscaleFixture):
             network_list=[self.rackconnect_network])
         self._common_scaling_group_assertions(pool_group_resp)
 
-    @tags(speed='slow', type='rcv3', rcv3_mimic='pass')
+    @tags(speed='slow', type='rcv3', rcv3_mimic='pass', convergence='yes')
     @unittest.skip(
         'Skip pending implementation of network validation by Otter')
     def test_create_scaling_group_with_pool_on_private(self):
@@ -183,13 +183,13 @@ class AutoscaleRackConnectFixture(AutoscaleFixture):
                                                       self.servicenet_network])
         self._common_scaling_group_assertions(pool_group_resp)
 
-    @tags(speed='slow', type='rcv3', rcv3_mimic='pass')
+    @tags(speed='slow', type='rcv3', rcv3_mimic='pass', convergence='yes')
     @unittest.skip(
         'Skip pending implementation of network validation by Otter')
     def test_create_scaling_group_with_pool_on_public(self):
         """
         Test that it is possible to create a scaling group with 0 entities
-        connected to an RCV3 LB pool with only private network specified
+        connected to an RCV3 LB pool with only public network specified
         """
         # Create a scaling group with zero servers
         lb_pools = [{'loadBalancerId': self.pool.id, 'type': 'RackConnectV3'}]
@@ -199,7 +199,7 @@ class AutoscaleRackConnectFixture(AutoscaleFixture):
                                                       self.public_network])
         self._common_scaling_group_assertions(pool_group_resp)
 
-    @tags(speed='slow', type='rcv3', rcv3_mimic='pass')
+    @tags(speed='slow', type='rcv3', rcv3_mimic='pass', convergence='yes')
     def test_create_nonzero_scaling_group_with_pool_on_cloud_network(self):
         """
         Test that it is possible to create a scaling group with min_servers
@@ -216,7 +216,7 @@ class AutoscaleRackConnectFixture(AutoscaleFixture):
             asserter=self)
         self.verify_group_state(pool_group_resp.entity.id, self.min_servers)
 
-    @tags(speed='slow', type='rcv3', rcv3_mimic='fail')
+    @tags(speed='slow', type='rcv3', rcv3_mimic='fail', convergence='error')
     @unittest.skipIf(autoscale_config.mimic,
                      "This test fails on mimic because it does not implement "
                      "cloud networks yet.")
@@ -248,7 +248,7 @@ class AutoscaleRackConnectFixture(AutoscaleFixture):
                  pool_group_resp.entity.id, self.min_servers, timeout=600,
                  asserter=self))
 
-    @tags(speed='slow', type='rcv3', rcv3_mimic='fail')
+    @tags(speed='slow', type='rcv3', rcv3_mimic='fail', convergence='error')
     @unittest.skipIf(autoscale_config.mimic,
                      "This test fails on mimic because it does not implement "
                      "cloud networks yet.")
@@ -280,7 +280,7 @@ class AutoscaleRackConnectFixture(AutoscaleFixture):
                  pool_group_resp.entity.id, self.min_servers, timeout=600,
                  asserter=self))
 
-    @tags(speed='slow', type='rcv3', rcv3_mimic='pass')
+    @tags(speed='slow', type='rcv3', rcv3_mimic='pass', convergence='yes')
     def test_create_scaling_group_with_pool_counts(self):
         """
         Test that it is possible to create a scaling group with min_servers
@@ -326,7 +326,7 @@ class AutoscaleRackConnectFixture(AutoscaleFixture):
                      new_counts['cloud_servers'], init_cloud_servers,
                      self.min_servers))
 
-    @tags(speed='slow', type='rcv3', rcv3_mimic='fail')
+    @tags(speed='slow', type='rcv3', rcv3_mimic='fail', convergence='yes')
     @unittest.skipIf(autoscale_config.mimic,
                      "This test fails on mimic because it does not implement "
                      "cloud networks yet.")
@@ -380,7 +380,7 @@ class AutoscaleRackConnectFixture(AutoscaleFixture):
             .format(status)
         )
 
-    @tags(speed='slow', type='rcv3', rcv3_mimic='pass')
+    @tags(speed='slow', type='rcv3', rcv3_mimic='pass', convergence='yes')
     def test_scale_up_down_on_rcv3_pool(self):
         """
         Attempt to scale up and down on a correctly configured RCv3 pool.
@@ -509,7 +509,7 @@ class AutoscaleRackConnectFixture(AutoscaleFixture):
                             msg='Initial node {0} was not in '
                             'the final list'.format(nid))
 
-    @tags(speed='slow', type='rcv3', rcv3_mimic='pass')
+    @tags(speed='slow', type='rcv3', rcv3_mimic='pass', convergence='yes')
     def test_scale_up_down_on_rcv3_and_clb(self):
         """
         As test_scale_up_down_on_rcv3, but includes a cloud load balancer as
@@ -665,7 +665,7 @@ class AutoscaleRackConnectFixture(AutoscaleFixture):
                           'count of {1}'.format(num_clb_nodes_after_scale,
                                                 self.min_servers))
 
-    @tags(speed='slow', type='rcv3', rcv3_mimic='pass')
+    @tags(speed='slow', type='rcv3', rcv3_mimic='pass', convergence='yes')
     def test_scale_down_after_manual_remove_node(self):
         """
         Verify that the RCV3 group can successfully scale down after a server

--- a/autoscale_cloudroast/test_repo/autoscale/system/integration/test_system_integration_rcv3.py
+++ b/autoscale_cloudroast/test_repo/autoscale/system/integration/test_system_integration_rcv3.py
@@ -18,22 +18,6 @@ from test_repo.autoscale.fixtures import (
 from test_repo.autoscale.system.integration import common
 
 
-class DummyAsserter(object):
-    def __init__(self):
-        self.err = None
-
-    def assertEquals(self, a, b, msg):  # nopep8 - ignore N802
-        if a != b:
-            self.fail(msg)
-
-    def assertNotEquals(self, a, b, msg):  # nopep8 - ignore N802
-        if a == b:
-            self.fail(msg)
-
-    def fail(self, msg):
-        self.err = msg
-
-
 @unittest.skipUnless(rcv3_client, "RCv3 is not supported by this account.")
 class AutoscaleRackConnectFixture(AutoscaleFixture):
     """
@@ -129,30 +113,18 @@ class AutoscaleRackConnectFixture(AutoscaleFixture):
                           cls.lbaas_client.delete_load_balancer)
 
         # OK, back to waiting for autoscale servers to spin up.
-        dummy_asserter = DummyAsserter()
         cls.autoscale_behaviors.wait_for_expected_number_of_active_servers(
             background_group_resp.entity.id,
             2,
             timeout=600,
-            api="Autoscale",
-            asserter=dummy_asserter)
-
-        # If there was an error waiting for servers to build, abort the
-        # testing.
-        if dummy_asserter.err:
-            print("SetUpClass failed: background servers")
+            api="Autoscale")
 
         # Wait for initial nodes to be added to the load balancer
         cls.autoscale_behaviors.wait_for_expected_number_of_active_servers(
             cls.pool.id,
             count_pre_nodes + 2,
             timeout=300,
-            api="RackConnect",
-            asserter=dummy_asserter)
-        # If there was an error waiting for servers to build, abort the
-        # testing.
-        if dummy_asserter.err:
-            print("SetUpClass failed: background LB nodes")
+            api="RackConnect")
 
     @tags(speed='slow', type='rcv3', rcv3_mimic='pass', convergence='yes')
     def test_create_scaling_group_with_pool_on_cloud_network(self):

--- a/autoscale_cloudroast/test_repo/autoscale/system/integration/test_system_integration_rcv3.py
+++ b/autoscale_cloudroast/test_repo/autoscale/system/integration/test_system_integration_rcv3.py
@@ -196,7 +196,9 @@ class AutoscaleRackConnectFixture(AutoscaleFixture):
             asserter=self)
         self.verify_group_state(pool_group_resp.entity.id, self.min_servers)
 
-    @tags(speed='slow', type='rcv3', rcv3_mimic='fail', convergence='error')
+    # This tests that the desired capacity drops as a result of configuration
+    # errors, which happens on the worker, but not in convergence.
+    @tags(speed='slow', type='rcv3', rcv3_mimic='fail', convergence='never')
     @unittest.skipIf(autoscale_config.mimic,
                      "This test fails on mimic because it does not implement "
                      "cloud networks yet.")
@@ -228,7 +230,9 @@ class AutoscaleRackConnectFixture(AutoscaleFixture):
                  pool_group_resp.entity.id, self.min_servers, timeout=600,
                  asserter=self))
 
-    @tags(speed='slow', type='rcv3', rcv3_mimic='fail', convergence='error')
+    # This tests that the desired capacity drops as a result of configuration
+    # errors, which happens on the worker, but not in convergence.
+    @tags(speed='slow', type='rcv3', rcv3_mimic='fail', convergence='never')
     @unittest.skipIf(autoscale_config.mimic,
                      "This test fails on mimic because it does not implement "
                      "cloud networks yet.")


### PR DESCRIPTION
Some changes to make RCv3 cafe tests run better and in convergence.

~~Still waiting on the following:~~
- [x] #1675 
- [x] https://github.com/rackerlabs/autoscaling-chef/pull/763

#1681 Should also be done, but possibly as a different PR.