### PR TITLE
Optionally split the CF messages as well.

### DIFF
--- a/otter/convergence/logging.py
+++ b/otter/convergence/logging.py
@@ -52,7 +52,7 @@ def _log_set_metadata(steps):
     effs = [
         cf_msg(
             'convergence-set-server-metadata',
-            servers=', '.join(sorted(s.server_id for s in kvsteps)),
+            servers=sorted(s.server_id for s in kvsteps),
             key=key, value=value
         )
         for (key, value), kvsteps in sorted(by_kv.iteritems())
@@ -64,7 +64,7 @@ def _log_set_metadata(steps):
 def _log_delete_servers(steps):
     return cf_msg(
         'convergence-delete-servers',
-        servers=', '.join(sorted([s.server_id for s in steps])))
+        servers=sorted([s.server_id for s in steps]))
 
 
 @_logger(AddNodesToCLB)
@@ -75,7 +75,7 @@ def _log_add_nodes_clb(steps):
             lbs[step.lb_id].append('%s:%s' % (address, config.port))
     effs = [
         cf_msg('convergence-add-clb-nodes',
-               lb_id=lb_id, addresses=', '.join(sorted(addresses)))
+               lb_id=lb_id, addresses=sorted(addresses))
         for lb_id, addresses in sorted(lbs.iteritems())
     ]
     return parallel(effs)
@@ -98,7 +98,7 @@ def _log_change_clb_node(steps):
     effs = [
         cf_msg('convergence-change-clb-nodes',
                lb_id=lb,
-               nodes=', '.join(sorted([s.node_id for s in grouped_steps])),
+               nodes=sorted([s.node_id for s in grouped_steps]),
                condition=condition.name, weight=weight, type=node_type.name)
         for (lb, condition, weight, node_type), grouped_steps
         in sorted(lbs.iteritems())
@@ -111,7 +111,7 @@ def _log_bulk_rcv3(event, steps):
     effs = [
         cf_msg(event,
                lb_id=lb_id,
-               servers=', '.join(sorted(p[1] for p in pairs)))
+               servers=sorted(p[1] for p in pairs))
         for lb_id, pairs in sorted(by_lbs.iteritems())
     ]
     return parallel(effs)

--- a/otter/convergence/service.py
+++ b/otter/convergence/service.py
@@ -325,7 +325,7 @@ def convergence_failed(scaling_group, reasons):
         presented_reasons = [u"Unknown error occurred"]
     yield cf_err(
         'group-status-error', status=ScalingGroupStatus.ERROR.name,
-        reasons='; '.join(presented_reasons))
+        reasons=presented_reasons)
     yield Effect(UpdateGroupErrorReasons(scaling_group, presented_reasons))
     yield do_return(ScalingGroupStatus.ERROR)
 

--- a/otter/log/spec.py
+++ b/otter/log/spec.py
@@ -10,8 +10,10 @@ from toolz.functoolz import compose, curry
 
 from twisted.python.failure import Failure
 
+from otter.log.formatters import LoggingEncoder
 
-_json_len = compose(len, curry(json.dumps, default=repr))
+
+_json_len = compose(len, curry(json.dumps, cls=LoggingEncoder))
 
 
 def split_execute_convergence(event, max_length=50000):

--- a/otter/log/spec.py
+++ b/otter/log/spec.py
@@ -10,8 +10,10 @@ from toolz.functoolz import compose, curry
 
 from twisted.python.failure import Failure
 
+from otter.log.formatters import LoggingEncoder
 
-_json_len = compose(len, json.dumps)
+
+_json_len = compose(len, curry(json.dumps, cls=LoggingEncoder))
 
 
 def split_execute_convergence(event, max_length=50000):

--- a/otter/log/spec.py
+++ b/otter/log/spec.py
@@ -10,10 +10,8 @@ from toolz.functoolz import compose, curry
 
 from twisted.python.failure import Failure
 
-from otter.log.formatters import LoggingEncoder
 
-
-_json_len = compose(len, curry(json.dumps, cls=LoggingEncoder))
+_json_len = compose(len, curry(json.dumps, default=repr))
 
 
 def split_execute_convergence(event, max_length=50000):

--- a/otter/log/spec.py
+++ b/otter/log/spec.py
@@ -150,8 +150,9 @@ msg_types = {
     "convergence-remove-rcv3-nodes": split_cf_messages(
         "Removing servers from RCv3 LB {lb_id}: {servers}", "servers"),
     "group-status-active": "Group's status is changed to ACTIVE",
-    "group-status-error":
-        "Group's status is changed to ERROR. Reasons: {reasons}",
+    "group-status-error": split_cf_messages(
+        "Group's status is changed to ERROR. Reasons: {reasons}", "reasons",
+        separator='; ')
 }
 
 

--- a/otter/test/convergence/test_logging.py
+++ b/otter/test/convergence/test_logging.py
@@ -67,7 +67,7 @@ class LogStepsTests(SynchronousTestCase):
                         DeleteServer(server_id='3')])
         self.assert_logs(deletes, [
             Log('convergence-delete-servers',
-                fields={'servers': '1, 2, 3', 'cloud_feed': True,
+                fields={'servers': ['1', '2', '3'], 'cloud_feed': True,
                         'cloud_feed_id': ANY})
         ])
 
@@ -86,11 +86,11 @@ class LogStepsTests(SynchronousTestCase):
         self.assert_logs(adds, [
             Log('convergence-add-clb-nodes',
                 fields={'lb_id': 'lbid1',
-                        'addresses': '10.0.0.1:1234, 10.0.0.2:1235',
+                        'addresses': ['10.0.0.1:1234', '10.0.0.2:1235'],
                         'cloud_feed': True, 'cloud_feed_id': ANY}),
             Log('convergence-add-clb-nodes',
                 fields={'lb_id': 'lbid2',
-                        'addresses': '10.0.0.1:4321',
+                        'addresses': ['10.0.0.1:4321'],
                         'cloud_feed': True, 'cloud_feed_id': ANY})
         ])
 
@@ -135,19 +135,19 @@ class LogStepsTests(SynchronousTestCase):
         self.assert_logs(changes, [
             Log('convergence-change-clb-nodes',
                 fields={
-                    'lb_id': 'lbid1', 'nodes': 'node3',
+                    'lb_id': 'lbid1', 'nodes': ['node3'],
                     'type': 'PRIMARY', 'condition': 'ENABLED', 'weight': 50,
                     'cloud_feed': True, 'cloud_feed_id': ANY
                 }),
             Log('convergence-change-clb-nodes',
                 fields={
-                    'lb_id': 'lbid1', 'nodes': 'node1, node2',
+                    'lb_id': 'lbid1', 'nodes': ['node1', 'node2'],
                     'type': 'PRIMARY', 'condition': 'DRAINING', 'weight': 50,
                     'cloud_feed': True, 'cloud_feed_id': ANY
                 }),
             Log('convergence-change-clb-nodes',
                 fields={
-                    'lb_id': 'lbid2', 'nodes': 'node4',
+                    'lb_id': 'lbid2', 'nodes': ['node4'],
                     'type': 'PRIMARY', 'condition': 'ENABLED', 'weight': 50,
                     'cloud_feed': True, 'cloud_feed_id': ANY
                 }),
@@ -166,16 +166,16 @@ class LogStepsTests(SynchronousTestCase):
         ])
         self.assert_logs(adds, [
             Log('convergence-add-rcv3-nodes',
-                fields={'lb_id': 'lb1', 'servers': 'node1, node2, nodea',
+                fields={'lb_id': 'lb1', 'servers': ['node1', 'node2', 'nodea'],
                         'cloud_feed': True, 'cloud_feed_id': ANY}),
             Log('convergence-add-rcv3-nodes',
-                fields={'lb_id': 'lb2', 'servers': 'node2, node3',
+                fields={'lb_id': 'lb2', 'servers': ['node2', 'node3'],
                         'cloud_feed': True, 'cloud_feed_id': ANY}),
             Log('convergence-add-rcv3-nodes',
-                fields={'lb_id': 'lb3', 'servers': 'node4',
+                fields={'lb_id': 'lb3', 'servers': ['node4'],
                         'cloud_feed': True, 'cloud_feed_id': ANY}),
             Log('convergence-add-rcv3-nodes',
-                fields={'lb_id': 'lba', 'servers': 'nodea, nodeb',
+                fields={'lb_id': 'lba', 'servers': ['nodea', 'nodeb'],
                         'cloud_feed': True, 'cloud_feed_id': ANY})
         ])
 
@@ -192,16 +192,16 @@ class LogStepsTests(SynchronousTestCase):
         ])
         self.assert_logs(adds, [
             Log('convergence-remove-rcv3-nodes',
-                fields={'lb_id': 'lb1', 'servers': 'node1, node2, nodea',
+                fields={'lb_id': 'lb1', 'servers': ['node1', 'node2', 'nodea'],
                         'cloud_feed': True, 'cloud_feed_id': ANY}),
             Log('convergence-remove-rcv3-nodes',
-                fields={'lb_id': 'lb2', 'servers': 'node2, node3',
+                fields={'lb_id': 'lb2', 'servers': ['node2', 'node3'],
                         'cloud_feed': True, 'cloud_feed_id': ANY}),
             Log('convergence-remove-rcv3-nodes',
-                fields={'lb_id': 'lb3', 'servers': 'node4',
+                fields={'lb_id': 'lb3', 'servers': ['node4'],
                         'cloud_feed': True, 'cloud_feed_id': ANY}),
             Log('convergence-remove-rcv3-nodes',
-                fields={'lb_id': 'lba', 'servers': 'nodea, nodeb',
+                fields={'lb_id': 'lba', 'servers': ['nodea', 'nodeb'],
                         'cloud_feed': True, 'cloud_feed_id': ANY})
         ])
 
@@ -215,9 +215,9 @@ class LogStepsTests(SynchronousTestCase):
 
         self.assert_logs(sets, [
             Log('convergence-set-server-metadata',
-                fields={'servers': 's1, s2', 'key': 'k1', 'value': 'v1',
+                fields={'servers': ['s1', 's2'], 'key': 'k1', 'value': 'v1',
                         'cloud_feed': True, 'cloud_feed_id': ANY}),
             Log('convergence-set-server-metadata',
-                fields={'servers': 's3', 'key': 'k2', 'value': 'v2',
+                fields={'servers': ['s3'], 'key': 'k2', 'value': 'v2',
                         'cloud_feed': True, 'cloud_feed_id': ANY})
         ])

--- a/otter/test/convergence/test_service.py
+++ b/otter/test/convergence/test_service.py
@@ -945,8 +945,8 @@ class ExecuteConvergenceTests(SynchronousTestCase):
             (Log('group-status-error',
                  dict(isError=True, cloud_feed=True,
                       cloud_feed_id=mock.ANY, status='ERROR',
-                      reasons='Cloud Load Balancer does not exist: nolb1; '
-                              'Cloud Load Balancer does not exist: nolb2')),
+                      reasons=['Cloud Load Balancer does not exist: nolb1',
+                               'Cloud Load Balancer does not exist: nolb2'])),
              noop),
             (UpdateGroupErrorReasons(
                 self.group,
@@ -980,7 +980,7 @@ class ExecuteConvergenceTests(SynchronousTestCase):
              noop),
             (Log('group-status-error',
                  dict(isError=True, cloud_feed=True, cloud_feed_id=mock.ANY,
-                      status='ERROR', reasons='Unknown error occurred')),
+                      status='ERROR', reasons=['Unknown error occurred'])),
              noop),
             (UpdateGroupErrorReasons(self.group, ['Unknown error occurred']),
              noop)

--- a/otter/test/log/test_spec.py
+++ b/otter/test/log/test_spec.py
@@ -289,12 +289,14 @@ class CFMessageSplitTests(SynchronousTestCase):
     """
     def test_no_need_to_split_if_below_length(self):
         """
-        Do not split the event if the message is sufficiently short.
+        Do not split the event if the message is sufficiently short.  However,
+        do format it so that the list becomes a comma-separated string.
         """
         message = 'Hello {there} human being {punctuation}'
         event = {'there': [1, 2, 3, 4], 'punctuation': '!', 'extra': 'unused'}
         result = split_cf_messages(message, 'there')(event)
-        self.assertEqual(result, [(event, message)])
+        self.assertEqual(result,
+                         [(assoc(event, 'there', '1, 2, 3, 4'), message)])
 
     def test_no_split_on_empty_field(self):
         """
@@ -304,7 +306,7 @@ class CFMessageSplitTests(SynchronousTestCase):
         message = 'Hello {there} human being {punctuation}'
         event = {'there': [], 'punctuation': '!', 'extra': 'unused'}
         result = split_cf_messages(message, 'there', max_length=5)(event)
-        self.assertEqual(result, [(event, message)])
+        self.assertEqual(result, [(assoc(event, 'there', ''), message)])
 
     def test_split_only_var_key(self):
         """


### PR DESCRIPTION
This is dependent upon #1672 getting merged.

This means that our CF messages that have variable length items, like server IDs or IP addresses, might get split across multiple messages if it exceeds the length.

Part of addressing #1583.