### PR TITLE
Refactor start convergence

### DIFF
--- a/otter/convergence/service.py
+++ b/otter/convergence/service.py
@@ -387,10 +387,14 @@ def delete_divergent_flag(tenant_id, group_id, version):
 
 
 def trigger_convergence(tenant_id, group_id):
+    """
+    Trigger convergence on a scaling group
+    """
     eff = with_log(mark_divergent(tenant_id, group_id),
                    tenant_id=tenant_id, scaling_group_id=group_id)
     return eff.on(success=lambda _: msg("mark-dirty-success"),
-                  error=lambda e: err("mark-dirty-failure"))
+                  error=lambda e: err(exc_info_to_failure(e),
+                                      "mark-dirty-failure"))
 
 
 class ConvergenceStarter(object):

--- a/otter/convergence/service.py
+++ b/otter/convergence/service.py
@@ -386,6 +386,13 @@ def delete_divergent_flag(tenant_id, group_id, version):
         yield msg('mark-clean-success')
 
 
+def trigger_convergence(tenant_id, group_id):
+    eff = with_log(mark_divergent(tenant_id, group_id),
+                   tenant_id=tenant_id, scaling_group_id=group_id)
+    return eff.on(success=lambda _: msg("mark-dirty-success"),
+                  error=lambda e: err("mark-dirty-failure"))
+
+
 class ConvergenceStarter(object):
     """
     A service that allows indicating that a group has diverged and needs

--- a/otter/rest/groups.py
+++ b/otter/rest/groups.py
@@ -21,6 +21,7 @@ from otter.json_schema.group_schemas import (
 )
 from otter.json_schema.rest_schemas import create_group_request
 from otter.log import log
+from otter.log.intents import with_log
 from otter.models.cass import CassScalingGroupServersCache
 from otter.models.interface import ScalingGroupStatus
 from otter.rest.bobby import get_bobby
@@ -673,7 +674,10 @@ class OtterGroup(object):
             group = self.store.get_scaling_group(
                 self.log, self.tenant_id, self.group_id)
             d = group.modify_state(is_group_paused)
-            eff = trigger_convergence(self.tenant_id, self.group_id)
+            eff = with_log(trigger_convergence(self.tenant_id, self.group_id),
+                           tenant_id=self.tenant_id,
+                           scaling_group_id=self.group_id,
+                           transaction_id=transaction_id(request))
             return d.addCallback(lambda _: perform(self.dispatcher, eff))
 
         else:

--- a/otter/test/convergence/test_service.py
+++ b/otter/test/convergence/test_service.py
@@ -71,11 +71,7 @@ class TriggerConvergenceTests(SynchronousTestCase):
         Divergent flag is set with bound log and msg is logged
         """
         seq = [
-            (BoundFields(mock.ANY, dict(tenant_id="t", scaling_group_id="g")),
-             nested_sequence([
-                 (CreateOrSet(path="/groups/divergent/t_g", content="dirty"),
-                  noop)
-             ])),
+            (CreateOrSet(path="/groups/divergent/t_g", content="dirty"), noop),
             (Log("mark-dirty-success", {}), noop)
         ]
         self.assertEqual(
@@ -84,22 +80,17 @@ class TriggerConvergenceTests(SynchronousTestCase):
 
     def test_failure(self):
         """
-        If setting divergent flag errors, then error is logged and
-        None returned
+        If setting divergent flag errors, then error is logged and raised
         """
         seq = [
-            (BoundFields(mock.ANY, dict(tenant_id="t", scaling_group_id="g")),
-             nested_sequence([
-                 (CreateOrSet(path="/groups/divergent/t_g", content="dirty"),
-                  lambda i: raise_(ValueError("oops")))
-             ])),
+            (CreateOrSet(path="/groups/divergent/t_g", content="dirty"),
+             lambda i: raise_(ValueError("oops"))),
             (LogErr(CheckFailureValue(ValueError("oops")),
                     "mark-dirty-failure", {}),
              noop)
         ]
-        self.assertEqual(
-            perform_sequence(seq, trigger_convergence("t", "g")),
-            None)
+        self.assertRaises(
+            ValueError, perform_sequence, seq, trigger_convergence("t", "g"))
 
 
 class ConvergenceStarterTests(SynchronousTestCase):

--- a/otter/test/rest/test_groups.py
+++ b/otter/test/rest/test_groups.py
@@ -29,6 +29,7 @@ from otter.json_schema.group_examples import (
     policy as policy_examples,
 )
 from otter.json_schema.group_schemas import MAX_ENTITIES
+from otter.log.intents import BoundFields
 from otter.models.interface import (
     GroupNotEmptyError,
     GroupState,
@@ -45,7 +46,8 @@ from otter.supervisor import (
     set_supervisor,
 )
 from otter.test.rest.request import DummyException, RestAPITestMixin
-from otter.test.utils import IsBoundWith, intent_func, matches, noop, patch
+from otter.test.utils import (
+    IsBoundWith, intent_func, matches, nested_sequence, noop, patch)
 from otter.util.config import set_config_data
 from otter.worker.validate_config import InvalidLaunchConfiguration
 
@@ -1157,7 +1159,12 @@ class OneGroupTestCase(RestAPITestMixin, SynchronousTestCase):
         set_config_data({'convergence-tenants': ['11111']})
         self.addCleanup(set_config_data, {})
         self.otter.dispatcher = SequenceDispatcher([
-            (("tg", "11111", "one"), noop)
+            (BoundFields(mock.ANY,
+                         dict(tenant_id='11111', scaling_group_id="one",
+                              transaction_id="transaction-id")),
+             nested_sequence([
+                (("tg", "11111", "one"), noop)
+             ]))
         ])
         self.mock_state = GroupState(
             '11111', 'one', '', {}, {}, None, {}, False,

--- a/otter/test/rest/test_groups.py
+++ b/otter/test/rest/test_groups.py
@@ -8,6 +8,8 @@ from copy import deepcopy
 
 from datetime import datetime
 
+from effect.testing import SequenceDispatcher
+
 from jsonschema import ValidationError
 
 import mock
@@ -43,7 +45,7 @@ from otter.supervisor import (
     set_supervisor,
 )
 from otter.test.rest.request import DummyException, RestAPITestMixin
-from otter.test.utils import IsBoundWith, matches, patch
+from otter.test.utils import IsBoundWith, intent_func, matches, noop, patch
 from otter.util.config import set_config_data
 from otter.worker.validate_config import InvalidLaunchConfiguration
 
@@ -876,6 +878,7 @@ class OneGroupTestCase(RestAPITestMixin, SynchronousTestCase):
         Set the uuid of the group to "one"
         """
         super(OneGroupTestCase, self).setUp()
+        self.otter.dispatcher = "disp"
         self.mock_group.uuid = "one"
         self.mock_controller = patch(self, 'otter.rest.groups.controller')
 
@@ -1096,7 +1099,7 @@ class OneGroupTestCase(RestAPITestMixin, SynchronousTestCase):
         self.mock_store.get_scaling_group.assert_called_once_with(
             mock.ANY, '11111', 'one')
         self.mock_controller.delete_group.assert_called_once_with(
-            mock.ANY, 'transaction-id', self.mock_group, False)
+            "disp", mock.ANY, 'transaction-id', self.mock_group, False)
 
     def test_group_delete_force(self):
         """
@@ -1108,7 +1111,7 @@ class OneGroupTestCase(RestAPITestMixin, SynchronousTestCase):
             204, endpoint="{0}?force=true".format(self.endpoint),
             method="DELETE")
         self.mock_controller.delete_group.assert_called_once_with(
-            mock.ANY, "transaction-id", self.mock_group, True)
+            "disp", mock.ANY, "transaction-id", self.mock_group, True)
 
     def test_group_delete_404(self):
         """
@@ -1121,7 +1124,7 @@ class OneGroupTestCase(RestAPITestMixin, SynchronousTestCase):
         self.mock_store.get_scaling_group.assert_called_once_with(
             mock.ANY, '11111', 'one')
         self.mock_controller.delete_group.assert_called_once_with(
-            mock.ANY, "transaction-id", self.mock_group, False)
+            "disp", mock.ANY, "transaction-id", self.mock_group, False)
 
         resp = json.loads(response_body)
         self.assertEqual(resp['error']['type'], 'NoSuchScalingGroupError')
@@ -1138,28 +1141,31 @@ class OneGroupTestCase(RestAPITestMixin, SynchronousTestCase):
         self.mock_store.get_scaling_group.assert_called_once_with(
             mock.ANY, '11111', 'one')
         self.mock_controller.delete_group.assert_called_once_with(
-            mock.ANY, "transaction-id", self.mock_group, False)
+            "disp", mock.ANY, "transaction-id", self.mock_group, False)
 
         resp = json.loads(response_body)
         self.assertEqual(resp['error']['type'], 'GroupNotEmptyError')
         self.flushLoggedErrors(GroupNotEmptyError)
 
-    @mock.patch('otter.rest.groups.get_convergence_starter')
-    def test_group_converge_enabled_tenant(self, mock_gcs):
+    @mock.patch('otter.rest.groups.trigger_convergence',
+                side_effect=intent_func("tg"))
+    def test_group_converge_enabled_tenant(self, mock_tg):
         """
         Calling `../converge` on convergence enabled tenant triggers
         convergence and returns Deferred with None after enabling it
         """
         set_config_data({'convergence-tenants': ['11111']})
         self.addCleanup(set_config_data, {})
-        cs = mock_gcs.return_value
-        cs.start_convergence.return_value = defer.succeed(None)
+        self.otter.dispatcher = SequenceDispatcher([
+            (("tg", "11111", "one"), noop)
+        ])
         self.mock_state = GroupState(
             '11111', 'one', '', {}, {}, None, {}, False,
             ScalingGroupStatus.ACTIVE)
-        self.assert_status_code(
-            204, endpoint='{}converge'.format(self.endpoint), method='POST')
-        cs.start_convergence.assert_called_once_with(mock.ANY, '11111', 'one')
+        with self.otter.dispatcher.consume():
+            self.assert_status_code(
+                204, endpoint='{}converge'.format(self.endpoint),
+                method='POST')
 
     def test_group_paused_converge(self):
         """
@@ -1324,6 +1330,7 @@ class GroupServersTests(RestAPITestMixin, SynchronousTestCase):
         Mock remove_server_from_group
         """
         super(GroupServersTests, self).setUp()
+        self.otter.dispatcher = "disp"
         self.mock_rsfg = patch(
             self, 'otter.rest.groups.controller.remove_server_from_group',
             return_value=None)
@@ -1350,6 +1357,7 @@ class GroupServersTests(RestAPITestMixin, SynchronousTestCase):
         Asserts that the call to :func:`remove_server_from_group` is correct.
         """
         self.mock_rsfg.assert_called_once_with(
+            "disp",
             matches(IsBoundWith(system='otter.rest.groups.delete_server',
                                 tenant_id='11111',
                                 scaling_group_id='one',

--- a/otter/test/test_controller.py
+++ b/otter/test/test_controller.py
@@ -24,7 +24,7 @@ from otter.cloud_client import (
     set_nova_metadata_item)
 from otter.convergence.model import DRAINING_METADATA
 from otter.convergence.service import (
-    ConvergenceStarter, get_convergence_starter, set_convergence_starter)
+    get_convergence_starter, set_convergence_starter)
 from otter.log.intents import BoundFields, Log
 from otter.models.intents import GetScalingGroupInfo, ModifyGroupStatePaused
 from otter.models.interface import (
@@ -1842,10 +1842,10 @@ class ConvergenceRemoveServerTests(SynchronousTestCase):
         new_state = assoc_obj(self.state, desired=self.state.desired - 1)
         disp = SequenceDispatcher([
             (BoundFields(mock.ANY, dict(server_id="server_id",
-                                       transaction_id=self.trans_id)),
+                                        transaction_id=self.trans_id)),
              nested_sequence([
                 (("crsfg", self.log, self.trans_id, "server_id", False, False,
-                self.group, self.state), lambda i: new_state),
+                  self.group, self.state), lambda i: new_state),
                 (("tg", "tenant_id", "group_id"), lambda i: "triggered")
              ]))
         ])


### PR DESCRIPTION
In the process of removing `ConvergenceStarter` and replacing it with effect based `trigger_convergence` function. This is possible since rest APIs objects have dispatcher that they can use to perform the effects. 

This is precursor to implementing #1669 which will remove `ConvergenceStarter` completely. 