### PR TITLE
Ensure all log observers fork below ErrorFormattingObserver

### DIFF
--- a/otter/integration/lib/trial_tools.py
+++ b/otter/integration/lib/trial_tools.py
@@ -48,7 +48,6 @@ from otter.log.formatters import (
     LoggingEncoder,
     PEP3101FormattingWrapper,
     StreamObserverWrapper,
-    copying_wrapper
 )
 
 from otter.util.logging_treq import LoggingTreq
@@ -151,6 +150,16 @@ def pretty_print_logs(observer):
             ["", message, json.dumps(eventdict, cls=LoggingEncoder, indent=2),
              "", "-" * 8]
         )})
+    return emit
+
+
+def copying_wrapper(observer):
+    """
+    An observer that copies the event-dict, so if there is more than one
+    observer chain that mutates events, we don't get any errors.
+    """
+    def emit(event_dict):
+        return observer(event_dict.copy())
     return emit
 
 

--- a/otter/log/cloudfeeds.py
+++ b/otter/log/cloudfeeds.py
@@ -16,14 +16,8 @@ from txeffect import perform
 from otter.cloud_client import TenantScope, publish_to_cloudfeeds
 from otter.effect_dispatcher import get_legacy_dispatcher
 from otter.log import log as otter_log
-from otter.log.formatters import (
-    ErrorFormattingWrapper,
-    LogLevel,
-    PEP3101FormattingWrapper,
-    copying_wrapper
-)
+from otter.log.formatters import LogLevel
 from otter.log.intents import err as err_effect, msg as msg_effect
-from otter.log.spec import SpecificationObserverWrapper
 from otter.util.http import APIError
 from otter.util.retry import (
     compose_retries,
@@ -213,17 +207,3 @@ class CloudFeedsObserver(object):
                 self.get_disp(self.reactor, self.authenticator, log,
                               self.service_configs),
                 eff).addErrback(log.err, 'cf-add-failure')
-
-
-def get_cf_observer(reactor, authenticator, tenant_id, region,
-                    service_configs):
-    """
-    Return cloud feeds observer after setting up some intial formatting
-    """
-    cf_observer = CloudFeedsObserver(
-        reactor=reactor, authenticator=authenticator, tenant_id=tenant_id,
-        region=region, service_configs=service_configs)
-    return copying_wrapper(
-        SpecificationObserverWrapper(
-            PEP3101FormattingWrapper(
-                ErrorFormattingWrapper(cf_observer))))

--- a/otter/log/formatters.py
+++ b/otter/log/formatters.py
@@ -35,7 +35,10 @@ _fanout = None
 
 def add_to_fanout(observer):
     """
-    :return: the global instance of :class:`FanoutObserver`
+    Add the given observer to the global instance of :class:`FanoutObserver`
+
+    :param callable observer: The observer to fan out to.
+    :return: `None`
     """
     global _fanout
     if _fanout is None:
@@ -54,6 +57,7 @@ def get_fanout():
 def set_fanout(fanout):
     """
     Set the global instance of :class:`FanoutObserver`.
+    :return: `None`
     """
     global _fanout
     _fanout = fanout

--- a/otter/log/formatters.py
+++ b/otter/log/formatters.py
@@ -42,7 +42,6 @@ def add_to_fanout(observer):
         _fanout = FanoutObserver(observer)
     else:
         _fanout.add_observer(observer)
-    return _fanout
 
 
 def get_fanout():

--- a/otter/log/formatters.py
+++ b/otter/log/formatters.py
@@ -30,6 +30,49 @@ THROTTLE_COUNT = 50
 NON_PEP3101_SYSTEMS = ('kazoo',)
 
 
+_fanout = None
+
+
+def get_fanout():
+    """
+    :return: the global instance of :class:`FanoutObserver`
+    """
+    return _fanout
+
+
+def set_fanout(fanout):
+    """
+    Set the global instance of :class:`FanoutObserver`.
+    """
+    global _fanout
+    _fanout = fanout
+
+
+class FanoutObserver(object):
+    """
+    A fanout observer that emits events that it receives to all its sub
+    observers.
+    """
+    def __init__(self, observer):
+        """
+        Initialize the subobservers with the first observer.
+        """
+        self.subobservers = [copying_wrapper(observer)]
+
+    def add_observer(self, observer):
+        """
+        Add another observer to the subobservers.
+        """
+        self.subobservers.append(copying_wrapper(observer))
+
+    def emit(self, event_dict):
+        """
+        Emit a copy of the event dict to every subobserver.
+        """
+        for ob in self.subobservers:
+            ob(event_dict)
+
+
 class LoggingEncoder(json.JSONEncoder):
     """
     A JSONEncoder that will decide how to serialize objects that the base

--- a/otter/log/formatters.py
+++ b/otter/log/formatters.py
@@ -57,20 +57,20 @@ class FanoutObserver(object):
         """
         Initialize the subobservers with the first observer.
         """
-        self.subobservers = [copying_wrapper(observer)]
+        self.subobservers = [observer]
 
     def add_observer(self, observer):
         """
         Add another observer to the subobservers.
         """
-        self.subobservers.append(copying_wrapper(observer))
+        self.subobservers.append(observer)
 
     def emit(self, event_dict):
         """
         Emit a copy of the event dict to every subobserver.
         """
         for ob in self.subobservers:
-            ob(event_dict)
+            ob(event_dict.copy())
 
 
 class LoggingEncoder(json.JSONEncoder):
@@ -323,14 +323,4 @@ def throttling_wrapper(observer):
         else:
             return observer(event)
 
-    return emit
-
-
-def copying_wrapper(observer):
-    """
-    An observer that copies the event-dict, so if there is more than one
-    observer chain that mutates events, we don't get any errors.
-    """
-    def emit(event_dict):
-        return observer(event_dict.copy())
     return emit

--- a/otter/log/formatters.py
+++ b/otter/log/formatters.py
@@ -33,6 +33,18 @@ NON_PEP3101_SYSTEMS = ('kazoo',)
 _fanout = None
 
 
+def add_to_fanout(observer):
+    """
+    :return: the global instance of :class:`FanoutObserver`
+    """
+    global _fanout
+    if _fanout is None:
+        _fanout = FanoutObserver(observer)
+    else:
+        _fanout.add_observer(observer)
+    return _fanout
+
+
 def get_fanout():
     """
     :return: the global instance of :class:`FanoutObserver`

--- a/otter/log/formatters.py
+++ b/otter/log/formatters.py
@@ -77,7 +77,7 @@ class FanoutObserver(object):
         """
         self.subobservers.append(observer)
 
-    def emit(self, event_dict):
+    def __call__(self, event_dict):
         """
         Emit a copy of the event dict to every subobserver.
         """

--- a/otter/log/setup.py
+++ b/otter/log/setup.py
@@ -12,6 +12,7 @@ from otter.log.formatters import (
     StreamObserverWrapper,
     SystemFilterWrapper,
     add_to_fanout,
+    get_fanout,
     throttling_wrapper,
 )
 from otter.log.spec import SpecificationObserverWrapper
@@ -21,18 +22,20 @@ def make_observer_chain(ultimate_observer, indent):
     """
     Return our feature observers wrapped our the ultimate_observer
     """
+    add_to_fanout(
+        ObserverWrapper(
+            JSONObserverWrapper(
+                ultimate_observer,
+                sort_keys=True,
+                indent=indent or None),
+            hostname=socket.gethostname()))
+
     return throttling_wrapper(
         SpecificationObserverWrapper(
             PEP3101FormattingWrapper(
                 SystemFilterWrapper(
                     ErrorFormattingWrapper(
-                        add_to_fanout(
-                            ObserverWrapper(
-                                JSONObserverWrapper(
-                                    ultimate_observer,
-                                    sort_keys=True,
-                                    indent=indent or None),
-                                hostname=socket.gethostname())))))))
+                        get_fanout())))))
 
 
 def observer_factory():

--- a/otter/log/setup.py
+++ b/otter/log/setup.py
@@ -6,13 +6,12 @@ import sys
 
 from otter.log.formatters import (
     ErrorFormattingWrapper,
-    FanoutObserver,
     JSONObserverWrapper,
     ObserverWrapper,
     PEP3101FormattingWrapper,
     StreamObserverWrapper,
     SystemFilterWrapper,
-    set_fanout,
+    add_to_fanout,
     throttling_wrapper,
 )
 from otter.log.spec import SpecificationObserverWrapper
@@ -22,21 +21,18 @@ def make_observer_chain(ultimate_observer, indent):
     """
     Return our feature observers wrapped our the ultimate_observer
     """
-    fanout = FanoutObserver(
-        ObserverWrapper(
-            JSONObserverWrapper(
-                ultimate_observer,
-                sort_keys=True,
-                indent=indent or None),
-            hostname=socket.gethostname()))
-    set_fanout(fanout)
-
     return throttling_wrapper(
         SpecificationObserverWrapper(
             PEP3101FormattingWrapper(
                 SystemFilterWrapper(
                     ErrorFormattingWrapper(
-                        fanout)))))
+                        add_to_fanout(
+                            ObserverWrapper(
+                                JSONObserverWrapper(
+                                    ultimate_observer,
+                                    sort_keys=True,
+                                    indent=indent or None),
+                                hostname=socket.gethostname())))))))
 
 
 def observer_factory():

--- a/otter/log/setup.py
+++ b/otter/log/setup.py
@@ -6,13 +6,14 @@ import sys
 
 from otter.log.formatters import (
     ErrorFormattingWrapper,
+    FanoutObserver,
     JSONObserverWrapper,
     ObserverWrapper,
     PEP3101FormattingWrapper,
     StreamObserverWrapper,
     SystemFilterWrapper,
+    set_fanout,
     throttling_wrapper,
-    copying_wrapper,
 )
 from otter.log.spec import SpecificationObserverWrapper
 
@@ -21,18 +22,21 @@ def make_observer_chain(ultimate_observer, indent):
     """
     Return our feature observers wrapped our the ultimate_observer
     """
-    return copying_wrapper(
-        throttling_wrapper(
-            SpecificationObserverWrapper(
-                PEP3101FormattingWrapper(
-                    SystemFilterWrapper(
-                        ErrorFormattingWrapper(
-                            ObserverWrapper(
-                                JSONObserverWrapper(
-                                    ultimate_observer,
-                                    sort_keys=True,
-                                    indent=indent or None),
-                                hostname=socket.gethostname())))))))
+    fanout = FanoutObserver(
+        ObserverWrapper(
+            JSONObserverWrapper(
+                ultimate_observer,
+                sort_keys=True,
+                indent=indent or None),
+            hostname=socket.gethostname()))
+    set_fanout(fanout)
+
+    return throttling_wrapper(
+        SpecificationObserverWrapper(
+            PEP3101FormattingWrapper(
+                SystemFilterWrapper(
+                    ErrorFormattingWrapper(
+                        fanout)))))
 
 
 def observer_factory():

--- a/otter/tap/api.py
+++ b/otter/tap/api.py
@@ -38,7 +38,7 @@ from otter.convergence.service import (
 from otter.effect_dispatcher import get_full_dispatcher
 from otter.log import log
 from otter.log.cloudfeeds import CloudFeedsObserver
-from otter.log.formatters import get_fanout
+from otter.log.formatters import add_to_fanout
 from otter.models.cass import CassAdmin, CassScalingGroupCollection
 from otter.rest.admin import OtterAdmin
 from otter.rest.application import Otter
@@ -251,10 +251,7 @@ def makeService(config):
     if cf_conf is not None:
         id_conf = deepcopy(config['identity'])
         id_conf['strategy'] = 'single_tenant'
-        fanout = get_fanout()
-        assert fanout is not None, "No twistd logger set up yet"
-
-        fanout.add_observer(CloudFeedsObserver(
+        add_to_fanout(CloudFeedsObserver(
             reactor=reactor,
             authenticator=generate_authenticator(reactor, id_conf),
             tenant_id=cf_conf['tenant_id'],

--- a/otter/test/log/test_cloudfeeds.py
+++ b/otter/test/log/test_cloudfeeds.py
@@ -23,7 +23,6 @@ from otter.log.cloudfeeds import (
     UnsuitableMessage,
     add_event,
     cf_err, cf_fail, cf_msg,
-    get_cf_observer,
     prepare_request,
     request_format,
     sanitize_event
@@ -34,7 +33,6 @@ from otter.test.utils import (
     CheckFailure,
     mock_log,
     nested_sequence,
-    patch,
     perform_sequence,
     raise_,
     retry_sequence,
@@ -399,45 +397,3 @@ class CloudFeedsObserverTests(SynchronousTestCase):
             None, 'cf-unsuitable-message', unsuitable_message='bad',
             event_data={'event': 'dict'}, system='otter.cloud_feed',
             cf_msg='m')
-
-    def test_get_cf_observer(self):
-        """
-        `get_cf_observer` returns CloudFeedsObserver with observer chain setup
-        before creating
-        """
-        def wrapper(name, observer):
-            def _observer(e):
-                e.update({name: 'done'})
-                observer(e)
-            return _observer
-
-        patch(self, 'otter.log.cloudfeeds.SpecificationObserverWrapper',
-              side_effect=partial(wrapper, 'spec'))
-        patch(self, 'otter.log.cloudfeeds.PEP3101FormattingWrapper',
-              side_effect=partial(wrapper, 'pep'))
-        patch(self, 'otter.log.cloudfeeds.ErrorFormattingWrapper',
-              side_effect=partial(wrapper, 'error'))
-
-        def cf_observer_called(text):
-            self.cf_observer_text = text
-
-        mock_cfo = patch(self, 'otter.log.cloudfeeds.CloudFeedsObserver')
-        cfo_class = mock_cfo.return_value
-        cfo_class.side_effect = cf_observer_called
-
-        cfo = get_cf_observer(*range(5))
-
-        mock_cfo.assert_called_once_with(
-            reactor=0, authenticator=1, tenant_id=2, region=3,
-            service_configs=4)
-
-        event_dict = {'init': 'test'}
-        cfo({'init': 'test'})
-        self.assertEqual(self.cf_observer_text,
-                         {'init': 'test',
-                          'spec': 'done',
-                          'pep': 'done',
-                          'error': 'done'})
-        self.assertEqual(event_dict, {'init': 'test'},
-                         "the original event dict shouldn't be mutated "
-                         "in case there is another observer chain.")

--- a/otter/test/log/test_log.py
+++ b/otter/test/log/test_log.py
@@ -651,15 +651,14 @@ class FanoutObserverTests(SynchronousTestCase):
         self.assertEqual(get_fanout(), None)
 
         # add_to_fanout when there is no fanout
-        fanout1 = add_to_fanout(obs1.append)
-        self.assertIs(fanout1, get_fanout())
-        self.assertEqual(fanout1.subobservers, [obs1.append])
+        add_to_fanout(obs1.append)
+        fanout = get_fanout()
+        self.assertEqual(fanout.subobservers, [obs1.append])
 
         # add_to_fanout when there is already a fanout
-        fanout2 = add_to_fanout(obs2.append)
-        self.assertIs(fanout2, fanout1)
-        self.assertIs(fanout1, get_fanout())
-        self.assertEqual(fanout2.subobservers, [obs1.append, obs2.append])
+        add_to_fanout(obs2.append)
+        self.assertIs(get_fanout(), fanout)
+        self.assertEqual(fanout.subobservers, [obs1.append, obs2.append])
 
         # set_fanout
         set_fanout(None)

--- a/otter/test/log/test_log.py
+++ b/otter/test/log/test_log.py
@@ -26,6 +26,7 @@ from otter.log.formatters import (
     PEP3101FormattingWrapper,
     StreamObserverWrapper,
     SystemFilterWrapper,
+    add_to_fanout,
     get_fanout,
     serialize_to_jsonable,
     set_fanout,
@@ -644,10 +645,11 @@ class FanoutObserverTests(SynchronousTestCase):
 
     def test_global_fanout(self):
         """
-        Setting and getting the global fanout observer.
+        Setting and getting and adding to the global fanout observer.
         """
+        obs = []
         self.assertEqual(get_fanout(), None)
-        self.addCleanup(set_fanout, None)
-        fanout = FanoutObserver([].append)
-        set_fanout(fanout)
-        self.assertIs(get_fanout(), fanout)
+        add_to_fanout(obs.append)
+        self.assertEqual(get_fanout().subobservers, [obs.append])
+        set_fanout(None)
+        self.assertEqual(get_fanout(), None)

--- a/otter/test/log/test_log.py
+++ b/otter/test/log/test_log.py
@@ -19,13 +19,16 @@ from otter.log import audit
 from otter.log.bound import BoundLog
 from otter.log.formatters import (
     ErrorFormattingWrapper,
+    FanoutObserver,
     JSONObserverWrapper,
     LogLevel,
     ObserverWrapper,
     PEP3101FormattingWrapper,
     StreamObserverWrapper,
     SystemFilterWrapper,
+    get_fanout,
     serialize_to_jsonable,
+    set_fanout,
     throttling_wrapper)
 from otter.test.utils import SameJSON, matches
 
@@ -589,3 +592,62 @@ class ThrottlingWrapperTests(SynchronousTestCase):
             logs,
             [{'message': ('Received Ping',), 'system': 'kazoo',
               'num_duplicate_throttled': 50}])
+
+
+class FanoutObserverTests(SynchronousTestCase):
+    """Tests for :obj:`FanoutObserver`"""
+
+    def test_fanout_single_observer(self):
+        """
+        Fanout observer successfully sends all events if it only has a single
+        subobserver.
+        """
+        messages = [{str(i): 'message'} for i in range(3)]
+        obs = []
+        fanout = FanoutObserver(obs.append)
+        for mess in messages:
+            fanout.emit(mess.copy())
+        self.assertEqual(obs, messages)
+
+    def test_fanout_multiple_observers(self):
+        """
+        More observers can be added to the Fanout observer, which successfully
+        sends all new events to all the sub-observers in its list.
+        """
+        messages = [{str(i): 'message'} for i in range(3)]
+        obs1, obs2 = [], []
+        fanout = FanoutObserver(obs1.append)
+        fanout.emit(messages[0].copy())
+        fanout.add_observer(obs2.append)
+        fanout.emit(messages[1].copy())
+        fanout.emit(messages[2].copy())
+        self.assertEqual(obs1, messages)
+        self.assertEqual(obs2, messages[1:])
+
+    def test_subobservers_do_not_affect_each_other(self):
+        """
+        A subobserver that mutates events will not affect other subobservers.
+        """
+        obs, obs_mutated = [], []
+
+        def mutate(event):
+            event.pop('delete_me', None)
+            event['added'] = 'added'
+            obs_mutated.append(event)
+
+        fanout = FanoutObserver(obs.append)
+        fanout.add_observer(mutate)
+        fanout.emit({'only': 'message', 'delete_me': 'go'})
+
+        self.assertEqual(obs, [{'only': 'message', 'delete_me': 'go'}])
+        self.assertEqual(obs_mutated, [{'only': 'message', 'added': 'added'}])
+
+    def test_global_fanout(self):
+        """
+        Setting and getting the global fanout observer.
+        """
+        self.assertEqual(get_fanout(), None)
+        self.addCleanup(set_fanout, None)
+        fanout = FanoutObserver([].append)
+        set_fanout(fanout)
+        self.assertIs(get_fanout(), fanout)

--- a/otter/test/log/test_log.py
+++ b/otter/test/log/test_log.py
@@ -647,9 +647,20 @@ class FanoutObserverTests(SynchronousTestCase):
         """
         Setting and getting and adding to the global fanout observer.
         """
-        obs = []
+        obs1, obs2 = [], []
         self.assertEqual(get_fanout(), None)
-        add_to_fanout(obs.append)
-        self.assertEqual(get_fanout().subobservers, [obs.append])
+
+        # add_to_fanout when there is no fanout
+        fanout1 = add_to_fanout(obs1.append)
+        self.assertIs(fanout1, get_fanout())
+        self.assertEqual(fanout1.subobservers, [obs1.append])
+
+        # add_to_fanout when there is already a fanout
+        fanout2 = add_to_fanout(obs2.append)
+        self.assertIs(fanout2, fanout1)
+        self.assertIs(fanout1, get_fanout())
+        self.assertEqual(fanout2.subobservers, [obs1.append, obs2.append])
+
+        # set_fanout
         set_fanout(None)
         self.assertEqual(get_fanout(), None)

--- a/otter/test/log/test_log.py
+++ b/otter/test/log/test_log.py
@@ -607,7 +607,7 @@ class FanoutObserverTests(SynchronousTestCase):
         obs = []
         fanout = FanoutObserver(obs.append)
         for mess in messages:
-            fanout.emit(mess.copy())
+            fanout(mess.copy())
         self.assertEqual(obs, messages)
 
     def test_fanout_multiple_observers(self):
@@ -618,10 +618,10 @@ class FanoutObserverTests(SynchronousTestCase):
         messages = [{str(i): 'message'} for i in range(3)]
         obs1, obs2 = [], []
         fanout = FanoutObserver(obs1.append)
-        fanout.emit(messages[0].copy())
+        fanout(messages[0].copy())
         fanout.add_observer(obs2.append)
-        fanout.emit(messages[1].copy())
-        fanout.emit(messages[2].copy())
+        fanout(messages[1].copy())
+        fanout(messages[2].copy())
         self.assertEqual(obs1, messages)
         self.assertEqual(obs2, messages[1:])
 
@@ -638,7 +638,7 @@ class FanoutObserverTests(SynchronousTestCase):
 
         fanout = FanoutObserver(obs.append)
         fanout.add_observer(mutate)
-        fanout.emit({'only': 'message', 'delete_me': 'go'})
+        fanout({'only': 'message', 'delete_me': 'go'})
 
         self.assertEqual(obs, [{'only': 'message', 'delete_me': 'go'}])
         self.assertEqual(obs_mutated, [{'only': 'message', 'added': 'added'}])

--- a/otter/test/tap/test_api.py
+++ b/otter/test/tap/test_api.py
@@ -18,6 +18,8 @@ from otter.auth import CachingAuthenticator, SingleTenantAuthenticator
 from otter.constants import (
     CONVERGENCE_DIRTY_DIR, ServiceType, get_service_configs)
 from otter.convergence.service import Converger
+from otter.log.cloudfeeds import CloudFeedsObserver
+from otter.log.formatters import FanoutObserver, set_fanout
 from otter.models.cass import CassScalingGroupCollection as OriginalStore
 from otter.supervisor import SupervisorService, get_supervisor, set_supervisor
 from otter.tap.api import (
@@ -474,12 +476,15 @@ class APIMakeServiceTests(SynchronousTestCase):
 
         self.assertEqual(get_supervisor(), supervisor_service)
 
-    @mock.patch('otter.tap.api.addObserver')
-    @mock.patch('otter.tap.api.get_cf_observer')
-    def test_cloudfeeds_setup(self, mock_getobserver, mock_addobserver):
+    def test_cloudfeeds_setup(self):
         """
         Cloud feeds observer is setup if it is there in config
         """
+        fanout = FanoutObserver([].append)
+        set_fanout(fanout)
+        self.addCleanup(set_fanout, None)
+        self.assertEqual(len(fanout.subobservers), 1)
+
         conf = deepcopy(test_config)
         conf['cloudfeeds'] = {'service': 'cloudFeeds', 'tenant_id': 'tid',
                               'url': 'url'}
@@ -487,24 +492,36 @@ class APIMakeServiceTests(SynchronousTestCase):
         serv_confs = get_service_configs(conf)
         serv_confs[ServiceType.CLOUD_FEEDS] = {
             'name': 'cloudFeeds', 'region': 'ord', 'url': 'url'}
-        mock_getobserver.assert_called_once_with(
-            self.reactor, matches(IsInstance(CachingAuthenticator)), 'tid',
-            'ord', serv_confs)
-        mock_addobserver.assert_called_once_with(mock_getobserver.return_value)
+
+        self.assertEqual(len(fanout.subobservers), 2)
+        cf_observer = fanout.subobservers[-1]
+        self.assertEqual(
+            cf_observer,
+            CloudFeedsObserver(
+                reactor=self.reactor,
+                authenticator=matches(IsInstance(CachingAuthenticator)),
+                tenant_id='tid',
+                region='ord',
+                service_configs=serv_confs))
 
         # single tenant authenticator is created
-        real_auth = mock_getobserver.call_args[0][1]
+        authenticator = cf_observer.authenticator
         self.assertIsInstance(
-            real_auth._authenticator._authenticator._authenticator,
+            authenticator._authenticator._authenticator._authenticator,
             SingleTenantAuthenticator)
 
-    @mock.patch('otter.tap.api.get_cf_observer')
-    def test_cloudfeeds_no_setup(self, mock_getobserver):
+    def test_cloudfeeds_no_setup(self):
         """
         Cloud feeds observer is not setup if it is not there in config
         """
+        fanout = FanoutObserver([].append)
+        set_fanout(fanout)
+        self.addCleanup(set_fanout, None)
+        self.assertEqual(len(fanout.subobservers), 1)
+
         makeService(test_config)
-        self.assertFalse(mock_getobserver.called)
+
+        self.assertEqual(len(fanout.subobservers), 1)
 
     @mock.patch('otter.tap.api.setup_scheduler')
     @mock.patch('otter.tap.api.TxKazooClient')


### PR DESCRIPTION
So that both the CF observer and the regular observer benefit from spec.py, which should do splitting messages (done) and generating CF IDs (not done).

Fixes #1673.

Unfortunately, this global state, since we want a singleton fanout observer.

This combines `copying_wrapper` with `FanoutObserver`, since `FanoutObserver` is where the event forks. (also, this made things easier to test).

I've tested this branch on the dev vm against mimic and a requestb.in-like twisted service in place of cloudfeeds.

Messages seem to correctly go to both our logs and the request.bin service on both twisted==15.0.0 and twisted==15.3.0 .  For example, our logs (on twisted 15.3.0):

```
2015-08-25_00:06:48.56661 {
2015-08-25_00:06:48.56662   "@timestamp": "2015-08-25T00:06:48.564904", 
2015-08-25_00:06:48.56662   "@version": 1, 
2015-08-25_00:06:48.56663   "cloud_feed": true, 
2015-08-25_00:06:48.56663   "cloud_feed_id": "a8c8827c-55ae-47a5-b664-650cba38dfd6", 
2015-08-25_00:06:48.56663   "converger_run_id": "e6217b26-3bab-40f6-9195-400db2bb42eb", 
2015-08-25_00:06:48.56663   "format": "%(log_legacy)s", 
2015-08-25_00:06:48.56664   "host": "vm", 
2015-08-25_00:06:48.56664   "lb_id": "26924", 
2015-08-25_00:06:48.56664   "level": 6, 
2015-08-25_00:06:48.56665   "log_format": "{log_text}", 
2015-08-25_00:06:48.56665   "log_legacy": "<twisted.logger._stdlib.StringifiableFromEvent object at 0x4cdc150>", 
2015-08-25_00:06:48.56665   "log_level": "<LogLevel=info>", 
2015-08-25_00:06:48.56665   "log_namespace": "log_legacy", 
2015-08-25_00:06:48.56666   "log_system": "otter", 
2015-08-25_00:06:48.56666   "log_text": "convergence-remove-clb-nodes", 
2015-08-25_00:06:48.56666   "log_time": 1440461208.564904, 
2015-08-25_00:06:48.56667   "message": "Removing nodes from CLB 26924: ['144480', '852956', '972535']", 
2015-08-25_00:06:48.56667   "nodes": [
2015-08-25_00:06:48.56668     "144480", 
2015-08-25_00:06:48.56668     "852956", 
2015-08-25_00:06:48.56668     "972535"
2015-08-25_00:06:48.56668   ], 
2015-08-25_00:06:48.56669   "otter_facility": "otter", 
2015-08-25_00:06:48.56669   "otter_msg_type": "convergence-remove-clb-nodes", 
2015-08-25_00:06:48.56669   "otter_service": "converger", 
2015-08-25_00:06:48.56669   "scaling_group_id": "dff09d73-bcf0-4eae-972e-c4d90c6ff625", 
2015-08-25_00:06:48.56670   "tenant_id": "000000"
2015-08-25_00:06:48.56670 }
```

And the CF request-bin service:

```
2015-08-25 00:11:41+0000 [-] 

        POST http://localhost:8080/autoscale/events

        {'Content-Length': ['552'], 'Accept-Encoding': ['gzip'], 'X-Otter-Request-Id': ['b103020b-f34a-4375-ab10-1e430eeefa15'], 'Accept': ['application/json'], 'X-Auth-Token': ['token_5552e416-2973-4cca-b01f-69d5373d28dd'], 'Host': ['localhost:8080'], 'User-Agent': ['OtterScale/0.0'], 'Content-Type': ['application/vnd.rackspace.atom+json']}

        {}

        {
          "entry": {
            "content": {
              "event": {
                "product": {
                  "scalingGroupId": "dff09d73-bcf0-4eae-972e-c4d90c6ff625", 
                  "message": "Removing nodes from CLB 26924: ['144480', '852956', '972535']", 
                  "version": "1", 
                  "serviceCode": "Autoscale", 
                  "@type": "http://docs.rackspace.com/event/autoscale"
                }, 
                "region": "ORD", 
                "eventTime": "2015-08-25T00:11:41.653050Z", 
                "tenantId": "000000", 
                "version": "2", 
                "id": "4a3b7c15-1b3b-4dbb-ba3e-40fc51db9900", 
                "type": "INFO", 
                "@type": "http://docs.rackspace.com/core/event"
              }
            }, 
            "@type": "http://www.w3.org/2005/Atom", 
            "title": "autoscale"
          }
        }
```