### PR TITLE
Change the inheritance order of SupervisorService and FakeSupervisor

### DIFF
--- a/otter/supervisor.py
+++ b/otter/supervisor.py
@@ -77,7 +77,7 @@ class RequestBag(object):
 
 
 @implementer(ISupervisor)
-class SupervisorService(object, Service):
+class SupervisorService(Service, object):
     """
     A service which manages execution of launch configurations.
 

--- a/otter/test/utils.py
+++ b/otter/test/utils.py
@@ -594,7 +594,7 @@ class DummyException(Exception):
 
 
 @implementer(ISupervisor)
-class FakeSupervisor(object, Service):
+class FakeSupervisor(Service, object):
     """
     A fake supervisor that keeps track of calls made
     """


### PR DESCRIPTION
Because:

```
>>> class A(object):
...    pass
... 
>>> class B(object, A):
...    pass
... 
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: Error when calling the metaclass bases
    Cannot create a consistent method resolution
order (MRO) for bases object, A
>>> class B(A, object):
...    pass
... 
>>> 
```

And it seems like `Service`, in Twisted, is now (15.3.0) a new-style class.  We get the same error for `SupervisorService` when running otter with the newest version of Twisted.