### PR TITLE
CF ID observer

### DIFF
--- a/otter/log/cloudfeeds.py
+++ b/otter/log/cloudfeeds.py
@@ -2,7 +2,6 @@
 Publishing events to Cloud feeds
 """
 from copy import deepcopy
-from uuid import uuid4
 
 from characteristic import attributes
 
@@ -168,17 +167,6 @@ def add_event(event, admin_tenant_id, region, log):
             retry_times(5)),
         exponential_backoff_interval(2))
     return Effect(TenantScope(tenant_id=admin_tenant_id, effect=eff))
-
-
-def cfid_wrapper(observer):
-    """
-    Wrapper that adds a cloud feeds ID to each cloud feeds event dictionary.
-    """
-    def emit(event_dict):
-        if event_dict.get('cloud_feed', False):
-            event_dict['cloud_feed_id'] = uuid4()
-        observer(event_dict)
-    return emit
 
 
 @attributes(['reactor', 'authenticator', 'tenant_id', 'region',

--- a/otter/log/cloudfeeds.py
+++ b/otter/log/cloudfeeds.py
@@ -1,13 +1,12 @@
 """
 Publishing events to Cloud feeds
 """
-
-import uuid
 from copy import deepcopy
+from uuid import uuid4
 
 from characteristic import attributes
 
-from effect import Effect, Func
+from effect import Effect
 
 from toolz.dicttoolz import keyfilter
 
@@ -169,6 +168,17 @@ def add_event(event, admin_tenant_id, region, log):
             retry_times(5)),
         exponential_backoff_interval(2))
     return Effect(TenantScope(tenant_id=admin_tenant_id, effect=eff))
+
+
+def cfid_wrapper(observer):
+    """
+    Wrapper that adds a cloud feeds ID to each cloud feeds event dictionary.
+    """
+    def emit(event_dict):
+        if event_dict.get('cloud_feed', False):
+            event_dict['cloud_feed_id'] = uuid4()
+        observer(event_dict)
+    return emit
 
 
 @attributes(['reactor', 'authenticator', 'tenant_id', 'region',

--- a/otter/log/cloudfeeds.py
+++ b/otter/log/cloudfeeds.py
@@ -47,37 +47,33 @@ log_cf_mapping = {
 }
 
 
-def _cf_log_with_id(log_effect, *args, **kwargs):
+def _cf_log(log_effect, *args, **kwargs):
     """
-    Helper helper function to generate a cloud feed ID before logging a
-    log cloud feed event.
+    Log cloud feeds message with a "cloud_feeds" tag parameter.
     """
-    def log_to_cf(uid):
-        kwargs.update({'cloud_feed': True, 'cloud_feed_id': uid})
-        return log_effect(*args, **kwargs)
-
-    return Effect(Func(uuid.uuid4)).on(str).on(log_to_cf)
+    kwargs['cloud_feed'] = True
+    return log_effect(*args, **kwargs)
 
 
 def cf_msg(msg, **fields):
     """
     Helper function to log cloud feeds event
     """
-    return _cf_log_with_id(msg_effect, msg, **fields)
+    return _cf_log(msg_effect, msg, **fields)
 
 
 def cf_err(msg, **fields):
     """
     Log cloud feed error event without failure
     """
-    return _cf_log_with_id(msg_effect, msg, isError=True, **fields)
+    return _cf_log(msg_effect, msg, isError=True, **fields)
 
 
 def cf_fail(failure, msg, **fields):
     """
     Log cloud feed error event with failure
     """
-    return _cf_log_with_id(err_effect, failure, msg, **fields)
+    return _cf_log(err_effect, failure, msg, **fields)
 
 
 def sanitize_event(event):

--- a/otter/log/formatters.py
+++ b/otter/log/formatters.py
@@ -4,6 +4,7 @@ Composable log observers for use with Twisted's log module.
 import json
 import time
 from datetime import datetime
+from uuid import uuid4
 
 from pyrsistent import pmap
 
@@ -338,4 +339,15 @@ def throttling_wrapper(observer):
         else:
             return observer(event)
 
+    return emit
+
+
+def cf_id_wrapper(observer):
+    """
+    Wrapper that adds a cloud feeds ID to each cloud feeds event dictionary.
+    """
+    def emit(event_dict):
+        if event_dict.get('cloud_feed', False):
+            event_dict['cloud_feed_id'] = str(uuid4())
+        observer(event_dict)
     return emit

--- a/otter/log/setup.py
+++ b/otter/log/setup.py
@@ -13,6 +13,7 @@ from otter.log.formatters import (
     SystemFilterWrapper,
     add_to_fanout,
     get_fanout,
+    cf_id_wrapper,
     throttling_wrapper,
 )
 from otter.log.spec import SpecificationObserverWrapper
@@ -35,7 +36,8 @@ def make_observer_chain(ultimate_observer, indent):
             PEP3101FormattingWrapper(
                 SystemFilterWrapper(
                     ErrorFormattingWrapper(
-                        get_fanout())))))
+                        cf_id_wrapper(
+                            get_fanout()))))))
 
 
 def observer_factory():

--- a/otter/test/convergence/test_logging.py
+++ b/otter/test/convergence/test_logging.py
@@ -5,8 +5,6 @@ Tests for logging in convergence (that steps are correctly logged).
 from effect import sync_perform
 from effect.testing import SequenceDispatcher
 
-from mock import ANY
-
 from pyrsistent import freeze, pbag, pset
 
 from twisted.trial.unittest import SynchronousTestCase

--- a/otter/test/convergence/test_logging.py
+++ b/otter/test/convergence/test_logging.py
@@ -54,10 +54,10 @@ class LogStepsTests(SynchronousTestCase):
         self.assert_logs(creates, [
             Log('convergence-create-servers',
                 fields={'num_servers': 2, 'server_config': cfg,
-                        'cloud_feed': True, 'cloud_feed_id': ANY}),
+                        'cloud_feed': True}),
             Log('convergence-create-servers',
                 fields={'num_servers': 1, 'server_config': cfg2,
-                        'cloud_feed': True, 'cloud_feed_id': ANY})
+                        'cloud_feed': True})
             ])
 
     def test_delete_servers(self):
@@ -67,8 +67,7 @@ class LogStepsTests(SynchronousTestCase):
                         DeleteServer(server_id='3')])
         self.assert_logs(deletes, [
             Log('convergence-delete-servers',
-                fields={'servers': ['1', '2', '3'], 'cloud_feed': True,
-                        'cloud_feed_id': ANY})
+                fields={'servers': ['1', '2', '3'], 'cloud_feed': True})
         ])
 
     def test_add_nodes_to_clbs(self):
@@ -87,11 +86,11 @@ class LogStepsTests(SynchronousTestCase):
             Log('convergence-add-clb-nodes',
                 fields={'lb_id': 'lbid1',
                         'addresses': ['10.0.0.1:1234', '10.0.0.2:1235'],
-                        'cloud_feed': True, 'cloud_feed_id': ANY}),
+                        'cloud_feed': True}),
             Log('convergence-add-clb-nodes',
                 fields={'lb_id': 'lbid2',
                         'addresses': ['10.0.0.1:4321'],
-                        'cloud_feed': True, 'cloud_feed_id': ANY})
+                        'cloud_feed': True})
         ])
 
     def test_remove_nodes_from_clbs(self):
@@ -105,11 +104,11 @@ class LogStepsTests(SynchronousTestCase):
             Log('convergence-remove-clb-nodes',
                 fields={'lb_id': 'lbid1',
                         'nodes': ['a', 'b', 'c'],
-                        'cloud_feed': True, 'cloud_feed_id': ANY}),
+                        'cloud_feed': True}),
             Log('convergence-remove-clb-nodes',
                 fields={'lb_id': 'lbid2',
                         'nodes': ['d', 'e', 'f'],
-                        'cloud_feed': True, 'cloud_feed_id': ANY}),
+                        'cloud_feed': True}),
         ])
 
     def test_change_clb_node(self):
@@ -137,19 +136,19 @@ class LogStepsTests(SynchronousTestCase):
                 fields={
                     'lb_id': 'lbid1', 'nodes': ['node3'],
                     'type': 'PRIMARY', 'condition': 'ENABLED', 'weight': 50,
-                    'cloud_feed': True, 'cloud_feed_id': ANY
+                    'cloud_feed': True
                 }),
             Log('convergence-change-clb-nodes',
                 fields={
                     'lb_id': 'lbid1', 'nodes': ['node1', 'node2'],
                     'type': 'PRIMARY', 'condition': 'DRAINING', 'weight': 50,
-                    'cloud_feed': True, 'cloud_feed_id': ANY
+                    'cloud_feed': True
                 }),
             Log('convergence-change-clb-nodes',
                 fields={
                     'lb_id': 'lbid2', 'nodes': ['node4'],
                     'type': 'PRIMARY', 'condition': 'ENABLED', 'weight': 50,
-                    'cloud_feed': True, 'cloud_feed_id': ANY
+                    'cloud_feed': True
                 }),
         ])
 
@@ -167,16 +166,16 @@ class LogStepsTests(SynchronousTestCase):
         self.assert_logs(adds, [
             Log('convergence-add-rcv3-nodes',
                 fields={'lb_id': 'lb1', 'servers': ['node1', 'node2', 'nodea'],
-                        'cloud_feed': True, 'cloud_feed_id': ANY}),
+                        'cloud_feed': True}),
             Log('convergence-add-rcv3-nodes',
                 fields={'lb_id': 'lb2', 'servers': ['node2', 'node3'],
-                        'cloud_feed': True, 'cloud_feed_id': ANY}),
+                        'cloud_feed': True}),
             Log('convergence-add-rcv3-nodes',
                 fields={'lb_id': 'lb3', 'servers': ['node4'],
-                        'cloud_feed': True, 'cloud_feed_id': ANY}),
+                        'cloud_feed': True}),
             Log('convergence-add-rcv3-nodes',
                 fields={'lb_id': 'lba', 'servers': ['nodea', 'nodeb'],
-                        'cloud_feed': True, 'cloud_feed_id': ANY})
+                        'cloud_feed': True})
         ])
 
     def test_bulk_remove_from_rcv3(self):
@@ -193,16 +192,16 @@ class LogStepsTests(SynchronousTestCase):
         self.assert_logs(adds, [
             Log('convergence-remove-rcv3-nodes',
                 fields={'lb_id': 'lb1', 'servers': ['node1', 'node2', 'nodea'],
-                        'cloud_feed': True, 'cloud_feed_id': ANY}),
+                        'cloud_feed': True}),
             Log('convergence-remove-rcv3-nodes',
                 fields={'lb_id': 'lb2', 'servers': ['node2', 'node3'],
-                        'cloud_feed': True, 'cloud_feed_id': ANY}),
+                        'cloud_feed': True}),
             Log('convergence-remove-rcv3-nodes',
                 fields={'lb_id': 'lb3', 'servers': ['node4'],
-                        'cloud_feed': True, 'cloud_feed_id': ANY}),
+                        'cloud_feed': True}),
             Log('convergence-remove-rcv3-nodes',
                 fields={'lb_id': 'lba', 'servers': ['nodea', 'nodeb'],
-                        'cloud_feed': True, 'cloud_feed_id': ANY})
+                        'cloud_feed': True})
         ])
 
     def test_set_metadata_item_on_server(self):
@@ -216,8 +215,8 @@ class LogStepsTests(SynchronousTestCase):
         self.assert_logs(sets, [
             Log('convergence-set-server-metadata',
                 fields={'servers': ['s1', 's2'], 'key': 'k1', 'value': 'v1',
-                        'cloud_feed': True, 'cloud_feed_id': ANY}),
+                        'cloud_feed': True}),
             Log('convergence-set-server-metadata',
                 fields={'servers': ['s3'], 'key': 'k2', 'value': 'v2',
-                        'cloud_feed': True, 'cloud_feed_id': ANY})
+                        'cloud_feed': True})
         ])

--- a/otter/test/convergence/test_service.py
+++ b/otter/test/convergence/test_service.py
@@ -855,11 +855,11 @@ class ExecuteConvergenceTests(SynchronousTestCase):
         sequence = [
             parallel_sequence([
                 [parallel_sequence([
-                     [(Log('convergence-create-servers',
-                           {'num_servers': 1, 'server_config': {'foo': 'bar'},
-                            'cloud_feed': True, 'cloud_feed_id': mock.ANY}),
-                       noop)]
-                 ])]
+                    [(Log('convergence-create-servers',
+                          {'num_servers': 1, 'server_config': {'foo': 'bar'},
+                           'cloud_feed': True}),
+                      noop)]
+                ])]
             ]),
             (Log(msg='execute-convergence', fields=mock.ANY), noop),
             parallel_sequence([
@@ -975,8 +975,7 @@ class ExecuteConvergenceTests(SynchronousTestCase):
                                status=ScalingGroupStatus.ERROR),
              noop),
             (Log('group-status-error',
-                 dict(isError=True, cloud_feed=True,
-                      cloud_feed_id=mock.ANY, status='ERROR',
+                 dict(isError=True, cloud_feed=True, status='ERROR',
                       reasons=['Cloud Load Balancer does not exist: nolb1',
                                'Cloud Load Balancer does not exist: nolb2'])),
              noop),
@@ -1011,8 +1010,8 @@ class ExecuteConvergenceTests(SynchronousTestCase):
                                status=ScalingGroupStatus.ERROR),
              noop),
             (Log('group-status-error',
-                 dict(isError=True, cloud_feed=True, cloud_feed_id=mock.ANY,
-                      status='ERROR', reasons=['Unknown error occurred'])),
+                 dict(isError=True, cloud_feed=True, status='ERROR',
+                      reasons=['Unknown error occurred'])),
              noop),
             (UpdateGroupErrorReasons(self.group, ['Unknown error occurred']),
              noop)
@@ -1042,8 +1041,7 @@ class ExecuteConvergenceTests(SynchronousTestCase):
                                status=ScalingGroupStatus.ACTIVE),
              noop),
             (Log('group-status-active',
-                 dict(cloud_feed=True, cloud_feed_id=mock.ANY,
-                      status='ACTIVE')),
+                 dict(cloud_feed=True, status='ACTIVE')),
              noop),
             (UpdateServersCache("tenant-id", "group-id", self.now,
                                 [{"id": "a", "_is_as_active": True},
@@ -1069,8 +1067,7 @@ class ExecuteConvergenceTests(SynchronousTestCase):
                                status=ScalingGroupStatus.ACTIVE),
              noop),
             (Log('group-status-active',
-                 dict(cloud_feed=True, cloud_feed_id=mock.ANY,
-                      status='ACTIVE')),
+                 dict(cloud_feed=True, status='ACTIVE')),
              noop),
             (UpdateServersCache("tenant-id", "group-id", self.now,
                                 [{"id": "a", "_is_as_active": True},

--- a/otter/test/log/test_cloudfeeds.py
+++ b/otter/test/log/test_cloudfeeds.py
@@ -22,7 +22,6 @@ from otter.log.cloudfeeds import (
     UnsuitableMessage,
     add_event,
     cf_err, cf_fail, cf_msg,
-    cfid_wrapper,
     prepare_request,
     request_format,
     sanitize_event
@@ -303,25 +302,6 @@ class EventTests(SynchronousTestCase):
             request_format, self.cf_event, True, "1970-01-01T00:00:00Z",
             'ord', 'tid', 'uuid')
         self.assertEqual(req, self._get_request('ERROR', 'uuid', 'tid'))
-
-
-class CFIDWrapperTests(SynchronousTestCase):
-    """
-    Tests for generating a CF ID as an observer/wrapper (:func:`cfid_wrapper`)
-    """
-    def test_add_cf_id_to_cloud_feeds_events(self):
-        """
-        CF event dictionaries have an ID added to them, non-CF events do not.
-        """
-        obs = []
-        id_observer = cfid_wrapper(obs.append)
-        id_observer({'cloud_feed': True, 'this': 'is a cf event'})
-        id_observer({'this': 'is not a cf event'})
-        self.assertEqual(
-            obs,
-            [{'cloud_feed': True, 'this': 'is a cf event',
-              'cloud_feed_id': mock.ANY},
-             {'this': 'is not a cf event'}])
 
 
 class CloudFeedsObserverTests(SynchronousTestCase):

--- a/otter/test/log/test_cloudfeeds.py
+++ b/otter/test/log/test_cloudfeeds.py
@@ -56,9 +56,7 @@ class CFHelperTests(SynchronousTestCase):
         `cf_msg` returns Effect with `Log` intent with cloud_feed=True
         """
         seq = [
-            (Func(uuid.uuid4), lambda _: 'uuid'),
-            (Log('message', dict(cloud_feed=True, cloud_feed_id='uuid',
-                                 a=2, b=3)),
+            (Log('message', dict(cloud_feed=True, a=2, b=3)),
                 lambda _: 'logged')
         ]
         self.assertEqual(perform_sequence(seq, cf_msg('message', a=2, b=3)),
@@ -70,9 +68,7 @@ class CFHelperTests(SynchronousTestCase):
         and isError=True
         """
         seq = [
-            (Func(uuid.uuid4), lambda _: 'uuid'),
-            (Log('message', dict(isError=True, cloud_feed=True,
-                                 cloud_feed_id='uuid', a=2, b=3)),
+            (Log('message', dict(isError=True, cloud_feed=True, a=2, b=3)),
                 lambda _: 'logged')
         ]
         self.assertEqual(perform_sequence(seq, cf_err('message', a=2, b=3)),
@@ -84,9 +80,7 @@ class CFHelperTests(SynchronousTestCase):
         """
         f = object()
         seq = [
-            (Func(uuid.uuid4), lambda _: 'uuid'),
-            (LogErr(f, 'message', dict(cloud_feed=True, cloud_feed_id='uuid',
-                                       a=2, b=3)),
+            (LogErr(f, 'message', dict(cloud_feed=True, a=2, b=3)),
                 lambda _: 'logged')
         ]
         self.assertEqual(

--- a/otter/test/log/test_cloudfeeds.py
+++ b/otter/test/log/test_cloudfeeds.py
@@ -1,11 +1,9 @@
 """
 Tests for otter.cloudfeeds
 """
-
-import uuid
 from functools import partial
 
-from effect import Effect, Func, TypeDispatcher
+from effect import Effect, TypeDispatcher
 from effect.testing import perform_sequence
 
 import mock
@@ -24,6 +22,7 @@ from otter.log.cloudfeeds import (
     UnsuitableMessage,
     add_event,
     cf_err, cf_fail, cf_msg,
+    cfid_wrapper,
     prepare_request,
     request_format,
     sanitize_event
@@ -304,6 +303,25 @@ class EventTests(SynchronousTestCase):
             request_format, self.cf_event, True, "1970-01-01T00:00:00Z",
             'ord', 'tid', 'uuid')
         self.assertEqual(req, self._get_request('ERROR', 'uuid', 'tid'))
+
+
+class CFIDWrapperTests(SynchronousTestCase):
+    """
+    Tests for generating a CF ID as an observer/wrapper (:func:`cfid_wrapper`)
+    """
+    def test_add_cf_id_to_cloud_feeds_events(self):
+        """
+        CF event dictionaries have an ID added to them, non-CF events do not.
+        """
+        obs = []
+        id_observer = cfid_wrapper(obs.append)
+        id_observer({'cloud_feed': True, 'this': 'is a cf event'})
+        id_observer({'this': 'is not a cf event'})
+        self.assertEqual(
+            obs,
+            [{'cloud_feed': True, 'this': 'is a cf event',
+              'cloud_feed_id': mock.ANY},
+             {'this': 'is not a cf event'}])
 
 
 class CloudFeedsObserverTests(SynchronousTestCase):


### PR DESCRIPTION
This adds CF IDs to every CF event dictionary.

This is so every split CF event may have a unique CF ID.

~~Depends upon #1679 and #1685 being merged.~~