### PR TITLE
Don't converge too fast

### DIFF
--- a/otter/cloud_client.py
+++ b/otter/cloud_client.py
@@ -1,6 +1,4 @@
-"""
-Integration point for HTTP clients in otter.
-"""
+"""A general-ish purpose Rackspace cloud client API, using Effect."""
 import json
 import re
 from functools import partial, wraps

--- a/otter/convergence/service.py
+++ b/otter/convergence/service.py
@@ -590,8 +590,6 @@ def converge_all_groups(currently_converging, recently_converged,
         tenant_id, group_id = info['tenant_id'], info['group_id']
         if group_id in recent_groups:
             # Don't converge a group if it has recently been converged.
-            # TODO: clean up the pmap so it doesn't accumulate an entry for all
-            # groups over time!
             continue
         eff = converge(tenant_id, group_id, info['dirty-flag'])
         effs.append(

--- a/otter/convergence/service.py
+++ b/otter/convergence/service.py
@@ -554,6 +554,13 @@ def converge_all_groups(currently_converging, recently_converged,
                                      stat.version, build_timeout)
             result = yield Effect(TenantScope(eff, tenant_id))
             time_done = yield Effect(Func(time.time))
+            # UGH. TODO: This is too late. This should really be removed
+            # synchronously with deleting the group from currently_converging,
+            # since there are other asynchronous things that happen after that
+            # (like deleting the divergent node in ZK.) That means that a
+            # convergence can sneak in between a previous one and the time we
+            # update the recently_converged dict here, which would defeat the
+            # mechanism.
             yield recently_converged.modify(
                 lambda rcg: rcg.set(group_id, time_done))
             yield do_return(result)

--- a/otter/convergence/service.py
+++ b/otter/convergence/service.py
@@ -563,13 +563,6 @@ def converge_all_groups(currently_converging, recently_converged,
                                      tenant_id, group_id,
                                      stat.version, build_timeout)
             result = yield Effect(TenantScope(eff, tenant_id))
-            # UGH. TODO: This is too late. This should really be removed
-            # synchronously with deleting the group from currently_converging,
-            # since there are other asynchronous things that happen after that
-            # (like deleting the divergent node in ZK.) That means that a
-            # convergence can sneak in between a previous one and the time we
-            # update the recently_converged dict here, which would defeat the
-            # mechanism.
             yield do_return(result)
 
     recent_groups = yield get_recently_converged_groups(recently_converged)

--- a/otter/tap/api.py
+++ b/otter/tap/api.py
@@ -318,7 +318,8 @@ def setup_converger(parent, kz_client, dispatcher, interval, build_timeout):
         partitioner_path=CONVERGENCE_PARTITIONER_PATH,
         time_boundary=15,  # time boundary
     )
-    cvg = Converger(log, dispatcher, 10, partitioner_factory, build_timeout)
+    cvg = Converger(log, dispatcher, 10, partitioner_factory, build_timeout,
+                    interval)
     cvg.setServiceParent(parent)
     watch_children(kz_client, CONVERGENCE_DIRTY_DIR, cvg.divergent_changed)
 

--- a/otter/test/tap/test_api.py
+++ b/otter/test/tap/test_api.py
@@ -703,6 +703,7 @@ class ConvergerSetupTests(SynchronousTestCase):
         self.assertIs(converger.__class__, Converger)
         self.assertEqual(converger.build_timeout, 35)
         self.assertEqual(converger._dispatcher, dispatcher)
+        self.assertEqual(converger.interval, interval)
         [partitioner] = converger.services
         [timer] = partitioner.services
         self.assertIs(partitioner.__class__, Partitioner)

--- a/otter/test/test_testutils.py
+++ b/otter/test/test_testutils.py
@@ -224,7 +224,7 @@ class NestedParallelTests(SynchronousTestCase):
         ]
         p = sequence([Effect(1), Effect(2), Effect(3)])
         e = self.assertRaises(FoldError, perform_sequence, seq, p)
-        self.assertIs(e.wrapped_exception[0], NoPerformerFoundError)
+        self.assertIs(e.wrapped_exception[0], AssertionError)
 
 
 class RetrySequenceTests(SynchronousTestCase):
@@ -260,7 +260,7 @@ class RetrySequenceTests(SynchronousTestCase):
             retry_sequence(r, [lambda _: raise_(Exception()),
                                lambda _: raise_(Exception())])
         ]
-        self.assertRaises(NoPerformerFoundError,
+        self.assertRaises(AssertionError,
                           perform_sequence, seq, Effect(r))
 
     def test_do_not_have_to_expect_an_exact_can_retry(self):

--- a/otter/test/test_testutils.py
+++ b/otter/test/test_testutils.py
@@ -2,7 +2,7 @@
 Tests for :obj:`otter.test.utils`.
 """
 from effect import (
-    ComposedDispatcher, Effect, NoPerformerFoundError,
+    ComposedDispatcher, Effect,
     base_dispatcher, parallel, sync_performer)
 from effect.fold import FoldError, sequence
 

--- a/otter/test/utils.py
+++ b/otter/test/utils.py
@@ -791,7 +791,8 @@ def perform_sequence(seq, eff, fallback_dispatcher=base_dispatcher):
         else:
             log.append(("NOT FOUND", intent))
             raise AssertionError(
-                "Performer not found: {}!\n{}".format(intent, fmt_log()))
+                "Performer not found: {}! Log follows:\n{}".format(
+                    intent, fmt_log()))
 
     sequence = SequenceDispatcher(seq)
     log = []


### PR DESCRIPTION
Fixes #1656 

This adds a `recently_converged` `Reference(pmap())`, which keeps track of groups that have recently been converged. If a group has recently been converged (within 10 seconds), it is not converged. The group will be left dirty, so the next time we check it, we will converge it.

Unrelated changes that I happened to make in this branch:

- did a big `s/lambda i: None/noop/` in service.py
- refactored some tests to more tersely describe some sequences
