### PR TITLE
Bump to effect 0.10 and use its new testing utilities

### DIFF
--- a/otter/test/convergence/test_gathering.py
+++ b/otter/test/convergence/test_gathering.py
@@ -14,7 +14,7 @@ from effect import (
 
 from effect.async import perform_parallel_async
 from effect.testing import (
-    EQDispatcher, EQFDispatcher, Stub)
+    EQDispatcher, EQFDispatcher, Stub, parallel_sequence, perform_sequence)
 
 import mock
 
@@ -53,10 +53,8 @@ from otter.test.utils import (
     EffectServersCache,
     StubResponse,
     intent_func,
-    nested_parallel,
     nested_sequence,
     patch,
-    perform_sequence,
     resolve_stubs,
     server
 )
@@ -416,10 +414,10 @@ class GetCLBContentsTests(SynchronousTestCase):
         seq = [
             lb_req('loadbalancers', True,
                    {'loadBalancers': [{'id': 1}, {'id': 2}]}),
-            nested_parallel([nodes_req(1, [node11, node12]),
-                             nodes_req(2, [node21, node22])]),
-            nested_parallel([node_feed_req(1, '11', '11feed'),
-                             node_feed_req(2, '22', '22feed')]),
+            parallel_sequence([[nodes_req(1, [node11, node12])],
+                               [nodes_req(2, [node21, node22])]]),
+            parallel_sequence([[node_feed_req(1, '11', '11feed')],
+                               [node_feed_req(2, '22', '22feed')]]),
         ]
         eff = get_clb_contents()
         self.assertEqual(
@@ -435,8 +433,8 @@ class GetCLBContentsTests(SynchronousTestCase):
         """
         seq = [
             lb_req('loadbalancers', True, {'loadBalancers': []}),
-            nested_parallel([]),  # No LBs to fetch
-            nested_parallel([]),  # No nodes to fetch
+            parallel_sequence([]),  # No LBs to fetch
+            parallel_sequence([]),  # No nodes to fetch
         ]
         eff = get_clb_contents()
         self.assertEqual(perform_sequence(seq, eff), [])
@@ -448,8 +446,8 @@ class GetCLBContentsTests(SynchronousTestCase):
         seq = [
             lb_req('loadbalancers', True,
                    {'loadBalancers': [{'id': 1}, {'id': 2}]}),
-            nested_parallel([nodes_req(1, []), nodes_req(2, [])]),
-            nested_parallel([]),  # No nodes to fetch
+            parallel_sequence([[nodes_req(1, [])], [nodes_req(2, [])]]),
+            parallel_sequence([]),  # No nodes to fetch
         ]
         self.assertEqual(perform_sequence(seq, get_clb_contents()), [])
 
@@ -460,9 +458,9 @@ class GetCLBContentsTests(SynchronousTestCase):
         seq = [
             lb_req('loadbalancers', True,
                    {'loadBalancers': [{'id': 1}, {'id': 2}]}),
-            nested_parallel([nodes_req(1, [node('11', 'a11')]),
-                             nodes_req(2, [node('21', 'a21')])]),
-            nested_parallel([])  # No nodes to fetch
+            parallel_sequence([[nodes_req(1, [node('11', 'a11')])],
+                               [nodes_req(2, [node('21', 'a21')])]]),
+            parallel_sequence([])  # No nodes to fetch
         ]
         make_desc = partial(CLBDescription, port=20, weight=2,
                             condition=CLBNodeCondition.ENABLED,
@@ -483,12 +481,12 @@ class GetCLBContentsTests(SynchronousTestCase):
         seq = [
             lb_req('loadbalancers', True,
                    {'loadBalancers': [{'id': 1}, {'id': 2}]}),
-            nested_parallel([
-                nodes_req(1, [node('11', 'a11')]),
-                lb_req('loadbalancers/2/nodes', True,
-                       CLBNotFoundError(lb_id=u'2')),
+            parallel_sequence([
+                [nodes_req(1, [node('11', 'a11')])],
+                [lb_req('loadbalancers/2/nodes', True,
+                        CLBNotFoundError(lb_id=u'2'))],
             ]),
-            nested_parallel([])  # No nodes to fetch
+            parallel_sequence([])  # No nodes to fetch
         ]
         make_desc = partial(CLBDescription, port=20, weight=2,
                             condition=CLBNodeCondition.ENABLED,
@@ -508,14 +506,14 @@ class GetCLBContentsTests(SynchronousTestCase):
         seq = [
             lb_req('loadbalancers', True,
                    {'loadBalancers': [{'id': 1}, {'id': 2}]}),
-            nested_parallel([
-                nodes_req(1, [node('11', 'a11', condition='DRAINING'),
-                              node('12', 'a12')]),
-                nodes_req(2, [node21])
+            parallel_sequence([
+                [nodes_req(1, [node('11', 'a11', condition='DRAINING'),
+                               node('12', 'a12')])],
+                [nodes_req(2, [node21])]
             ]),
-            nested_parallel([
-                node_feed_req(1, '11', CLBNotFoundError(lb_id=u'1')),
-                node_feed_req(2, '21', '22feed')]),
+            parallel_sequence([
+                [node_feed_req(1, '11', CLBNotFoundError(lb_id=u'1'))],
+                [node_feed_req(2, '21', '22feed')]]),
         ]
         eff = get_clb_contents()
         self.assertEqual(

--- a/otter/test/convergence/test_service.py
+++ b/otter/test/convergence/test_service.py
@@ -7,7 +7,7 @@ from effect import (
     ComposedDispatcher, Effect, Error, Func, base_dispatcher, sync_perform)
 from effect.ref import ReadReference, Reference, reference_dispatcher
 from effect.testing import (
-    SequenceDispatcher, perform_sequence, parallel_sequence)
+    SequenceDispatcher, parallel_sequence, perform_sequence)
 
 from kazoo.exceptions import BadVersionError, NoNodeError
 from kazoo.recipe.partitioner import PartitionState
@@ -562,7 +562,7 @@ class ConvergeAllGroupsTests(SynchronousTestCase):
              lambda i: None),
             parallel_sequence([
                 [(BoundFields(mock.ANY, fields={'tenant_id': '00',
-                                               'scaling_group_id': 'g1'}),
+                                                'scaling_group_id': 'g1'}),
                   nested_sequence(get_bound_sequence('00', 'g1')))],
              ]),
         ]

--- a/otter/test/convergence/test_service.py
+++ b/otter/test/convergence/test_service.py
@@ -6,7 +6,8 @@ from datetime import datetime
 from effect import (
     ComposedDispatcher, Effect, Error, Func, base_dispatcher, sync_perform)
 from effect.ref import ReadReference, Reference, reference_dispatcher
-from effect.testing import SequenceDispatcher
+from effect.testing import (
+    SequenceDispatcher, perform_sequence, parallel_sequence)
 
 from kazoo.exceptions import BadVersionError, NoNodeError
 from kazoo.recipe.partitioner import PartitionState
@@ -50,10 +51,8 @@ from otter.test.utils import (
     TestStep,
     intent_func,
     mock_group, mock_log,
-    nested_parallel,
     nested_sequence,
     noop,
-    perform_sequence,
     raise_,
     raise_to_exc_info,
     test_dispatcher,
@@ -481,13 +480,13 @@ class ConvergeAllGroupsTests(SynchronousTestCase):
             (Log('converge-all-groups',
                  dict(group_infos=self.group_infos, currently_converging=[])),
              lambda i: None),
-            nested_parallel([
-                (BoundFields(mock.ANY, fields={'tenant_id': '00',
-                                               'scaling_group_id': 'g1'}),
-                 nested_sequence(get_bound_sequence('00', 'g1'))),
-                (BoundFields(mock.ANY, fields={'tenant_id': '01',
-                                               'scaling_group_id': 'g2'}),
-                 nested_sequence(get_bound_sequence('01', 'g2'))),
+            parallel_sequence([
+                [(BoundFields(mock.ANY, fields={'tenant_id': '00',
+                                                'scaling_group_id': 'g1'}),
+                  nested_sequence(get_bound_sequence('00', 'g1')))],
+                [(BoundFields(mock.ANY, fields={'tenant_id': '01',
+                                                'scaling_group_id': 'g2'}),
+                  nested_sequence(get_bound_sequence('01', 'g2')))],
              ])
         ]
         self.assertEqual(perform_sequence(sequence, eff),
@@ -507,18 +506,18 @@ class ConvergeAllGroupsTests(SynchronousTestCase):
                       currently_converging=['g1'])),
              lambda i: None),
 
-            nested_parallel([
-                (BoundFields(mock.ANY, dict(tenant_id='01',
-                                            scaling_group_id='g2')),
-                 nested_sequence([
-                    (GetStat(path='/groups/divergent/01_g2'),
-                     lambda i: ZNodeStatStub(version=5)),
-                    (TenantScope(mock.ANY, '01'),
-                     nested_sequence([
-                        (('converge', '01', 'g2', 5, 3600),
-                         lambda i: 'converged two!'),
-                     ])),
-                 ])),
+            parallel_sequence([
+                [(BoundFields(mock.ANY, dict(tenant_id='01',
+                                             scaling_group_id='g2')),
+                  nested_sequence([
+                     (GetStat(path='/groups/divergent/01_g2'),
+                      lambda i: ZNodeStatStub(version=5)),
+                     (TenantScope(mock.ANY, '01'),
+                      nested_sequence([
+                         (('converge', '01', 'g2', 5, 3600),
+                          lambda i: 'converged two!'),
+                      ])),
+                  ]))],
              ])
         ]
         self.assertEqual(perform_sequence(sequence, eff), ['converged two!'])
@@ -561,10 +560,10 @@ class ConvergeAllGroupsTests(SynchronousTestCase):
                  dict(group_infos=[self.group_infos[0]],
                       currently_converging=[])),
              lambda i: None),
-            nested_parallel([
-                (BoundFields(mock.ANY, fields={'tenant_id': '00',
+            parallel_sequence([
+                [(BoundFields(mock.ANY, fields={'tenant_id': '00',
                                                'scaling_group_id': 'g1'}),
-                 nested_sequence(get_bound_sequence('00', 'g1'))),
+                  nested_sequence(get_bound_sequence('00', 'g1')))],
              ]),
         ]
         self.assertEqual(perform_sequence(sequence, eff), [None])
@@ -689,10 +688,10 @@ class ExecuteConvergenceTests(SynchronousTestCase):
     def get_seq(self):
         return [
             (Func(datetime.utcnow), lambda i: self.now),
-            nested_parallel([
-                (self.gsgi, lambda i: self.gsgi_result),
-                (("gacd", self.tenant_id, self.group_id, self.now),
-                 lambda i: (self.servers, ()))
+            parallel_sequence([
+                [(self.gsgi, lambda i: self.gsgi_result)],
+                [(("gacd", self.tenant_id, self.group_id, self.now),
+                  lambda i: (self.servers, ()))]
             ]),
             (UpdateServersCache(
                 self.tenant_id, self.group_id, self.now, self.cache), noop)
@@ -712,7 +711,7 @@ class ExecuteConvergenceTests(SynchronousTestCase):
         for serv in self.servers:
             serv.desired_lbs = pset()
         sequence = [
-            nested_parallel([]),
+            parallel_sequence([]),
             (Log('execute-convergence', mock.ANY), noop),
             (Log('execute-convergence-results',
                  {'results': [], 'worst_status': 'SUCCESS'}), noop),
@@ -756,14 +755,14 @@ class ExecuteConvergenceTests(SynchronousTestCase):
             return steps
 
         sequence = [
-            nested_parallel([]),
+            parallel_sequence([]),
             (Log('execute-convergence',
                  dict(servers=self.servers, lb_nodes=(), steps=steps,
                       now=self.now, desired=dgs)), noop),
-            nested_parallel([
-                ({'dgs': dgs, 'servers': self.servers,
-                  'lb_nodes': (), 'now': 0},
-                 noop)
+            parallel_sequence([
+                [({'dgs': dgs, 'servers': self.servers,
+                   'lb_nodes': (), 'now': 0},
+                  noop)]
             ]),
             (Log('execute-convergence-results',
                  {'results': [{'step': steps[0],
@@ -828,14 +827,14 @@ class ExecuteConvergenceTests(SynchronousTestCase):
             ],
             'worst_status': 'RETRY'}
         sequence = [
-            nested_parallel([]),
+            parallel_sequence([]),
             (Log(msg='execute-convergence', fields=mock.ANY), noop),
-            nested_parallel([
-                ("step_intent", lambda i: (
-                    StepResult.RETRY, [
-                        ErrorReason.Exception(exc_info),
-                        ErrorReason.String('foo'),
-                        ErrorReason.Structured({'foo': 'bar'})]))
+            parallel_sequence([
+                [("step_intent", lambda i: (
+                     StepResult.RETRY, [
+                         ErrorReason.Exception(exc_info),
+                         ErrorReason.String('foo'),
+                         ErrorReason.Structured({'foo': 'bar'})]))]
             ]),
             (Log(msg='execute-convergence-results', fields=expected_fields),
              noop)
@@ -854,17 +853,17 @@ class ExecuteConvergenceTests(SynchronousTestCase):
             return pbag([step])
 
         sequence = [
-            nested_parallel([
-                nested_parallel([
-                    (Log('convergence-create-servers',
-                         {'num_servers': 1, 'server_config': {'foo': 'bar'},
-                          'cloud_feed': True, 'cloud_feed_id': mock.ANY}),
-                     noop)
-                ])
+            parallel_sequence([
+                [parallel_sequence([
+                     [(Log('convergence-create-servers',
+                           {'num_servers': 1, 'server_config': {'foo': 'bar'},
+                            'cloud_feed': True, 'cloud_feed_id': mock.ANY}),
+                       noop)]
+                 ])]
             ]),
             (Log(msg='execute-convergence', fields=mock.ANY), noop),
-            nested_parallel([
-                ("create-server", lambda i: (StepResult.RETRY, []))
+            parallel_sequence([
+                [("create-server", lambda i: (StepResult.RETRY, []))]
             ]),
             (Log(msg='execute-convergence-results', fields=mock.ANY), noop)
         ]
@@ -881,10 +880,10 @@ class ExecuteConvergenceTests(SynchronousTestCase):
 
         self.state.status = ScalingGroupStatus.DELETING
         sequence = [
-            nested_parallel([]),
+            parallel_sequence([]),
             (Log('execute-convergence', mock.ANY), noop),
-            nested_parallel([
-                ("step", lambda i: (step_result, []))
+            parallel_sequence([
+                [("step", lambda i: (step_result, []))]
             ]),
             (Log('execute-convergence-results', mock.ANY), noop),
         ]
@@ -925,12 +924,12 @@ class ExecuteConvergenceTests(SynchronousTestCase):
                 TestStep(Effect("retry"))]
 
         sequence = [
-            nested_parallel([]),
+            parallel_sequence([]),
             (Log('execute-convergence', mock.ANY), noop),
-            nested_parallel([
-                ("step1", lambda i: (StepResult.SUCCESS, [])),
-                ("retry", lambda i: (StepResult.RETRY,
-                                     [ErrorReason.String('mywish')]))
+            parallel_sequence([
+                [("step1", lambda i: (StepResult.SUCCESS, []))],
+                [("retry", lambda i: (StepResult.RETRY,
+                                      [ErrorReason.String('mywish')]))],
             ]),
             (Log('execute-convergence-results', mock.ANY), noop)
         ]
@@ -959,17 +958,17 @@ class ExecuteConvergenceTests(SynchronousTestCase):
             return StepResult.SUCCESS, []
 
         sequence = [
-            nested_parallel([]),
+            parallel_sequence([]),
             (Log(msg='execute-convergence', fields=mock.ANY), noop),
-            nested_parallel([
-                ("success1", success),
-                ("retry", lambda i: (StepResult.RETRY, [])),
-                ("success2", success),
-                ("fail1", lambda i: (StepResult.FAILURE,
-                                     [ErrorReason.Exception(exc_info)])),
-                ("fail2", lambda i: (StepResult.FAILURE,
-                                     [ErrorReason.Exception(exc_info2)])),
-                ("success3", success)
+            parallel_sequence([
+                [("success1", success)],
+                [("retry", lambda i: (StepResult.RETRY, []))],
+                [("success2", success)],
+                [("fail1", lambda i: (StepResult.FAILURE,
+                                      [ErrorReason.Exception(exc_info)]))],
+                [("fail2", lambda i: (StepResult.FAILURE,
+                                      [ErrorReason.Exception(exc_info2)]))],
+                [("success3", success)],
             ]),
             (Log(msg='execute-convergence-results', fields=mock.ANY), noop),
             (UpdateGroupStatus(scaling_group=self.group,
@@ -1001,11 +1000,11 @@ class ExecuteConvergenceTests(SynchronousTestCase):
             return [TestStep(Effect("fail"))]
 
         sequence = [
-            nested_parallel([]),
+            parallel_sequence([]),
             (Log(msg='execute-convergence', fields=mock.ANY), noop),
-            nested_parallel([
-                ("fail", lambda i: (StepResult.FAILURE,
-                                    [ErrorReason.Exception(exc_info)]))
+            parallel_sequence([
+                [("fail", lambda i: (StepResult.FAILURE,
+                                     [ErrorReason.Exception(exc_info)]))]
             ]),
             (Log(msg='execute-convergence-results', fields=mock.ANY), noop),
             (UpdateGroupStatus(scaling_group=self.group,
@@ -1033,10 +1032,10 @@ class ExecuteConvergenceTests(SynchronousTestCase):
             return pbag([TestStep(Effect("step"))])
 
         sequence = [
-            nested_parallel([]),
+            parallel_sequence([]),
             (Log(msg='execute-convergence', fields=mock.ANY), noop),
-            nested_parallel([
-                ("step", lambda i: (StepResult.SUCCESS, []))
+            parallel_sequence([
+                [("step", lambda i: (StepResult.SUCCESS, []))]
             ]),
             (Log(msg='execute-convergence-results', fields=mock.ANY), noop),
             (UpdateGroupStatus(scaling_group=self.group,
@@ -1063,7 +1062,7 @@ class ExecuteConvergenceTests(SynchronousTestCase):
         for serv in self.servers:
             serv.desired_lbs = pset()
         sequence = [
-            nested_parallel([]),
+            parallel_sequence([]),
             (Log(msg='execute-convergence', fields=mock.ANY), noop),
             (Log(msg='execute-convergence-results', fields=mock.ANY), noop),
             (UpdateGroupStatus(scaling_group=self.group,

--- a/otter/test/convergence/test_steps.py
+++ b/otter/test/convergence/test_steps.py
@@ -2,7 +2,7 @@
 import json
 
 from effect import Effect, Func, base_dispatcher, sync_perform
-from effect.testing import SequenceDispatcher
+from effect.testing import SequenceDispatcher, perform_sequence
 
 from mock import ANY, patch
 
@@ -60,7 +60,6 @@ from otter.log.intents import Log
 from otter.test.utils import (
     StubResponse,
     matches,
-    perform_sequence,
     raise_,
     resolve_effect,
     stub_pure_response,

--- a/otter/test/log/test_cloudfeeds.py
+++ b/otter/test/log/test_cloudfeeds.py
@@ -6,6 +6,7 @@ import uuid
 from functools import partial
 
 from effect import Effect, Func, TypeDispatcher
+from effect.testing import perform_sequence
 
 import mock
 
@@ -35,7 +36,6 @@ from otter.test.utils import (
     mock_log,
     nested_sequence,
     patch,
-    perform_sequence,
     raise_,
     retry_sequence,
     stub_pure_response

--- a/otter/test/models/test_cass_models.py
+++ b/otter/test/models/test_cass_models.py
@@ -10,7 +10,7 @@ from functools import partial
 
 from effect import (
     Constant, Effect, ParallelEffects, TypeDispatcher, sync_perform)
-from effect.testing import resolve_effect
+from effect.testing import resolve_effect, perform_sequence
 
 from jsonschema import ValidationError
 
@@ -71,7 +71,6 @@ from otter.test.utils import (
     LockMixin,
     matches,
     mock_log,
-    perform_sequence,
     patch,
     test_dispatcher)
 from otter.util.config import set_config_data

--- a/otter/test/models/test_cass_models.py
+++ b/otter/test/models/test_cass_models.py
@@ -10,7 +10,7 @@ from functools import partial
 
 from effect import (
     Constant, Effect, ParallelEffects, TypeDispatcher, sync_perform)
-from effect.testing import resolve_effect, perform_sequence
+from effect.testing import perform_sequence, resolve_effect
 
 from jsonschema import ValidationError
 

--- a/otter/test/test_cloud_client.py
+++ b/otter/test/test_cloud_client.py
@@ -11,7 +11,7 @@ from effect import (
     TypeDispatcher,
     base_dispatcher,
     sync_perform)
-from effect.testing import EQFDispatcher, SequenceDispatcher
+from effect.testing import EQFDispatcher, SequenceDispatcher, perform_sequence
 
 import mock
 
@@ -69,7 +69,6 @@ from otter.log.intents import Log
 from otter.test.utils import (
     StubResponse,
     nested_sequence,
-    perform_sequence,
     raise_,
     resolve_effect,
     stub_json_response,

--- a/otter/test/test_controller.py
+++ b/otter/test/test_controller.py
@@ -77,7 +77,8 @@ class PauseGroupTests(SynchronousTestCase):
              nested_sequence([
                  parallel_sequence([
                      [(ModifyGroupStatePaused(self.group, True), noop)],
-                     [(DeleteNode(path="/groups/divergent/tid_gid", version=-1),
+                     [(DeleteNode(path="/groups/divergent/tid_gid",
+                                  version=-1),
                        noop),
                       (Log("mark-clean-success", {}), noop)],
                  ])

--- a/otter/test/test_controller.py
+++ b/otter/test/test_controller.py
@@ -7,7 +7,8 @@ from effect import (
     ComposedDispatcher,
     Effect,
     sync_perform)
-from effect.testing import SequenceDispatcher
+from effect.testing import (
+    SequenceDispatcher, parallel_sequence, perform_sequence)
 
 import mock
 
@@ -40,11 +41,9 @@ from otter.test.utils import (
     matches,
     mock_group as util_mock_group,
     mock_log,
-    nested_parallel,
     nested_sequence,
     noop,
     patch,
-    perform_sequence,
     raise_,
     test_dispatcher)
 from otter.util.config import set_config_data
@@ -76,11 +75,11 @@ class PauseGroupTests(SynchronousTestCase):
                                         tenant_id="tid",
                                         scaling_group_id="gid")),
              nested_sequence([
-                 nested_parallel([
-                     (ModifyGroupStatePaused(self.group, True), noop),
-                     (DeleteNode(path="/groups/divergent/tid_gid", version=-1),
-                      noop),
-                     (Log("mark-clean-success", {}), noop)
+                 parallel_sequence([
+                     [(ModifyGroupStatePaused(self.group, True), noop)],
+                     [(DeleteNode(path="/groups/divergent/tid_gid", version=-1),
+                       noop),
+                      (Log("mark-clean-success", {}), noop)],
                  ])
              ]))
         ]
@@ -119,12 +118,12 @@ class PauseGroupTests(SynchronousTestCase):
                                         tenant_id="tid",
                                         scaling_group_id="gid")),
              nested_sequence([
-                 nested_parallel([
-                     (ModifyGroupStatePaused(self.group, False), noop),
-                     (CreateOrSet(path="/groups/divergent/tid_gid",
-                                  content="dirty"),
-                      noop),
-                     (Log("mark-dirty-success", {}), noop)
+                 parallel_sequence([
+                     [(ModifyGroupStatePaused(self.group, False), noop)],
+                     [(CreateOrSet(path="/groups/divergent/tid_gid",
+                                   content="dirty"),
+                       noop),
+                      (Log("mark-dirty-success", {}), noop)]
                  ])
              ]))
         ]

--- a/otter/test/test_testutils.py
+++ b/otter/test/test_testutils.py
@@ -5,6 +5,7 @@ from effect import (
     ComposedDispatcher, Effect, NoPerformerFoundError,
     base_dispatcher, parallel, sync_performer)
 from effect.fold import FoldError, sequence
+from effect.testing import perform_sequence
 
 from mock import ANY
 
@@ -16,8 +17,6 @@ from zope.interface import Attribute, Interface
 
 from otter.test.utils import (
     iMock,
-    nested_parallel,
-    perform_sequence,
     raise_,
     retry_sequence
 )

--- a/otter/test/test_testutils.py
+++ b/otter/test/test_testutils.py
@@ -205,7 +205,7 @@ class RetrySequenceTests(SynchronousTestCase):
             retry_sequence(r, [lambda _: raise_(Exception()),
                                lambda _: raise_(Exception())])
         ]
-        self.assertRaises(NoPerformerFoundError,
+        self.assertRaises(AssertionError,
                           perform_sequence, seq, Effect(r))
 
     def test_do_not_have_to_expect_an_exact_can_retry(self):

--- a/otter/test/test_testutils.py
+++ b/otter/test/test_testutils.py
@@ -173,60 +173,6 @@ class IMockTests(SynchronousTestCase):
         self.assertEqual(im.another_attribute, 'what')
 
 
-class NestedParallelTests(SynchronousTestCase):
-    """Tests for :func:`nested_parallel`."""
-
-    def test_nested_parallel(self):
-        """
-        Ensures that all parallel effects are found in the given intents, in
-        order, and returns the results associated with those intents.
-        """
-        seq = [
-            nested_parallel([
-                (1, lambda i: "one!"),
-                (2, lambda i: "two!"),
-                (3, lambda i: "three!"),
-            ])
-        ]
-        p = parallel([Effect(1), Effect(2), Effect(3)])
-        self.assertEqual(perform_sequence(seq, p), ['one!', 'two!', 'three!'])
-
-    def test_fallback(self):
-        """
-        Accepts a ``fallback`` dispatcher that will be used when the sequence
-        doesn't contain an intent.
-        """
-        def dispatch_2(intent):
-            if intent == 2:
-                return sync_performer(lambda d, i: "two!")
-        fallback = ComposedDispatcher([dispatch_2, base_dispatcher])
-        seq = [
-            nested_parallel([
-                (1, lambda i: 'one!'),
-                (3, lambda i: 'three!'),
-                ],
-                fallback_dispatcher=fallback),
-        ]
-        p = parallel([Effect(1), Effect(2), Effect(3)])
-        self.assertEqual(perform_sequence(seq, p), ['one!', 'two!', 'three!'])
-
-    def test_must_be_parallel(self):
-        """
-        If the sequences aren't run in parallel, the nested_parallel won't
-        match and a FoldError of NoPerformerFoundError will be raised.
-        """
-        seq = [
-            nested_parallel([
-                (1, lambda i: "one!"),
-                (2, lambda i: "two!"),
-                (3, lambda i: "three!"),
-            ])
-        ]
-        p = sequence([Effect(1), Effect(2), Effect(3)])
-        e = self.assertRaises(FoldError, perform_sequence, seq, p)
-        self.assertIs(e.wrapped_exception[0], NoPerformerFoundError)
-
-
 class RetrySequenceTests(SynchronousTestCase):
     """Tests for :func:`retry_sequence`."""
 

--- a/otter/test/test_testutils.py
+++ b/otter/test/test_testutils.py
@@ -1,10 +1,7 @@
 """
 Tests for :obj:`otter.test.utils`.
 """
-from effect import (
-    ComposedDispatcher, Effect, NoPerformerFoundError,
-    base_dispatcher, parallel, sync_performer)
-from effect.fold import FoldError, sequence
+from effect import ComposedDispatcher, Effect, base_dispatcher, sync_performer
 from effect.testing import perform_sequence
 
 from mock import ANY

--- a/otter/test/utils.py
+++ b/otter/test/utils.py
@@ -10,14 +10,12 @@ from operator import attrgetter
 
 from effect import (
     ComposedDispatcher, Constant, Effect, ParallelEffects, TypeDispatcher,
-    base_dispatcher, sync_perform)
+    base_dispatcher)
 from effect.async import perform_parallel_async
-from effect.fold import sequence
 from effect.testing import (
-    SequenceDispatcher,
+    perform_sequence,
     resolve_effect as eff_resolve_effect,
-    resolve_stubs as eff_resolve_stubs,
-    perform_sequence as PS)
+    resolve_stubs as eff_resolve_stubs)
 
 from kazoo.recipe.partitioner import PartitionState
 
@@ -762,7 +760,8 @@ def retry_sequence(expected_retry_intent, performers,
         seq = [(expected_retry_intent.effect.intent, performer)
                for performer in performers]
 
-        return PS(seq, new_retry_effect, ComposedDispatcher(_dispatchers))
+        return perform_sequence(seq, new_retry_effect,
+                                ComposedDispatcher(_dispatchers))
 
     return (expected_retry_intent, perform_retry_without_delay)
 
@@ -797,7 +796,7 @@ def nested_sequence(seq, get_effect=attrgetter('effect'),
         sequence dispatcher.
     """
     return compose(
-        partial(PS, seq,
+        partial(perform_sequence, seq,
                 fallback_dispatcher=fallback_dispatcher),
         get_effect)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ jsonfig==0.1.1
 testtools==0.9.32
 croniter==0.3.5
 txkazoo==0.0.6b2
-effect==0.9
+effect==0.10
 txeffect==0.9
 characteristic==14.3.0
 attrs==15.0.0


### PR DESCRIPTION
I've moved the perform_sequence function to effect, and also moved (and modified) `nested_parallel` to effect. I renamed it to `parallel_sequence` and also changed its behavior, because I realized the version we had didn't allow distinguishing chains of parallelized effects from top-level parallel effects.

e.g. `nested_parallel([(a, noop), (b, noop)])` would match both of the following: `parallel([a, b])` and `parallel([a.on(lambda r: b)])`. So, parallel_sequence requires a list of lists, where each list represents the sequence of effects that each parallelized effect goes through.

unfortunately lots of whitespace changes, but the changes themselves are trivial.