### PR TITLE
Modify state and trigger convergence

### DIFF
--- a/otter/controller.py
+++ b/otter/controller.py
@@ -50,8 +50,7 @@ from otter.cloud_client import (
 from otter.convergence.composition import tenant_is_enabled
 from otter.convergence.model import DRAINING_METADATA, group_id_from_metadata
 from otter.convergence.service import (
-    delete_divergent_flag, get_convergence_starter, mark_divergent,
-    trigger_convergence)
+    delete_divergent_flag, mark_divergent, trigger_convergence)
 from otter.json_schema.group_schemas import MAX_ENTITIES
 from otter.log import audit
 from otter.log.intents import BoundFields, msg, with_log

--- a/otter/controller.py
+++ b/otter/controller.py
@@ -703,13 +703,6 @@ def remove_server_from_group(log, trans_id, server_id, replace, purge,
 
     # convergence case - requires that the convergence dispatcher handles
     # EvictServerFromScalingGroup
-    cs = get_convergence_starter()
-    d = perform_convergence_remove_from_group(
+    return perform_convergence_remove_from_group(
         log, trans_id, server_id, replace, purge, group, state,
         cs.dispatcher)
-
-    def kick_off_convergence(new_state):
-        cs.start_convergence(log, group.tenant_id, group.uuid)
-        return new_state
-
-    return d.addCallback(kick_off_convergence)

--- a/otter/controller.py
+++ b/otter/controller.py
@@ -349,17 +349,11 @@ def converge(log, transaction_id, config, scaling_group, state, launch_config,
         # For convergence tenants, find delta based on group's desired
         # capacity
         delta = apply_delta(log, state.desired, state, config, policy)
-        # Delta could be 0, however we may still want to trigger convergence
-        d = get_convergence_starter().start_convergence(
-            log, scaling_group.tenant_id, scaling_group.uuid)
         if delta == 0:
             # No change in servers. Return None synchronously
             return None
         else:
-            # We honor start_convergence's deferred here so that we can
-            # communicate back a strong acknowledgement that convergence
-            # has been triggered on the group
-            return d.addCallback(lambda _: state)
+            return defer.succeed(state)
 
     # For non-convergence tenants, the value used for desired-capacity is
     # the sum of active+pending, which is 0, so the delta ends up being

--- a/otter/log/bound.py
+++ b/otter/log/bound.py
@@ -29,3 +29,23 @@ class BoundLog(object):
         err = functools.partial(self.err, **kwargs)
 
         return self.__class__(msg, err)
+
+
+def bound_log_kwargs(log):
+    """
+    Return keyword arguments bound to given logger
+    """
+    f = log.msg
+    kwargs_list = []
+    while True:
+        try:
+            kwargs_list.append(f.keywords)
+        except AttributeError:
+            break
+        else:
+            f = f.func
+    # combine them in order they were bound
+    kwargs = {}
+    for kwa in reversed(kwargs_list):
+        kwargs.update(kwa)
+    return kwargs

--- a/otter/rest/application.py
+++ b/otter/rest/application.py
@@ -67,7 +67,8 @@ class Otter(object):
         """
         execute route handled by OtterExecute
         """
-        return OtterExecute(self.store, cap_version, cap_hash).app.resource()
+        return OtterExecute(self.store, cap_version, cap_hash,
+                            self.dispatcher).app.resource()
 
     @app.route('/v1.0/<string:tenant_id>/limits')
     def limits(self, request, tenant_id):

--- a/otter/rest/configs.py
+++ b/otter/rest/configs.py
@@ -127,7 +127,9 @@ class OtterConfig(object):
             self.log, self.tenant_id, self.group_id)
         deferred = rec.update_config(data)
         deferred.addCallback(
-            lambda _: rec.modify_state(
+            lambda _: controller.modify_and_trigger(
+                group,
+                self.log
                 _get_launch_and_obey_config_change,
                 modify_state_reason='edit_config_for_scaling_group'))
         return deferred

--- a/otter/rest/groups.py
+++ b/otter/rest/groups.py
@@ -13,7 +13,6 @@ from txeffect import perform
 from otter import controller
 from otter.controller import GroupPausedError
 from otter.convergence.composition import tenant_is_enabled
-from otter.convergence.service import trigger_convergence
 from otter.effect_dispatcher import get_working_cql_dispatcher
 from otter.json_schema.group_schemas import (
     MAX_ENTITIES,
@@ -21,7 +20,7 @@ from otter.json_schema.group_schemas import (
 )
 from otter.json_schema.rest_schemas import create_group_request
 from otter.log import log
-from otter.log.intents import with_log
+from otter.log.bound import bound_log_kwargs
 from otter.models.cass import CassScalingGroupServersCache
 from otter.models.interface import ScalingGroupStatus
 from otter.rest.bobby import get_bobby
@@ -412,11 +411,13 @@ class OtterGroups(object):
             launch = result['launchConfiguration']
             group = self.store.get_scaling_group(
                 self.log, self.tenant_id, group_id)
+            log = self.log.bind(scaling_group_id=group_id)
             d = controller.modify_and_trigger(
+                self.dispatcher,
                 group,
-                self.log,
+                bound_log_kwargs(log),
                 partial(
-                    controller.obey_config_change, self.log,
+                    controller.obey_config_change, log,
                     transaction_id(request), config, launch_config=launch),
                 modify_state_reason='create_new_scaling_group')
             return d.addCallback(lambda _: result)
@@ -676,8 +677,10 @@ class OtterGroup(object):
         if tenant_is_enabled(self.tenant_id, config_value):
             group = self.store.get_scaling_group(
                 self.log, self.tenant_id, self.group_id)
-            return modify_and_trigger(
-                group, self.log.bind(transaction_id=transaction_id(request)),
+            return controller.modify_and_trigger(
+                self.dispatcher,
+                group,
+                bound_log_kwargs(log),
                 is_group_paused)
         else:
             request.setResponseCode(404)
@@ -726,7 +729,8 @@ class OtterGroup(object):
         """
         config route handled by OtterConfig
         """
-        config = OtterConfig(self.store, self.tenant_id, self.group_id)
+        config = OtterConfig(self.store, self.tenant_id, self.group_id,
+                             self.dispatcher)
         return config.app.resource()
 
     @app.route('/launch/')
@@ -742,7 +746,8 @@ class OtterGroup(object):
         """
         policies routes handled by OtterPolicies
         """
-        policies = OtterPolicies(self.store, self.tenant_id, self.group_id)
+        policies = OtterPolicies(self.store, self.tenant_id, self.group_id,
+                                 self.dispatcher)
         return policies.app.resource()
 
 
@@ -792,12 +797,14 @@ class OtterServers(object):
         """
         group = self.store.get_scaling_group(
             self.log, self.tenant_id, self.scaling_group_id)
+        log = self.log.bind(server_id=server_id)
         d = controller.modify_and_trigger(
+            self.dispatcher,
             group,
-            self.log,
+            bound_log_kwargs(log),
             partial(controller.remove_server_from_group,
                     self.dispatcher,
-                    self.log.bind(server_id=server_id),
+                    log,
                     transaction_id(request), server_id,
                     extract_bool_arg(request, 'replace', True),
                     extract_bool_arg(request, 'purge', True)),

--- a/otter/rest/policies.py
+++ b/otter/rest/policies.py
@@ -2,23 +2,29 @@
 Autoscale REST endpoints having to do with creating/reading/updating/deleting
 the scaling policies associated with a particular scaling group.
 
-(/tenantId/groups/groupId/policies and /tenantId/groups/groupId/policies/policyId)
+(/tenantId/groups/groupId/policies and
+ /tenantId/groups/groupId/policies/policyId)
 """
 
-from functools import partial
 import json
+from functools import partial
+
+from jsonschema import ValidationError
+
 from twisted.internet import defer
 
-from otter.json_schema import rest_schemas, group_schemas
+from otter import controller
+from otter.json_schema import group_schemas, rest_schemas
 from otter.log import log
-from otter.rest.decorators import (validate_body, fails_with, auditable,
-                                   succeeds_with, with_transaction_id, paginatable)
+from otter.log.bound import bound_log_kwargs
+from otter.rest.decorators import (
+    auditable, fails_with, paginatable, succeeds_with, validate_body,
+    with_transaction_id)
 from otter.rest.errors import exception_codes
 from otter.rest.otterapp import OtterApp
 from otter.rest.webhooks import OtterWebhooks
-from otter.util.http import get_autoscale_links, transaction_id, get_policies_links
-from otter import controller
-from jsonschema import ValidationError
+from otter.util.http import (
+    get_autoscale_links, get_policies_links, transaction_id)
 
 
 def linkify_policy_list(policy_list, tenantId, groupId):
@@ -55,13 +61,14 @@ class OtterPolicies(object):
     """
     app = OtterApp()
 
-    def __init__(self, store, tenant_id, scaling_group_id):
+    def __init__(self, store, tenant_id, scaling_group_id, dispatcher):
         self.log = log.bind(system='otter.rest.policies',
                             tenant_id=tenant_id,
                             scaling_group_id=scaling_group_id)
         self.store = store
         self.tenant_id = tenant_id
         self.scaling_group_id = scaling_group_id
+        self.dispatcher = dispatcher
 
     @app.route('/', methods=['GET'])
     @with_transaction_id()
@@ -258,7 +265,7 @@ class OtterPolicies(object):
         """
         return OtterPolicy(self.store, self.tenant_id,
                            self.scaling_group_id,
-                           policy_id).app.resource()
+                           policy_id, self.dispatcher).app.resource()
 
 
 class OtterPolicy(object):
@@ -267,7 +274,8 @@ class OtterPolicy(object):
     """
     app = OtterApp()
 
-    def __init__(self, store, tenant_id, scaling_group_id, policy_id):
+    def __init__(self, store, tenant_id, scaling_group_id, policy_id,
+                 dispatcher):
         self.log = log.bind(system='otter.log.policy',
                             tenant_id=tenant_id,
                             scaling_group_id=scaling_group_id,
@@ -276,6 +284,7 @@ class OtterPolicy(object):
         self.tenant_id = tenant_id
         self.scaling_group_id = scaling_group_id
         self.policy_id = policy_id
+        self.dispatcher = dispatcher
 
     @app.route('/', methods=['GET'])
     @with_transaction_id()
@@ -372,8 +381,9 @@ class OtterPolicy(object):
         group = self.store.get_scaling_group(self.log, self.tenant_id,
                                              self.scaling_group_id)
         d = controller.modify_and_trigger(
+            self.dispatcher,
             group,
-            self.log,
+            bound_log_kwargs(self.log),
             partial(controller.maybe_execute_scaling_policy,
                     self.log, transaction_id(request),
                     policy_id=self.policy_id),
@@ -387,4 +397,5 @@ class OtterPolicy(object):
         webhook routes handled by OtterWebhooks
         """
         return OtterWebhooks(self.store, self.tenant_id,
-                             self.scaling_group_id, self.policy_id).app.resource()
+                             self.scaling_group_id,
+                             self.policy_id).app.resource()

--- a/otter/rest/policies.py
+++ b/otter/rest/policies.py
@@ -371,7 +371,9 @@ class OtterPolicy(object):
         """
         group = self.store.get_scaling_group(self.log, self.tenant_id,
                                              self.scaling_group_id)
-        d = group.modify_state(
+        d = controller.modify_and_trigger(
+            group,
+            self.log,
             partial(controller.maybe_execute_scaling_policy,
                     self.log, transaction_id(request),
                     policy_id=self.policy_id),

--- a/otter/rest/webhooks.py
+++ b/otter/rest/webhooks.py
@@ -6,26 +6,26 @@ policy.
 (/tenantId/groups/groupId/policy/policyId/webhook
  /tenantId/groups/groupId/policy/policyId/webhook/webhookId)
 """
-from functools import partial
 import json
+from functools import partial
 
-from otter.log import log
+from otter import controller
+from otter.controller import CannotExecutePolicyError
 from otter.json_schema import group_schemas
 from otter.json_schema import rest_schemas
-from otter.rest.decorators import (validate_body, fails_with, succeeds_with,
-                                   with_transaction_id, paginatable)
+from otter.log import log
+from otter.log.bound import bound_log_kwargs
+from otter.models.interface import (
+    NoSuchPolicyError,
+    NoSuchScalingGroupError,
+    UnrecognizedCapabilityError
+)
+from otter.rest.decorators import (
+    fails_with, paginatable, succeeds_with, validate_body, with_transaction_id)
 from otter.rest.errors import exception_codes
 from otter.rest.otterapp import OtterApp
-from otter.util.http import get_autoscale_links, transaction_id, get_webhooks_links
-
-from otter.models.interface import (
-    UnrecognizedCapabilityError,
-    NoSuchPolicyError,
-    NoSuchScalingGroupError
-)
-
-from otter.controller import CannotExecutePolicyError
-from otter import controller
+from otter.util.http import (
+    get_autoscale_links, get_webhooks_links, transaction_id)
 
 
 def _format_webhook(webhook_model, tenant_id, group_id, policy_id,
@@ -333,13 +333,14 @@ class OtterExecute(object):
     """
     app = OtterApp()
 
-    def __init__(self, store, capability_version, capability_hash):
+    def __init__(self, store, capability_version, capability_hash, dispatcher):
         self.log = log.bind(system='otter.rest.execute',
                             capability_version=capability_version,
                             capability_hash=capability_hash)
         self.store = store
         self.capability_version = capability_version
         self.capability_hash = capability_hash
+        self.dispatcher = dispatcher
 
     @app.route('/', methods=['POST'])
     @with_transaction_id()
@@ -370,9 +371,10 @@ class OtterExecute(object):
             logl[0] = bound_log
             group = self.store.get_scaling_group(bound_log, tenant_id,
                                                  group_id)
-            return modify_and_trigger(
+            return controller.modify_and_trigger(
+                self.dispatcher,
                 group,
-                bound_log,
+                bound_log_kwargs(bound_log),
                 partial(controller.maybe_execute_scaling_policy,
                         bound_log, transaction_id(request),
                         policy_id=policy_id),

--- a/otter/rest/webhooks.py
+++ b/otter/rest/webhooks.py
@@ -370,7 +370,9 @@ class OtterExecute(object):
             logl[0] = bound_log
             group = self.store.get_scaling_group(bound_log, tenant_id,
                                                  group_id)
-            return group.modify_state(
+            return modify_and_trigger(
+                group,
+                bound_log,
                 partial(controller.maybe_execute_scaling_policy,
                         bound_log, transaction_id(request),
                         policy_id=policy_id),

--- a/otter/scheduler.py
+++ b/otter/scheduler.py
@@ -11,8 +11,9 @@ from twisted.application.service import MultiService
 from twisted.internet import defer
 
 from otter.controller import (
-    CannotExecutePolicyError, maybe_execute_scaling_policy)
+    CannotExecutePolicyError, maybe_execute_scaling_policy, modify_and_trigger)
 from otter.log import log as otter_log
+from otter.log.bound import bound_log_kwargs
 from otter.models.interface import (
     NoSuchPolicyError, NoSuchScalingGroupError, next_cron_occurrence)
 from otter.util.deferredutils import ignore_and_log
@@ -24,10 +25,12 @@ class SchedulerService(MultiService):
     Service to trigger scheduled events
     """
 
-    def __init__(self, batchsize, store, partitioner_factory, threshold=60):
+    def __init__(self, dispatcher, batchsize, store, partitioner_factory,
+                 threshold=60):
         """
         Initialize the scheduler service
 
+        :param dispatcher: Effect dispatcher
         :param int batchsize: number of events to fetch on each iteration
         :param store: cassandra store
         :param partitioner_factory: Callable of (log, callback) ->
@@ -40,6 +43,7 @@ class SchedulerService(MultiService):
         self.partitioner = partitioner_factory(
             self.log, partial(self._check_events, batchsize))
         self.partitioner.setServiceParent(self)
+        self.dispatcher = dispatcher
 
     def reset(self, path):
         """
@@ -94,16 +98,17 @@ class SchedulerService(MultiService):
 
         return defer.gatherResults(
             [check_events_in_bucket(
-                log, self.store, bucket, utcnow, batchsize)
+                log, self.dispatcher, self.store, bucket, utcnow, batchsize)
              for bucket in buckets])
 
 
-def check_events_in_bucket(log, store, bucket, now, batchsize):
+def check_events_in_bucket(log, dispatcher, store, bucket, now, batchsize):
     """
     Retrieves events in the given bucket that occur before or at now,
     in batches of batchsize, for processing
 
     :param log: A bound log for logging
+    :param dispatcher: Effect dispatcher
     :param store: `IScalingGroupCollection` provider
     :param bucket: Bucket to check events in
     :param now: Time before which events are checked
@@ -120,7 +125,7 @@ def check_events_in_bucket(log, store, bucket, now, batchsize):
 
     def _do_check():
         d = store.fetch_and_delete(bucket, now, batchsize)
-        d.addCallback(process_events, store, log)
+        d.addCallback(process_events, dispatcher, store, log)
         d.addCallback(check_for_more)
         d.addErrback(log.err)
         return d
@@ -128,11 +133,13 @@ def check_events_in_bucket(log, store, bucket, now, batchsize):
     return _do_check()
 
 
-def process_events(events, store, log):
+def process_events(events, dispatcher, store, log):
     """
-    Executes all the events and adds the next occurrence of each event to the buckets
+    Executes all the events and adds the next occurrence of each event
+    to the buckets
 
     :param events: list of event dict to process
+    :param dispatcher: Effect dispatcher
     :param store: `IScalingGroupCollection` provider
     :param log: A bound log for logging
 
@@ -146,7 +153,7 @@ def process_events(events, store, log):
     deleted_policy_ids = set()
 
     deferreds = [
-        execute_event(store, log, event, deleted_policy_ids)
+        execute_event(dispatcher, store, log, event, deleted_policy_ids)
         for event in events
     ]
     d = defer.gatherResults(deferreds, consumeErrors=True)
@@ -181,10 +188,11 @@ def add_cron_events(store, log, events, deleted_policy_ids):
         return store.add_cron_events(new_cron_events)
 
 
-def execute_event(store, log, event, deleted_policy_ids):
+def execute_event(dispatcher, store, log, event, deleted_policy_ids):
     """
     Execute a single event
 
+    :param dispatcher: Effect dispatcher
     :param store: `IScalingGroupCollection` provider
     :param log: A bound log for logging
     :param event: event dict to execute
@@ -201,8 +209,9 @@ def execute_event(store, log, event, deleted_policy_ids):
     log.msg('Scheduler executing policy {policy_id}')
     group = store.get_scaling_group(log, tenant_id, group_id)
     d = modify_and_trigger(
+        dispatcher,
         group,
-        log,
+        bound_log_kwargs(log),
         partial(maybe_execute_scaling_policy,
                 log, generate_transaction_id(),
                 policy_id=policy_id, version=event['version']),

--- a/otter/scheduler.py
+++ b/otter/scheduler.py
@@ -200,7 +200,9 @@ def execute_event(store, log, event, deleted_policy_ids):
                    policy_id=policy_id)
     log.msg('Scheduler executing policy {policy_id}')
     group = store.get_scaling_group(log, tenant_id, group_id)
-    d = group.modify_state(
+    d = modify_and_trigger(
+        group,
+        log,
         partial(maybe_execute_scaling_policy,
                 log, generate_transaction_id(),
                 policy_id=policy_id, version=event['version']),

--- a/otter/test/rest/request.py
+++ b/otter/test/rest/request.py
@@ -313,6 +313,25 @@ class RestAPITestMixin(RequestTestMixin):
             self.assert_status_code(405, method=method)
 
 
+def setup_mod_and_trigger(testcase):
+    """
+    Mock `modify_and_trigger` function by calling internal modifier
+
+    :param testcase: test case that is expected to have mocked controller
+        as `mock_controller` attr
+    """
+
+    testcase.otter.dispatcher = "disp"
+
+    def mod_and_trigger(disp, group, la, mod, modify_state_reason=None,
+                        *args, **kwargs):
+        testcase.assertEqual(disp, "disp")
+        return defer.maybeDeferred(
+            mod, testcase.mock_group, testcase.mock_state, *args, **kwargs)
+
+    testcase.mock_controller.modify_and_trigger.side_effect = mod_and_trigger
+
+
 class AdminRestAPITestMixin(RequestTestMixin):
     """
     Mixin for setting up tests against the OtterAdmin REST API

--- a/otter/test/rest/test_groups.py
+++ b/otter/test/rest/test_groups.py
@@ -1154,9 +1154,7 @@ class OneGroupTestCase(RestAPITestMixin, SynchronousTestCase):
         self.assertEqual(resp['error']['type'], 'GroupNotEmptyError')
         self.flushLoggedErrors(GroupNotEmptyError)
 
-    @mock.patch('otter.rest.groups.trigger_convergence',
-                side_effect=intent_func("tg"))
-    def test_group_converge_enabled_tenant(self, mock_tg):
+    def test_group_converge_enabled_tenant(self):
         """
         Calling `../converge` on convergence enabled tenant triggers
         convergence and returns Deferred with None after enabling it
@@ -1169,6 +1167,7 @@ class OneGroupTestCase(RestAPITestMixin, SynchronousTestCase):
         self.assert_status_code(
             204, endpoint='{}converge'.format(self.endpoint),
             method='POST')
+        self.assertTrue(self.mock_controller.modify_and_trigger.called)
 
     def test_group_paused_converge(self):
         """
@@ -1182,6 +1181,7 @@ class OneGroupTestCase(RestAPITestMixin, SynchronousTestCase):
             ScalingGroupStatus.ACTIVE)
         self.assert_status_code(
             403, endpoint='{}converge'.format(self.endpoint), method='POST')
+        self.assertTrue(self.mock_controller.modify_and_trigger.called)
 
     def test_group_converge_worker_tenant(self):
         """

--- a/otter/test/rest/test_groups.py
+++ b/otter/test/rest/test_groups.py
@@ -8,8 +8,6 @@ from copy import deepcopy
 
 from datetime import datetime
 
-from effect.testing import SequenceDispatcher
-
 from jsonschema import ValidationError
 
 import mock
@@ -29,7 +27,6 @@ from otter.json_schema.group_examples import (
     policy as policy_examples,
 )
 from otter.json_schema.group_schemas import MAX_ENTITIES
-from otter.log.intents import BoundFields
 from otter.models.interface import (
     GroupNotEmptyError,
     GroupState,
@@ -45,9 +42,10 @@ from otter.supervisor import (
     ServerNotFoundError,
     set_supervisor,
 )
-from otter.test.rest.request import DummyException, RestAPITestMixin
+from otter.test.rest.request import (
+    DummyException, RestAPITestMixin, setup_mod_and_trigger)
 from otter.test.utils import (
-    IsBoundWith, intent_func, matches, nested_sequence, noop, patch)
+    IsBoundWith, intent_func, matches, patch)
 from otter.util.config import set_config_data
 from otter.worker.validate_config import InvalidLaunchConfiguration
 
@@ -269,6 +267,7 @@ class AllGroupsEndpointTestCase(RestAPITestMixin, SynchronousTestCase):
         """
         super(AllGroupsEndpointTestCase, self).setUp()
         self.mock_controller = patch(self, 'otter.rest.groups.controller')
+        setup_mod_and_trigger(self)
 
         # Patch supervisor
         self.supervisor = mock.Mock(spec=['validate_launch_config'])
@@ -726,18 +725,23 @@ class AllGroupsEndpointTestCase(RestAPITestMixin, SynchronousTestCase):
             manifest)
         self._test_successful_create(manifest)
 
-        self.mock_group.modify_state.assert_called_once_with(
-            mock.ANY, modify_state_reason='create_new_scaling_group')
+        self.mock_controller.modify_and_trigger.assert_called_once_with(
+            "disp", self.mock_group,
+            dict(tenant_id="11111", scaling_group_id="1",
+                 transaction_id="transaction-id",
+                 system="otter.rest.groups.create_new_scaling_group"),
+            mock.ANY,
+            modify_state_reason='create_new_scaling_group')
         self.mock_controller.obey_config_change.assert_called_once_with(
             mock.ANY, "transaction-id", expected_config, self.mock_group,
             self.mock_state, launch_config=launch)
 
-    def test_create_group_propagates_modify_state_errors(self):
+    def test_create_group_propagates_modify_trigger_errors(self):
         """
-        If there is an error when modify state is called, even if the group
-        creation succeeds, a 500 is returned.
+        If there is an error when modify_and_trigger is called, even if the
+        group creation succeeds, a 500 is returned.
         """
-        self.mock_group.modify_state.side_effect = AssertionError
+        self.mock_controller.modify_and_trigger.side_effect = AssertionError
         config = config_examples()[0]
         launch = launch_examples()[0]
 
@@ -809,6 +813,7 @@ class AllGroupsBobbyEndpointTestCase(RestAPITestMixin, SynchronousTestCase):
         self.mock_controller = patch(self, 'otter.rest.groups.controller')
         set_config_data({'url_root': ''})
         self.addCleanup(set_config_data, {})
+        setup_mod_and_trigger(self)
 
         # Patch supervisor
         supervisor = mock.Mock(spec=['validate_launch_config'])
@@ -880,9 +885,9 @@ class OneGroupTestCase(RestAPITestMixin, SynchronousTestCase):
         Set the uuid of the group to "one"
         """
         super(OneGroupTestCase, self).setUp()
-        self.otter.dispatcher = "disp"
-        self.mock_group.uuid = "one"
         self.mock_controller = patch(self, 'otter.rest.groups.controller')
+        setup_mod_and_trigger(self)
+        self.mock_group.uuid = "one"
 
     def test_view_manifest_404(self):
         """
@@ -1158,21 +1163,12 @@ class OneGroupTestCase(RestAPITestMixin, SynchronousTestCase):
         """
         set_config_data({'convergence-tenants': ['11111']})
         self.addCleanup(set_config_data, {})
-        self.otter.dispatcher = SequenceDispatcher([
-            (BoundFields(mock.ANY,
-                         dict(tenant_id='11111', scaling_group_id="one",
-                              transaction_id="transaction-id")),
-             nested_sequence([
-                (("tg", "11111", "one"), noop)
-             ]))
-        ])
         self.mock_state = GroupState(
             '11111', 'one', '', {}, {}, None, {}, False,
             ScalingGroupStatus.ACTIVE)
-        with self.otter.dispatcher.consume():
-            self.assert_status_code(
-                204, endpoint='{}converge'.format(self.endpoint),
-                method='POST')
+        self.assert_status_code(
+            204, endpoint='{}converge'.format(self.endpoint),
+            method='POST')
 
     def test_group_paused_converge(self):
         """

--- a/otter/test/rest/test_groups.py
+++ b/otter/test/rest/test_groups.py
@@ -44,8 +44,7 @@ from otter.supervisor import (
 )
 from otter.test.rest.request import (
     DummyException, RestAPITestMixin, setup_mod_and_trigger)
-from otter.test.utils import (
-    IsBoundWith, intent_func, matches, patch)
+from otter.test.utils import IsBoundWith, matches, patch
 from otter.util.config import set_config_data
 from otter.worker.validate_config import InvalidLaunchConfiguration
 

--- a/otter/test/tap/test_api.py
+++ b/otter/test/tap/test_api.py
@@ -747,7 +747,7 @@ class SchedulerSetupTests(SynchronousTestCase):
         `SchedulerService` is configured with config values and set as parent
         to passed `MultiService`
         """
-        svc = setup_scheduler(self.parent, self.store, self.kz_client)
+        svc = setup_scheduler(self.parent, "disp", self.store, self.kz_client)
         buckets = range(1, 11)
         self.store.set_scheduler_buckets.assert_called_once_with(buckets)
         self.assertEqual(self.parent.services, [svc])
@@ -755,6 +755,7 @@ class SchedulerSetupTests(SynchronousTestCase):
         self.assertEqual(svc.partitioner.buckets, buckets)
         self.assertEqual(svc.partitioner.kz_client, self.kz_client)
         self.assertEqual(svc.partitioner.partitioner_path, '/part_path')
+        self.assertEqual(svc.dispatcher, "disp")
 
     def test_mock_store_with_scheduler(self):
         """
@@ -763,6 +764,6 @@ class SchedulerSetupTests(SynchronousTestCase):
         self.config['mock'] = True
         set_config_data(self.config)
         self.assertIs(
-            setup_scheduler(self.parent, self.store, self.kz_client),
+            setup_scheduler(self.parent, "disp", self.store, self.kz_client),
             None)
         self.assertFalse(self.store.set_scheduler_buckets.called)

--- a/otter/test/tap/test_api.py
+++ b/otter/test/tap/test_api.py
@@ -506,6 +506,7 @@ class APIMakeServiceTests(SynchronousTestCase):
         makeService(test_config)
         self.assertFalse(mock_getobserver.called)
 
+    @mock.patch('otter.tap.api.get_full_dispatcher', return_value="disp")
     @mock.patch('otter.tap.api.setup_scheduler')
     @mock.patch('otter.tap.api.TxKazooClient')
     @mock.patch('otter.tap.api.KazooClient')
@@ -513,7 +514,7 @@ class APIMakeServiceTests(SynchronousTestCase):
     @mock.patch('otter.tap.api.TxLogger')
     def test_kazoo_client_success(self, mock_tx_logger, mock_thread_pool,
                                   mock_kazoo_client, mock_txkz,
-                                  mock_setup_scheduler):
+                                  mock_setup_scheduler, mock_gfd):
         """
         TxKazooClient is started and calls `setup_scheduler`. Its instance
         is also set in store.kz_client after start has finished, and the
@@ -554,7 +555,7 @@ class APIMakeServiceTests(SynchronousTestCase):
         # they are called after start completes
         start_d.callback(None)
         mock_setup_scheduler.assert_called_once_with(
-            parent, self.store, kz_client)
+            parent, "disp", self.store, kz_client)
         self.assertEqual(self.store.kz_client, kz_client)
         sch = mock_setup_scheduler.return_value
         self.assertEqual(self.health_checker.checks['scheduler'],

--- a/otter/test/test_scheduler.py
+++ b/otter/test/test_scheduler.py
@@ -27,7 +27,9 @@ from otter.test.utils import (
     CheckFailure,
     DeferredFunctionMixin,
     FakePartitioner,
+    IsBoundWith,
     iMock,
+    matches,
     mock_log,
     patch
 )
@@ -72,7 +74,7 @@ class SchedulerServiceTests(SchedulerTests, DeferredFunctionMixin):
             return self.fake_partitioner
 
         self.scheduler_service = SchedulerService(
-            100, self.mock_store, pfactory, threshold=600)
+            "disp", 100, self.mock_store, pfactory, threshold=600)
         otter_log.bind.assert_called_once_with(system='otter.scheduler')
         self.scheduler_service.running = True
         self.assertIdentical(self.fake_partitioner,
@@ -193,8 +195,10 @@ class SchedulerServiceTests(SchedulerTests, DeferredFunctionMixin):
             scheduler_run_id='transaction-id', utcnow='utcnow')
         log = self.scheduler_service.log.bind.return_value
         self.assertEqual(self.check_events_in_bucket.mock_calls,
-                         [mock.call(log, self.mock_store, 2, 'utcnow', 100),
-                          mock.call(log, self.mock_store, 3, 'utcnow', 100)])
+                         [mock.call(log, "disp", self.mock_store, 2,
+                                    'utcnow', 100),
+                          mock.call(log, "disp", self.mock_store, 3,
+                                    'utcnow', 100)])
 
 
 class CheckEventsInBucketTests(SchedulerTests):
@@ -219,14 +223,15 @@ class CheckEventsInBucketTests(SchedulerTests):
         self.mock_store.fetch_and_delete.side_effect = _responses
         self.process_events = patch(
             self, 'otter.scheduler.process_events',
-            side_effect=lambda events, store, log: defer.succeed(len(events)))
+            side_effect=lambda e, d, s, l: defer.succeed(len(e)))
         self.log = mock.Mock()
 
     def test_fetch_called(self):
         """
         `fetch_and_delete` called correctly
         """
-        d = check_events_in_bucket(self.log, self.mock_store, 1, 'utcnow', 100)
+        d = check_events_in_bucket(self.log, "disp", self.mock_store, 1,
+                                   'utcnow', 100)
         self.successResultOf(d)
         self.mock_store.fetch_and_delete.assert_called_once_with(
             1, 'utcnow', 100)
@@ -234,10 +239,11 @@ class CheckEventsInBucketTests(SchedulerTests):
 
     def test_no_events(self):
         """When no events are fetched, they are not processed."""
-        d = check_events_in_bucket(self.log, self.mock_store, 1, 'utcnow', 100)
+        d = check_events_in_bucket(self.log, "disp", self.mock_store, 1,
+                                   'utcnow', 100)
         self.successResultOf(d)
         self.process_events.assert_called_once_with(
-            [], self.mock_store, self.log.bind())
+            [], "disp", self.mock_store, self.log.bind())
 
     def test_events_in_limit(self):
         """
@@ -252,14 +258,15 @@ class CheckEventsInBucketTests(SchedulerTests):
                   for i in range(10)]
         self.returns = [events]
 
-        d = check_events_in_bucket(self.log, self.mock_store, 1, 'utcnow', 100)
+        d = check_events_in_bucket(self.log, "disp", self.mock_store, 1,
+                                   'utcnow', 100)
 
         self.successResultOf(d)
         # Ensure fetch_and_delete and process_events is called only once
         self.mock_store.fetch_and_delete.assert_called_once_with(
             1, 'utcnow', 100)
         self.process_events.assert_called_once_with(
-            events, self.mock_store, self.log.bind())
+            events, "disp", self.mock_store, self.log.bind())
 
     def test_events_process_error(self):
         """
@@ -267,7 +274,8 @@ class CheckEventsInBucketTests(SchedulerTests):
         """
         self.returns = [ValueError('e')]
 
-        d = check_events_in_bucket(self.log, self.mock_store, 1, 'now', 100)
+        d = check_events_in_bucket(self.log, "disp", self.mock_store, 1,
+                                   'utcnow', 100)
 
         self.successResultOf(d)
         self.log.bind.return_value.err.assert_called_once_with(
@@ -292,16 +300,19 @@ class CheckEventsInBucketTests(SchedulerTests):
                    for i in range(10)]
         self.returns = [events1, events2]
 
-        d = check_events_in_bucket(self.log, self.mock_store, 1, 'now', 100)
+        d = check_events_in_bucket(self.log, "disp", self.mock_store, 1,
+                                   'now', 100)
 
         self.successResultOf(d)
         self.assertEqual(self.mock_store.fetch_and_delete.mock_calls,
                          [mock.call(1, 'now', 100)] * 2)
         self.assertEqual(self.process_events.mock_calls,
                          [mock.call(events1,
+                                    "disp",
                                     self.mock_store,
                                     self.log.bind()),
                           mock.call(events2,
+                                    "disp",
                                     self.mock_store,
                                     self.log.bind())])
 
@@ -319,14 +330,16 @@ class CheckEventsInBucketTests(SchedulerTests):
                   for i in range(100)]
         self.returns = [events, ValueError('some')]
 
-        d = check_events_in_bucket(self.log, self.mock_store, 1, 'now', 100)
+        d = check_events_in_bucket(self.log, "disp", self.mock_store, 1,
+                                   'now', 100)
 
         self.successResultOf(d)
         self.log.bind.return_value.err.assert_called_once_with(
             CheckFailure(ValueError))
         self.assertEqual(self.mock_store.fetch_and_delete.mock_calls,
                          [mock.call(1, 'now', 100)] * 2)
-        self.process_events.assert_called_once_with(events, self.mock_store,
+        self.process_events.assert_called_once_with(events, "disp",
+                                                    self.mock_store,
                                                     self.log.bind())
 
     def test_events_batch_process(self):
@@ -354,13 +367,15 @@ class CheckEventsInBucketTests(SchedulerTests):
                     'bucket': 1} for i in range(10)]
         self.returns = [events1, events2, events3]
 
-        d = check_events_in_bucket(self.log, self.mock_store, 1, 'now', 100)
+        d = check_events_in_bucket(self.log, "disp", self.mock_store, 1,
+                                   'now', 100)
 
         self.successResultOf(d)
         self.assertEqual(self.mock_store.fetch_and_delete.mock_calls,
                          [mock.call(1, 'now', 100)] * 3)
         self.assertEqual(self.process_events.mock_calls,
-                         [mock.call(events, self.mock_store, self.log.bind())
+                         [mock.call(events, "disp", self.mock_store,
+                                    self.log.bind())
                           for events in [events1, events2, events3]])
 
 
@@ -389,7 +404,8 @@ class ProcessEventsTests(SchedulerTests):
         """
         Does nothing on no events.
         """
-        process_events([], self.mock_store, self.log)
+        r = process_events([], "disp", self.mock_store, self.log)
+        self.assertEqual(r, 0)
         self.assertFalse(self.log.msg.called)
         self.assertFalse(self.execute_event.called)
         self.assertFalse(self.add_cron_events.called)
@@ -400,13 +416,13 @@ class ProcessEventsTests(SchedulerTests):
         each event and calls `add_cron_events.`
         """
         events = range(10)
-        d = process_events(events, self.mock_store, self.log)
+        d = process_events(events, "disp", self.mock_store, self.log)
         self.assertEqual(self.successResultOf(d), 10)
         self.log.msg.assert_called_once_with(
             'Processing {num_events} events', num_events=10)
         self.assertEqual(
             self.execute_event.mock_calls,
-            [mock.call(self.mock_store, self.log, event, set())
+            [mock.call("disp", self.mock_store, self.log, event, set())
              for event in events])
         self.add_cron_events.assert_called_once_with(
             self.mock_store, self.log, events, set())
@@ -495,23 +511,25 @@ class ExecuteEventTests(SchedulerTests):
         self.mock_group = iMock(IScalingGroup)
         self.mock_store.get_scaling_group.return_value = self.mock_group
 
-        # mock out modify state
-        self.mock_state = mock.MagicMock(spec=[])  # so nothing can call it
+        # mock out modify_and_trigger
+        self.mock_mt = patch(self, "otter.scheduler.modify_and_trigger")
         self.new_state = None
 
         def _set_new_state(new_state):
             self.new_state = new_state
 
-        def _mock_modify_state(modifier, modify_state_reason=None,
-                               *args, **kwargs):
-            d = modifier(self.mock_group, self.mock_state, *args, **kwargs)
+        def _mock_modify_trigger(disp, group, logargs, modifier,
+                                 modify_state_reason=None, *args, **kwargs):
+            self.assertEqual(disp, "disp")
+            d = modifier(group, "state", *args, **kwargs)
             return d.addCallback(_set_new_state)
 
-        self.mock_group.modify_state.side_effect = _mock_modify_state
+        self.mock_mt.side_effect = _mock_modify_trigger
+
         self.maybe_exec_policy = patch(
             self, 'otter.scheduler.maybe_execute_scaling_policy',
             return_value=defer.succeed('newstate'))
-        self.log = mock.Mock()
+        self.log = mock_log()
         self.log_args = {
             'tenant_id': '1234',
             'scaling_group_id': 'scal44',
@@ -532,17 +550,17 @@ class ExecuteEventTests(SchedulerTests):
         Event is executed successfully and appropriate logs logged.
         """
         del_pol_ids = set()
-        d = execute_event(self.mock_store, self.log, self.event, del_pol_ids)
+        d = execute_event("disp", self.mock_store, self.log, self.event,
+                          del_pol_ids)
 
         self.assertIsNone(self.successResultOf(d))
-        self.log.bind.assert_called_with(**self.log_args)
-        log = self.log.bind.return_value
-        log.msg.assert_called_once_with(
-            'Scheduler executing policy {policy_id}')
+        self.log.msg.assert_called_once_with(
+            'Scheduler executing policy {policy_id}', **self.log_args)
         self.maybe_exec_policy.assert_called_once_with(
-            log, 'transaction-id', self.mock_group, self.mock_state,
+            matches(IsBoundWith(**self.log_args)), 'transaction-id',
+            self.mock_group, "state",
             policy_id=self.event['policyId'], version=self.event['version'])
-        self.assertTrue(self.mock_group.modify_state.called)
+        self.assertTrue(self.mock_mt.called)
         self.assertEqual(self.new_state, 'newstate')
         self.assertEqual(len(del_pol_ids), 0)
 
@@ -552,10 +570,11 @@ class ExecuteEventTests(SchedulerTests):
         Its policyId is logged, and no attempt is made to execute it.
         """
         del_pol_ids = set()
-        self.mock_group.modify_state.side_effect = \
+        self.mock_mt.side_effect = \
             lambda *_, **__: defer.fail(NoSuchScalingGroupError(1, 2))
 
-        d = execute_event(self.mock_store, self.log, self.event, del_pol_ids)
+        d = execute_event("disp", self.mock_store, self.log, self.event,
+                          del_pol_ids)
 
         self.assertIsNone(self.successResultOf(d))
         self.assertEqual(del_pol_ids, set(['pol44']))
@@ -568,10 +587,11 @@ class ExecuteEventTests(SchedulerTests):
         made to execute it.
         """
         del_pol_ids = set()
-        self.mock_group.modify_state.side_effect = (
+        self.mock_mt.side_effect = (
             lambda *_, **__: defer.fail(NoSuchPolicyError(1, 2, 3)))
 
-        d = execute_event(self.mock_store, self.log, self.event, del_pol_ids)
+        d = execute_event("disp", self.mock_store, self.log, self.event,
+                          del_pol_ids)
 
         self.assertIsNone(self.successResultOf(d))
         self.assertEqual(del_pol_ids, set(['pol44']))
@@ -586,26 +606,27 @@ class ExecuteEventTests(SchedulerTests):
         self.maybe_exec_policy.return_value = defer.fail(
             CannotExecutePolicyError(*range(4)))
 
-        d = execute_event(self.mock_store, self.log, self.event, del_pol_ids)
+        d = execute_event("disp", self.mock_store, self.log, self.event,
+                          del_pol_ids)
 
         self.assertIsNone(self.successResultOf(d))
         self.assertEqual(len(del_pol_ids), 0)
-        self.log.bind.return_value.msg.assert_called_with(
+        self.log.msg.assert_called_with(
             'Scheduler cannot execute policy {policy_id}',
-            reason=CheckFailure(CannotExecutePolicyError))
+            reason=CheckFailure(CannotExecutePolicyError), **self.log_args)
 
     def test_unknown_error(self):
         """
         Unknown error occurs. It is logged and not propagated.
         """
         del_pol_ids = set()
-        self.log.bind.return_value.err.return_value = None
         self.maybe_exec_policy.return_value = defer.fail(ValueError(4))
 
-        d = execute_event(self.mock_store, self.log, self.event, del_pol_ids)
+        d = execute_event("disp", self.mock_store, self.log, self.event,
+                          del_pol_ids)
 
         self.assertIsNone(self.successResultOf(d))
         self.assertEqual(len(del_pol_ids), 0)
-        self.log.bind.return_value.err.assert_called_with(
+        self.log.err.assert_called_with(
             CheckFailure(ValueError),
-            'Scheduler failed to execute policy {policy_id}')
+            'Scheduler failed to execute policy {policy_id}', **self.log_args)

--- a/otter/test/utils.py
+++ b/otter/test/utils.py
@@ -40,7 +40,7 @@ from zope.interface import directlyProvides, implementer, interface
 from zope.interface.verify import verifyObject
 
 from otter.convergence.model import NovaServer
-from otter.log.bound import BoundLog
+from otter.log.bound import BoundLog, bound_log_kwargs
 from otter.models.interface import IScalingGroup, IScalingGroupServersCache
 from otter.supervisor import ISupervisor
 from otter.util.deferredutils import DeferredPool
@@ -110,24 +110,13 @@ class IsBoundWith(object):
         """
         if not isinstance(log, BoundLog):
             return Mismatch('log is not a BoundLog')
-        # Collect kwargs
-        f = log.msg
-        kwargs_list = []
-        while True:
-            try:
-                kwargs_list.append(f.keywords)
-            except AttributeError:
-                break
-            else:
-                f = f.func
-        # combine them in order they were bound
-        kwargs = {}
-        [kwargs.update(kwa) for kwa in reversed(kwargs_list)]
-        # Compare and return accordingly
+        kwargs = bound_log_kwargs(log)
         if self.kwargs == kwargs:
             return None
         else:
-            return Mismatch('Expected kwargs {} but got {} instead'.format(self.kwargs, kwargs))
+            return Mismatch(
+                'Expected kwargs {} but got {} instead'.format(self.kwargs,
+                                                               kwargs))
 
 
 class Provides(object):


### PR DESCRIPTION
Closes #1669.

This also completely removes `ConvergenceStarter` since the dispatcher created in `tap/api.py` is passed to REST and scheduler objects. Sorry this turned out to be much bigger than I anticipated :confused: 