### PR TITLE
Metrics timely tenants

### DIFF
--- a/otter/log/intents.py
+++ b/otter/log/intents.py
@@ -14,6 +14,8 @@ from toolz.dicttoolz import merge
 
 from twisted.python.failure import Failure
 
+from txeffect import exc_info_to_failure
+
 from otter.log import log as default_log
 
 
@@ -42,6 +44,8 @@ class LogErr(object):
         # Failure here.
         if failure is None:
             failure = Failure()
+        if type(failure) is tuple:
+            failure = exc_info_to_failure(failure)
         self.failure = failure
         self.msg = msg
         self.fields = fields

--- a/otter/metrics.py
+++ b/otter/metrics.py
@@ -126,7 +126,7 @@ def get_scaling_groups(client):
     """
     Get valid scaling groups grouped on tenantId from Cassandra
 
-    :param :class:`silverber.client.CQLClient` client: A cassandra client
+    :param :class:`silverberg.client.CQLClient` client: A cassandra client
     :return: `Deferred` fired with ``dict`` of the form
         {"tenantId1": [{group_dict_1...}, {group_dict_2..}],
          "tenantId2": [{group_dict_1...}, {group_dict_2..}, ...]}
@@ -144,7 +144,7 @@ def get_scaling_group_rows(client, props=None, batch_size=100):
     dict has 'tenantId', 'groupId', 'desired', 'active', 'pending'
     and any other properties given in `props`
 
-    :param :class:`silverber.client.CQLClient` client: A cassandra client
+    :param :class:`silverberg.client.CQLClient` client: A cassandra client
     :param ``list`` props: List of extra properties to extract
     :param int batch_size: Number of groups to fetch at a time
     :return: `Deferred` fired with ``list`` of ``dict``

--- a/otter/metrics.py
+++ b/otter/metrics.py
@@ -14,7 +14,7 @@ from functools import partial
 
 import attr
 
-from effect import Effect, Func, TypeDispatcher, ComposedDispatcher
+from effect import ComposedDispatcher, Effect, Func, TypeDispatcher
 from effect.do import do, do_return
 
 from silverberg.client import ConsistencyLevel
@@ -22,8 +22,6 @@ from silverberg.cluster import RoundRobinCassandraCluster
 
 from toolz.curried import filter, get_in, groupby
 from toolz.dicttoolz import keyfilter, merge
-from toolz.functoolz import curry, identity
-from toolz.itertoolz import mapcat
 
 from twisted.application.internet import TimerService
 from twisted.application.service import Service
@@ -42,7 +40,7 @@ from otter.log import log as otter_log
 from otter.log.intents import err
 from otter.util.fileio import (
     ReadFileLines, WriteFileLines, get_dispatcher as file_dispatcher)
-from otter.util.fp import partition_bool, predicate_all
+from otter.util.fp import partition_bool
 from otter.util.timestamp import datetime_to_epoch
 
 
@@ -311,6 +309,7 @@ def add_to_cloud_metrics(ttl, region, total_desired, total_actual,
             for metric, value in totals]
     yield service_request(ServiceType.CLOUD_METRICS_INGEST,
                           'POST', 'ingest', data=data, log=log)
+
 
 def connect_cass_servers(reactor, config):
     """

--- a/otter/metrics.py
+++ b/otter/metrics.py
@@ -360,9 +360,11 @@ def collect_metrics(reactor, config, log, client=None, authenticator=None,
                                 get_service_configs(config), _client)
 
     # calculate metrics
+    fpath = get_in(["metrics", "last_tenant_fpath"], config,
+                   default="last_tenant.txt")
     tenanted_groups = yield perform(
         dispatcher,
-        get_todays_scaling_groups(convergence_tids, "last_tenant.txt"))
+        get_todays_scaling_groups(convergence_tids, fpath))
     group_metrics = yield get_all_metrics(
         dispatcher, tenanted_groups, log, _print=_print)
 

--- a/otter/metrics.py
+++ b/otter/metrics.py
@@ -291,7 +291,7 @@ def add_to_cloud_metrics(ttl, region, total_desired, total_actual,
     :param int total_pending: Total number of servers currently
         building in a region
     :param int no_tenants: total number of tenants
-    :param int no_tenants: total number of groups
+    :param int no_groups: total number of groups
 
     :return: `Effect` with None
     """

--- a/otter/metrics.py
+++ b/otter/metrics.py
@@ -71,7 +71,7 @@ def get_last_info(fname):
                        datetime.utcfromtimestamp(float(lines[1]))))
 
     def log_and_return(e):
-        _eff = err(e, "error reading last tenant")
+        _eff = err(e, "error reading previous number of tenants")
         return _eff.on(lambda _: (None, None))
 
     return eff.on(error=log_and_return)
@@ -81,7 +81,7 @@ def update_last_info(fname, tenants_len, time):
     eff = Effect(
         WriteFileLines(
             fname, [tenants_len, datetime_to_epoch(time)]))
-    return eff.on(error=lambda e: err(e, "error updating last tenant"))
+    return eff.on(error=lambda e: err(e, "error updating number of tenants"))
 
 
 @attr.s

--- a/otter/metrics.py
+++ b/otter/metrics.py
@@ -100,10 +100,8 @@ def get_todays_tenants(tenants, today, last_tenants_len, last_date):
     days = (today - last_date).days
     if days <= 0:
         return tenants[:last_tenants_len], last_tenants_len, today
-    if len(tenants) < last_tenants_len + batch_size:
-        return tenants, len(tenants), today
-    return (tenants[:last_tenants_len + batch_size],
-            last_tenants_len + batch_size, today)
+    tenants = tenants[:last_tenants_len + batch_size]
+    return tenants, len(tenants), today
 
 
 @do

--- a/otter/metrics.py
+++ b/otter/metrics.py
@@ -384,8 +384,8 @@ def collect_metrics(reactor, config, log, client=None, authenticator=None,
     metr_conf = config.get("metrics", None)
     if metr_conf is not None:
         eff = add_to_cloud_metrics(
-            metr_conf['ttl'], config['region'], total_desired,
-            total_actual, total_pending, log)
+            metr_conf['ttl'], config['region'], total_desired, total_actual,
+            total_pending, len(tenanted_groups), len(group_metrics), log)
         eff = Effect(TenantScope(eff, metr_conf['tenant_id']))
         yield perform(dispatcher, eff)
         log.msg('added to cloud metrics')

--- a/otter/metrics.py
+++ b/otter/metrics.py
@@ -336,15 +336,14 @@ def get_dispatcher(reactor, authenticator, log, service_configs, client):
         get_log_dispatcher(log, {}),
         TypeDispatcher({
             GetAllGroups: partial(get_scaling_groups_performer, client)
-            }),
+        }),
         file_dispatcher()
     ])
 
 
 @defer.inlineCallbacks
 def collect_metrics(reactor, config, log, client=None, authenticator=None,
-                    _print=False, perform=perform,
-                    get_legacy_dispatcher=get_legacy_dispatcher):
+                    _print=False):
     """
     Start collecting the metrics
 
@@ -361,7 +360,7 @@ def collect_metrics(reactor, config, log, client=None, authenticator=None,
 
     :return: :class:`Deferred` with None
     """
-    convergence_tids = config.get('convergence-tenants', None)
+    convergence_tids = config.get('convergence-tenants', [])
     _client = client or connect_cass_servers(reactor, config['cassandra'])
     authenticator = authenticator or generate_authenticator(reactor,
                                                             config['identity'])
@@ -393,7 +392,7 @@ def collect_metrics(reactor, config, log, client=None, authenticator=None,
     if metr_conf is not None:
         eff = add_to_cloud_metrics(
             metr_conf['ttl'], config['region'], total_desired,
-            total_actual, total_pending, log=log)
+            total_actual, total_pending, log)
         eff = Effect(TenantScope(eff, metr_conf['tenant_id']))
         yield perform(dispatcher, eff)
         log.msg('added to cloud metrics')

--- a/otter/test/log/test_intents.py
+++ b/otter/test/log/test_intents.py
@@ -105,6 +105,16 @@ class LogDispatcherTests(SynchronousTestCase):
             CheckFailureValue(RuntimeError('original')),
             'why', f1='v')
 
+    def test_err_from_tuple(self):
+        """
+        exc_info tuple can be passed as failure when constructing LogErr
+        in which case failure will be constructed from the tuple
+        """
+        eff = err((ValueError, ValueError("a"), None), "why")
+        sync_perform(self.disp, eff)
+        self.log.err.assert_called_once_with(
+            CheckFailureValue(ValueError('a')), 'why', f1='v')
+
     def test_err_with_params(self):
         """
         error is logged with its fields combined

--- a/otter/test/test_metrics.py
+++ b/otter/test/test_metrics.py
@@ -31,28 +31,27 @@ from otter.cloud_client import TenantScope, service_request
 from otter.constants import ServiceType
 from otter.log.intents import LogErr
 from otter.metrics import (
-    GroupMetrics,
     GetAllGroups,
+    GroupMetrics,
     MetricsService,
     Options,
     QUERY_GROUPS_OF_TENANTS,
     add_to_cloud_metrics,
     collect_metrics,
-    unchanged_divergent_groups,
     get_all_metrics,
     get_all_metrics_effects,
-    get_scaling_groups,
     get_scaling_group_rows,
+    get_scaling_groups,
     get_specific_scaling_groups,
     get_tenant_metrics,
-    get_todays_tenants,
     get_todays_scaling_groups,
-    makeService
+    get_todays_tenants,
+    makeService,
+    unchanged_divergent_groups
 )
 from otter.test.test_auth import identity_config
 from otter.test.utils import (
     CheckFailureValue,
-    IsCallable,
     Provides,
     const,
     intent_func,
@@ -61,6 +60,7 @@ from otter.test.utils import (
     nested_sequence,
     noop,
     patch,
+    raise_,
     resolve_effect,
 )
 from otter.util.fileio import ReadFileLines, WriteFileLines
@@ -487,7 +487,7 @@ class GetTodaysScalingGroupsTests(SynchronousTestCase):
             lambda g: g["tenantId"],
             ([{"tenantId": "t1", "a": "1"}, {"tenantId": "t1", "a": "2"}] +
              [{"tenantId": "t{}".format(i), "b": str(i)}
-               for i in range(2, 10)]))
+              for i in range(2, 10)]))
 
     def test_success(self):
         """

--- a/otter/test/test_metrics.py
+++ b/otter/test/test_metrics.py
@@ -577,13 +577,13 @@ class CollectMetricsTests(SynchronousTestCase):
         self.config = {'cassandra': 'c', 'identity': identity_config,
                        'metrics': {'service': 'ms', 'tenant_id': 'tid',
                                    'region': 'IAD',
-                                   'ttl': 200},
+                                   'ttl': 200, "last_tenant_fpath": "lpath"},
                        'region': 'r', 'cloudServersOpenStack': 'nova',
                        'cloudLoadBalancers': 'clb', 'rackconnect': 'rc',
                        "convergence-tenants": ["ct"]}
 
         self.sequence = SequenceDispatcher([
-            (("gtsg", ["ct"], "last_tenant.txt"), const(self.groups)),
+            (("gtsg", ["ct"], "lpath"), const(self.groups)),
             (TenantScope(mock.ANY, "tid"),
              nested_sequence([
                  (("atcm", 200, "r", 107, 26, 1, 2, 3, self.log), noop)

--- a/otter/test/test_metrics.py
+++ b/otter/test/test_metrics.py
@@ -514,7 +514,8 @@ class GetTodaysScalingGroupsTests(SynchronousTestCase):
         seq = [
             (GetAllGroups(), const(self.groups)),
             (ReadFileLines("file"), lambda i: raise_(IOError("e"))),
-            (LogErr(mock.ANY, "error reading last tenant", {}), noop),
+            (LogErr(mock.ANY, "error reading previous number of tenants", {}),
+             noop),
             (Func(datetime.utcnow), const(datetime(1970, 1, 2))),
             (WriteFileLines("file", [5, 86400.0]), noop)
         ]
@@ -534,7 +535,7 @@ class GetTodaysScalingGroupsTests(SynchronousTestCase):
             (Func(datetime.utcnow), const(datetime(1970, 1, 2))),
             (WriteFileLines("file", [7, 86400.0]),
              lambda i: raise_(IOError("bad"))),
-            (LogErr(mock.ANY, "error updating last tenant", {}), noop)
+            (LogErr(mock.ANY, "error updating number of tenants", {}), noop)
         ]
         r = perform_sequence(seq, get_todays_scaling_groups(["t1"], "file"))
         self.assertEqual(

--- a/otter/test/utils.py
+++ b/otter/test/utils.py
@@ -904,7 +904,8 @@ def const(v):
     Return function that takes an argument but always return given `v`.
     Useful with `SequenceDispatcher`. For example,
 
-    >>> SequenceDispatcher([(Func(datetime.now), const(datetime(1970, 1, 1)))])
+    >>> dt = datetime(1970, 1, 1)
+    >>> SequenceDispatcher([(Func(datetime.now), const(dt))])
     """
 
     return lambda i: v

--- a/otter/test/utils.py
+++ b/otter/test/utils.py
@@ -899,6 +899,17 @@ def noop(_):
     pass
 
 
+def const(v):
+    """
+    Return function that takes an argument but always return given `v`.
+    Useful with `SequenceDispatcher`. For example,
+
+    >>> SequenceDispatcher([(Func(datetime.now), const(datetime(1970, 1, 1)))])
+    """
+
+    return lambda i: v
+
+
 def intent_func(fname):
     """
     Return function that returns Effect of tuple of fname and its args. Useful

--- a/otter/util/fileio.py
+++ b/otter/util/fileio.py
@@ -27,7 +27,7 @@ def perform_read_file_lines(disp, intent):
 @sync_performer
 def perform_write_files_lines(disp, intent):
     with open(intent.fname, "w") as f:
-        f.writelines(intent.lines)
+        f.writelines(map(lambda line: "{}\n".format(line), intent.lines))
 
 
 def get_dispatcher():

--- a/otter/util/fileio.py
+++ b/otter/util/fileio.py
@@ -1,0 +1,36 @@
+"""
+Effect based file IO
+"""
+
+import attr
+
+from effect import TypeDispatcher, sync_performer
+
+
+@attr.s
+class ReadFileLines(object):
+    fname = attr.ib()
+
+
+@attr.s
+class WriteFileLines(object):
+    fname = attr.ib()
+    lines = attr.ib()
+
+
+@sync_performer
+def perform_read_file_lines(disp, intent):
+    with open(intent.fname, "r") as f:
+        return f.readlines()
+
+
+@sync_performer
+def perform_write_files_lines(disp, intent):
+    with open(intent.fname, "w") as f:
+        f.writelines(intent.lines)
+
+
+def get_dispatcher():
+    return TypeDispatcher({
+        ReadFileLines: perform_read_file_lines,
+        WriteFileLines: perform_write_files_lines})

--- a/scripts/load_cql.py
+++ b/scripts/load_cql.py
@@ -21,7 +21,7 @@ from twisted.internet.endpoints import clientFromString
 from txeffect import perform
 
 from otter.effect_dispatcher import get_working_cql_dispatcher
-from otter.metrics import get_scaling_groups
+from otter.metrics import get_scaling_group_rows
 from otter.models.cass import CassScalingGroupCollection
 from otter.test.resources import CQLGenerator
 from otter.util.cqlbatch import batch
@@ -176,7 +176,7 @@ def insert_deleting_false(reactor, conn):
     """
     Insert false to all group's deleting column
     """
-    groups = yield get_scaling_groups(conn, with_null_desired=True)
+    groups = yield get_scaling_group_rows(conn)
     query = (
         'INSERT INTO scaling_group ("tenantId", "groupId", deleting) '
         'VALUES (:tenantId{i}, :groupId{i}, false);')


### PR DESCRIPTION
Closes #1691. Every day 5 new tenants info are fetched from Nova and ingested in CM. It does this by storing number of non-convergence tenants fetched till now along with last time they were fetched in a file. 

Also did some extra stuff:
- Number of tenants and number of groups are also ingested as metrics
- `LogErr` intent handles failure as `exc_info` tuple also
- Effect based file IO in `util/fileio.py`
