### PR TITLE
Support many more server states

### DIFF
--- a/otter/convergence/model.py
+++ b/otter/convergence/model.py
@@ -73,9 +73,9 @@ class ServerState(Names):
     Most of these constants correspond to Nova states of the same name.
     """
     ACTIVE = NamedConstant()
-    ERROR = NamedConstant()
     BUILD = NamedConstant()
     DELETED = NamedConstant()
+    ERROR = NamedConstant()
     HARD_REBOOT = NamedConstant()
     MIGRATING = NamedConstant()
     PASSWORD = NamedConstant()
@@ -83,9 +83,10 @@ class ServerState(Names):
     RESCUE = NamedConstant()
     RESIZE = NamedConstant()
     REVERT_RESIZE = NamedConstant()
-    VERIFY_RESIZE = NamedConstant()
     SHUTOFF = NamedConstant()
+    SUSPENDED = NamedConstant()
     UNKNOWN = NamedConstant()
+    VERIFY_RESIZE = NamedConstant()
 
     DRAINING = NamedConstant()
     """"

--- a/otter/convergence/model.py
+++ b/otter/convergence/model.py
@@ -69,22 +69,23 @@ class CLBNodeType(Names):
 class ServerState(Names):
     """
     Constants representing the state of a Nova cloud server.
-    """
 
+    Most of these constants correspond to Nova states of the same name.
+    """
     ACTIVE = NamedConstant()
-    """
-    Corresponds to Nova's ``ACTIVE`` state.
-    """
-
     ERROR = NamedConstant()
-    """
-    Corresponds to Nova's ``ERROR`` state.
-    """
-
     BUILD = NamedConstant()
-    """
-    Corresponds to Nova's ``BUILD`` and ``BUILDING`` states.
-    """
+    DELETED = NamedConstant()
+    HARD_REBOOT = NamedConstant()
+    MIGRATING = NamedConstant()
+    PASSWORD = NamedConstant()
+    REBUILD = NamedConstant()
+    RESCUE = NamedConstant()
+    RESIZE = NamedConstant()
+    REVERT_RESIZE = NamedConstant()
+    VERIFY_RESIZE = NamedConstant()
+    SHUTOFF = NamedConstant()
+    UNKNOWN = NamedConstant()
 
     DRAINING = NamedConstant()
     """"
@@ -93,9 +94,10 @@ class ServerState(Names):
     is basically functional, but that Autoscale would like to delete it.
     """
 
-    DELETED = NamedConstant()
+    UNKNOWN_TO_OTTER = NamedConstant()
     """
-    Corresponds to Nova's ``DELETED`` state.
+    Indicates that some state was returned by Nova that Otter doesn't know
+    about. The real state will be on the NovaServer object.
     """
 
 

--- a/otter/convergence/model.py
+++ b/otter/convergence/model.py
@@ -97,7 +97,7 @@ class ServerState(Names):
     UNKNOWN_TO_OTTER = NamedConstant()
     """
     Indicates that some state was returned by Nova that Otter doesn't know
-    about. The real state will be on the NovaServer object.
+    about. The real state will be in `NovaServer.json`.
     """
 
 
@@ -256,7 +256,10 @@ class NovaServer(object):
 
         :return: :obj:`NovaServer` instance
         """
-        server_state = ServerState.lookupByName(server_json['status'])
+        try:
+            server_state = ServerState.lookupByName(server_json['status'])
+        except ValueError:
+            server_state = ServerState.UNKNOWN_TO_OTTER
         if server_json.get("OS-EXT-STS:task_state", "") == "deleting":
             server_state = ServerState.DELETED
         metadata = server_json.get('metadata', {})

--- a/otter/convergence/planning.py
+++ b/otter/convergence/planning.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 from pyrsistent import pbag, pset
 
 from toolz.curried import filter
-from toolz.itertoolz import concat, groupby, mapcat
+from toolz.itertoolz import groupby, mapcat
 
 from twisted.python.constants import NamedConstant, Names
 
@@ -236,14 +236,8 @@ _DESTINY_TO_STATES = {
         ServerState.UNKNOWN_TO_OTTER],
 }
 
-# Ensure we've covered all the server states
-for st in ServerState.iterconstants():
-    assert st in concat(_DESTINY_TO_STATES.values()), st
-# Ensure states only map to one destiny
-_all_destiny_states = list(concat(_DESTINY_TO_STATES.values()))
-assert len(_all_destiny_states) == len(set(_all_destiny_states))
 
-STATE_TO_DESTINY = {
+_STATE_TO_DESTINY = {
     state: destiny
     for destiny, states in _DESTINY_TO_STATES.iteritems()
     for state in states}
@@ -251,7 +245,7 @@ STATE_TO_DESTINY = {
 
 def get_destiny(server):
     """Get the obj:`Destiny` of a server."""
-    return STATE_TO_DESTINY.get(server.state)
+    return _STATE_TO_DESTINY.get(server.state)
 
 
 def converge(desired_state, servers_with_cheese, load_balancer_contents, now,

--- a/otter/convergence/planning.py
+++ b/otter/convergence/planning.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 from pyrsistent import pbag, pset
 
 from toolz.curried import filter
-from toolz.itertoolz import concat, concatv, groupby, mapcat
+from toolz.itertoolz import concat, groupby, mapcat
 
 from twisted.python.constants import NamedConstant, Names
 
@@ -301,12 +301,12 @@ def converge(desired_state, servers_with_cheese, load_balancer_contents, now,
     # Scale down over capacity, starting with building, then WAIT, then
     # DO_NOT_REPLACE, then active, preferring older.  Also, finish
     # draining/deleting servers already in draining state
-    servers_in_preferred_order = concatv(
-        servers_in_active,
-        servers[Destiny.DO_NOT_REPLACE],
-        servers[Destiny.WAIT],
+    servers_in_preferred_order = (
+        servers_in_active +
+        servers[Destiny.DO_NOT_REPLACE] +
+        servers[Destiny.WAIT] +
         waiting_for_build)
-    servers_to_delete = list(servers_in_preferred_order)[desired_state.capacity:]
+    servers_to_delete = servers_in_preferred_order[desired_state.capacity:]
 
     def drain_and_delete_a_server(server):
         return _drain_and_delete(

--- a/otter/convergence/planning.py
+++ b/otter/convergence/planning.py
@@ -186,7 +186,7 @@ class Destiny(Names):
     WAIT = NamedConstant()
     """Waiting for the server to transition to active."""
 
-    DO_NOT_REPLACE = NamedConstant()
+    AVOID_REPLACING = NamedConstant()
     """
     Unavailable, still costing money, and not imminently transitioning to
     another state, but we want to leave it around anyway.
@@ -219,7 +219,7 @@ _DESTINY_TO_STATES = {
         ServerState.RESIZE,  # either transitions to ACTIVE or VERIFY_RESIZE
         ServerState.REVERT_RESIZE,
     ],
-    Destiny.DO_NOT_REPLACE: [
+    Destiny.AVOID_REPLACING: [
         ServerState.RESCUE,
         ServerState.VERIFY_RESIZE,
         ServerState.SUSPENDED,
@@ -290,14 +290,14 @@ def converge(desired_state, servers_with_cheese, load_balancer_contents, now,
             len(servers_in_active) +
             len(waiting_for_build) +
             len(servers[Destiny.WAIT]) +
-            len(servers[Destiny.DO_NOT_REPLACE])))
+            len(servers[Destiny.AVOID_REPLACING])))
 
     # Scale down over capacity, starting with building, then WAIT, then
-    # DO_NOT_REPLACE, then active, preferring older.  Also, finish
+    # AVOID_REPLACING, then active, preferring older.  Also, finish
     # draining/deleting servers already in draining state
     servers_in_preferred_order = (
         servers_in_active +
-        servers[Destiny.DO_NOT_REPLACE] +
+        servers[Destiny.AVOID_REPLACING] +
         servers[Destiny.WAIT] +
         waiting_for_build)
     servers_to_delete = servers_in_preferred_order[desired_state.capacity:]

--- a/otter/convergence/planning.py
+++ b/otter/convergence/planning.py
@@ -215,7 +215,9 @@ STATES_TO_DESTINY = {
     for state in states}
 
 
-get_destiny = STATES_TO_DESTINY.get
+def get_destiny(server):
+    """Get the obj:`Destiny` of a server."""
+    return STATES_TO_DESTINY.get(server.state)
 
 
 def converge(desired_state, servers_with_cheese, load_balancer_contents, now,
@@ -241,9 +243,7 @@ def converge(desired_state, servers_with_cheese, load_balancer_contents, now,
     """
     newest_to_oldest = sorted(servers_with_cheese, key=lambda s: -s.created)
 
-    servers = defaultdict(
-        lambda: [],
-        groupby(lambda s: get_destiny(s.state), newest_to_oldest))
+    servers = defaultdict(lambda: [], groupby(get_destiny, newest_to_oldest))
     servers_in_active = servers[Destiny.CONSIDER_AVAILABLE]
 
     building_too_long, waiting_for_build = partition_bool(

--- a/otter/test/convergence/test_model.py
+++ b/otter/test/convergence/test_model.py
@@ -655,6 +655,18 @@ class NovaServerTests(SynchronousTestCase):
                 'valid_image', 'valid_flavor', self.links[0], set(), '',
                 expected_json]]))
 
+    def test_unknown_state(self):
+        """
+        When nova provides an unknown server state, it's set to
+        ``ServerState.UNKNOWN_TO_OTTER`` on the :obj:`NovaServer`.
+        """
+        server_json = self.servers[0].copy()
+        # add a bunch more fields
+        server_json['status'] = 'ablrduelh'
+        server = NovaServer.from_server_details_json(server_json)
+        self.assertEqual(server.state, ServerState.UNKNOWN_TO_OTTER)
+        self.assertEqual(server.json['status'], 'ablrduelh')
+
 
 class IPAddressTests(SynchronousTestCase):
     """

--- a/otter/test/convergence/test_planning.py
+++ b/otter/test/convergence/test_planning.py
@@ -17,7 +17,7 @@ from otter.convergence.model import (
     RCv3Description,
     RCv3Node,
     ServerState)
-from otter.convergence.planning import Destiny, converge, plan
+from otter.convergence.planning import Destiny, converge, get_destiny, plan
 from otter.convergence.steps import (
     AddNodesToCLB,
     BulkAddToRCv3,
@@ -1113,3 +1113,13 @@ class PlanTests(SynchronousTestCase):
                 DeleteServer(server_id='server1'),
                 CreateServer(server_config=pmap({}))
             ]))
+
+
+class DestinyTests(SynchronousTestCase):
+    """Tests for :func:`get_destiny`."""
+
+    def test_all_server_states_have_destinies(self):
+        """All server states have an associated destiny."""
+        for st in ServerState.iterconstants():
+            s = server('s1', state=st)
+            self.assertIsNot(get_destiny(s), None)

--- a/otter/test/convergence/test_planning.py
+++ b/otter/test/convergence/test_planning.py
@@ -819,9 +819,9 @@ class ConvergeTests(SynchronousTestCase):
                 ConvergeLater(
                     reasons=[ErrorReason.String('waiting for servers')])]))
 
-    def test_count_do_not_replace_as_meeting_capacity(self):
+    def test_count_AVOID_REPLACING_as_meeting_capacity(self):
         """
-        If a server's destiny is DO_NOT_REPLACE, we won't provision more
+        If a server's destiny is AVOID_REPLACING, we won't provision more
         servers to take up the slack, and just leave it there without causing
         another convergence iteration, because servers in this status are only
         transitioned to other states manually.
@@ -975,14 +975,14 @@ class ConvergeTests(SynchronousTestCase):
 
         - WAIT_WITH_TIMEOUT
         - WAIT
-        - DO_NOT_REPLACE
+        - AVOID_REPLACING
         - CONSIDER_ACTIVE
         """
         order = (Destiny.WAIT_WITH_TIMEOUT, Destiny.WAIT,
-                 Destiny.DO_NOT_REPLACE, Destiny.CONSIDER_AVAILABLE)
+                 Destiny.AVOID_REPLACING, Destiny.CONSIDER_AVAILABLE)
         examples = {Destiny.WAIT_WITH_TIMEOUT: ServerState.BUILD,
                     Destiny.WAIT: ServerState.HARD_REBOOT,
-                    Destiny.DO_NOT_REPLACE: ServerState.RESCUE,
+                    Destiny.AVOID_REPLACING: ServerState.RESCUE,
                     Destiny.CONSIDER_AVAILABLE: ServerState.ACTIVE}
         for combo in combinations(order, 2):
             before, after = combo

--- a/otter/test/convergence/test_planning.py
+++ b/otter/test/convergence/test_planning.py
@@ -821,9 +821,9 @@ class ConvergeTests(SynchronousTestCase):
 
     def test_count_do_not_replace_as_meeting_capacity(self):
         """
-        If a server's destiny is DO_NOT_REPLACE, we won't provision more servers
-        to take up the slack, and just leave it there without causing another
-        convergence iteration, because servers in this status are only
+        If a server's destiny is DO_NOT_REPLACE, we won't provision more
+        servers to take up the slack, and just leave it there without causing
+        another convergence iteration, because servers in this status are only
         transitioned to other states manually.
         """
         self.assertEqual(
@@ -847,6 +847,21 @@ class ConvergeTests(SynchronousTestCase):
                 0),
             pbag([
                 DeleteServer(server_id='abc'),
+                CreateServer(server_config=pmap()),
+            ]))
+
+    def test_ignore_ignored(self):
+        """
+        If a server we created becomes IGNORED, we leave it be and reprovision
+        a server.
+        """
+        self.assertEqual(
+            converge(
+                DesiredGroupState(server_config={}, capacity=1),
+                set([server('abc', ServerState.UNKNOWN_TO_OTTER)]),
+                set(),
+                0),
+            pbag([
                 CreateServer(server_config=pmap()),
             ]))
 


### PR DESCRIPTION
Fixes #1694.

- Added a bunch of definitions to ServerState for all the rest of the states we know about
- added a new enum, "Destiny", which indicates what we want to _do_ with a server, separate from its state
- map states to destinies

Actual behavior changes:
- previously unhandled states are:
  - HARD_REBOOT -> WAIT
  - MIGRATING -> WAIT
  - PASSWORD -> WAIT
  - REBUILD -> WAIT
  - RESIZE -> WAIT
  - REVERT_RESIZE -> WAIT
  - RESCUE -> DO_NOT_REPLACE
  - VERIFY_RESIZE -> DO_NOT_REPLACE
  - SUSPENDED -> DO_NOT_REPLACE
  - SHUTOFF -> DELETE
  - UNKNOWN -> IGNORE

- The behavior of `Destiny.WAIT` is similar to how we handle `BUILD`, but without the timeout.
- The behavior of `Destiny.DO_NOT_REPLACE` is mostly the same as `ACTIVE`, except no load balancer convergence will happen for those nodes.

Request for comments on:
- A thought occurred to me as I was writing this description: perhaps we should explicitly _remove_ `WAIT` and `DO_NOT_REPLACE` servers from the load balancers?
- Better names for destinies?

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/rackerlabs/otter/1702)
<!-- Reviewable:end -->
