### PR TITLE
Two tests for moving servers between CLBs

### DIFF
--- a/otter/integration/lib/cloud_load_balancer.py
+++ b/otter/integration/lib/cloud_load_balancer.py
@@ -90,13 +90,13 @@ class CloudLoadBalancer(object):
             }
         }
 
-    def scaling_group_spec(self):
+    def scaling_group_spec(self, port=80):
         """Computes the necessary CLB specification to use when creating a
         scaling group.  See also the lib.autoscale.create_scaling_group_dict
         function for more details.
         """
         return {
-            "port": 80,
+            "port": port,
             "loadBalancerId": self.clb_id,
         }
 

--- a/otter/integration/lib/trial_tools.py
+++ b/otter/integration/lib/trial_tools.py
@@ -211,7 +211,10 @@ class TestHelper(object):
             the server name prefix used for the scaling group.
         """
         if self.clbs:
-            kwargs['use_lbs'] = [clb.scaling_group_spec() for clb in self.clbs]
+            # allow us to override the CLB setup
+            kwargs.setdefault(
+                'use_lbs',
+                [clb.scaling_group_spec() for clb in self.clbs])
 
         kwargs.setdefault("image_ref", image_ref)
         kwargs.setdefault("flavor_ref", flavor_ref)

--- a/otter/integration/tests/test_lbsh.py
+++ b/otter/integration/tests/test_lbsh.py
@@ -319,3 +319,91 @@ class TestLoadBalancerSelfHealing(unittest.TestCase):
             ),
             timeout=timeout_default
         )
+
+    @inlineCallbacks
+    def test_convergence_heals_two_groups_on_same_clb_1(
+            self, remove_from_clb=False):
+        """
+        Autoscale removes a server from a CLB if it's not supposed to be on
+        the CLB, not touching any other autoscale servers on the same CLB.
+
+        1. Create 2 AS groups on the same CLB, both with min 1 server,
+           each group mapped to different ports
+        2. Add group1's server to the CLB on group2's port without deleting
+           it from group1's port.
+        3. Converge both groups.
+        4. Group1's servers should be only on group1's port, and group2's
+           servers should only be on group2's port.
+        """
+        clb = self.helper.clbs[0]
+        group1, _ = self.helper.create_group(
+            min_entities=1, use_lbs=[clb.scaling_group_spec(80)])
+        group2, _ = self.helper.create_group(
+            min_entities=1, use_lbs=[clb.scaling_group_spec(8080)])
+
+        yield gatherResults([
+            self.helper.start_group_and_wait(group, self.rcs)
+            for group in (group1, group2)])
+
+        # assert that they're both on the CLB on the right ports
+        groups = yield gatherResults([
+            group.get_servicenet_ips(self.rcs) for group in (group1, group2)])
+        group1_ip, group2_ip = [g.values()[0] for g in groups]
+
+        expected_nodes = [
+            ContainsDict({'port': Equals(80),
+                          'address': Equals(group1_ip)}),
+            ContainsDict({'port': Equals(8080),
+                          'address': Equals(group1_ip)}),
+            ContainsDict({'port': Equals(8080),
+                          'address': Equals(group2_ip)})]
+
+        nodes = yield clb.wait_for_nodes(
+            self.rcs,
+            MatchesSetwise(expected_nodes[0], expected_nodes[2]),
+            timeout=timeout_default
+        )
+
+        # add/remove another node
+        perturb = [
+            clb.add_nodes(self.rcs, [{'address': group1_ip,
+                                      'port': 8080,
+                                      'condition': 'ENABLED',
+                                      'type': 'PRIMARY'}])
+        ]
+        if remove_from_clb:
+            perturb.append(
+                clb.delete_nodes(self.rcs,
+                                 [n['id'] for n in nodes
+                                  if n['address'] == group1_ip]))
+        yield gatherResults(perturb)
+
+        node_matchers = expected_nodes
+        if remove_from_clb:
+            node_matchers = expected_nodes[1:]
+        yield clb.wait_for_nodes(
+            self.rcs, MatchesSetwise(*node_matchers), timeout=timeout_default)
+
+        yield gatherResults([group.trigger_convergence(self.rcs)
+                             for group in (group1, group2)])
+
+        yield clb.wait_for_nodes(
+            self.rcs,
+            MatchesSetwise(expected_nodes[0], expected_nodes[2]),
+            timeout=timeout_default
+        )
+
+    def test_convergence_heals_two_groups_on_same_clb_2(self):
+        """
+        Autoscale puts a server back on the desired CLB, not touching any other
+        autoscale servers on the same CLB.
+
+        1. Create 2 AS groups on the same CLB, both with min 1 server,
+           each group mapped to different ports
+        2. Add group1's server to the CLB on group2's port and remove it from
+           group1's port.
+        3. Converge both groups.
+        4. Group1's servers should be only on group1's port, and group2's
+           servers should only be on group2's port.
+        """
+        return self.test_convergence_heals_two_groups_on_same_clb_1(True)


### PR DESCRIPTION
Tests that ensure that autoscale will self-heal a server on a CLB, but won't touch other autoscale servers on the same CLB.

Fixes #1488.
Fixes #1489.