### PR TITLE
Tests for autoscale self-healing changes in CLB params

### DIFF
--- a/otter/cloud_client.py
+++ b/otter/cloud_client.py
@@ -575,7 +575,7 @@ def add_clb_nodes(lb_id, nodes):
         log_success_response('request-add-clb-nodes', identity))
 
 
-def change_clb_node(lb_id, node_id, condition, weight):
+def change_clb_node(lb_id, node_id, condition, weight, _type="PRIMARY"):
     """
     Generate effect to change a node on a load balancer.
 
@@ -584,9 +584,7 @@ def change_clb_node(lb_id, node_id, condition, weight):
     :param str condition: The condition to change to: one of "ENABLED",
         "DRAINING", or "DISABLED"
     :param int weight: The weight to change to.
-
-    Note: this does not support "type" yet, since it doesn't make sense to add
-    autoscaled servers as secondary.
+    :param str _type: The type to change the CLB node to.
 
     :return: :class:`ServiceRequest` effect
 
@@ -597,7 +595,8 @@ def change_clb_node(lb_id, node_id, condition, weight):
         ServiceType.CLOUD_LOAD_BALANCERS,
         'PUT',
         append_segments('loadbalancers', lb_id, 'nodes', node_id),
-        data={'condition': condition, 'weight': weight},
+        data={'node': {
+            'condition': condition, 'weight': weight, 'type': _type}},
         success_pred=has_code(202))
 
     @_only_json_api_errors

--- a/otter/convergence/steps.py
+++ b/otter/convergence/steps.py
@@ -17,11 +17,13 @@ from zope.interface import Interface, implementer
 
 from otter.cloud_client import (
     CLBNodeLimitError,
+    CLBNotActiveError,
     CLBNotFoundError,
     CreateServerConfigurationError,
     CreateServerOverQuoteError,
     NoSuchCLBNodeError,
     add_clb_nodes,
+    change_clb_node,
     create_server,
     has_code,
     remove_clb_nodes,
@@ -315,44 +317,17 @@ class ChangeCLBNode(object):
     An existing port mapping on a load balancer must have its condition,
     weight, or type modified.
     """
-
     def as_effect(self):
         """Produce a :obj:`Effect` to modify a load balancer node."""
-        handled_codes = _clb_check_change_node_handlers.keys()
-        eff = service_request(
-            ServiceType.CLOUD_LOAD_BALANCERS,
-            'PUT',
-            append_segments('loadbalancers', self.lb_id,
-                            'nodes', self.node_id),
-            data={'condition': self.condition.name,
-                  'weight': self.weight},
-            success_pred=has_code(*handled_codes))
-        return eff.on(partial(_clb_check_change_node, self))
-
-
-def _clb_check_change_node(step, result):
-    """
-    Check to what extent a :class:`ChangeCLBNode` response was successful.
-    """
-    response, body = result
-    handler = _clb_check_change_node_handlers[response.code]
-    return handler(step, result)
-
-
-def _clb_check_change_node_retry_on_404(step, result):
-    """
-    When updating a node results in a 404, convergence should be retried.
-    """
-    return StepResult.RETRY, [
-        ErrorReason.Structured({'reason': 'CLB node not found',
-                                'lb': step.lb_id,
-                                'node': step.node_id})]
-
-
-_clb_check_change_node_handlers = {
-    202: lambda _step, _result: (StepResult.SUCCESS, []),
-    404: _clb_check_change_node_retry_on_404
-}
+        eff = change_clb_node(self.lb_id, self.node_id, weight=self.weight,
+                              condition=self.condition.name,
+                              _type=self.type.name)
+        return eff.on(
+            success=lambda _: (StepResult.RETRY, [ErrorReason.String(
+                'must re-gather after CLB change in order to update the '
+                'active cache')]),
+            error=_failure_reporter(CLBNotFoundError, NoSuchCLBNodeError,
+                                    CLBNotActiveError))
 
 
 def _rackconnect_bulk_request(lb_node_pairs, method, success_pred):

--- a/otter/convergence/steps.py
+++ b/otter/convergence/steps.py
@@ -17,7 +17,6 @@ from zope.interface import Interface, implementer
 
 from otter.cloud_client import (
     CLBNodeLimitError,
-    CLBNotActiveError,
     CLBNotFoundError,
     CreateServerConfigurationError,
     CreateServerOverQuoteError,
@@ -326,8 +325,7 @@ class ChangeCLBNode(object):
             success=lambda _: (StepResult.RETRY, [ErrorReason.String(
                 'must re-gather after CLB change in order to update the '
                 'active cache')]),
-            error=_failure_reporter(CLBNotFoundError, NoSuchCLBNodeError,
-                                    CLBNotActiveError))
+            error=_failure_reporter(CLBNotFoundError, NoSuchCLBNodeError))
 
 
 def _rackconnect_bulk_request(lb_node_pairs, method, success_pred):

--- a/otter/integration/tests/test_lbsh.py
+++ b/otter/integration/tests/test_lbsh.py
@@ -358,6 +358,7 @@ class TestLoadBalancerSelfHealing(unittest.TestCase):
             timeout=timeout_default
         )
 
+    @inlineCallbacks
     def test_convergence_heals_two_groups_on_same_clb_1(
             self, remove_from_clb=False):
         """

--- a/otter/test/convergence/test_steps.py
+++ b/otter/test/convergence/test_steps.py
@@ -389,7 +389,6 @@ class StepAsEffectTests(SynchronousTestCase):
         eff = self._change_node_eff()
         terminal = (NoSuchCLBNodeError(lb_id=u'abc123', node_id=u'node1'),
                     CLBNotFoundError(lb_id=u'abc123'),
-                    CLBNotActiveError(lb_id=u'abc123'),
                     APIError(code=400, body="", headers={}))
         for exception in terminal:
             self.assertEqual(
@@ -401,6 +400,7 @@ class StepAsEffectTests(SynchronousTestCase):
         """Some errors during :obj:`ChangeCLBNode` make convergence retry."""
         eff = self._change_node_eff()
         nonterminal = (APIError(code=500, body="", headers={}),
+                       CLBNotActiveError(lb_id=u'abc123'),
                        CLBRateLimitError(lb_id=u'abc123'))
         for exception in nonterminal:
             self.assertEqual(

--- a/otter/test/convergence/test_steps.py
+++ b/otter/test/convergence/test_steps.py
@@ -17,11 +17,13 @@ from otter.cloud_client import (
     CLBDuplicateNodesError,
     CLBImmutableError,
     CLBNodeLimitError,
+    CLBNotActiveError,
     CLBNotFoundError,
     CLBRateLimitError,
     CreateServerConfigurationError,
     CreateServerOverQuoteError,
     NoSuchCLBError,
+    NoSuchCLBNodeError,
     NoSuchServerError,
     NovaComputeFaultError,
     NovaRateLimitError,
@@ -50,8 +52,6 @@ from otter.convergence.steps import (
     _RCV3_LB_INACTIVE_PATTERN,
     _RCV3_NODE_ALREADY_A_MEMBER_PATTERN,
     _RCV3_NODE_NOT_A_MEMBER_PATTERN,
-    _clb_check_change_node,
-    _clb_check_change_node_handlers,
     _rcv3_check_bulk_add,
     _rcv3_check_bulk_delete,
     delete_and_verify,
@@ -373,21 +373,30 @@ class StepAsEffectTests(SynchronousTestCase):
             weight=50,
             type=CLBNodeType.PRIMARY)
         eff = change_node.as_effect()
+        retry_result = (
+            StepResult.RETRY,
+            [ErrorReason.String(
+                'must re-gather after CLB change in order to update the '
+                'active cache')])
+        seq = [(eff.intent, lambda i: (StubResponse(202, {}), {}))]
+        self.assertEqual(perform_sequence(seq, eff), retry_result)
+        terminal = (NoSuchCLBNodeError(lb_id=u'abc123', node_id=u'node1'),
+                    CLBNotFoundError(lb_id=u'abc123'),
+                    CLBNotActiveError(lb_id=u'abc123'),
+                    APIError(code=400, body="", headers={}))
+        for exception in terminal:
+            self.assertEqual(
+                perform_sequence([(eff.intent, lambda i: raise_(exception))],
+                                 eff),
+                (StepResult.FAILURE, [ANY]))
 
-        handled_codes = _clb_check_change_node_handlers.keys()
-        expected_intent = service_request(
-            ServiceType.CLOUD_LOAD_BALANCERS,
-            'PUT',
-            'loadbalancers/abc123/nodes/node1',
-            data={'condition': 'DRAINING',
-                  'weight': 50},
-            success_pred=has_code(*handled_codes)).intent
-        self.assertEqual(eff.intent, expected_intent)
-
-        (on_success, on_error), = eff.callbacks
-        self.assertIdentical(on_error, None)
-        self.assertIdentical(on_success.func, _clb_check_change_node)
-        self.assertEqual(on_success.args, (change_node,))
+        nonterminal = (APIError(code=500, body="", headers={}),
+                       CLBRateLimitError(lb_id=u'abc123'))
+        for exception in nonterminal:
+            self.assertEqual(
+                perform_sequence([(eff.intent, lambda i: raise_(exception))],
+                                 eff),
+                (StepResult.RETRY, ANY))
 
     def test_add_nodes_to_clb(self):
         """
@@ -711,41 +720,6 @@ class StepAsEffectTests(SynchronousTestCase):
         load balancers.
         """
         self._generic_bulk_rcv3_step_test(BulkRemoveFromRCv3, "DELETE")
-
-
-class CLBCheckChangeNodeTests(SynchronousTestCase):
-    """
-    Tests for :func:`_clb_check_change_node`.
-    """
-    example_step = ChangeCLBNode(lb_id="lb_id",
-                                 node_id="node_id",
-                                 condition=CLBNodeCondition.ENABLED,
-                                 weight=10,
-                                 type=CLBNodeType.PRIMARY)
-
-    def test_good_response(self):
-        """
-        If the response code indicates success, the response was successful.
-        """
-        response = StubResponse(202, {})
-        body = None
-        result = _clb_check_change_node(self.example_step, (response, body))
-        self.assertEqual(result, (StepResult.SUCCESS, []))
-
-    def test_disappearing_server(self):
-        """
-        If the node we're trying to update has vanished, retry convergence.
-        """
-        response = StubResponse(404, {})
-        body = None
-        result = _clb_check_change_node(self.example_step, (response, body))
-        self.assertEqual(
-            result,
-            (StepResult.RETRY,
-             [ErrorReason.Structured(
-                 {"reason": "CLB node not found",
-                  "node": self.example_step.node_id,
-                  "lb": self.example_step.lb_id})]))
 
 
 _RCV3_TEST_DATA = {


### PR DESCRIPTION
This was originally just an integration tests that fixes #1491.

However, found a bug where we were not passing the right payload to CLB - we were passing something like `{"weight": 1, "condition": "ENABLED"}` instead of `{"node": {"weight": 1, "condition": "ENABLED", "type": "PRIMARY"}}`.

So changed that in `cloud_client`, but that also required a change to `steps`.

Fixes #1241.
Fixes #1242.
Fixes #1243.
Fixes #1267.

This makes `ChangeCLBNode` fail if the CLB has been deleted, but maybe that is not always the desired outcome.  See #1705.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/rackerlabs/otter/1704)
<!-- Reviewable:end -->
