### PR TITLE
reduced recent convergence interval

### DIFF
--- a/otter/tap/api.py
+++ b/otter/tap/api.py
@@ -317,7 +317,7 @@ def setup_converger(parent, kz_client, dispatcher, interval, build_timeout):
         time_boundary=15,  # time boundary
     )
     cvg = Converger(log, dispatcher, 10, partitioner_factory, build_timeout,
-                    interval)
+                    interval / 2)
     cvg.setServiceParent(parent)
     watch_children(kz_client, CONVERGENCE_DIRTY_DIR, cvg.divergent_changed)
 

--- a/otter/test/tap/test_api.py
+++ b/otter/test/tap/test_api.py
@@ -717,7 +717,7 @@ class ConvergerSetupTests(SynchronousTestCase):
         self.assertIs(converger.__class__, Converger)
         self.assertEqual(converger.build_timeout, 35)
         self.assertEqual(converger._dispatcher, dispatcher)
-        self.assertEqual(converger.interval, interval)
+        self.assertEqual(converger.interval, interval / 2)
         [partitioner] = converger.services
         [timer] = partitioner.services
         self.assertIs(partitioner.__class__, Partitioner)


### PR DESCRIPTION
In tests, convergence seem to be running every 2 * interval time after https://github.com/rackerlabs/otter/pull/1688. This change reduces the check to half of interval seconds hoping that convergence will happen every interval seconds. I've also made #1707 to address this.