### PR TITLE
next day bugfix

### DIFF
--- a/otter/metrics.py
+++ b/otter/metrics.py
@@ -77,8 +77,10 @@ def get_todays_tenants(tenants, today, last_tenants_len, last_date):
     if last_tenants_len is None:
         return tenants[:batch_size], batch_size, today
     days = (today - last_date).days
-    if days <= 0:
+    if days < 0:
         return tenants[:last_tenants_len], last_tenants_len, today
+    if days == 0:
+        return tenants[:last_tenants_len], last_tenants_len, last_date
     tenants = tenants[:last_tenants_len + batch_size]
     return tenants, len(tenants), today
 

--- a/otter/test/test_metrics.py
+++ b/otter/test/test_metrics.py
@@ -427,10 +427,11 @@ class GetTodaysTenants(SynchronousTestCase):
         """
         returns same tenants as last time if asked within same day
         """
-        last_date = self.today.replace(hour=13, minute=20)
+        today = self.today.replace(hour=13, minute=20)
+        last_date = self.today
         self.assertEqual(
-            get_todays_tenants(self.tenants, self.today, 3, last_date),
-            (self.tenants[:3], 3, self.today))
+            get_todays_tenants(self.tenants, today, 3, last_date),
+            (self.tenants[:3], 3, last_date))
 
     def test_next_day(self):
         """


### PR DESCRIPTION
the current time was always returned for same day resulting in current time being stored in file every minute. Now, it will return old date for same day and today only for new batch. This way the file will be updated with new date at beginning of each day. 