### PR TITLE
LIMITED_RETRY step result

### DIFF
--- a/otter/convergence/model.py
+++ b/otter/convergence/model.py
@@ -110,6 +110,14 @@ class StepResult(Names):
     Convergence should be retried later.
     """
 
+    LIMITED_RETRY = NamedConstant()
+    """
+    Converge should be retried, but only a limited number of times.
+
+    This is used when we're waiting for upstream resources to become available
+    but aren't certain that they ever will be.
+    """
+
     FAILURE = NamedConstant()
     """
     The step failed. Retrying convergence won't help.

--- a/otter/convergence/planning.py
+++ b/otter/convergence/planning.py
@@ -344,9 +344,15 @@ def converge(desired_state, servers_with_cheese, load_balancer_contents, now,
     # Converge again if we expect state transitions on any servers
     converge_later = []
     if any((s not in servers_to_delete
-            for s in waiting_for_build + servers[Destiny.WAIT])):
+            for s in waiting_for_build)):
         converge_later = [
             ConvergeLater(reasons=[ErrorReason.String('waiting for servers')])]
+
+    if any((s not in servers_to_delete for s in servers[Destiny.WAIT])):
+        converge_later.append(
+            ConvergeLater(limited=True, reasons=[ErrorReason.String(
+                'waiting for temporarily unavailable server to become ACTIVE'
+            )]))
 
     return pbag(create_steps +
                 scale_down_steps +

--- a/otter/convergence/service.py
+++ b/otter/convergence/service.py
@@ -187,7 +187,8 @@ def _execute_steps(steps):
     if len(steps) > 0:
         results = yield steps_to_effect(steps)
 
-        severity = [StepResult.FAILURE, StepResult.RETRY, StepResult.SUCCESS]
+        severity = [StepResult.FAILURE, StepResult.RETRY,
+                    StepResult.LIMITED_RETRY, StepResult.SUCCESS]
         priority = sorted(results,
                           key=lambda (status, reasons): severity.index(status))
         worst_status = priority[0][0]
@@ -309,8 +310,8 @@ def convergence_succeeded(scaling_group, group_state, servers, now):
     yield Effect(
         UpdateServersCache(
             scaling_group.tenant_id, scaling_group.uuid, now,
-            [merge(thaw(s.json), {"_is_as_active": True})
-                for s in servers if s.state != ServerState.DELETED]))
+            [thaw(s.json.set("_is_as_active", True))
+             for s in servers if s.state != ServerState.DELETED]))
     yield do_return(ScalingGroupStatus.ACTIVE)
 
 

--- a/otter/convergence/service.py
+++ b/otter/convergence/service.py
@@ -102,7 +102,6 @@ from pyrsistent import thaw
 
 import six
 
-from toolz.dicttoolz import merge
 from toolz.functoolz import curry
 
 from twisted.application.service import MultiService

--- a/otter/convergence/steps.py
+++ b/otter/convergence/steps.py
@@ -3,6 +3,8 @@ import re
 
 from functools import partial
 
+import attr
+
 from characteristic import Attribute, attributes
 
 from effect import Constant, Effect, Func, catch
@@ -519,17 +521,21 @@ def _rcv3_check_bulk_delete(attempted_pairs, result):
 
 
 @implementer(IStep)
-@attributes(['reasons'], apply_with_init=False)
+@attr.s(init=False)
 class ConvergeLater(object):
     """
     Converge later in some time
     """
+    reasons = attr.ib()
+    limited = attr.ib()
 
-    def __init__(self, reasons):
+    def __init__(self, reasons, limited=False):
         self.reasons = freeze(reasons)
+        self.limited = limited
 
     def as_effect(self):
         """
         Return an effect that always results in retry
         """
-        return Effect(Constant((StepResult.RETRY, list(self.reasons))))
+        result = StepResult.LIMITED_RETRY if self.limited else StepResult.RETRY
+        return Effect(Constant((result, list(self.reasons))))

--- a/otter/test/convergence/test_planning.py
+++ b/otter/test/convergence/test_planning.py
@@ -822,7 +822,10 @@ class ConvergeTests(SynchronousTestCase):
                 0),
             pbag([
                 ConvergeLater(
-                    reasons=[ErrorReason.String('waiting for servers')])]))
+                    reasons=[ErrorReason.String(
+                        'waiting for temporarily unavailable server to become '
+                        'ACTIVE')],
+                    limited=True)]))
 
     def test_count_AVOID_REPLACING_as_meeting_capacity(self):
         """
@@ -996,7 +999,11 @@ class ConvergeTests(SynchronousTestCase):
                 # If we're waiting for some other servers we need to also
                 # expect a ConvergeLater
                 also = [ConvergeLater(reasons=[
-                    ErrorReason.String('waiting for servers')])]
+                    ErrorReason.String(
+                        'waiting for temporarily unavailable server to become '
+                        'ACTIVE')],
+                    limited=True)]
+
             self.assertEqual(
                 converge(
                     DesiredGroupState(server_config={}, capacity=2),


### PR DESCRIPTION
This introduces a new StepResult.LIMITED_RETRY`, and the planner returns it for servers in `Destiny.WAIT`.

Nothing else is currently done with it. 