### PR TITLE
schema changes to accomodate draining timeout

### DIFF
--- a/otter/json_schema/group_examples.py
+++ b/otter/json_schema/group_examples.py
@@ -42,7 +42,8 @@ def launch_server_config():
                         "loadBalancerId": 2200,
                         "port": 8081
                     }
-                ]
+                ],
+                "draining_timeout": 30
             }
         },
         {

--- a/otter/json_schema/group_schemas.py
+++ b/otter/json_schema/group_schemas.py
@@ -243,7 +243,16 @@ launch_server = {
                         "type": [_clb_lb, _rcv3_lb]
                     }
                 },
-
+                "draining_timeout": {
+                    "type": "number",
+                    "description": (
+                        "Number of seconds the server will be put in draining "
+                        "before removing it from load balancer. The load "
+                        "balancer can be CLB or RCv3"),
+                    "required": False,
+                    "minimum": 30,
+                    "maximum": 3600  # 1 hour
+                }
             },
             "additionalProperties": False
         }

--- a/otter/test/json_schema/test_schemas.py
+++ b/otter/test/json_schema/test_schemas.py
@@ -336,6 +336,27 @@ class ServerLaunchConfigTestCase(SynchronousTestCase):
         self.assertRaises(ValidationError, validate, invalid,
                           group_schemas.launch_server)
 
+    def test_draining_nan(self):
+        """
+        Draining timeout must be a number
+        """
+        lc = deepcopy(group_examples.launch_server_config()[0])
+        lc["args"]["draining_timeout"] = "string"
+        self.assertRaises(ValidationError, validate, lc,
+                          group_schemas.launch_server)
+
+    def test_draining_minmax(self):
+        """
+        Draining timeout must be >= 30 and <= 3600
+        """
+        lc = deepcopy(group_examples.launch_server_config()[0])
+        lc["args"]["draining_timeout"] = 20
+        self.assertRaises(ValidationError, validate, lc,
+                          group_schemas.launch_server)
+        lc["args"]["draining_timeout"] = 3601
+        self.assertRaises(ValidationError, validate, lc,
+                          group_schemas.launch_server)
+
 
 class LaunchConfigServerPayloadValidationTests(SynchronousTestCase):
     """


### PR DESCRIPTION
Part of #1721 