### PR TITLE
Draining implemented

### DIFF
--- a/otter/convergence/composition.py
+++ b/otter/convergence/composition.py
@@ -52,9 +52,6 @@ def get_desired_group_state(group_id, launch_config, desired):
     :param dict launch_config: Group's launch config as per
         :obj:`otter.json_schema.group_schemas.launch_config`
     :param int desired: Group's desired capacity
-
-    NOTE: Currently this ignores draining timeout settings, since it has
-    not been added to any schema yet.
     """
     lbs = freeze(launch_config['args'].get('loadBalancers', []))
     lbs = json_to_LBConfigs(lbs)
@@ -62,9 +59,11 @@ def get_desired_group_state(group_id, launch_config, desired):
         group_id,
         freeze({'server': launch_config['args']['server']}),
         lbs)
+    draining = float(launch_config["args"].get("draining_timeout", 0.0))
     desired_state = DesiredGroupState(
         server_config=server_lc,
-        capacity=desired, desired_lbs=lbs)
+        capacity=desired, desired_lbs=lbs,
+        draining_timeout=draining)
     return desired_state
 
 

--- a/otter/integration/lib/autoscale.py
+++ b/otter/integration/lib/autoscale.py
@@ -53,7 +53,7 @@ def extract_active_ids(group_status):
 def create_scaling_group_dict(
     image_ref=None, flavor_ref=None, min_entities=0, name=None,
     max_entities=25, use_lbs=None, server_name_prefix=None,
-    key_name=None
+    key_name=None, draining_timeout=None
 ):
     """This function returns a dictionary containing a scaling group's JSON
     payload.  Note: this function does NOT create a scaling group.
@@ -127,6 +127,9 @@ def create_scaling_group_dict(
 
     if key_name is not None:
         launch_config_args["server"]["key_name"] = key_name
+
+    if draining_timeout is not None:
+        launch_config_args["draining_timeout"] = draining_timeout
 
     return obj
 

--- a/otter/integration/tests/test_lbsh.py
+++ b/otter/integration/tests/test_lbsh.py
@@ -28,6 +28,7 @@ from otter.integration.lib.nova import NovaServer
 from otter.integration.lib.resources import TestResources
 from otter.integration.lib.trial_tools import (
     TestHelper,
+    convergence_interval,
     get_identity,
     get_resource_mapping,
     region,
@@ -641,7 +642,11 @@ class TestLoadBalancerSelfHealing(unittest.TestCase):
             2)  # interval
 
         # After 30s the node should be removed
-        yield clb.wait_for_nodes(self.rcs, HasLength(0), 35)
+        # Extra 5s due to feed latency
+        # extra 2 convergence intervals assuming 35s pass at end of one cycle.
+        # Next cycle would remove node and wait for another for safety
+        yield clb.wait_for_nodes(self.rcs, HasLength(0),
+                                 30 + 5 + convergence_interval * 2)
         yield group.wait_for_state(
             self.rcs,
             ContainsDict({"activeCapacity": Equals(0),

--- a/otter/test/convergence/test_composition.py
+++ b/otter/test/convergence/test_composition.py
@@ -68,7 +68,8 @@ class GetDesiredGroupStateTests(SynchronousTestCase):
                             'whatsit': 'invalid'},
                            {'loadBalancerId': 23, 'port': 90},
                            {'loadBalancerId': 23, 'type': 'RackConnectV3'},
-                           {'loadBalancerId': '12', 'type': 'RackConnectV3'}]}}
+                           {'loadBalancerId': '12', 'type': 'RackConnectV3'}],
+                       'draining_timeout': 35}}
 
         expected_server_config = {
             'server': {
@@ -95,13 +96,15 @@ class GetDesiredGroupStateTests(SynchronousTestCase):
                     CLBDescription(lb_id='23', port=80),
                     CLBDescription(lb_id='23', port=90),
                     RCv3Description(lb_id='23'),
-                    RCv3Description(lb_id='12')])))
+                    RCv3Description(lb_id='12')]),
+                draining_timeout=35.0))
         self.assert_server_config_hashable(state)
 
     def test_no_lbs(self):
         """
         When no loadBalancers are specified, the returned DesiredGroupState has
-        an empty mapping for desired_lbs.
+        an empty mapping for desired_lbs. If no draining_timeout is provided,
+        returned DesiredGroupState has draining_timeout as 0.0
         """
         server_config = {'name': 'test', 'flavorRef': 'f'}
         lc = {'args': {'server': server_config}}
@@ -119,7 +122,8 @@ class GetDesiredGroupStateTests(SynchronousTestCase):
             DesiredGroupState(
                 server_config=expected_server_config,
                 capacity=2,
-                desired_lbs=pset()))
+                desired_lbs=pset(),
+                draining_timeout=0.0))
         self.assert_server_config_hashable(state)
 
 


### PR DESCRIPTION
Taking draining timeout from launch config and integration test for draining. With this draining is complete. Needs https://github.com/rackerlabs/mimic/pull/428 merged before running integration tests.

Implements 1st and 2nd task of #1721.