### PR TITLE
add sumtype for status of execute_convergence

### DIFF
--- a/otter/convergence/model.py
+++ b/otter/convergence/model.py
@@ -125,6 +125,14 @@ class StepResult(Names):
 
 
 @sumtype
+class ConvergenceIterationStatus(object):
+    """Result of a single convergence iteration."""
+    Stop = constructor()  # Stop converging. Dirty flag can be deleted
+    Continue = constructor()  # Continue converging. Don't delete flag.
+    GroupDeleted = constructor()  # Group disappeared; force-delete dirty flag.
+
+
+@sumtype
 class ErrorReason(object):
     """A reason for a step to be in a RETRY or FAILURE state."""
     Exception = constructor('exc_info')

--- a/otter/convergence/service.py
+++ b/otter/convergence/service.py
@@ -90,7 +90,7 @@ from datetime import datetime
 from functools import partial
 from hashlib import sha1
 
-from effect import Effect, FirstError, Func, parallel
+from effect import Constant, Effect, FirstError, Func, parallel
 from effect.do import do, do_return
 from effect.ref import Reference
 
@@ -101,6 +101,8 @@ from pyrsistent import pmap, pset
 from pyrsistent import thaw
 
 import six
+
+from sumtypes import match
 
 from toolz.functoolz import curry
 
@@ -115,7 +117,8 @@ from otter.convergence.effecting import steps_to_effect
 from otter.convergence.errors import present_reasons, structure_reason
 from otter.convergence.gathering import get_all_convergence_data
 from otter.convergence.logging import log_steps
-from otter.convergence.model import ServerState, StepResult
+from otter.convergence.model import (
+    ConvergenceIterationStatus, ServerState, StepResult)
 from otter.convergence.planning import plan
 from otter.log.cloudfeeds import cf_err, cf_msg
 from otter.log.intents import err, msg, msg_with_time, with_log
@@ -256,9 +259,7 @@ def execute_convergence(tenant_id, group_id, build_timeout,
         :func`get_all_convergence_data`, used for testing.
     :param callable plan: like :func:`plan`, to be used for test injection only
 
-    :return: Effect of two-tuple of (most severe StepResult, group status).
-        When group status is None it means the group has been successfully
-        deleted.
+    :return: Effect of :obj:`ConvergenceIterationStatus`.
     :raise: :obj:`NoSuchScalingGroupError` if the group doesn't exist.
     """
     # Gather data
@@ -283,14 +284,14 @@ def execute_convergence(tenant_id, group_id, build_timeout,
     worst_status, reasons = yield _execute_steps(steps)
 
     # Handle the status from execution
-    result_status = group_state.status
     if worst_status == StepResult.SUCCESS:
-        result_status = yield convergence_succeeded(
+        result = yield convergence_succeeded(
             scaling_group, group_state, servers, now_dt)
     elif worst_status == StepResult.FAILURE:
-        result_status = yield convergence_failed(scaling_group, reasons)
-
-    yield do_return((worst_status, result_status))
+        result = yield convergence_failed(scaling_group, reasons)
+    else:
+        result = ConvergenceIterationStatus.Continue()
+    yield do_return(result)
 
 
 @do
@@ -302,7 +303,7 @@ def convergence_succeeded(scaling_group, group_state, servers, now):
         # servers have been deleted. Delete the group for real
         yield Effect(DeleteGroup(tenant_id=scaling_group.tenant_id,
                                  group_id=scaling_group.uuid))
-        yield do_return(None)
+        yield do_return(ConvergenceIterationStatus.GroupDeleted())
     elif group_state.status == ScalingGroupStatus.ERROR:
         yield Effect(UpdateGroupStatus(scaling_group=scaling_group,
                                        status=ScalingGroupStatus.ACTIVE))
@@ -314,7 +315,7 @@ def convergence_succeeded(scaling_group, group_state, servers, now):
             scaling_group.tenant_id, scaling_group.uuid, now,
             [thaw(s.json.set("_is_as_active", True))
              for s in servers if s.state != ServerState.DELETED]))
-    yield do_return(ScalingGroupStatus.ACTIVE)
+    yield do_return(ConvergenceIterationStatus.Stop())
 
 
 @do
@@ -331,7 +332,7 @@ def convergence_failed(scaling_group, reasons):
         'group-status-error', status=ScalingGroupStatus.ERROR.name,
         reasons=presented_reasons)
     yield Effect(UpdateGroupErrorReasons(scaling_group, presented_reasons))
-    yield do_return(ScalingGroupStatus.ERROR)
+    yield do_return(ConvergenceIterationStatus.Stop())
 
 
 def format_dirty_flag(tenant_id, group_id):
@@ -531,15 +532,19 @@ def converge_one_group(currently_converging, recently_converged,
         # unexpected errors, so convergence will be retried.
         yield err(None, 'converge-non-fatal-error')
     else:
-        if result[0] in (StepResult.FAILURE, StepResult.SUCCESS):
-            # In order to avoid doing extra work and reporting spurious errors,
-            # if the group status is None it means the group has successfully
-            # been deleted by execute_convergence. And so we will
-            # unconditionally delete the divergent flag to avoid any further
-            # queued-up convergences that will imminently fail.
-            if result[1] is None:
-                version = -1
-            yield delete_divergent_flag(tenant_id, group_id, version)
+        @match(ConvergenceIterationStatus)
+        class clean_up(object):
+            def Continue():
+                return Effect(Constant(None))
+
+            def Stop():
+                return delete_divergent_flag(tenant_id, group_id, version)
+
+            def GroupDeleted():
+                # Delete the divergent flag to avoid any queued-up convergences
+                # that will imminently fail.
+                return delete_divergent_flag(tenant_id, group_id, -1)
+        yield clean_up(result)
 
 
 @do


### PR DESCRIPTION
This simplifies our code so that the weird two-tuple of `(worst_status, group_status)` doesn't need to escape from `execute_convergence` and processed with some opaque behavior (which was my own fault for introducing!)

Now there's sumtype representing the various results that executing convergence can have: Continue, Stop, and GroupDeleted.

(I decided to do this when I found a bug in the code I introduced in #1724, in the handling of the result of execute_convergence.  This change makes that change a lot simpler, not to mention the existing code).
