### PR TITLE
Move group-fetching code from metrics.py to core model code

### DIFF
--- a/otter/models/intents.py
+++ b/otter/models/intents.py
@@ -15,6 +15,16 @@ from otter.models.cass import CassScalingGroupServersCache
 from otter.util.fp import assoc_obj
 
 
+@attr.s
+class GetAllGroups(object):
+    pass
+
+
+@deferred_performer
+def perform_get_all_groups(store, dispatcher, intent):
+    return store.get_all_groups()
+
+
 @attributes(['tenant_id', 'group_id'])
 class GetScalingGroupInfo(object):
     """Get a scaling group and its manifest."""
@@ -127,5 +137,6 @@ def get_model_dispatcher(log, store):
         UpdateGroupStatus: perform_update_group_status,
         UpdateServersCache: perform_update_servers_cache,
         UpdateGroupErrorReasons: perform_update_error_reasons,
-        ModifyGroupStatePaused: perform_modify_group_state_paused
+        ModifyGroupStatePaused: perform_modify_group_state_paused,
+        GetAllGroups: partial(perform_get_all_groups, store),
     })

--- a/otter/test/test_metrics.py
+++ b/otter/test/test_metrics.py
@@ -35,8 +35,6 @@ from otter.metrics import (
     collect_metrics,
     get_all_metrics,
     get_all_metrics_effects,
-    # get_scaling_group_rows,
-    # get_scaling_groups,
     get_tenant_metrics,
     get_todays_scaling_groups,
     get_todays_tenants,


### PR DESCRIPTION
This is a fairly simple refactoring to move the get_scaling_groups and GetAllGroups intent into otter.models. I figure we will want to use this code in order to implement naive self-healing in the convergence codepath, so it should be in a more accessible place than otter.metrics.