### PR TITLE
Implement ConvergenceExecutor

### DIFF
--- a/otter/convergence/service.py
+++ b/otter/convergence/service.py
@@ -133,6 +133,9 @@ from otter.util.zk import CreateOrSet, DeleteNode, GetChildren, GetStat
 
 
 def get_executor(launch_config):
+    """
+    Returns a ConvergenceExecutor based upon the launch_config type given.
+    """
     if launch_config['type'] == 'launch_server':
         return launch_server_executor
     raise NotImplementedError
@@ -815,6 +818,10 @@ class Converger(MultiService):
 
 @attr.s
 class ConvergenceExecutor(object):
+    """
+    A bag of methods to enable configurable logic for different types of launch
+    configurations.
+    """
     gather = attr.ib()
     plan = attr.ib()
     get_desired_group_state = attr.ib()

--- a/otter/convergence/service.py
+++ b/otter/convergence/service.py
@@ -90,6 +90,8 @@ from datetime import datetime
 from functools import partial
 from hashlib import sha1
 
+import attr
+
 from effect import Constant, Effect, Func, parallel
 from effect.do import do, do_return
 from effect.ref import Reference
@@ -130,6 +132,12 @@ from otter.util.timestamp import datetime_to_epoch
 from otter.util.zk import CreateOrSet, DeleteNode, GetChildren, GetStat
 
 
+def get_executor(launch_config):
+    if launch_config['type'] == 'launch_server':
+        return LaunchServerExecutor()
+    raise NotImplementedError
+
+
 def server_to_json(server):
     """
     Convert a NovaServer to a dict representation suitable for returning to the
@@ -162,7 +170,7 @@ def is_autoscale_active(server, lb_nodes):
                              if node.matches(server)]))
 
 
-def update_cache(group, servers, lb_nodes, now, include_deleted=True):
+def update_servers_cache(group, servers, lb_nodes, now, include_deleted=True):
     """
     Updates the cache, adding servers, with a flag if autoscale is active on
     each one.
@@ -220,7 +228,7 @@ def _execute_steps(steps):
 
 @do
 def convergence_exec_data(tenant_id, group_id, now,
-                          get_all_launch_server_data):
+                          get_executor):
     """
     Get data required while executing convergence
     """
@@ -232,7 +240,9 @@ def convergence_exec_data(tenant_id, group_id, now,
     group_state = manifest['state']
     launch_config = manifest['launchConfiguration']
 
-    gather_eff = get_all_launch_server_data(tenant_id, group_id, now)
+    executor = get_executor(launch_config)
+
+    gather_eff = executor.gather(tenant_id, group_id, now)
 
     (servers, lb_nodes) = yield gather_eff
 
@@ -240,12 +250,12 @@ def convergence_exec_data(tenant_id, group_id, now,
         desired_capacity = 0
     else:
         desired_capacity = group_state.desired
-        yield update_cache(scaling_group, servers, lb_nodes, now)
+        yield executor.update_cache(scaling_group, servers, lb_nodes, now)
 
-    desired_group_state = get_desired_server_group_state(
+    desired_group_state = executor.get_desired_group_state(
         group_id, launch_config, desired_capacity)
 
-    yield do_return((scaling_group, group_state, desired_group_state,
+    yield do_return((executor, scaling_group, group_state, desired_group_state,
                      servers, lb_nodes))
 
 
@@ -257,8 +267,7 @@ def _clean_waiting(waiting, group_id):
 @do
 def execute_convergence(tenant_id, group_id, build_timeout,
                         waiting, limited_retry_iterations,
-                        get_all_launch_server_data=get_all_launch_server_data,
-                        plan_launch_server=plan_launch_server):
+                        get_executor=get_executor):
     """
     Gather data, plan a convergence, save active and pending servers to the
     group state, and then execute the convergence.
@@ -285,13 +294,13 @@ def execute_convergence(tenant_id, group_id, build_timeout,
         "gather-convergence-data",
         convergence_exec_data(
             tenant_id, group_id, now_dt,
-            get_all_launch_server_data=get_all_launch_server_data))
-    (scaling_group, group_state, desired_group_state,
+            get_executor=get_executor))
+    (executor, scaling_group, group_state, desired_group_state,
      servers, lb_nodes) = all_data
 
     # prepare plan
-    steps = plan_launch_server(desired_group_state, servers, lb_nodes,
-                               datetime_to_epoch(now_dt), build_timeout)
+    steps = executor.plan(desired_group_state, servers, lb_nodes,
+                          datetime_to_epoch(now_dt), build_timeout)
     yield log_steps(steps)
 
     # Execute plan
@@ -307,8 +316,8 @@ def execute_convergence(tenant_id, group_id, build_timeout,
 
     # Handle the status from execution
     if worst_status == StepResult.SUCCESS:
-        result = yield convergence_succeeded_servers(
-            scaling_group, group_state, servers, lb_nodes, now_dt)
+        result = yield convergence_succeeded(
+            executor, scaling_group, group_state, servers, lb_nodes, now_dt)
     elif worst_status == StepResult.FAILURE:
         result = yield convergence_failed(scaling_group, reasons)
     elif worst_status is StepResult.LIMITED_RETRY:
@@ -330,8 +339,8 @@ def execute_convergence(tenant_id, group_id, build_timeout,
 
 
 @do
-def convergence_succeeded_servers(scaling_group, group_state, servers,
-                                  lb_nodes, now):
+def convergence_succeeded(executor, scaling_group, group_state, servers,
+                          lb_nodes, now):
     """
     Handle convergence success
     """
@@ -346,8 +355,8 @@ def convergence_succeeded_servers(scaling_group, group_state, servers,
         yield cf_msg('group-status-active',
                      status=ScalingGroupStatus.ACTIVE.name)
     # update servers cache with latest servers
-    yield update_cache(scaling_group, servers, lb_nodes, now,
-                       include_deleted=False)
+    yield executor.update_cache(scaling_group, servers, lb_nodes, now,
+                                include_deleted=False)
     yield do_return(ConvergenceIterationStatus.Stop())
 
 
@@ -802,3 +811,18 @@ class Converger(MultiService):
             # the return value is ignored, but we return this for testing
             eff = self._converge_all(my_buckets, children)
             return perform(self._dispatcher, self._with_conv_runid(eff))
+
+
+class ConvergenceExecutor(object):
+    gather = attr.ib()
+    plan = attr.ib()
+    get_desired_group_state = attr.ib()
+    update_cache = attr.ib()
+
+
+@attr.s
+class LaunchServerExecutor(ConvergenceExecutor):
+    gather = attr.ib(default=get_all_launch_server_data)
+    plan = attr.ib(default=plan_launch_server)
+    get_desired_group_state = attr.ib(default=get_desired_server_group_state)
+    update_cache = attr.ib(default=update_servers_cache)

--- a/otter/convergence/service.py
+++ b/otter/convergence/service.py
@@ -134,7 +134,7 @@ from otter.util.zk import CreateOrSet, DeleteNode, GetChildren, GetStat
 
 def get_executor(launch_config):
     if launch_config['type'] == 'launch_server':
-        return LaunchServerExecutor()
+        return launch_server_executor
     raise NotImplementedError
 
 
@@ -813,6 +813,7 @@ class Converger(MultiService):
             return perform(self._dispatcher, self._with_conv_runid(eff))
 
 
+@attr.s
 class ConvergenceExecutor(object):
     gather = attr.ib()
     plan = attr.ib()
@@ -820,9 +821,8 @@ class ConvergenceExecutor(object):
     update_cache = attr.ib()
 
 
-@attr.s
-class LaunchServerExecutor(ConvergenceExecutor):
-    gather = attr.ib(default=get_all_launch_server_data)
-    plan = attr.ib(default=plan_launch_server)
-    get_desired_group_state = attr.ib(default=get_desired_server_group_state)
-    update_cache = attr.ib(default=update_servers_cache)
+launch_server_executor = ConvergenceExecutor(
+    gather=get_all_launch_server_data,
+    plan=plan_launch_server,
+    get_desired_group_state=get_desired_server_group_state,
+    update_cache=update_servers_cache)

--- a/otter/test/convergence/test_service.py
+++ b/otter/test/convergence/test_service.py
@@ -36,11 +36,11 @@ from otter.convergence.service import (
     ConvergenceExecutor,
     ConvergenceStarter,
     Converger,
-    LaunchServerExecutor,
     converge_all_groups,
     converge_one_group,
     execute_convergence, get_my_divergent_groups,
     is_autoscale_active,
+    launch_server_executor,
     non_concurrently,
     trigger_convergence,
     update_servers_cache)
@@ -864,7 +864,8 @@ class ExecuteConvergenceTests(SynchronousTestCase):
 
     def _invoke(self, plan=None):
         kwargs = {'plan': plan} if plan is not None else {}
-        executor = LaunchServerExecutor(gather=intent_func("gacd"), **kwargs)
+        executor = attr.assoc(launch_server_executor,
+                              gather=intent_func("gacd"), **kwargs)
         return execute_convergence(
             self.tenant_id, self.group_id, build_timeout=3600,
             waiting=self.waiting,
@@ -1436,7 +1437,7 @@ class ConvergenceExecutorTests(SynchronousTestCase):
             'get_desired_group_state': 'gdgs',
             'update_cache': 'uc',
         }
-        self.lse = LaunchServerExecutor()
+        self.lse = launch_server_executor
 
     def test_launch_server_executor(self):
         attrs = {
@@ -1449,5 +1450,5 @@ class ConvergenceExecutorTests(SynchronousTestCase):
         self.assertEqual(attr.asdict(self.lse), attrs)
 
     def test_launch_server_overrides(self):
-        ce = LaunchServerExecutor(**self.fake_attrs)
+        ce = attr.assoc(launch_server_executor, **self.fake_attrs)
         self.assertEqual(attr.asdict(ce), self.fake_attrs)

--- a/otter/test/convergence/test_service.py
+++ b/otter/test/convergence/test_service.py
@@ -1430,6 +1430,9 @@ class IsAutoscaleActiveTests(SynchronousTestCase):
 
 
 class ConvergenceExecutorTests(SynchronousTestCase):
+    """
+    Tests for :obj:`ConvergenceExecutor`.
+    """
     def setUp(self):
         self.fake_attrs = {
             'gather': 'g',
@@ -1440,6 +1443,9 @@ class ConvergenceExecutorTests(SynchronousTestCase):
         self.lse = launch_server_executor
 
     def test_launch_server_executor(self):
+        """
+        Ensures :obj:`launch_server_executor` contains the correct methods.
+        """
         attrs = {
             'gather': get_all_launch_server_data,
             'plan': plan_launch_server,
@@ -1450,5 +1456,8 @@ class ConvergenceExecutorTests(SynchronousTestCase):
         self.assertEqual(attr.asdict(self.lse), attrs)
 
     def test_launch_server_overrides(self):
+        """
+        Ensures methods in :obj:`launch_server_executor` can be overridden.
+        """
         ce = attr.assoc(launch_server_executor, **self.fake_attrs)
         self.assertEqual(attr.asdict(ce), self.fake_attrs)


### PR DESCRIPTION
ConvergenceExecutor allows simple polymorphism when running convergence, which is useful for changing behavior depending on launch config type. Interestingly, the way this is implemented makes `ConvergenceExecutor`'s methods static, so I was able to directly replace free function calls with the executor version without having to add `self` to the original function.

Testing works almost the same way as before, except a `get_executor` method is passed which can return a custom executor that has the mock methods attached, because all of its methods can be overridden. (See how `_invoke` has changed and see `test_launch_server_overrides`)

The exact methods contained in `ConvergenceExecutor` may change. For example, just `UpdateServersCache` instead of the entirety of `convergence_succeeded_servers` since most of the code there isn't specific to launch_server.

@radix, @manishtomar, let me know what you think!