### PR TITLE
Convergence throttling is optional

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -69,7 +69,7 @@
     "cloud_client": {
     	"throttling": {
     	    "create_server_delay": 1,
-    	    "delete_server_delay": 0.2
+            "delete_server_delay": 0.4
     	}
     }
 }

--- a/otter/cloud_client.py
+++ b/otter/cloud_client.py
@@ -269,13 +269,12 @@ def _default_throttler(clock, stype, method):
     # no more than that are executed by a node, plus serialization of requests
     # will make it quite a bit lower than that.
 
-    cloud_client_config = config_value('cloud_client')
-    if cloud_client_config is None:
-        cloud_client_config = {}
-    throttling_config = cloud_client_config.get('throttling', {})
+    throttling_config = config_value('cloud_client.throttling')
+    if throttling_config is None:
+        return None
+
     create_server_delay = throttling_config.get('create_server_delay', 1)
     delete_server_delay = throttling_config.get('delete_server_delay', 0.4)
-
     policy = {
         (ServiceType.CLOUD_SERVERS, 'post'):
             _serialize_and_delay(clock, create_server_delay),

--- a/otter/cloud_client.py
+++ b/otter/cloud_client.py
@@ -261,26 +261,21 @@ def _serialize_and_delay(clock, delay):
 
 
 def _default_throttler(clock, stype, method):
-    """Get a throttler function with default throttling policies."""
-    # Serialize creation and deletion of cloud servers because the Compute team
-    # has suggested we do this.
+    """
+    Get a throttler function with throttling policies based on configuration.
+    """
+    policy = {}
 
-    # Compute suggested 150 deletion req/min. A delay of 0.4 should guarantee
-    # no more than that are executed by a node, plus serialization of requests
-    # will make it quite a bit lower than that.
+    conf = config_value('cloud_client.throttling.create_server_delay')
+    if conf is not None:
+        policy[(ServiceType.CLOUD_SERVERS, 'post')] = _serialize_and_delay(
+            clock, conf)
 
-    throttling_config = config_value('cloud_client.throttling')
-    if throttling_config is None:
-        return None
+    conf = config_value('cloud_client.throttling.delete_server_delay')
+    if conf is not None:
+        policy[(ServiceType.CLOUD_SERVERS, 'delete')] = _serialize_and_delay(
+            clock, conf)
 
-    create_server_delay = throttling_config.get('create_server_delay', 1)
-    delete_server_delay = throttling_config.get('delete_server_delay', 0.4)
-    policy = {
-        (ServiceType.CLOUD_SERVERS, 'post'):
-            _serialize_and_delay(clock, create_server_delay),
-        (ServiceType.CLOUD_SERVERS, 'delete'):
-            _serialize_and_delay(clock, delete_server_delay),
-    }
     return policy.get((stype, method))
 
 

--- a/otter/test/test_cloud_client.py
+++ b/otter/test/test_cloud_client.py
@@ -393,9 +393,6 @@ class SerializeAndDelayTests(SynchronousTestCase):
 class DefaultThrottlerTests(SynchronousTestCase):
     """Tests for :func:`_default_throttler`."""
 
-    def setUp(self):
-        set_config_data({"cloud_client": {"throttling": {}}})
-
     def tearDown(self):
         set_config_data(None)
 
@@ -406,33 +403,16 @@ class DefaultThrottlerTests(SynchronousTestCase):
 
     def test_no_config(self):
         """ No config results in no throttling """
-        set_config_data(None)
         bracket = _default_throttler(None, ServiceType.CLOUD_SERVERS, 'get')
         self.assertIs(bracket, None)
-
-    def test_post_cloud_servers(self):
-        """POSTs to cloud servers get throttled by a second."""
-        clock = Clock()
-        bracket = _default_throttler(clock, ServiceType.CLOUD_SERVERS, 'post')
-        d = bracket(lambda: 'foo')
-        self.assertNoResult(d)
-        clock.advance(1)
-        self.assertEqual(self.successResultOf(d), 'foo')
-
-    def test_delete_cloud_servers(self):
-        """DELETEs to cloud servers get throttled by a second."""
-        clock = Clock()
-        bracket = _default_throttler(clock,
-                                     ServiceType.CLOUD_SERVERS, 'delete')
-        d = bracket(lambda: 'foo')
-        self.assertNoResult(d)
-        clock.advance(0.4)
-        self.assertEqual(self.successResultOf(d), 'foo')
 
     def test_post_and_delete_not_the_same(self):
         """
         The throttlers for POST and DELETE to cloud servers are different.
         """
+        set_config_data(
+            {"cloud_client": {"throttling": {"create_server_delay": 1,
+                                             "delete_server_delay": 0.4}}})
         clock = Clock()
         deleter = _default_throttler(clock, ServiceType.CLOUD_SERVERS,
                                      'delete')
@@ -456,7 +436,6 @@ class DefaultThrottlerTests(SynchronousTestCase):
         """The delay for deleting servers is configurable."""
         set_config_data(
             {'cloud_client': {'throttling': {'delete_server_delay': 500}}})
-        self.addCleanup(set_config_data, {})
         clock = Clock()
         bracket = _default_throttler(clock,
                                      ServiceType.CLOUD_SERVERS, 'delete')

--- a/otter/test/test_cloud_client.py
+++ b/otter/test/test_cloud_client.py
@@ -393,9 +393,22 @@ class SerializeAndDelayTests(SynchronousTestCase):
 class DefaultThrottlerTests(SynchronousTestCase):
     """Tests for :func:`_default_throttler`."""
 
+    def setUp(self):
+        self.conf = {"cloud_client": {"throttling": {}}}
+        set_config_data(self.conf)
+
+    def tearDown(self):
+        set_config_data(None)
+
     def test_mismatch(self):
         """policy doesn't have a throttler for random junk."""
         bracket = _default_throttler(None, 'foo', 'get')
+        self.assertIs(bracket, None)
+
+    def test_no_config(self):
+        """ No config results in no throttling """
+        set_config_data(None)
+        bracket = _default_throttler(None, ServiceType.CLOUD_SERVERS, 'get')
         self.assertIs(bracket, None)
 
     def test_post_cloud_servers(self):

--- a/otter/test/test_cloud_client.py
+++ b/otter/test/test_cloud_client.py
@@ -394,8 +394,7 @@ class DefaultThrottlerTests(SynchronousTestCase):
     """Tests for :func:`_default_throttler`."""
 
     def setUp(self):
-        self.conf = {"cloud_client": {"throttling": {}}}
-        set_config_data(self.conf)
+        set_config_data({"cloud_client": {"throttling": {}}})
 
     def tearDown(self):
         set_config_data(None)

--- a/otter/test/test_cloud_client.py
+++ b/otter/test/test_cloud_client.py
@@ -488,6 +488,10 @@ class GetCloudClientDispatcherTests(SynchronousTestCase):
         # 2. the ServiceRequest is run within a lock, since it matches the
         #    default throttling policy
 
+        set_config_data(
+            {"cloud_client": {"throttling": {"create_server_delay": 1,
+                                             "delete_server_delay": 0.4}}})
+        self.addCleanup(set_config_data, None)
         clock = Clock()
         authenticator = object()
         log = object()


### PR DESCRIPTION
It will be turned off when settings are not provided. This should allow high parallelism and reduce [integration tests times](https://as-jenkins.rax.io/job/_ci-integration-convergence-cafe/buildTimeTrend) from 15min to 5-6mins. Needs https://github.com/rackerlabs/autoscaling-chef/pull/781 merged before merging this.