### PR TITLE
worker throttling optional

### DIFF
--- a/otter/test/utils.py
+++ b/otter/test/utils.py
@@ -42,6 +42,7 @@ from otter.convergence.model import HeatStack, NovaServer, ServerState
 from otter.log.bound import BoundLog, bound_log_kwargs
 from otter.models.interface import IScalingGroup, IScalingGroupServersCache
 from otter.supervisor import ISupervisor
+from otter.util.config import set_config_data
 from otter.util.deferredutils import DeferredPool
 from otter.util.fp import set_in
 from otter.util.retry import Retry, ShouldDelayAndRetry, perform_retry
@@ -579,6 +580,14 @@ class DummyException(Exception):
     """
     Fake exception
     """
+
+
+def set_config_for_test(testcase, data):
+    """
+    Set config data for test. Will reset to {} after test is run
+    """
+    set_config_data(data)
+    testcase.addCleanup(set_config_data, {})
 
 
 @implementer(ISupervisor)

--- a/otter/test/worker/test_launch_server_v1.py
+++ b/otter/test/worker/test_launch_server_v1.py
@@ -890,6 +890,14 @@ def _get_server_info(metadata=None, created=None):
     return config
 
 
+def reset_semaphores(testcase):
+    """
+    reset global sempahores to empty in beginning of test as it is module-wise
+    info retained in every test
+    """
+    testcase.patch(launch_server_v1, "_semaphores", {})
+
+
 class ServerTests(RequestBagTestMixin, SynchronousTestCase):
     """
     Test server manipulation functions.
@@ -912,9 +920,7 @@ class ServerTests(RequestBagTestMixin, SynchronousTestCase):
             'otter.worker.launch_server_v1.generate_server_name')
         self.generate_server_name.return_value = 'as000000'
 
-        # reset it to empty in beginning of test as it is module-wise
-        # info retained in every test
-        launch_server_v1._semaphores = {}
+        reset_semaphores(self)
 
         self.scaling_group_uuid = '1111111-11111-11111-11111111'
 
@@ -2220,9 +2226,7 @@ class DeleteServerTests(RequestBagTestMixin, SynchronousTestCase):
             self, 'otter.worker.launch_server_v1.remove_from_load_balancer')
         self.remove_from_load_balancer.return_value = succeed(None)
 
-        # reset it to empty in beginning of test as it is module-wise
-        # info retained in every test
-        launch_server_v1._semaphores = {}
+        reset_semaphores(self)
 
         self.clock = Clock()
         self.url = 'http://url'

--- a/otter/test/worker/test_launch_server_v1.py
+++ b/otter/test/worker/test_launch_server_v1.py
@@ -32,7 +32,8 @@ from otter.test.utils import (
     matches,
     mock_log,
     mock_treq,
-    patch)
+    patch,
+    set_config_for_test)
 from otter.test.worker.test_rcv3 import _rcv3_add_response_body
 from otter.undo import IUndoStack
 from otter.util.config import set_config_data
@@ -1172,7 +1173,7 @@ class ServerTests(RequestBagTestMixin, SynchronousTestCase):
             'imageRef': '1',
             'flavorRef': '3'
         }
-        set_config_data({"worker": {"create_server_limit": 1}})
+        set_config_for_test(self, {"worker": {"create_server_limit": 1}})
 
         ret_ds = [create_server('http://url/', 'my-auth-token',
                                 server_config, clock=self.clock)
@@ -2425,8 +2426,7 @@ class DeleteServerTests(RequestBagTestMixin, SynchronousTestCase):
         :func:`delete_and_verify` limits the number of delete server requests
         to 1. It also delays response by 1 second
         """
-        set_config_data({"worker": {"delete_server_limit": 1}})
-        self.addCleanup(set_config_data, None)
+        set_config_for_test(self, {"worker": {"delete_server_limit": 1}})
 
         deferreds = [Deferred() for i in range(3)]
         delete_ds = deferreds[:]

--- a/otter/worker/launch_server_v1.py
+++ b/otter/worker/launch_server_v1.py
@@ -160,6 +160,12 @@ def get_sempahore(operation, conf_name):
     """
     Get global semaphore of given operation if configured based on conf_name.
     Otherwise return None
+
+    :param str operation: Operation for which semaphore is required. Must be
+        same each time it is called for that operation
+    :param str conf_name: Semaphore is returned only if this config exists
+
+    :return: A :obj:`DeferredSemaphore` object corresponding to the operation
     """
     sem = _semaphores.get(operation)
     if sem is not None:


### PR DESCRIPTION
Needs `worker.create|delete_server_limit` for throttling to kick in. This allows higher number of tests to run concurrently increasing test run times. Requires https://github.com/rackerlabs/autoscaling-chef/pull/807 merged before this.