### PR TITLE
allow specifying "all" as the value for "convergence-tenants"

### DIFF
--- a/otter/convergence/composition.py
+++ b/otter/convergence/composition.py
@@ -23,6 +23,8 @@ def tenant_is_enabled(tenant_id, get_config_value):
     :param callable get_config_value: config key -> config value.
     """
     enabled_tenant_ids = get_config_value("convergence-tenants")
+    if enabled_tenant_ids == 'all':
+        return True
     if enabled_tenant_ids is not None:
         return (tenant_id in enabled_tenant_ids)
     return False

--- a/otter/test/convergence/test_composition.py
+++ b/otter/test/convergence/test_composition.py
@@ -168,3 +168,10 @@ class FeatureFlagTest(SynchronousTestCase):
         returned.
         """
         self.assertEqual(tenant_is_enabled('foo', lambda x: None), False)
+
+    def test_all(self):
+        """When the value is ``'all'``, True is returned for any tenant."""
+        def get_config_value(config_key):
+            self.assertEqual(config_key, "convergence-tenants")
+            return 'all'
+        self.assertEqual(tenant_is_enabled('foo', get_config_value), True)


### PR DESCRIPTION
super simple PR. When `convergence-tenants` is set to the string `"all"` (as opposed to a list of specific tenant IDs), then all tenants have convergence enabled.