### PR TITLE
Allow bfv server config with block_device_mapping_v2 setting

### DIFF
--- a/otter/json_schema/group_schemas.py
+++ b/otter/json_schema/group_schemas.py
@@ -87,6 +87,10 @@ _bfv_server = {
     }
 }
 
+_bfv2_server = deepcopy(_bfv_server)
+bdm = _bfv2_server["properties"].pop("block_device_mapping")
+_bfv2_server["properties"]["block_device_mapping_v2"] = bdm
+
 _non_bfv_server = {
     "type": "object",
     "properties": {
@@ -159,7 +163,7 @@ _clb_lb = {
 
 
 server = {
-    "type": [_bfv_server, _non_bfv_server],
+    "type": [_bfv_server, _bfv2_server, _non_bfv_server],
     # The schema for the create server attributes should come
     # from Nova, or Nova should provide some no-op method to
     # validate creating a server. Autoscale should not

--- a/otter/json_schema/group_schemas.py
+++ b/otter/json_schema/group_schemas.py
@@ -88,8 +88,8 @@ _bfv_server = {
 }
 
 _bfv2_server = deepcopy(_bfv_server)
-bdm = _bfv2_server["properties"].pop("block_device_mapping")
-_bfv2_server["properties"]["block_device_mapping_v2"] = bdm
+_bdm = _bfv2_server["properties"].pop("block_device_mapping")
+_bfv2_server["properties"]["block_device_mapping_v2"] = _bdm
 
 _non_bfv_server = {
     "type": "object",

--- a/otter/test/json_schema/test_schemas.py
+++ b/otter/test/json_schema/test_schemas.py
@@ -380,7 +380,7 @@ class LaunchConfigServerPayloadValidationTests(SynchronousTestCase):
     def test_empty_image_no_bfv(self):
         """
         Empty string or null for ``imageRef`` is not valid, if no
-        ``block_device_mapping`` is provided.
+        ``block_device_mapping`` or ``block_device_mapping_v2`` is provided.
         """
         for ref in ('', None):
             self.server['imageRef'] = ref
@@ -390,7 +390,7 @@ class LaunchConfigServerPayloadValidationTests(SynchronousTestCase):
     def test_null_image_no_bfv(self):
         """
         Not providing ``imageRef`` is not valid, if no
-        ``block_device_mapping`` is provided.
+        ``block_device_mapping`` or ``block_device_mapping_v2`` is provided.
         """
         self.server.pop('imageRef')
         self.assertRaisesRegexp(ValidationError, "is not of type",
@@ -399,20 +399,26 @@ class LaunchConfigServerPayloadValidationTests(SynchronousTestCase):
     def test_empty_image_bfv(self):
         """
         Empty string or null for ``imageRef`` is valid, if
-        ``block_device_mapping`` is provided.
+        ``block_device_mapping`` or ``block_device_mapping_v2`` is provided.
         """
         for ref in ('', None):
             self.server['imageRef'] = ref
             self.server['block_device_mapping'] = [{'volume_id': '235'}]
             validate(self.server, group_schemas.server)
+            self.server.pop('block_device_mapping')
+            self.server['block_device_mapping_v2'] = [{'volume_id': '235'}]
+            validate(self.server, group_schemas.server)
 
     def test_no_image_bfv(self):
         """
-        Not providing ``imageRef`` is valid, if ``block_device_mapping`` is
-        provided.
+        Not providing ``imageRef`` is valid, if ``block_device_mapping``
+        or ``block_device_mapping_v2`` is provided.
         """
         self.server.pop('imageRef')
         self.server['block_device_mapping'] = [{'volume_id': '235'}]
+        validate(self.server, group_schemas.server)
+        self.server.pop('block_device_mapping')
+        self.server['block_device_mapping_v2'] = [{'volume_id': '235'}]
         validate(self.server, group_schemas.server)
 
     def test_blank_image(self):


### PR DESCRIPTION
All the [Nova docs](https://developer.rackspace.com/docs/cloud-servers/v2/developer-guide/#post-create-server-servers) point to _v2 setting. `block_device_mapping` is legacy. 

Closes #1780.