### PR TITLE
converge?on_error query arg

### DIFF
--- a/otter/rest/groups.py
+++ b/otter/rest/groups.py
@@ -670,10 +670,20 @@ class OtterGroup(object):
         Trigger convergence on given scaling group
         """
 
-        def is_group_paused(group, state):
+        class ConvergeErrorGroup(Exception):
+            pass
+
+        def can_converge(group, state):
             if state.paused:
                 raise GroupPausedError(group.tenant_id, group.uuid, "converge")
+            conv_on_error = extract_bool_arg(request, 'on_error', True)
+            if not conv_on_error and state.status == ScalingGroupStatus.ERROR:
+                raise ConvergeErrorGroup()
             return state
+
+        def converge_error_group_header(f):
+            f.trap(ConvergeErrorGroup)
+            request.setHeader("x-not-converging", "true")
 
         if tenant_is_enabled(self.tenant_id, config_value):
             group = self.store.get_scaling_group(
@@ -682,7 +692,7 @@ class OtterGroup(object):
                 self.dispatcher,
                 group,
                 bound_log_kwargs(self.log),
-                is_group_paused)
+                can_converge).addErrback(converge_error_group_header)
         else:
             request.setResponseCode(404)
 

--- a/otter/test/rest/test_groups.py
+++ b/otter/test/rest/test_groups.py
@@ -1199,6 +1199,24 @@ class OneGroupTestCase(RestAPITestMixin, SynchronousTestCase):
             403, endpoint='{}converge'.format(self.endpoint), method='POST')
         self.assertTrue(self.mock_controller.modify_and_trigger.called)
 
+    def test_error_group_converge(self):
+        """
+        Calling `../converge?on_error=False` will not trigger convergence
+        on ERROR group
+        """
+        set_config_data({'convergence-tenants': ['11111']})
+        self.addCleanup(set_config_data, {})
+        self.mock_state = GroupState(
+            '11111', 'one', '', {}, {}, None, {}, False,
+            ScalingGroupStatus.ERROR)  # error group
+        response_wrapper = self.request(
+            endpoint='{}converge?on_error=false'.format(self.endpoint),
+            method='POST')
+        self.assert_response(response_wrapper, 204)
+        values = response_wrapper.response.headers.getRawHeaders(
+            'x-not-converging')
+        self.assertEqual(values, ["true"])
+
     def test_group_converge_worker_tenant(self):
         """
         Calling `../converge` on non-convergence enabled tenant returns 404


### PR DESCRIPTION
to trigger convergence or not when group is in ERROR. Useful in `trigger_convergence.py` to trigger convergence only on non-ERROR group