### PR TITLE
Specify ids of temp unavailable servers

### DIFF
--- a/otter/convergence/planning.py
+++ b/otter/convergence/planning.py
@@ -419,11 +419,13 @@ def converge_launch_server(desired_state, servers_with_cheese,
         converge_later = [
             ConvergeLater(reasons=[ErrorReason.String('waiting for servers')])]
 
-    if any((s not in servers_to_delete for s in servers[Destiny.WAIT])):
-        converge_later.append(
-            ConvergeLater(limited=True, reasons=[ErrorReason.UserMessage(
-                'Waiting for temporarily unavailable server to become ACTIVE'
-            )]))
+    unavail_fmt = ('Waiting for server {server_id} to transition to ACTIVE '
+                   'from {status}')
+    reasons = [ErrorReason.UserMessage(unavail_fmt.format(server_id=s.id,
+                                                          status=s.state.name))
+               for s in servers[Destiny.WAIT] if s not in servers_to_delete]
+    if reasons:
+        converge_later.append(ConvergeLater(limited=True, reasons=reasons))
 
     return pbag(create_steps +
                 scale_down_steps +

--- a/otter/convergence/steps.py
+++ b/otter/convergence/steps.py
@@ -546,7 +546,7 @@ class ConvergeLater(object):
     limited = attr.ib()
 
     def __init__(self, reasons, limited=False):
-        self.reasons = freeze(reasons)
+        self.reasons = pset(reasons)
         self.limited = limited
 
     def as_effect(self):

--- a/otter/test/convergence/test_planning.py
+++ b/otter/test/convergence/test_planning.py
@@ -831,18 +831,20 @@ class ConvergeLaunchServerTests(SynchronousTestCase):
         If a server's destiny is WAIT, we won't provision more servers to take
         up the slack, but rather just wait for it to come back.
         """
+        msg1 = ErrorReason.UserMessage(
+            'Waiting for server abc to transition to ACTIVE from HARD_REBOOT')
+        msg2 = ErrorReason.UserMessage(
+            'Waiting for server def to transition to ACTIVE from PASSWORD')
         self.assertEqual(
             converge_launch_server(
-                DesiredServerGroupState(server_config={}, capacity=1),
-                set([server('abc', ServerState.HARD_REBOOT)]),
+                DesiredServerGroupState(server_config={}, capacity=2),
+                set([server('abc', ServerState.HARD_REBOOT),
+                     server('def', ServerState.PASSWORD)]),
                 set(),
-                0),
-            pbag([
-                ConvergeLater(
-                    reasons=[ErrorReason.UserMessage(
-                        'Waiting for temporarily unavailable server to become '
-                        'ACTIVE')],
-                    limited=True)]))
+                0
+            ),
+            pbag([ConvergeLater(reasons=[msg1, msg2], limited=True)])
+        )
 
     def test_count_AVOID_REPLACING_as_meeting_capacity(self):
         """
@@ -1015,11 +1017,16 @@ class ConvergeLaunchServerTests(SynchronousTestCase):
             if after == Destiny.WAIT:
                 # If we're waiting for some other servers we need to also
                 # expect a ConvergeLater
-                also = [ConvergeLater(reasons=[
-                    ErrorReason.UserMessage(
-                        'Waiting for temporarily unavailable server to become '
-                        'ACTIVE')],
-                    limited=True)]
+                also = [
+                    ConvergeLater(reasons=[
+                        ErrorReason.UserMessage(
+                            'Waiting for server abc to transition to ACTIVE '
+                            'from HARD_REBOOT'),
+                        ErrorReason.UserMessage(
+                            'Waiting for server ghi to transition to ACTIVE '
+                            'from HARD_REBOOT')],
+                        limited=True)
+                ]
 
             self.assertEqual(
                 converge_launch_server(

--- a/otter/test/convergence/test_service.py
+++ b/otter/test/convergence/test_service.py
@@ -1294,7 +1294,8 @@ class ExecuteConvergenceTests(SynchronousTestCase):
         When we've been waiting too long for a LIMITED_RETRY step, we'll
         give up and put the group into ERROR.
         """
-        reasons = [ErrorReason.UserMessage('foo')]
+        reasons = [ErrorReason.UserMessage('foo'),
+                   ErrorReason.UserMessage("bar")]
         self.waiting = Reference(pmap({self.group_id: 44}))
 
         def plan(*args, **kwargs):
@@ -1313,9 +1314,10 @@ class ExecuteConvergenceTests(SynchronousTestCase):
              noop),
             (Log('group-status-error',
                  dict(isError=True, cloud_feed=True, status='ERROR',
-                      reasons=['foo'])),
+                      reasons=['Timed out: bar', "Timed out: foo"])),
              noop),
-            (UpdateGroupErrorReasons(self.group, ['foo']), noop),
+            (UpdateGroupErrorReasons(
+                self.group, ['Timed out: bar', "Timed out: foo"]), noop),
         ]
         self.assertEqual(
             perform_sequence(self.get_seq() + sequence, self._invoke(plan)),


### PR DESCRIPTION
Implements #1804. When a group is put in ERROR due to servers being temporarily unavailable then server ids along with their current status is mentioned in reasons