### PR TITLE
set_config_data with None works

### DIFF
--- a/otter/test/test_util.py
+++ b/otter/test/test_util.py
@@ -507,6 +507,15 @@ class ConfigTest(SynchronousTestCase):
         self.assertEqual(config.config_value("baz.some.other"), "who")
         self.assertEqual(config.config_value("baz.bax"), "quux")
 
+    def test_set_config_None(self):
+        """
+        Setting `None` via :func:`config.set_config_data` also works
+        and does not raise exceptions on subsequent update or get
+        """
+        config.set_config_data(None)
+        self.assertIsNone(config.config_value("a"))
+        config.update_config_data("a.b", 2)
+
 
 class WithLockTests(SynchronousTestCase):
     """

--- a/otter/util/config.py
+++ b/otter/util/config.py
@@ -13,7 +13,10 @@ def set_config_data(data):
     :param dict data: The configuration data, probably loaded from some JSON.
     """
     global _config_data
-    _config_data = data
+    if data is None:
+        _config_data = {}
+    else:
+        _config_data = data
 
 
 def update_config_data(name, value):


### PR DESCRIPTION
this is needed since some old tests sets None and breaks random order of test runs