### PR TITLE
update cache bugfix

### DIFF
--- a/otter/models/cass.py
+++ b/otter/models/cass.py
@@ -1827,7 +1827,10 @@ class CassScalingGroupServersCache(object):
         See :method:`IScalingGroupServersCache.insert_servers`
         """
         if len(servers) == 0:
-            return Effect(Constant(None))
+            if clear_others:
+                return self.delete_servers()
+            else:
+                return Effect(Constant(None))
         query = ('INSERT INTO {cf} ("tenantId", "groupId", last_update, '
                  'server_id, server_blob, server_as_active) '
                  'VALUES(:tenantId, :groupId, :last_update, :server_id{i}, '

--- a/otter/test/models/test_cass_models.py
+++ b/otter/test/models/test_cass_models.py
@@ -3838,7 +3838,8 @@ class CassGroupServersCacheTests(SynchronousTestCase):
         `insert_servers` issues query to insert server as json blobs
         """
         eff = self.cache.insert_servers(
-            self.dt, [{"id": "a", "_is_as_active": True}, {"id": "b"}], False)
+            self.dt, [{"id": "a", "_is_as_active": True}, {"id": "b"}],
+            clear_others=False)
         self._test_insert_servers(eff)
 
     def test_insert_servers_delete(self):
@@ -3848,7 +3849,8 @@ class CassGroupServersCacheTests(SynchronousTestCase):
         """
         self.cache.delete_servers = lambda: Effect("delete")
         eff = self.cache.insert_servers(
-            self.dt, [{"id": "a", "_is_as_active": True}, {"id": "b"}], True)
+            self.dt, [{"id": "a", "_is_as_active": True}, {"id": "b"}],
+            clear_others=True)
         self.assertEqual(eff.intent, "delete")
         self.clock.advance(1)
         eff = resolve_effect(eff, None)
@@ -3859,7 +3861,7 @@ class CassGroupServersCacheTests(SynchronousTestCase):
         `insert_servers` does nothing if called with empty servers list
         """
         self.assertEqual(
-            self.cache.insert_servers(self.dt, [], False),
+            self.cache.insert_servers(self.dt, [], clear_others=False),
             Effect(Constant(None)))
 
     def test_insert_empty_delete(self):
@@ -3868,7 +3870,7 @@ class CassGroupServersCacheTests(SynchronousTestCase):
         nothing if passed list is empty
         """
         self.cache.delete_servers = lambda: Effect("delete")
-        eff = self.cache.insert_servers(self.dt, [], True)
+        eff = self.cache.insert_servers(self.dt, [], clear_others=True)
         self.assertEqual(eff.intent, "delete")
         self.assertIsNone(resolve_effect(eff, None))
 

--- a/otter/test/models/test_cass_models.py
+++ b/otter/test/models/test_cass_models.py
@@ -3862,6 +3862,16 @@ class CassGroupServersCacheTests(SynchronousTestCase):
             self.cache.insert_servers(self.dt, [], False),
             Effect(Constant(None)))
 
+    def test_insert_empty_delete(self):
+        """
+        `insert_servers` deletes servers when clear_others=True and does
+        nothing if passed list is empty
+        """
+        self.cache.delete_servers = lambda: Effect("delete")
+        eff = self.cache.insert_servers(self.dt, [], True)
+        self.assertEqual(eff.intent, "delete")
+        self.assertIsNone(resolve_effect(eff, None))
+
     def test_delete_servers(self):
         """
         `delete_servers` issues query to delete the whole cache


### PR DESCRIPTION
`insert_servers` when called with empty list and `clear_others=True` did not clear existing cache. Now fixed. This causes DELETED servers to remain in cache under certain scenario.