### PR TITLE
create server steps limit is configurable

### DIFF
--- a/otter/convergence/transforming.py
+++ b/otter/convergence/transforming.py
@@ -18,6 +18,7 @@ from otter.convergence.steps import (
     CreateServer,
     CreateStack,
     RemoveNodesFromCLB)
+from otter.util.config import config_value
 
 
 _optimizers = {}
@@ -92,7 +93,7 @@ def optimize_steps(steps):
 
 
 _DEFAULT_STEP_LIMITS = pmap({
-    CreateServer: 10,
+    CreateServer: config_value("converger.create_server_steps_limit") or 10,
     CreateStack: 10
 })
 

--- a/otter/test/convergence/test_transforming.py
+++ b/otter/test/convergence/test_transforming.py
@@ -20,6 +20,7 @@ from otter.convergence.transforming import (
     _limit_step_count,
     limit_steps_by_count,
     optimize_steps)
+from otter.test.utils import set_config_for_test
 
 
 class LimitStepCount(SynchronousTestCase):
@@ -84,6 +85,17 @@ class LimitStepCount(SynchronousTestCase):
         """
         limits = limit_steps_by_count.keywords["step_limits"]
         self.assertEqual(limits, pmap({CreateServer: 10, CreateStack: 10}))
+
+    def test_default_step_limit_config(self):
+        """
+        The default limit limits server creation to up to 10 steps.
+        """
+        set_config_for_test(
+            self, {"converger": {"create_server_steps_limit": 100}})
+        from otter.convergence import transforming as t
+        reload(t)
+        limits = t.limit_steps_by_count.keywords["step_limits"]
+        self.assertEqual(limits, pmap({CreateServer: 100, CreateStack: 10}))
 
 
 class OptimizerTests(SynchronousTestCase):

--- a/otter/test/convergence/test_transforming.py
+++ b/otter/test/convergence/test_transforming.py
@@ -86,9 +86,9 @@ class LimitStepCount(SynchronousTestCase):
         limits = limit_steps_by_count.keywords["step_limits"]
         self.assertEqual(limits, pmap({CreateServer: 10, CreateStack: 10}))
 
-    def test_default_step_limit_config(self):
+    def test_create_server_step_limit_configurable(self):
         """
-        The default limit limits server creation to up to 10 steps.
+        The create server steps limit is configurable
         """
         set_config_for_test(
             self, {"converger": {"create_server_steps_limit": 100}})


### PR DESCRIPTION
This along with https://github.com/rackerlabs/autoscaling-chef/pull/812 will allow 100 servers to be created in one convergence cycle.