### PR TITLE
actual step limits configurable

### DIFF
--- a/otter/convergence/planning.py
+++ b/otter/convergence/planning.py
@@ -533,7 +533,8 @@ def plan_launch_server(desired_group_state, now, build_timeout, step_limits,
     """
     Get an optimized convergence plan.
 
-    Takes the same arguments as :func:`converge_launch_server`.
+    Takes the same arguments as :func:`converge_launch_server`
+    except `step_limits` which is dict of step class -> limit
     """
     steps = converge_launch_server(desired_group_state, servers, lb_nodes, now,
                                    timeout=build_timeout)
@@ -548,7 +549,8 @@ def plan_launch_stack(desired_group_state, now, build_timeout, step_limits,
 
     The arguments `now` and `build_timeout` are ignored and only necessary to
     match those of `plan_launch_server`. The arguments `desired_group_state`
-    and `stacks` are the same as in `converge_launch_stack`.
+    and `stacks` are the same as in `converge_launch_stack`. `step_limits` is
+    dict of step class -> limit
     """
     steps = converge_launch_stack(desired_group_state, stacks)
     steps = limit_steps_by_count(steps, step_limits)

--- a/otter/convergence/planning.py
+++ b/otter/convergence/planning.py
@@ -528,8 +528,8 @@ def converge_launch_stack(desired_state, stacks):
                 converge_later)
 
 
-def plan_launch_server(desired_group_state, now, build_timeout, servers,
-                       lb_nodes):
+def plan_launch_server(desired_group_state, now, build_timeout, step_limits,
+                       servers, lb_nodes):
     """
     Get an optimized convergence plan.
 
@@ -537,11 +537,12 @@ def plan_launch_server(desired_group_state, now, build_timeout, servers,
     """
     steps = converge_launch_server(desired_group_state, servers, lb_nodes, now,
                                    timeout=build_timeout)
-    steps = limit_steps_by_count(steps)
+    steps = limit_steps_by_count(steps, step_limits)
     return optimize_steps(steps)
 
 
-def plan_launch_stack(desired_group_state, now, build_timeout, stacks):
+def plan_launch_stack(desired_group_state, now, build_timeout, step_limits,
+                      stacks):
     """
     Get an optimized convergence plan.
 
@@ -550,7 +551,7 @@ def plan_launch_stack(desired_group_state, now, build_timeout, stacks):
     and `stacks` are the same as in `converge_launch_stack`.
     """
     steps = converge_launch_stack(desired_group_state, stacks)
-    steps = limit_steps_by_count(steps)
+    steps = limit_steps_by_count(steps, step_limits)
     return optimize_steps(steps)
 
 

--- a/otter/convergence/service.py
+++ b/otter/convergence/service.py
@@ -286,9 +286,9 @@ def execute_convergence(tenant_id, group_id, build_timeout, waiting,
     :param Reference waiting: pmap of waiting groups
     :param int limited_retry_iterations: number of iterations to wait for
         LIMITED_RETRY steps
-    :param callable get_all_convergence_data: like
-        :func`get_all_convergence_data`, used for testing.
-    :param callable plan: like :func:`plan`, to be used for test injection only
+    :param dict step_limits: Mapping of step class to number of executions
+        allowed in a convergence cycle
+    :param callable get_executor: like :func`get_executor`, used for testing.
 
     :return: Effect of :obj:`ConvergenceIterationStatus`.
     :raise: :obj:`NoSuchScalingGroupError` if the group doesn't exist.
@@ -568,6 +568,8 @@ def converge_one_group(currently_converging, recently_converged, waiting,
         building before it's is timed out and deleted
     :param int limited_retry_iterations: number of iterations to wait for
         LIMITED_RETRY steps
+    :param dict step_limits: Mapping of step class to number of executions
+        allowed in a convergence cycle
     :param callable execute_convergence: like :func`execute_convergence`, to
         be used for test injection only
     """
@@ -757,6 +759,8 @@ class Converger(MultiService):
             to be used for test injection only
         :param int limited_retry_iterations: number of iterations to wait for
             LIMITED_RETRY steps
+        :param dict step_limits: Mapping of step name to number of executions
+            allowed in a convergence cycle
         """
         MultiService.__init__(self)
         self.log = log.bind(otter_service='converger')

--- a/otter/convergence/transforming.py
+++ b/otter/convergence/transforming.py
@@ -6,11 +6,10 @@ Functions for transforming collections of steps.
 - limiting (by truncating the number of steps we take)
 """
 
-from functools import partial
-
 from pyrsistent import pbag, pmap, pset
 
 from toolz.curried import groupby
+from toolz.dicttoolz import merge
 from toolz.itertoolz import concat, concatv
 
 from otter.convergence.steps import (
@@ -18,7 +17,6 @@ from otter.convergence.steps import (
     CreateServer,
     CreateStack,
     RemoveNodesFromCLB)
-from otter.util.config import config_value
 
 
 _optimizers = {}
@@ -93,12 +91,29 @@ def optimize_steps(steps):
 
 
 _DEFAULT_STEP_LIMITS = pmap({
-    CreateServer: config_value("converger.create_server_steps_limit") or 10,
+    CreateServer: 10,
     CreateStack: 10
 })
 
 
-def _limit_step_count(steps, step_limits):
+step_conf_to_class = {"create_server": CreateServer}
+
+
+def get_step_limits_from_conf(limit_conf):
+    """
+    Get step limits along with defaults for steps not in limit_conf
+
+    :param dict limit_conf: step name -> limit mapping
+
+    :return: `dict` of step class -> limit
+    """
+    step_limits = {
+        step_conf_to_class[step_conf]: limit
+        for step_conf, limit in limit_conf.items()}
+    return merge(_DEFAULT_STEP_LIMITS, step_limits)
+
+
+def limit_steps_by_count(steps, step_limits):
     """
     Limits step count by type.
 
@@ -111,7 +126,3 @@ def _limit_step_count(steps, step_limits):
     return pbag(concat(typed_steps[:step_limits.get(cls)]
                        for (cls, typed_steps)
                        in groupby(type, steps).iteritems()))
-
-
-limit_steps_by_count = partial(
-    _limit_step_count, step_limits=_DEFAULT_STEP_LIMITS)

--- a/otter/tap/api.py
+++ b/otter/tap/api.py
@@ -298,7 +298,8 @@ def makeService(config):
                 parent, kz_client, dispatcher,
                 config_value('converger.interval') or 10,
                 config_value('converger.build_timeout') or 3600,
-                config_value('converger.limited_retry_iterations') or 10)
+                config_value('converger.limited_retry_iterations') or 10,
+                config_value('converger.step_limits') or {})
 
         d.addCallback(on_client_ready)
         d.addErrback(log.err, 'Could not start TxKazooClient')
@@ -307,7 +308,7 @@ def makeService(config):
 
 
 def setup_converger(parent, kz_client, dispatcher, interval, build_timeout,
-                    limited_retry_iterations):
+                    limited_retry_iterations, step_limits):
     """
     Create a Converger service, which has a Partitioner as a child service, so
     that if the Converger is stopped, the partitioner is also stopped.
@@ -317,11 +318,10 @@ def setup_converger(parent, kz_client, dispatcher, interval, build_timeout,
         kz_client=kz_client,
         interval=interval,
         partitioner_path=CONVERGENCE_PARTITIONER_PATH,
-        time_boundary=15,  # time boundary
+        time_boundary=1,  # time boundary
     )
     cvg = Converger(log, dispatcher, 10, partitioner_factory, build_timeout,
-                    interval / 2,
-                    limited_retry_iterations)
+                    interval / 2, limited_retry_iterations, step_limits)
     cvg.setServiceParent(parent)
     watch_children(kz_client, CONVERGENCE_DIRTY_DIR, cvg.divergent_changed)
 

--- a/otter/tap/api.py
+++ b/otter/tap/api.py
@@ -318,7 +318,7 @@ def setup_converger(parent, kz_client, dispatcher, interval, build_timeout,
         kz_client=kz_client,
         interval=interval,
         partitioner_path=CONVERGENCE_PARTITIONER_PATH,
-        time_boundary=1,  # time boundary
+        time_boundary=15,  # time boundary
     )
     cvg = Converger(log, dispatcher, 10, partitioner_factory, build_timeout,
                     interval / 2, limited_retry_iterations, step_limits)

--- a/otter/test/convergence/test_planning.py
+++ b/otter/test/convergence/test_planning.py
@@ -1114,6 +1114,7 @@ class PlanLaunchServerTests(SynchronousTestCase):
             desired_group_state,
             0,
             build_timeout=3600,
+            step_limits={CreateServer: 10},
             servers=set([server('server1', state=ServerState.ACTIVE,
                                 servicenet_address='1.1.1.1',
                                 desired_lbs=desired_lbs),
@@ -1139,6 +1140,7 @@ class PlanLaunchServerTests(SynchronousTestCase):
             desired_group_state,
             now=1,
             build_timeout=1,
+            step_limits={},
             servers=set([server('server1', state=ServerState.BUILD,
                         servicenet_address='1.1.1.1', created=0)]),
             lb_nodes=set())
@@ -1608,6 +1610,7 @@ class PlanLaunchStackTests(SynchronousTestCase):
             desired_group_state=desired_group_state,
             now=0,
             build_timeout=3600,
+            step_limits={CreateStack: 10},
             stacks=set([stack('stack1'),
                         stack('stack2', action='CHECK', status='COMPLETE')]))
 


### PR DESCRIPTION
steps limit is taken from config when creating `Converger` and it is passed all the way down to planner which limits the number of steps executed. 

This fixes for previous not working #1829 PR. https://github.com/rackerlabs/autoscaling-chef/pull/813 sets the respective config. 