### PR TITLE
Replace "changes to project'

### DIFF
--- a/api-docs/rst/dev-guide/README.md
+++ b/api-docs/rst/dev-guide/README.md
@@ -18,7 +18,7 @@ Contributions are welcome!
 
 * To suggest changes or report a problem, submit an [issue](https://github.com/rackerlabs/otter/issues). 
 
-* To make changes to a project, create your own fork of the repository. Then, submit a [pull 
+* To make changes to the documentation, create your own fork of the repository. Then, submit a [pull 
 request](https://github.com/rackerlabs/otter/compare?expand=1) to have your changes reviewed 
 and merged into the master branch as appropriate.
 


### PR DESCRIPTION
Updated instructions for contributing to specify "changes to the documentation" to differentiate from  "changes to the product source code" per review comment.