### PR TITLE
Add metadata to _deconst.json for Edit link

### DIFF
--- a/api-docs/rst/dev-guide/_deconst.json
+++ b/api-docs/rst/dev-guide/_deconst.json
@@ -1,3 +1,8 @@
 {
-  "contentIDBase": "https://github.com/rackerlabs/otter/"
+  "contentIDBase": "https://github.com/rackerlabs/otter/",
+  "githubUrl": "https://github.com/rackerlabs/otter/",
+  "githubBranch": "master",
+  "meta": {
+    "preferGithubIssues": false
+  }
 }


### PR DESCRIPTION
Putting this metadata in place is to support the Edit on github feature to be added to the docs user interface.  The feature is not implemented yet.  In the meantime, the metadata has no effect. 