### PR TITLE
Change user guide create scaling link refid

### DIFF
--- a/api-docs/rst/dev-guide/getting-started/examples/create-scaling-group.rst
+++ b/api-docs/rst/dev-guide/getting-started/examples/create-scaling-group.rst
@@ -1,4 +1,4 @@
-.. _create-scaling-group:
+.. _create-a-scaling-group:
 
 Create a scaling group
 ~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Refid duplicates API reference link title for Create scaling group
operation.