### PR TITLE
Filter launch stack groups

### DIFF
--- a/otter/metrics.py
+++ b/otter/metrics.py
@@ -42,7 +42,7 @@ from otter.convergence.model import (
 from otter.effect_dispatcher import get_legacy_dispatcher, get_log_dispatcher
 from otter.log import log as otter_log
 from otter.models.cass import CassScalingGroupCollection
-from otter.models.intents import GetAllGroups, get_model_dispatcher
+from otter.models.intents import GetAllValidGroups, get_model_dispatcher
 from otter.util.fp import partition_bool
 
 
@@ -266,7 +266,7 @@ def collect_metrics(reactor, config, log, client=None, authenticator=None,
                                 get_service_configs(config), store)
 
     # calculate metrics on launch_server groups
-    groups = yield perform(dispatcher, Effect(GetAllGroups()))
+    groups = yield perform(dispatcher, Effect(GetAllValidGroups()))
     groups = [g for g in groups
               if json.loads(g["launch_config"]).get("type") == "launch_server"]
     tenanted_groups = groupby(lambda g: g["tenantId"], groups)

--- a/otter/models/cass.py
+++ b/otter/models/cass.py
@@ -1710,9 +1710,9 @@ class CassScalingGroupCollection:
                               self.reactor.seconds() - start_time}))
         return d
 
-    def get_all_groups(self):
+    def get_all_valid_groups(self):
         """
-        Get *all* valid scaling groups, grouped by tenantId.
+        Get all *valid* scaling groups
 
         :return: `Deferred` fired with ``list`` of group ``dict``
         """

--- a/otter/models/intents.py
+++ b/otter/models/intents.py
@@ -16,13 +16,13 @@ from otter.util.fp import assoc_obj
 
 
 @attr.s
-class GetAllGroups(object):
+class GetAllValidGroups(object):
     pass
 
 
 @deferred_performer
-def perform_get_all_groups(store, dispatcher, intent):
-    return store.get_all_groups()
+def perform_get_all_valid_groups(store, dispatcher, intent):
+    return store.get_all_valid_groups()
 
 
 @attributes(['tenant_id', 'group_id'])
@@ -138,5 +138,5 @@ def get_model_dispatcher(log, store):
         UpdateServersCache: perform_update_servers_cache,
         UpdateGroupErrorReasons: perform_update_error_reasons,
         ModifyGroupStatePaused: perform_modify_group_state_paused,
-        GetAllGroups: partial(perform_get_all_groups, store),
+        GetAllValidGroups: partial(perform_get_all_valid_groups, store),
     })

--- a/otter/test/models/test_cass_models.py
+++ b/otter/test/models/test_cass_models.py
@@ -3972,9 +3972,8 @@ class GetScalingGroupsTests(SynchronousTestCase):
         rows = [assoc(row, "tenantId", "t1") for row in rows]
         mock_gsgr.return_value = defer.succeed(rows)
         results = self.successResultOf(collection.get_all_groups())
-        self.assertEqual(results, {"t1": [rows[0], rows[3]]})
-        mock_gsgr.assert_called_once_with(
-            props=["status", "deleting", "created_at"])
+        self.assertEqual(results, [rows[0], rows[3]])
+        mock_gsgr.assert_called_once_with()
 
 
 class GetScalingGroupRowsTests(SynchronousTestCase):
@@ -3992,9 +3991,7 @@ class GetScalingGroupRowsTests(SynchronousTestCase):
             return defer.succeed(self.exec_args[freeze((query, params))])
 
         self.client.execute.side_effect = _exec
-        self.select = ('SELECT "groupId","tenantId",'
-                       'active,desired,pending '
-                       'FROM scaling_group ')
+        self.select = 'SELECT * FROM scaling_group '
 
     def _add_exec_args(self, query, params, ret):
         self.exec_args[freeze((query, params))] = ret
@@ -4013,15 +4010,14 @@ class GetScalingGroupRowsTests(SynchronousTestCase):
 
     def test_gets_props(self):
         """
-        If props arg is given then returns groups with that property in it
+        If props arg is given then returns groups with only that property in it
         """
         groups = [{'tenantId': 1, 'groupId': 2, 'desired': 3,
                    'created_at': 'c', 'launch': 'l'},
                   {'tenantId': 1, 'groupId': 3, 'desired': 2,
                    'created_at': 'c', 'launch': 'b'}]
         self._add_exec_args(
-            ('SELECT "groupId","tenantId",active,'
-             'desired,launch,pending '
+            ('SELECT launch '
              'FROM scaling_group  LIMIT :limit;'),
             {'limit': 5}, groups)
         d = self.collection.get_scaling_group_rows(props=['launch'],

--- a/otter/test/models/test_cass_models.py
+++ b/otter/test/models/test_cass_models.py
@@ -3953,7 +3953,7 @@ class CassAdminTestCase(SynchronousTestCase):
 
 
 class GetScalingGroupsTests(SynchronousTestCase):
-    """Tests for ``get_all_groups``."""
+    """Tests for ``get_all_valid_groups``."""
 
     @mock.patch("otter.models.cass.CassScalingGroupCollection"
                 ".get_scaling_group_rows")
@@ -3971,7 +3971,7 @@ class GetScalingGroupsTests(SynchronousTestCase):
             {'created_at': '0', 'desired': 'some', 'status': 'ERROR'}]
         rows = [assoc(row, "tenantId", "t1") for row in rows]
         mock_gsgr.return_value = defer.succeed(rows)
-        results = self.successResultOf(collection.get_all_groups())
+        results = self.successResultOf(collection.get_all_valid_groups())
         self.assertEqual(results, [rows[0], rows[3]])
         mock_gsgr.assert_called_once_with()
 

--- a/otter/test/test_metrics.py
+++ b/otter/test/test_metrics.py
@@ -321,9 +321,13 @@ class CollectMetricsTests(SynchronousTestCase):
              "launch_config": '{"type": "launch_server"}'},
             {"tenantId": "t1", "groupId": "g2",
              "launch_config": '{"type": "launch_server"}'},
+            {"tenantId": "t1", "groupId": "g12",
+             "launch_config": '{"type": "launch_stack"}'},
             {"tenantId": "t3", "groupId": "g3",
-             "launch_config": '{"type": "launch_stack"}'}]
-        self.lc_groups = {"t1": self.groups[:2]}
+             "launch_config": '{"type": "launch_stack"}'},
+            {"tenantId": "t2", "groupId": "g11",
+             "launch_config": '{"type": "launch_server"}'}]
+        self.lc_groups = {"t1": self.groups[:2], "t2": [self.groups[-1]]}
 
         self.add_to_cloud_metrics = patch(
             self, 'otter.metrics.add_to_cloud_metrics',
@@ -343,7 +347,7 @@ class CollectMetricsTests(SynchronousTestCase):
             (GetAllGroups(), const(self.groups)),
             (TenantScope(mock.ANY, "tid"),
              nested_sequence([
-                 (("atcm", 200, "r", "metrics", 1, self.config,
+                 (("atcm", 200, "r", "metrics", 2, self.config,
                    self.log, False), noop)
              ]))
         ])

--- a/otter/test/test_metrics.py
+++ b/otter/test/test_metrics.py
@@ -24,7 +24,7 @@ from otter.auth import IAuthenticator
 from otter.cloud_client import TenantScope, service_request
 from otter.constants import ServiceType
 from otter.metrics import (
-    GetAllGroups,
+    GetAllValidGroups,
     GroupMetrics,
     MetricsService,
     Options,
@@ -344,7 +344,7 @@ class CollectMetricsTests(SynchronousTestCase):
                        "non-convergence-tenants": ["ct"]}
 
         self.sequence = SequenceDispatcher([
-            (GetAllGroups(), const(self.groups)),
+            (GetAllValidGroups(), const(self.groups)),
             (TenantScope(mock.ANY, "tid"),
              nested_sequence([
                  (("atcm", 200, "r", "metrics", 2, self.config,
@@ -399,7 +399,7 @@ class CollectMetricsTests(SynchronousTestCase):
         Doesnt add metrics to blueflood if metrics config is not there
         """
         sequence = SequenceDispatcher([
-            (GetAllGroups(), const(self.groups))
+            (GetAllValidGroups(), const(self.groups))
         ])
         self.get_dispatcher.return_value = sequence
         del self.config["metrics"]


### PR DESCRIPTION
While testing #1848 I found that `launch_stack` groups skewing the metric. Hence filtering it out. Might need to implement separate metric that involves fetching stacks instead of servers for these kind of groups.