### PR TITLE
Convergence tenants metrics fix

### DIFF
--- a/otter/metrics.py
+++ b/otter/metrics.py
@@ -42,7 +42,6 @@ from otter.effect_dispatcher import get_legacy_dispatcher, get_log_dispatcher
 from otter.log import log as otter_log
 from otter.models.cass import CassScalingGroupCollection
 from otter.models.intents import GetAllGroups, get_model_dispatcher
-from otter.util.config import config_value
 from otter.util.fp import partition_bool
 
 

--- a/otter/metrics.py
+++ b/otter/metrics.py
@@ -164,7 +164,7 @@ def calc_total(group_metrics):
 
 
 @do
-def add_to_cloud_metrics(ttl, region, group_metrics, no_tenants, config,
+def add_to_cloud_metrics(ttl, region, group_metrics, num_tenants, config,
                          log=None, _print=False):
     """
     Add total number of desired, actual and pending servers of a region
@@ -172,7 +172,7 @@ def add_to_cloud_metrics(ttl, region, group_metrics, no_tenants, config,
 
     :param str region: which region's metric is collected
     :param group_metrics: List of :obj:`GroupMetric`
-    :param int no_tenants: total number of tenants
+    :param int num_tenants: total number of tenants
     :param dict config: Config json dict containing convergence tenants info
     :param log: Optional logger
     :param bool _print: Should it print activity on stdout? Useful when running
@@ -194,7 +194,7 @@ def add_to_cloud_metrics(ttl, region, group_metrics, no_tenants, config,
             total.desired, total.actual, total.pending))
 
     metrics = [('desired', total.desired), ('actual', total.actual),
-               ('pending', total.pending), ('tenants', no_tenants),
+               ('pending', total.pending), ('tenants', num_tenants),
                ('groups', len(group_metrics))]
     for tenant_id, metric in sorted(tenanted_metrics.items()):
         metrics.append(("{}.desired".format(tenant_id), metric.desired))

--- a/otter/metrics.py
+++ b/otter/metrics.py
@@ -165,8 +165,8 @@ def calc_total(group_metrics):
 
 
 @do
-def add_to_cloud_metrics(ttl, region, group_metrics, no_tenants, log=None,
-                         _print=False):
+def add_to_cloud_metrics(ttl, region, group_metrics, no_tenants, config,
+                         log=None, _print=False):
     """
     Add total number of desired, actual and pending servers of a region
     to Cloud metrics.
@@ -174,6 +174,7 @@ def add_to_cloud_metrics(ttl, region, group_metrics, no_tenants, log=None,
     :param str region: which region's metric is collected
     :param group_metrics: List of :obj:`GroupMetric`
     :param int no_tenants: total number of tenants
+    :param dict config: Config json dict containing convergence tenants info
     :param log: Optional logger
     :param bool _print: Should it print activity on stdout? Useful when running
         as a script
@@ -203,7 +204,8 @@ def add_to_cloud_metrics(ttl, region, group_metrics, no_tenants, log=None,
 
     # convergence tenants desired and actual
     conv_tenants = keyfilter(
-        partial(tenant_is_enabled, get_config_value=config_value),
+        partial(tenant_is_enabled,
+                get_config_value=lambda k: get_in([k], config)),
         tenanted_metrics)
     conv_desired = sum(m.desired for m in conv_tenants.itervalues())
     conv_actual = sum(m.actual for m in conv_tenants.itervalues())
@@ -273,7 +275,7 @@ def collect_metrics(reactor, config, log, client=None, authenticator=None,
     if metr_conf is not None:
         eff = add_to_cloud_metrics(
             metr_conf['ttl'], config['region'], group_metrics,
-            len(tenanted_groups), log, _print)
+            len(tenanted_groups), config, log, _print)
         eff = Effect(TenantScope(eff, metr_conf['tenant_id']))
         yield perform(dispatcher, eff)
         log.msg('added to cloud metrics')
@@ -282,7 +284,8 @@ def collect_metrics(reactor, config, log, client=None, authenticator=None,
     if _print:
         group_metrics.sort(key=lambda g: abs(g.desired - g.actual),
                            reverse=True)
-        print('groups sorted as per divergence', *group_metrics, sep='\n')
+        print('groups sorted as per divergence')
+        print('\n'.join(map(str, group_metrics)))
 
     # Disconnect only if we created the client
     if not client:

--- a/otter/test/test_metrics.py
+++ b/otter/test/test_metrics.py
@@ -192,7 +192,7 @@ class AddToCloudMetricsTests(SynchronousTestCase):
                    GroupMetrics('t2', 'g1', 4, 4, 1),
                    GroupMetrics('t2', 'g', 100, 20, 0),
                    GroupMetrics('t3', 'g3', 5, 3, 0)]
-        set_config_for_test(self, {"non-convergence-tenants": ["t1"]})
+        config = {"non-convergence-tenants": ["t1"]}
         m = {'collectionTime': 100000, 'ttlInSeconds': 5 * 24 * 60 * 60}
         md = merge(m, {'metricValue': 112, 'metricName': 'ord.desired'})
         ma = merge(m, {'metricValue': 29, 'metricName': 'ord.actual'})
@@ -222,7 +222,8 @@ class AddToCloudMetricsTests(SynchronousTestCase):
                 ServiceType.CLOUD_METRICS_INGEST, "POST", "ingest",
                 data=req_data, log=log).intent, noop)
         ]
-        eff = add_to_cloud_metrics(m['ttlInSeconds'], 'ord', metrics, 3, log)
+        eff = add_to_cloud_metrics(m['ttlInSeconds'], 'ord', metrics, 3,
+                                   config, log)
         self.assertIsNone(perform_sequence(seq, eff))
         log.msg.assert_called_once_with(
             'total desired: {td}, total_actual: {ta}, total pending: {tp}',
@@ -335,7 +336,8 @@ class CollectMetricsTests(SynchronousTestCase):
             (GetAllGroups(), const(self.groups)),
             (TenantScope(mock.ANY, "tid"),
              nested_sequence([
-                 (("atcm", 200, "r", "metrics", 2, self.log, False), noop)
+                 (("atcm", 200, "r", "metrics", 2, self.config,
+                   self.log, False), noop)
              ]))
         ])
         self.get_dispatcher = patch(self, "otter.metrics.get_dispatcher",

--- a/otter/test/test_metrics.py
+++ b/otter/test/test_metrics.py
@@ -221,7 +221,8 @@ class AddToCloudMetricsTests(SynchronousTestCase):
                 ServiceType.CLOUD_METRICS_INGEST, "POST", "ingest",
                 data=req_data, log=log).intent, noop)
         ]
-        eff = add_to_cloud_metrics(m['ttlInSeconds'], 'ord', metrics, 3,
+        eff = add_to_cloud_metrics(m['ttlInSeconds'], 'ord', metrics,
+                                   3, # number of tenants
                                    config, log)
         self.assertIsNone(perform_sequence(seq, eff))
         log.msg.assert_called_once_with(

--- a/otter/test/test_metrics.py
+++ b/otter/test/test_metrics.py
@@ -48,8 +48,7 @@ from otter.test.utils import (
     nested_sequence,
     noop,
     patch,
-    resolve_effect,
-    set_config_for_test
+    resolve_effect
 )
 
 

--- a/otter/test/test_metrics.py
+++ b/otter/test/test_metrics.py
@@ -330,7 +330,7 @@ class CollectMetricsTests(SynchronousTestCase):
                        'cloudLoadBalancers': 'clb',
                        'cloudOrchestration': 'orch',
                        'rackconnect': 'rc',
-                       "convergence-tenants": ["ct"]}
+                       "non-convergence-tenants": ["ct"]}
 
         self.sequence = SequenceDispatcher([
             (GetAllGroups(), const(self.groups)),

--- a/otter/test/test_metrics.py
+++ b/otter/test/test_metrics.py
@@ -222,7 +222,7 @@ class AddToCloudMetricsTests(SynchronousTestCase):
                 data=req_data, log=log).intent, noop)
         ]
         eff = add_to_cloud_metrics(m['ttlInSeconds'], 'ord', metrics,
-                                   3, # number of tenants
+                                   3,  # number of tenants
                                    config, log)
         self.assertIsNone(perform_sequence(seq, eff))
         log.msg.assert_called_once_with(


### PR DESCRIPTION
Turns out I didn't set the global config data via `set_config_data` to use `config_value` in #1848 :confused: . However, instead of doing that I am passing config to the function that is done throughout `metrics.py` which is much better than managing global state. Functional programming yo.. (i miss @radix). Have tested this.