### PR TITLE
draining info in delete server docs

### DIFF
--- a/api-docs/rst/dev-guide/api-operations/methods/delete-delete-server-from-scaling-group-v1.0-tenantid-groups-groupid-servers-serverid.rst
+++ b/api-docs/rst/dev-guide/api-operations/methods/delete-delete-server-from-scaling-group-v1.0-tenantid-groups-groupid-servers-serverid.rst
@@ -8,7 +8,7 @@ Delete server from scaling group
 
     DELETE /v1.0/{tenantId}/groups/{groupId}/servers/{serverId}
 
-This operation deletes and replaces a specified server in a scaling group.
+This operation deletes and replaces a specified server in a scaling group. If group launch configuration has ``draining_timeout`` then the load balancer node associated with this server is put in DRAINING for the given time before the server is deleted.
 
 You can delete and replace a server in a scaling group with a new server in that scaling group. By default, the specified server is deleted and replaced. The replacement server has the current launch configuration settings and a different IP address.
 
@@ -17,10 +17,6 @@ You can delete and replace a server in a scaling group with a new server in that
    The ``replace`` parameter is optional for this method. The default setting is ``replace=true``, even if this parameter is not passed. Use ``replace=false`` if you do not want the deleted server replaced.
 
    Similarly, the ``purge`` parameter is also optional. Default is ``purge=true``, which automatically deletes the server from the account. Use ``purge=false`` if you do not want the deleted server removed from the account. You may want to do this if you want to investigate the server.
-
-..note::
-
-   This operation can be useful if you have deleted a server by using a nova command or another method that Auto Scale does not recognize. In those cases, even though the server is deleted, Auto Scale calculates that the server still exists. You can use this operation to rectify this error and bring Auto Scale in sync with the previously unrecognized delete server operation.
 
 .. note::
 

--- a/api-docs/rst/dev-guide/api-operations/methods/delete-delete-server-from-scaling-group-v1.0-tenantid-groups-groupid-servers-serverid.rst
+++ b/api-docs/rst/dev-guide/api-operations/methods/delete-delete-server-from-scaling-group-v1.0-tenantid-groups-groupid-servers-serverid.rst
@@ -30,7 +30,7 @@ You can delete and replace a server in a scaling group with a new server in that
 
 .. note::
 
-   Deleting and replacing the server takes some time. The time required depends on
+   Deleting and replacing servers in a scaling group takes some time. The time required depends on
    server type, size, and the complexity of the launch configuration settings for the replacement server.
 
 

--- a/api-docs/rst/dev-guide/api-operations/methods/delete-delete-server-from-scaling-group-v1.0-tenantid-groups-groupid-servers-serverid.rst
+++ b/api-docs/rst/dev-guide/api-operations/methods/delete-delete-server-from-scaling-group-v1.0-tenantid-groups-groupid-servers-serverid.rst
@@ -8,19 +8,30 @@ Delete server from scaling group
 
     DELETE /v1.0/{tenantId}/groups/{groupId}/servers/{serverId}
 
-This operation deletes and replaces a specified server in a scaling group. If group launch configuration has ``draining_timeout`` then the load balancer node associated with this server is put in DRAINING for the given time before the server is deleted.
+This operation deletes and replaces a specified server in a scaling group.
+If the group launch configuration specifies a ``draining_timeout`` value,
+then the load balancer node associated with this server is put in DRAINING mode
+for the specified number of seconds before the server is deleted.
 
 You can delete and replace a server in a scaling group with a new server in that scaling group. By default, the specified server is deleted and replaced. The replacement server has the current launch configuration settings and a different IP address.
 
 .. note::
 
-   The ``replace`` parameter is optional for this method. The default setting is ``replace=true``, even if this parameter is not passed. Use ``replace=false`` if you do not want the deleted server replaced.
+  The ``replace`` and ``purge`` parameters are optional for this method.
 
-   Similarly, the ``purge`` parameter is also optional. Default is ``purge=true``, which automatically deletes the server from the account. Use ``purge=false`` if you do not want the deleted server removed from the account. You may want to do this if you want to investigate the server.
+  - The *replace* parameter determines whether the server is replaced while it is being deleted.
+    If the parameter is not specified, the value defaults to ``replace=true``.
+    Specify ``replace=false`` if you do not want the deleted server to be replaced.
+
+  - The *purge* parameter determines whether the server is removed from the account.
+    If the parameter is not specified, the value defaults to  ``purge=true``.
+    Specify ``purge=false`` to leave the server on the account.
+    This setting is useful if you want to investigate the server image after deleting it.
 
 .. note::
 
-   Deleting and replacing the server takes some time, how long depends mainly on the server image and complexity of the launch configuration settings of the replacement server.
+   Deleting and replacing the server takes some time. The time required depends on
+   server type, size, and the complexity of the launch configuration settings for the replacement server.
 
 
 

--- a/api-docs/rst/dev-guide/concepts.rst
+++ b/api-docs/rst/dev-guide/concepts.rst
@@ -644,12 +644,10 @@ When deleting servers, Autoscale follows these rules:
 -  If new servers are in the process of being built and in a "pending"
    state, these servers are chosen to be deleted first.
 
--  After choosing the servers to delete autoscale will put the server's
-   corresponding load balancer's node in DRAINING **if** the group launch
-   configuration has cloud load balancer and ``draining_timeout`` in it.
-   The server will be deleted after ``draining_timeout`` has expired. If the
-   group launch configuration doesn't have cloud load balancer and ``draining_timeout``
-   then server is just deleted
+-  After selecting servers for deletion, Autoscale deletes each server immediately,
+   unless the server has an associated load balancer that has been configured
+   with a draining timeout period. In these cases, Autoscale deletes the server
+   after the draining timeout period for the load balancer expires.
 
 The following diagram illustrates how the deletion process works.
 

--- a/api-docs/rst/dev-guide/concepts.rst
+++ b/api-docs/rst/dev-guide/concepts.rst
@@ -639,10 +639,17 @@ and how many resources to delete.
 When deleting servers, Autoscale follows these rules:
 
 -  If no new servers are in the process of being built, the oldest
-   servers are deleted first.
+   servers are chosen to be deleted first.
 
 -  If new servers are in the process of being built and in a "pending"
-   state, these servers are deleted first.
+   state, these servers are chosen to be deleted first.
+
+-  After choosing the servers to delete autoscale will put the server's
+   corresponding load balancer's node in DRAINING **if** the group launch
+   configuration has cloud load balancer and ``draining_timeout`` in it.
+   The server will be deleted after ``draining_timeout`` has expired. If the
+   group launch configuration doesn't have cloud load balancer and ``draining_timeout``
+   then server is just deleted
 
 The following diagram illustrates how the deletion process works.
 

--- a/api-docs/rst/dev-guide/concepts.rst
+++ b/api-docs/rst/dev-guide/concepts.rst
@@ -644,10 +644,11 @@ When deleting servers, Autoscale follows these rules:
 -  If new servers are in the process of being built and in a "pending"
    state, these servers are chosen to be deleted first.
 
--  After selecting servers for deletion, Autoscale deletes each server immediately,
-   unless the server has an associated load balancer that has been configured
-   with a draining timeout period. In these cases, Autoscale deletes the server
-   after the draining timeout period for the load balancer expires.
+- After selecting servers for deletion, the Autoscale process deletes each server
+  immediately, unless the server has an associated load balancer that has been
+  configured with a draining timeout period. In these cases, Autoscale puts the
+  load balancer node in DRAINING mode and waits for the draining_timeout period
+  to end before deleting the server from the scaling group.
 
 The following diagram illustrates how the deletion process works.
 


### PR DESCRIPTION
Add information about server being DRAINed before being deleted when using delete server API. @meker12 review please?