### PR TITLE
Edits for organization and clarification

### DIFF
--- a/api-docs/rst/dev-guide/api-operations/methods/delete-delete-server-from-scaling-group-v1.0-tenantid-groups-groupid-servers-serverid.rst
+++ b/api-docs/rst/dev-guide/api-operations/methods/delete-delete-server-from-scaling-group-v1.0-tenantid-groups-groupid-servers-serverid.rst
@@ -8,19 +8,20 @@ Delete server from scaling group
 
     DELETE /v1.0/{tenantId}/groups/{groupId}/servers/{serverId}
 
-This operation deletes and replaces a specified server in a scaling group. If group launch configuration has ``draining_timeout`` then the load balancer node associated with this server is put in DRAINING for the given time before the server is deleted.
+This operation deletes and replaces a specified server in a scaling group. If the group launch configuration specifies a ``draining_timeout`` value, then the load balancer node associated with this server is put in DRAINING mode for the specified number of seconds   before the server is deleted.
 
 You can delete and replace a server in a scaling group with a new server in that scaling group. By default, the specified server is deleted and replaced. The replacement server has the current launch configuration settings and a different IP address.
 
 .. note::
+   The ``replace`` and ``purge`` parameters are optional for this method.
+   
+   - The *replace* parameter determines whether the server is replaced after it is deleted. If the parameter is not specified, the value defaults to ``replace=true``. Specify ``replace=false`` if you do not want the deleted server to be replaced.
 
-   The ``replace`` parameter is optional for this method. The default setting is ``replace=true``, even if this parameter is not passed. Use ``replace=false`` if you do not want the deleted server replaced.
-
-   Similarly, the ``purge`` parameter is also optional. Default is ``purge=true``, which automatically deletes the server from the account. Use ``purge=false`` if you do not want the deleted server removed from the account. You may want to do this if you want to investigate the server.
+   - The *purge* parameter determines whether the deleted server is removed from the account. If the parameter is not specified, the value defaults to  ``purge=true``.  Specify ``purge=false`` to leave the server on the account. This setting is useful if you want to investigate the server image after deleting it.
 
 .. note::
 
-   Deleting and replacing the server takes some time, how long depends mainly on the server image and complexity of the launch configuration settings of the replacement server.
+   Deleting and replacing the server takes some time. The time required depends on server type, size, and the complexity of the launch configuration settings for the replacement server.
 
 
 


### PR DESCRIPTION
Wasn't sure whether this edit is correct:  

   Deleting and replacing the server takes some time. The time required depends on server type, size, and the complexity of the launch configuration settings for the replacement server.

Not sure what characteristics of the server affect the time to delete and replace.  -- server image type and size?   or something else.