### PR TITLE
trigger_convergence.py get_all_groups fix

### DIFF
--- a/scripts/trigger_convergence.py
+++ b/scripts/trigger_convergence.py
@@ -120,13 +120,13 @@ def get_groups(parsed, store, conf):
         return succeed(
             [{"tenantId": tid, "groupId": gid} for tid, gid in groups])
     elif parsed.all:
-        d = store.get_all_groups()
+        d = store.get_all_valid_groups()
         d.addCallback(lambda tgs: concat(tgs.values()))
     elif parsed.tenant_id:
         d = get_groups_of_tenants(log, store, parsed.tenant_id)
     elif parsed.disabled_tenants:
         non_conv_tenants = conf["non-convergence-tenants"]
-        d = store.get_all_groups()
+        d = store.get_all_valid_groups()
         d.addCallback(keyfilter(lambda k: k not in set(non_conv_tenants)))
         d.addCallback(lambda tgs: concat(tgs.values()))
     elif parsed.conf_conv_tenants:

--- a/scripts/trigger_convergence.py
+++ b/scripts/trigger_convergence.py
@@ -20,7 +20,7 @@ from datetime import datetime
 from effect import Effect, Func, parallel
 from effect.do import do, do_return
 
-from toolz.curried import keyfilter
+from toolz.curried import filter
 from toolz.itertoolz import concat
 
 import treq
@@ -121,14 +121,14 @@ def get_groups(parsed, store, conf):
             [{"tenantId": tid, "groupId": gid} for tid, gid in groups])
     elif parsed.all:
         d = store.get_all_valid_groups()
-        d.addCallback(lambda tgs: concat(tgs.values()))
     elif parsed.tenant_id:
         d = get_groups_of_tenants(log, store, parsed.tenant_id)
     elif parsed.disabled_tenants:
         non_conv_tenants = conf["non-convergence-tenants"]
         d = store.get_all_valid_groups()
-        d.addCallback(keyfilter(lambda k: k not in set(non_conv_tenants)))
-        d.addCallback(lambda tgs: concat(tgs.values()))
+        d.addCallback(
+            filter(lambda g: g["tenantId"] not in set(non_conv_tenants)))
+        d.addCallback(list)
     elif parsed.conf_conv_tenants:
         d = get_groups_of_tenants(log, store, conf["convergence-tenants"])
     else:


### PR DESCRIPTION
This script broke with #1849 since it used the older `get_all_groups` function. Now using renamed function `get_all_valid_groups`. This shows lack of regression tests and monitoring for this script. I think its better to move away from the script and add self-healing in otter-api itself via simple kazoo leader election. See #1855.