### PR TITLE
Filter error group servers

### DIFF
--- a/otter/metrics.py
+++ b/otter/metrics.py
@@ -70,6 +70,8 @@ def get_tenant_metrics(tenant_id, scaling_groups, grouped_servers,
         servers = grouped_servers.get(group_id, [])
         if group_id in groups:
             group = groups[group_id]
+            if group.get("status") in ("ERROR", "DISABLED"):
+                continue
         else:
             group = {'groupId': group_id_from_metadata(servers[0]['metadata']),
                      'desired': 0}

--- a/otter/models/cass.py
+++ b/otter/models/cass.py
@@ -1719,7 +1719,6 @@ class CassScalingGroupCollection:
         def _valid_group_row(row):
             return (row.get('created_at') is not None and
                     row.get('desired') is not None and
-                    row.get('status') not in ('DISABLED', 'ERROR') and
                     not row.get('deleting', False))
 
         d = self.get_scaling_group_rows()

--- a/otter/test/models/test_cass_models.py
+++ b/otter/test/models/test_cass_models.py
@@ -3972,7 +3972,7 @@ class GetScalingGroupsTests(SynchronousTestCase):
         rows = [assoc(row, "tenantId", "t1") for row in rows]
         mock_gsgr.return_value = defer.succeed(rows)
         results = self.successResultOf(collection.get_all_valid_groups())
-        self.assertEqual(results, [rows[0], rows[3]])
+        self.assertEqual(results, [rows[0], rows[3], rows[4], rows[6]])
         mock_gsgr.assert_called_once_with()
 
 

--- a/otter/test/test_metrics.py
+++ b/otter/test/test_metrics.py
@@ -62,10 +62,14 @@ class GetTenantMetricsTests(SynchronousTestCase):
                    [_server('g1', 'BUILD')] * 2 +
                    [_server("g1", "ERROR"), _server("g1", "DELETED"),
                     _server("g1", "SHUTOFF"), _server("g1", "PASSWORD")]),
-            'g3': [_server("g3", 'ACTIVE')]
+            'g3': [_server("g3", 'ACTIVE')],
+            'g4': [_server("g4", 'ACTIVE')],
+            'g5': [_server("g5", 'ACTIVE')]
         }
         groups = [{'groupId': 'g1', 'desired': 3},
-                  {'groupId': 'g2', 'desired': 4}]
+                  {'groupId': 'g2', 'desired': 4, "status": "ACTIVE"},
+                  {'groupId': 'g5', 'desired': 1, "status": "DISABLED"},
+                  {'groupId': 'g4', 'desired': 5, "status": "ERROR"}]
         self.assertEqual(
             set(get_tenant_metrics('t', groups, servers)),
             # g1 2 BUILD and 1 PASSWORD servers is considered pending


### PR DESCRIPTION
Fixes #1867. Note that even though behavior of `get_all_valid_groups` is changed, it should not have impact on `trigger_convergence.py` since it might want to trigger convergence on ERROR groups. In fact it fixes the script's behavior when `no_error=true` is passed. 