### PR TITLE
Change Edit on Github link to submit an issue link

### DIFF
--- a/api-docs/rst/dev-guide/_deconst.json
+++ b/api-docs/rst/dev-guide/_deconst.json
@@ -3,6 +3,6 @@
   "githubUrl": "https://github.com/rackerlabs/otter/",
   "githubBranch": "master",
   "meta": {
-    "preferGithubIssues": false
+    "preferGithubIssues": true
   }
 }


### PR DESCRIPTION
Since we use the singlehtml template, Edit on Github always opens the index.rst file.  Doesn't help people by opening the source file for current location.  Changing link to Submit and Issue.   When people click, they go to issues page where they can create a new issue.