### PR TITLE
use get_destiny to calculate active and pending servers

### DIFF
--- a/otter/test/test_metrics.py
+++ b/otter/test/test_metrics.py
@@ -59,11 +59,13 @@ class GetTenantMetricsTests(SynchronousTestCase):
         """Extracts metrics from the servers."""
         servers = {
             'g1': ([_server('g1', 'ACTIVE')] * 2 +
-                   [_server('g1', 'SUSPENDED')] +
+                   [_server('g1', 'SUSPENDED')] +   # Destiny.AVOID_REPLACING
                    [_server('g1', 'BUILD')] * 2 +
-                   [_server('g1', 'UNKNOWN')] +
-                   [_server("g1", "ERROR"), _server("g1", "DELETED"),
-                    _server("g1", "SHUTOFF"), _server("g1", "PASSWORD")]),
+                   [_server('g1', 'UNKNOWN')] +  # Destiny.IGNORE
+                   [_server("g1", "ERROR"),  # Destiny.DELETE
+                    _server("g1", "DELETED"),  # Destiny.CLEANUP
+                    _server("g1", "SHUTOFF"),  # Destiny.DELETE
+                    _server("g1", "PASSWORD")]),  # Destiny.WAIT
             'g3': [_server("g3", 'ACTIVE')],
             'g4': [_server("g4", 'ACTIVE')],
             'g5': [_server("g5", 'ACTIVE')]

--- a/otter/test/test_metrics.py
+++ b/otter/test/test_metrics.py
@@ -58,8 +58,10 @@ class GetTenantMetricsTests(SynchronousTestCase):
     def test_get_tenant_metrics(self):
         """Extracts metrics from the servers."""
         servers = {
-            'g1': ([_server('g1', 'ACTIVE')] * 3 +
+            'g1': ([_server('g1', 'ACTIVE')] * 2 +
+                   [_server('g1', 'SUSPENDED')] +
                    [_server('g1', 'BUILD')] * 2 +
+                   [_server('g1', 'UNKNOWN')] +
                    [_server("g1", "ERROR"), _server("g1", "DELETED"),
                     _server("g1", "SHUTOFF"), _server("g1", "PASSWORD")]),
             'g3': [_server("g3", 'ACTIVE')],


### PR DESCRIPTION
since that is used by convergence. This way metrics handles all the server statues. For example, it now handles SUSPENDED state through `get_destiny`. 