### PR TITLE
RCv3 LB_ID case insensitive

### DIFF
--- a/otter/cloud_client/rcv3.py
+++ b/otter/cloud_client/rcv3.py
@@ -7,7 +7,8 @@ import re
 
 from pyrsistent import pset
 
-from toolz.functoolz import curry, identity
+from toolz.functoolz import compose, curry, identity
+from toolz.curried import map
 
 from otter.cloud_client import (
     ExceptionWithMessage, ServiceType, log_success_response, service_request)
@@ -189,7 +190,8 @@ def _check_bulk_add(attempted_pairs, result):
     if errors:
         raise BulkErrors(errors)
     elif exists:
-        to_retry = pset(attempted_pairs) - exists
+        lc_set = compose(pset, map(lambda (l, s): (l.lower(), s.lower())))
+        to_retry = lc_set(attempted_pairs) - lc_set(exists)
         return bulk_add(to_retry) if to_retry else None
     else:
         raise UnknownBulkResponse(body)
@@ -262,7 +264,8 @@ def _check_bulk_delete(attempted_pairs, result):
     if errors:
         raise BulkErrors(errors)
     elif non_members:
-        to_retry = pset(attempted_pairs) - non_members
+        lc_set = compose(pset, map(lambda (l, s): (l.lower(), s.lower())))
+        to_retry = lc_set(attempted_pairs) - lc_set(non_members)
         return bulk_delete(to_retry) if to_retry else None
     else:
         raise UnknownBulkResponse(body)

--- a/otter/cloud_client/rcv3.py
+++ b/otter/cloud_client/rcv3.py
@@ -7,7 +7,6 @@ import re
 
 from pyrsistent import pset
 
-from toolz.curried import map
 from toolz.functoolz import curry, identity
 
 from otter.cloud_client import (
@@ -136,6 +135,14 @@ class UnknownBulkResponse(ExceptionWithMessage):
             "Unknown bulk API response: {}".format(body))
 
 
+def normalize_lb_id(lb_id):
+    """
+    Load balancer IDs are case insensitive. Here, we normalize it to lower case
+    for consistency and comparison
+    """
+    return lb_id.lower()
+
+
 def bulk_add(lb_node_pairs):
     """
     Bulk add RCv3 LB Nodes. If RCv3 returns error about a pair being already
@@ -147,9 +154,10 @@ def bulk_add(lb_node_pairs):
         when all pairs are already members. Otherwise raises `BulkErrors` or
         `UnknownBulkResponse`
     """
-    eff = _rackconnect_bulk_request(lb_node_pairs, "POST",
+    pairs = [(normalize_lb_id(l), n) for l, n in lb_node_pairs]
+    eff = _rackconnect_bulk_request(pairs, "POST",
                                     success_pred=has_code(201, 409))
-    return eff.on(_check_bulk_add(lb_node_pairs))
+    return eff.on(_check_bulk_add(pairs))
 
 
 @curry
@@ -168,8 +176,8 @@ def _check_bulk_add(attempted_pairs, result):
         match = _NODE_ALREADY_A_MEMBER_PATTERN.match(error)
         if match is not None:
             pair = match.groupdict()
-            # lb_id returned in upper case
-            exists = exists.add((pair["lb_id"].lower(), pair["node_id"]))
+            exists = exists.add(
+                (normalize_lb_id(pair["lb_id"]), pair["node_id"]))
             continue
 
         match = _LB_INACTIVE_PATTERN.match(error)
@@ -191,9 +199,7 @@ def _check_bulk_add(attempted_pairs, result):
     if errors:
         raise BulkErrors(errors)
     elif exists:
-        # lb_id is case-insensitive and could've been called with upper case
-        attempted = pset(map(lambda p: (p[0].lower(), p[1]), attempted_pairs))
-        to_retry = attempted - exists
+        to_retry = pset(attempted_pairs) - exists
         return bulk_add(to_retry) if to_retry else None
     else:
         raise UnknownBulkResponse(body)
@@ -215,9 +221,10 @@ def bulk_delete(lb_node_pairs):
         all nodes are already deleted. Otherwise raises `BulkErrors` or
         `UnknownBulkResponse`
     """
-    eff = _rackconnect_bulk_request(lb_node_pairs, "DELETE",
+    pairs = [(normalize_lb_id(l), n) for l, n in lb_node_pairs]
+    eff = _rackconnect_bulk_request(pairs, "DELETE",
                                     success_pred=has_code(204, 409))
-    return eff.on(_check_bulk_delete(lb_node_pairs))
+    return eff.on(_check_bulk_delete(pairs))
 
 
 @curry
@@ -236,9 +243,8 @@ def _check_bulk_delete(attempted_pairs, result):
         match = _SERVER_NOT_A_MEMBER_PATTERN.match(error)
         if match is not None:
             pair = match.groupdict()
-            # lb_id returned is in upper case
             non_members = non_members.add(
-                (pair["lb_id"].lower(), pair["server_id"]))
+                (normalize_lb_id(pair["lb_id"]), pair["server_id"]))
             continue
 
         match = _LB_INACTIVE_PATTERN.match(error)
@@ -248,8 +254,7 @@ def _check_bulk_delete(attempted_pairs, result):
 
         match = _LB_DOESNT_EXIST_PATTERN.match(error)
         if match is not None:
-            # lb_id returned is in upper case
-            del_lb_id = match.group("lb_id").lower()
+            del_lb_id = normalize_lb_id(match.group("lb_id"))
             # consider all pairs with this LB to be removed
             removed = [(lb_id, node_id) for lb_id, node_id in attempted_pairs
                        if lb_id == del_lb_id]
@@ -269,9 +274,7 @@ def _check_bulk_delete(attempted_pairs, result):
     if errors:
         raise BulkErrors(errors)
     elif non_members:
-        # LB_ID is case-insensitive and could've been called with upper case
-        attempted = pset(map(lambda p: (p[0].lower(), p[1]), attempted_pairs))
-        to_retry = attempted - non_members
+        to_retry = pset(attempted_pairs) - non_members
         return bulk_delete(to_retry) if to_retry else None
     else:
         raise UnknownBulkResponse(body)

--- a/otter/test/cloud_client/test_rcv3.py
+++ b/otter/test/cloud_client/test_rcv3.py
@@ -106,53 +106,8 @@ class BulkAddTests(RCv3Tests):
                   r.ServerUnprocessableError(self.nodes[2])])
         )
 
-    def test_retries(self):
-        """
-        If bulk adding only returns "lb node pair is already member" error with
-        409 then other pairs are retried
-        """
-        errors = {
-            "errors": [
-                node_already_member(self.lbs[0].upper(), self.nodes[0])
-            ]
-        }
-        retried_data = r._sorted_data(
-            self.pairs - pset([(self.lbs[0], self.nodes[0])]))
+    def _check_retries(self, pairs, data, retried_data, errors):
         resp = {"response": "yo"}
-        seq = [
-            (self.svc_req_intent(self.data),
-             const(stub_json_response(errors, 409))),
-            (log_intent(
-                "request-rcv3-bulk", errors,
-                req_body=("jsonified", self.data)),
-             noop),
-            (self.svc_req_intent(retried_data),
-             const(stub_json_response(resp, 201))),
-            (log_intent(
-                "request-rcv3-bulk", resp,
-                req_body=("jsonified", retried_data)),
-             noop)
-        ]
-        self.assertEqual(perform_sequence(seq, r.bulk_add(self.pairs)), resp)
-
-    def test_retries_uppercase(self):
-        """
-        If bulk adding is called with upper case LB ID and it only returns
-        "lb node pair is already member" error with 409 then other pairs
-        are retried
-        """
-        errors = {
-            "errors": [
-                node_already_member(self.lbs[0].upper(), self.nodes[0])
-            ]
-        }
-        retried_data = r._sorted_data(
-            self.pairs - pset([(self.lbs[0], self.nodes[0])]))
-        resp = {"response": "yo"}
-        lbs = self.lbs[:]
-        lbs[0] = lbs[0].upper()
-        pairs = pset(zip(lbs, self.nodes))
-        data = r._sorted_data(pairs)
         seq = [
             (self.svc_req_intent(data),
              const(stub_json_response(errors, 409))),
@@ -168,6 +123,38 @@ class BulkAddTests(RCv3Tests):
              noop)
         ]
         self.assertEqual(perform_sequence(seq, r.bulk_add(pairs)), resp)
+
+    def test_retries(self):
+        """
+        If bulk adding only returns "lb node pair is already member" error with
+        409 then other pairs are retried
+        """
+        errors = {
+            "errors": [
+                node_already_member(self.lbs[0].upper(), self.nodes[0])
+            ]
+        }
+        retried_data = r._sorted_data(
+            self.pairs - pset([(self.lbs[0], self.nodes[0])]))
+        self._check_retries(self.pairs, self.data, retried_data, errors)
+
+    def test_retries_uppercase(self):
+        """
+        If bulk adding is called with upper case LB ID and it only returns
+        "lb node pair is already member" error with 409 then other pairs
+        are retried
+        """
+        lbs = self.lbs[:]
+        lbs[0] = lbs[0].upper()
+        pairs = pset(zip(lbs, self.nodes))
+        retried_data = r._sorted_data(
+            pairs - pset([(lbs[0], self.nodes[0])]))
+        errors = {
+            "errors": [
+                node_already_member(lbs[0], self.nodes[0])
+            ]
+        }
+        self._check_retries(pairs, self.data, retried_data, errors)
 
     def test_all_already_member(self):
         """
@@ -303,11 +290,7 @@ class BulkDeleteTests(RCv3Tests):
             pset([r.LBInactive(self.lbs[0]), r.LBInactive(self.lbs[1])])
         )
 
-    def test_retries(self):
-        """
-        If bulk_delete only returns "server not a member", lb or server deleted
-        error(s) with 409 then other pairs are retried
-        """
+    def _check_retries(self, get_pairs_data):
         errors = {
             "errors": [
                 server_not_member(self.lbs[0].upper(), self.nodes[0]),
@@ -320,12 +303,7 @@ class BulkDeleteTests(RCv3Tests):
         noder1 = "a95ae0c4-6ab8-4873-b82f-f8433840cff2"
         lbr2 = "e6d3aa7c-dfa5-4e61-96ee-1d54ac1075d2"
         noder2 = "e95ae0c4-6ab8-4873-b82f-f8433840cff2"
-        pairs = pset(
-            [(self.lbs[0], self.nodes[1]),  # test same server pairs
-             (self.lbs[2], self.nodes[0]),  # test same lb pairs
-             (lbr1, noder1), (lbr2, noder2)])
-        pairs = self.pairs | pairs
-        data = r._sorted_data(pairs)
+        pairs, data = get_pairs_data(lbr1, noder1, lbr2, noder2)
         retried_data = r._sorted_data([(lbr1, noder1), (lbr2, noder2)])
         success_resp = {"good": "response"}
         seq = [
@@ -344,51 +322,39 @@ class BulkDeleteTests(RCv3Tests):
         self.assertEqual(
             perform_sequence(seq, r.bulk_delete(pairs)), success_resp)
 
+    def test_retries(self):
+        """
+        If bulk_delete only returns "server not a member", lb or server deleted
+        error(s) with 409 then other pairs are retried
+        """
+        def get_pairs_data(lbr1, noder1, lbr2, noder2):
+            pairs = pset(
+                [(self.lbs[0], self.nodes[1]),  # test same server pairs
+                 (self.lbs[2], self.nodes[0]),  # test same lb pairs
+                 (lbr1, noder1), (lbr2, noder2)])
+            pairs |= self.pairs
+            return pairs, r._sorted_data(pairs)
+        self._check_retries(get_pairs_data)
+
     def test_retries_uppercase(self):
         """
         If bulk_delete is called with upper case LB ID and it only returns
         "server not a member", lb or server deleted error(s) with 409 then
         other pairs are retried
         """
-        errors = {
-            "errors": [
-                server_not_member(self.lbs[0].upper(), self.nodes[0]),
-                "Cloud Server {} does not exist".format(self.nodes[1]),
-                "Load Balancer Pool {} does not exist".format(
-                    self.lbs[2].upper())
-            ]
-        }
-        lbr1 = "d6d3aa7c-dfa5-4e61-96ee-1d54ac1075d2"
-        noder1 = "a95ae0c4-6ab8-4873-b82f-f8433840cff2"
-        lbr2 = "e6d3aa7c-dfa5-4e61-96ee-1d54ac1075d2"
-        noder2 = "e95ae0c4-6ab8-4873-b82f-f8433840cff2"
-        new_pairs = pset(
-            [(self.lbs[0], self.nodes[1]),  # test same server pairs
-             (self.lbs[2], self.nodes[0]),  # test same lb pairs
-             (lbr1, noder1), (lbr2, noder2)])
-        # existing pairs with upper case LB
-        lbs = self.lbs[:]
-        lbs[0] = lbs[0].upper()
-        existing_pairs = pset(zip(lbs, self.nodes))
-        pairs = existing_pairs | new_pairs
-        data = r._sorted_data(pairs)
-        retried_data = r._sorted_data([(lbr1, noder1), (lbr2, noder2)])
-        success_resp = {"good": "response"}
-        seq = [
-            (self.svc_req_intent(data),
-             const(stub_json_response(errors, 409))),
-            (log_intent(
-                "request-rcv3-bulk", errors, req_body=("jsonified", data)),
-             noop),
-            (self.svc_req_intent(retried_data),
-             const(stub_json_response(success_resp, 204))),
-            (log_intent(
-                "request-rcv3-bulk", success_resp,
-                req_body=("jsonified", retried_data)),
-             noop)
-        ]
-        self.assertEqual(
-            perform_sequence(seq, r.bulk_delete(pairs)), success_resp)
+        def get_pairs_data(lbr1, noder1, lbr2, noder2):
+            new_pairs = pset(
+                [(self.lbs[0], self.nodes[1]),  # test same server pairs
+                 (self.lbs[2], self.nodes[0]),  # test same lb pairs
+                 (lbr1, noder1), (lbr2, noder2)])
+            # existing pairs with upper case LB
+            lbs = self.lbs[:]
+            lbs[0] = lbs[0].upper()
+            existing_pairs = pset(zip(lbs, self.nodes))
+            pairs = existing_pairs | new_pairs
+            # The data will still be self.pairs since lbs[0] will be normalized
+            return pairs, r._sorted_data(self.pairs | new_pairs)
+        self._check_retries(get_pairs_data)
 
     def test_all_retries(self):
         """

--- a/otter/test/cloud_client/test_rcv3.py
+++ b/otter/test/cloud_client/test_rcv3.py
@@ -276,8 +276,10 @@ class BulkDeleteTests(RCv3Tests):
         errors = {
             "errors": [
                 server_not_member(self.lbs[0], self.nodes[0]),
+                server_not_member(self.lbs[0].upper(), self.nodes[0]),
                 "Cloud Server {} does not exist".format(self.nodes[1]),
-                "Load Balancer Pool {} does not exist".format(self.lbs[2])
+                "Load Balancer Pool {} does not exist".format(self.lbs[2]),
+                "Load Balancer Pool {} does not exist".format(self.lbs[2].upper())
             ]
         }
         lbr1 = "d6d3aa7c-dfa5-4e61-96ee-1d54ac1075d2"
@@ -316,8 +318,10 @@ class BulkDeleteTests(RCv3Tests):
         errors = {
             "errors": [
                 server_not_member(self.lbs[0], self.nodes[0]),
+                server_not_member(self.lbs[0].upper(), self.nodes[0]),
                 "Cloud Server {} does not exist".format(self.nodes[1]),
-                "Load Balancer Pool {} does not exist".format(self.lbs[2])
+                "Load Balancer Pool {} does not exist".format(self.lbs[2]),
+                "Load Balancer Pool {} does not exist".format(self.lbs[2].upper())
             ]
         }
         pairs = pset([
@@ -343,7 +347,8 @@ class BulkDeleteTests(RCv3Tests):
         errors = {
             "errors": [
                 lb_inactive(self.lbs[0]),
-                server_not_member(self.lbs[1], self.nodes[1])
+                server_not_member(self.lbs[1], self.nodes[1]),
+                server_not_member(self.lbs[1].upper(), self.nodes[1])
             ]
         }
         seq = [


### PR DESCRIPTION
LB_ID is case-insensitive and this PR handles that in request and response parsing. It primarily helps in handling response that results in retrying other pairs. Like "server already member" while adding or "server not a member" while deleting. I think it will help if mimic also gives LB_ID in upper case.