### PR TITLE
Remove optional part in description

### DIFF
--- a/api-docs/rst/dev-guide/api-operations/methods/put-update-scaling-group-configuration-v1.0-tenantid-groups-groupid-config.rst
+++ b/api-docs/rst/dev-guide/api-operations/methods/put-update-scaling-group-configuration-v1.0-tenantid-groups-groupid-config.rst
@@ -144,17 +144,17 @@ This table shows the body parameters for the request:
 |                          |                         |be an integer between 0  |
 |                          |                         |and 1000.                |
 +--------------------------+-------------------------+-------------------------+
-|\ **metadata**            |Object *(Required)*      |Optional. Custom         |
-|                          |                         |metadata for your group  |
-|                          |                         |configuration. You can   |
-|                          |                         |use this parameter for   |
-|                          |                         |custom automation, but   |
-|                          |                         |it does not change any   |
-|                          |                         |functionality in Auto    |
-|                          |                         |Scale. There currently   |
-|                          |                         |is no limitation on      |
-|                          |                         |depth.                   |
-+--------------------------+-------------------------+-------------------------+
+|\ **metadata**            |Object *(Required)*      |Custom metadata for your |
+|                          |                         |group  configuration.    |
+|                          |                         |You can use this         |
+|                          |                         |parameter for custom     |
+|                          |                         |automation, but it does  |
+|                          |                         |not change any           |
+|                          |                         |functionality in         |
+|                          |                         |Auto Scale. There        |
+|                          |                         |currently is no          |
+|                          |                         |limitation on depth.     |
+--------------------------+-------------------------+--------------------------+
 
 
 

--- a/api-docs/rst/dev-guide/api-operations/methods/put-update-scaling-group-configuration-v1.0-tenantid-groups-groupid-config.rst
+++ b/api-docs/rst/dev-guide/api-operations/methods/put-update-scaling-group-configuration-v1.0-tenantid-groups-groupid-config.rst
@@ -154,7 +154,7 @@ This table shows the body parameters for the request:
 |                          |                         |Auto Scale. There        |
 |                          |                         |currently is no          |
 |                          |                         |limitation on depth.     |
----------------------------+-------------------------+-------------------------+
++--------------------------+-------------------------+-------------------------+
 
 
 

--- a/api-docs/rst/dev-guide/api-operations/methods/put-update-scaling-group-configuration-v1.0-tenantid-groups-groupid-config.rst
+++ b/api-docs/rst/dev-guide/api-operations/methods/put-update-scaling-group-configuration-v1.0-tenantid-groups-groupid-config.rst
@@ -144,16 +144,15 @@ This table shows the body parameters for the request:
 |                          |                         |be an integer between 0  |
 |                          |                         |and 1000.                |
 +--------------------------+-------------------------+-------------------------+
-|\ **metadata**            |Object *(Required)*      |Custom metadata for your |
-|                          |                         |group configuration.     |
-|                          |                         |You can use this         |
-|                          |                         |parameter for custom     |
-|                          |                         |automation, but it does  |
-|                          |                         |not change any           |
-|                          |                         |functionality in         |
-|                          |                         |Auto Scale. There        |
-|                          |                         |currently is no          |
-|                          |                         |limitation on depth.     |
+|\ **metadata**            |Object *(Required)*      |Specifies custom metadata|
+|                          |                         |for your group           |
+|                          |                         |configuration. You can   |
+|                          |                         |use this object to enable|
+|                          |                         |custom automation. The   |
+|                          |                         |specification does not   |
+|                          |                         |affect Auto Scale        |
+|                          |                         |functionality. There is  |
+|                          |                         |no limitation on depth.  |
 +--------------------------+-------------------------+-------------------------+
 
 

--- a/api-docs/rst/dev-guide/api-operations/methods/put-update-scaling-group-configuration-v1.0-tenantid-groups-groupid-config.rst
+++ b/api-docs/rst/dev-guide/api-operations/methods/put-update-scaling-group-configuration-v1.0-tenantid-groups-groupid-config.rst
@@ -145,7 +145,7 @@ This table shows the body parameters for the request:
 |                          |                         |and 1000.                |
 +--------------------------+-------------------------+-------------------------+
 |\ **metadata**            |Object *(Required)*      |Custom metadata for your |
-|                          |                         |group  configuration.    |
+|                          |                         |group configuration.     |
 |                          |                         |You can use this         |
 |                          |                         |parameter for custom     |
 |                          |                         |automation, but it does  |
@@ -154,7 +154,7 @@ This table shows the body parameters for the request:
 |                          |                         |Auto Scale. There        |
 |                          |                         |currently is no          |
 |                          |                         |limitation on depth.     |
---------------------------+-------------------------+--------------------------+
+---------------------------+-------------------------+-------------------------+
 
 
 


### PR DESCRIPTION
since it was incorrect and is duplicated information. Fixes #1874 