### PR TITLE
Getting CLB node draining and creation time

### DIFF
--- a/otter/cloud_client/__init__.py
+++ b/otter/cloud_client/__init__.py
@@ -743,7 +743,10 @@ def get_clb_node_feed(lb_id, node_id):
         if entries == []:
             yield do_return(all_entries)
         all_entries.extend(entries)
-        params = parse_qs(urlparse(atom.next_link(feed)).query)
+        next_link = atom.next_link(feed)
+        if not next_link:
+            yield do_return(all_entries)
+        params = parse_qs(urlparse(next_link).query)
 
 
 def _expand_clb_matches(matches_tuples, lb_id, node_id=None):

--- a/otter/convergence/gathering.py
+++ b/otter/convergence/gathering.py
@@ -190,7 +190,7 @@ def get_clb_contents():
         if node.description.lb_id in deleted_lbs:
             return None
         if feed is not None:
-            return assoc_obj(node, drained_at=extract_CLB_drained_at(feed))
+            return assoc_obj(node, drained_at=extract_clb_drained_at(feed))
         else:
             return node
     nodes = map(update_drained_at, concat(lb_nodes.values()))
@@ -207,7 +207,7 @@ _DRAINING_RE = re.compile(
     "({})|({})".format(_DRAINING_UPDATED_RE, _DRAINING_CREATED_RE))
 
 
-def extract_CLB_drained_at(feed):
+def extract_clb_drained_at(feed):
     """
     Extract time when node was changed to DRAINING from a CLB atom feed. Will
     return node's creation time if node was created with DRAINING. Return None

--- a/otter/indexer/atom.py
+++ b/otter/indexer/atom.py
@@ -42,21 +42,30 @@ def entries(feed):
     return xpath('./atom:entry', feed)
 
 
-def previous_link(feed):
+def _link(feed, direction):
     """
-    Get the previous link from a particular AtomHopper feed
+    Get the previous/next link from a particular AtomHopper feed
 
     :type feed: :class:`ElementTree`
+    :param str direction: "next" or "previous"
 
     :return: the URL to the previous feed
     :rtype: ``str``
     """
-    links = xpath('./atom:link[@rel="previous"]', feed)
+    links = xpath('./atom:link[@rel="{}"]'.format(direction), feed)
 
     if len(links) == 0:
         return None
 
     return links[0].attrib['href']
+
+
+def previous_link(feed):
+    return _link(feed, "previous")
+
+
+def next_link(feed):
+    return _link(feed, "next")
 
 
 def summary(entry):

--- a/otter/indexer/atom.py
+++ b/otter/indexer/atom.py
@@ -49,7 +49,7 @@ def _link(feed, direction):
     :type feed: :class:`ElementTree`
     :param str direction: "next" or "previous"
 
-    :return: the URL to the previous feed
+    :return: the URL to the previous feed if found, otherwise ``None``
     :rtype: ``str``
     """
     links = xpath('./atom:link[@rel="{}"]'.format(direction), feed)
@@ -61,10 +61,26 @@ def _link(feed, direction):
 
 
 def previous_link(feed):
+    """
+    Get the previous link from a particular AtomHopper feed
+
+    :type feed: :class:`ElementTree`
+
+    :return: the URL to the previous feed if found, otherwise ``None``
+    :rtype: ``str``
+    """
     return _link(feed, "previous")
 
 
 def next_link(feed):
+    """
+    Get the next link from a particular AtomHopper feed
+
+    :type feed: :class:`ElementTree`
+
+    :return: the URL to the next feed if found, otherwise ``None``
+    :rtype: ``str``
+    """
     return _link(feed, "next")
 
 

--- a/otter/test/cloud_client/test_init.py
+++ b/otter/test/cloud_client/test_init.py
@@ -1005,6 +1005,21 @@ class GetCLBNodeFeedTests(SynchronousTestCase):
             [atom.summary(entry) for entry in entries],
             ["summ1", "summ2", "summ3", "summ4"])
 
+    def test_no_next_link(self):
+        """
+        Returns entries collected till now if there is no next link
+        """
+        feedstr = (
+            '<feed xmlns="http://www.w3.org/2005/Atom">'
+            '<entry><summary>summary</summary></entry></feed>')
+        seq = [
+            (self.svc_intent(), const(stub_json_response(feedstr))),
+            (log_intent("request-get-clb-node-feed", feedstr),
+             const(feedstr))
+        ]
+        entries = perform_sequence(seq, get_clb_node_feed("12", "13"))
+        self.assertEqual(atom.summary(entries[0]), "summary")
+
     def test_error_handling(self):
         """
         Parses regular CLB errors and raises corresponding exceptions

--- a/otter/test/cloud_client/test_init.py
+++ b/otter/test/cloud_client/test_init.py
@@ -602,12 +602,18 @@ class PerformTenantScopeTests(SynchronousTestCase):
              self.throttler, 1, ereq.intent))
 
 
-def assert_parses_common_clb_errors(testcase, intent, eff, lb_id="123456"):
+def assert_parses_common_clb_errors(testcase, intent, eff, lb_id):
     """
     Assert that the effect produced performs the common CLB error parsing:
     :class:`CLBImmutableError`, :class:`CLBDescription`,
     :class:`NoSuchCLBError`, :class:`CLBRateLimitError`,
     :class:`APIError`
+
+    :param :obj:`twisted.trial.unittest.TestCase` testcase: Test object
+    :param intent: expected ``ServiceRequest`` intent
+    :param eff: Effect returned from function being tested
+    :param lb_id: ID of load balancer being accessed in the function being
+        tested
     """
     json_responses_and_errs = [
         ("Load Balancer '{0}' has a status of 'BUILD' and is "
@@ -740,7 +746,7 @@ class CLBClientTests(SynchronousTestCase):
                                node_id=u'1234'))
 
         # all the common failures
-        assert_parses_common_clb_errors(self, expected.intent, eff)
+        assert_parses_common_clb_errors(self, expected.intent, eff, "123456")
 
     def test_change_clb_node_default_type(self):
         """
@@ -818,7 +824,7 @@ class CLBClientTests(SynchronousTestCase):
                               node_limit=25))
 
         # all the common failures
-        assert_parses_common_clb_errors(self, expected.intent, eff)
+        assert_parses_common_clb_errors(self, expected.intent, eff, "123456")
 
     def expected_node_removal_req(self, nodes=(1, 2)):
         """
@@ -851,7 +857,7 @@ class CLBClientTests(SynchronousTestCase):
         """
         eff = remove_clb_nodes(self.lb_id, [1, 2])
         assert_parses_common_clb_errors(
-            self, self.expected_node_removal_req().intent, eff)
+            self, self.expected_node_removal_req().intent, eff, "123456")
 
     def test_remove_clb_nodes_non_202(self):
         """Any random HTTP response code is bubbled up as an APIError."""
@@ -926,7 +932,7 @@ class CLBClientTests(SynchronousTestCase):
             ServiceType.CLOUD_LOAD_BALANCERS,
             'GET', 'loadbalancers/123456/nodes')
         assert_parses_common_clb_errors(
-            self, expected.intent, get_clb_nodes(self.lb_id))
+            self, expected.intent, get_clb_nodes(self.lb_id), "123456")
 
 
 class GetCLBNodeFeedTests(SynchronousTestCase):

--- a/otter/test/convergence/test_gathering.py
+++ b/otter/test/convergence/test_gathering.py
@@ -32,7 +32,7 @@ from otter.cloud_client import (
 )
 from otter.constants import ServiceType
 from otter.convergence.gathering import (
-    extract_CLB_drained_at,
+    extract_clb_drained_at,
     get_all_launch_server_data,
     get_all_launch_stack_data,
     get_all_scaling_group_servers,
@@ -319,7 +319,7 @@ class GetScalingGroupServersTests(SynchronousTestCase):
 
 class ExtractDrainedTests(SynchronousTestCase):
     """
-    Tests for :func:`otter.convergence.extract_CLB_drained_at`
+    Tests for :func:`otter.convergence.extract_clb_drained_at`
     """
     updated_summary = ("Node successfully updated with address: "
                        "'10.23.45.6', port: '8080', weight: '1', "
@@ -345,7 +345,7 @@ class ExtractDrainedTests(SynchronousTestCase):
             (self.updated_summary, self.updated1),
             ("don't care", self.updated2))
         self.assertEqual(
-            extract_CLB_drained_at(feed), timestamp_to_epoch(self.updated1))
+            extract_clb_drained_at(feed), timestamp_to_epoch(self.updated1))
 
     def test_created(self):
         """
@@ -354,7 +354,7 @@ class ExtractDrainedTests(SynchronousTestCase):
         feed = self.parsed_feed(
             ("summary", "2000-10-01Z"), (self.created_summary, self.updated2))
         self.assertEqual(
-            extract_CLB_drained_at(feed), timestamp_to_epoch(self.updated2))
+            extract_clb_drained_at(feed), timestamp_to_epoch(self.updated2))
 
     def test_no_match(self):
         """
@@ -362,13 +362,13 @@ class ExtractDrainedTests(SynchronousTestCase):
         """
         feed = self.parsed_feed(
             ("summary", self.updated1), ("don't care", self.updated2))
-        self.assertIsNone(extract_CLB_drained_at(feed))
+        self.assertIsNone(extract_clb_drained_at(feed))
 
     def test_empty(self):
         """
         Returns None when there are no entries in the feed
         """
-        self.assertIsNone(extract_CLB_drained_at([]))
+        self.assertIsNone(extract_clb_drained_at([]))
 
 
 def lb_req(url, json_response, response):
@@ -435,10 +435,10 @@ class GetCLBContentsTests(SynchronousTestCase):
     """
 
     def setUp(self):
-        """mock `extract_CLB_drained_at`"""
+        """mock `extract_clb_drained_at`"""
         self.feeds = {'11feed': 1.0, '22feed': 2.0}
         self.mock_eda = patch(
-            self, 'otter.convergence.gathering.extract_CLB_drained_at',
+            self, 'otter.convergence.gathering.extract_clb_drained_at',
             side_effect=lambda f: self.feeds[f])
         patch(self, "otter.convergence.gathering.get_clb_node_feed",
               side_effect=intent_func("gcnf"))

--- a/otter/test/convergence/test_gathering.py
+++ b/otter/test/convergence/test_gathering.py
@@ -405,6 +405,18 @@ def nodes_req(lb_id, nodes):
 
 
 def node_feed_req(lb_id, node_id, response):
+    """
+    Return (intent, performer) sequence for getting clb node's feed that
+    wrapped with retry intent.
+
+    :param lb_id: Lodbalancer ID
+    :param node_id: LB node ID
+    :param response: The response returned when getting CLB node feed. It is
+        either string containing feed or Exception object that will be raised
+        when getting the feed
+
+    :return: (intent, performer) tuple
+    """
     if isinstance(response, Exception):
         def handler(i): raise response
     else:

--- a/otter/test/convergence/test_gathering.py
+++ b/otter/test/convergence/test_gathering.py
@@ -51,8 +51,8 @@ from otter.convergence.model import (
     RCv3Description,
     RCv3Node,
     ServerState)
-from otter.log.intents import Log
 from otter.indexer import atom
+from otter.log.intents import Log
 from otter.test.utils import (
     EffectServersCache,
     StubResponse,

--- a/otter/test/fixtures/simple.atom
+++ b/otter/test/fixtures/simple.atom
@@ -6,6 +6,8 @@
     <link href="http://example.org/" />
     <link href="http://example.org/feed/?marker=urn:uuid:1225c695-cfb8-4ebb-aaaa-80da344efa6a"
         rel="previous" />
+    <link href="http://example.org/feed/?marker=urn:uuid:e5caea3a-188c-11e6-8692-acbc32badee9"
+        rel="next" />
     <id>urn:uuid:60a76c80-d399-11d9-b91C-0003939e0af6</id>
     <updated>2003-12-13T18:30:02Z</updated>
     <entry>

--- a/otter/test/indexer/test_atom.py
+++ b/otter/test/indexer/test_atom.py
@@ -4,11 +4,12 @@ Tests for :mod:`otter.indexer.atom`
 
 from twisted.trial.unittest import SynchronousTestCase
 
-from otter.test.utils import fixture
-
 from otter.indexer.atom import (
-    parse, summary, categories, entries, previous_link, updated, content
+    categories, content, entries, next_link, parse, previous_link, summary,
+    updated
 )
+
+from otter.test.utils import fixture
 
 
 class SimpleAtomTestCase(SynchronousTestCase):
@@ -68,6 +69,17 @@ class SimpleAtomTestCase(SynchronousTestCase):
             previous_link(self.simple_atom),
             ('http://example.org/feed/?'
              'marker=urn:uuid:1225c695-cfb8-4ebb-aaaa-80da344efa6a')
+        )
+
+    def test_next_link(self):
+        """
+        :func:`otter.indexer.next_link` finds the next link in the
+        simple sample atom feed.
+        """
+        self.assertEqual(
+            next_link(self.simple_atom),
+            ('http://example.org/feed/?'
+             'marker=urn:uuid:e5caea3a-188c-11e6-8692-acbc32badee9')
         )
 
     def test_updated(self):


### PR DESCRIPTION
Beginning of #1870.

- `extract_CLB_drained_at` now returns time when the node was updated with DRAINING or when it was created with DRAINING since technically the node was drained at the time it was created for a new node. This will be used to get new node's creation time for #1870.
- `get_clb_node_feed` now fetches more atom's next link until there are no entries effectively fixing #1443. This required changes in `atom` to parse `next_link`
