### PR TITLE
Updating mimic to "CLB node status" change

### DIFF
--- a/requirements/mimic.txt
+++ b/requirements/mimic.txt
@@ -1,1 +1,1 @@
-git+https://github.com/rackerlabs/mimic.git@b4ffe4b066430404f5363d7506a6228fcc2d5b4f
+git+https://github.com/rackerlabs/mimic.git@66deba876d69525a68235a8fdbe1ad19ef98ae38


### PR DESCRIPTION
to check that https://github.com/rackerlabs/mimic/pull/642 PR does not cause existing otter tests to fail.