### PR TITLE
Getting CLB health monitor

### DIFF
--- a/otter/cloud_client/__init__.py
+++ b/otter/cloud_client/__init__.py
@@ -763,6 +763,23 @@ def get_clb_node_feed(lb_id, node_id):
     yield do_return(all_entries)
 
 
+def is_clb_health_monitor_enabled(lb_id):
+    """
+    Does given CLB has health monitor enabled?
+    """
+    return service_request(
+        ServiceType.CLOUD_LOAD_BALANCERS,
+        'GET',
+        append_segments('loadbalancers', str(lb_id), 'healthmonitor')
+    ).on(
+        error=_only_json_api_errors(
+            lambda c, b: _process_clb_api_error(c, b, lb_id))
+    ).on(
+        log_success_response('request-get-clb-healthmon', identity)
+    ).on(
+        success=lambda (response, body): bool(body["healthMonitor"]))
+
+
 def _expand_clb_matches(matches_tuples, lb_id, node_id=None):
     """
     All CLB messages have only the keys ("message",), and the exception tpye

--- a/otter/cloud_client/__init__.py
+++ b/otter/cloud_client/__init__.py
@@ -763,9 +763,13 @@ def get_clb_node_feed(lb_id, node_id):
     yield do_return(all_entries)
 
 
-def is_clb_health_monitor_enabled(lb_id):
+def get_clb_health_monitor(lb_id):
     """
-    Does given CLB has health monitor enabled?
+    Return CLB health monitor setting
+
+    :param int lb_id: Loadbalancer ID
+
+    :return: ``Effect`` of ``dict`` representing health monitor config
     """
     return service_request(
         ServiceType.CLOUD_LOAD_BALANCERS,
@@ -777,7 +781,7 @@ def is_clb_health_monitor_enabled(lb_id):
     ).on(
         log_success_response('request-get-clb-healthmon', identity)
     ).on(
-        success=lambda (response, body): bool(body["healthMonitor"]))
+        success=lambda (response, body): body["healthMonitor"])
 
 
 def _expand_clb_matches(matches_tuples, lb_id, node_id=None):

--- a/otter/convergence/model.py
+++ b/otter/convergence/model.py
@@ -66,6 +66,22 @@ class CLBNodeType(Names):
     """
 
 
+class CLBNodeStatus(Names):
+    """
+    Constants representing online/offline status of CLB node
+    """
+
+    ONLINE = NamedConstant()
+    """
+    Node is ONLINE and is receiving traffic
+    """
+
+    OFFLINE = NamedConstant()
+    """
+    Node is marked OFFLINE by CLB and is not receiving traffic
+    """
+
+
 class ServerState(Names):
     """
     Constants representing the state of a Nova cloud server.
@@ -568,6 +584,8 @@ class CLBDescription(object):
              Attribute("description", instance_of=CLBDescription),
              Attribute("address", instance_of=basestring),
              Attribute("drained_at", default_value=0.0, instance_of=float),
+             Attribute("status", instance_of=NamedConstant,
+                       default_value=CLBNodeStatus.ONLINE),
              Attribute("connections", default_value=None)])
 class CLBNode(object):
     """
@@ -585,6 +603,10 @@ class CLBNode(object):
         nodes with the same IP and port cannot exist on a single CLB.
     :ivar float drained_at: EPOCH at which this node was put in DRAINING.
         Should be 0 if node is not DRAINING.
+
+    :ivar status: One of ``ONLINE`` or ``OFFLINE``
+    :type status: A member of :class:`CLBNodeStatus`
+
     :ivar int connections: The number of active connections on the node - this
         is None by default (the stat is not available yet).
     """
@@ -622,6 +644,7 @@ class CLBNode(object):
         return cls(
             node_id=str(json['id']),
             address=json['address'],
+            status=CLBNodeStatus.lookupByName(json["status"]),
             description=CLBDescription(
                 lb_id=str(lb_id),
                 port=json['port'],

--- a/otter/convergence/model.py
+++ b/otter/convergence/model.py
@@ -547,7 +547,9 @@ class IDrainable(Interface):
              Attribute("condition", default_value=CLBNodeCondition.ENABLED,
                        instance_of=NamedConstant),
              Attribute("type", default_value=CLBNodeType.PRIMARY,
-                       instance_of=NamedConstant)])
+                       instance_of=NamedConstant),
+             Attribute("health_monitor", default_value=False,
+                       instance_of=bool)])
 class CLBDescription(object):
     """
     Information representing a Rackspace CLB port mapping; how a particular
@@ -636,7 +638,7 @@ class CLBNode(object):
         return self.description.condition != CLBNodeCondition.DISABLED
 
     @classmethod
-    def from_node_json(cls, lb_id, json):
+    def from_node_json(cls, lb_id, json, health_mon):
         """
         Create an instance of this class based on node JSON data from the CLB
         API.
@@ -650,7 +652,8 @@ class CLBNode(object):
                 port=json['port'],
                 weight=json.get('weight', 1),
                 condition=CLBNodeCondition.lookupByName(json['condition']),
-                type=CLBNodeType.lookupByName(json['type'])))
+                type=CLBNodeType.lookupByName(json['type']),
+                health_monitor=health_mon))
 
 
 @implementer(ILBDescription)

--- a/otter/convergence/model.py
+++ b/otter/convergence/model.py
@@ -568,6 +568,8 @@ class CLBDescription(object):
 
     :ivar type: One of ``PRIMARY`` or ``SECONDARY`` - default is ``PRIMARY``
     :type type: A member of :class:`CLBNodeType`
+
+    :ivar bool health_monitor: Is health monitor enabled on this CLB?
     """
     def equivalent_definition(self, other_description):
         """

--- a/otter/test/convergence/test_model.py
+++ b/otter/test/convergence/test_model.py
@@ -251,7 +251,7 @@ class CLBNodeTests(SynchronousTestCase):
         node_json = {'id': 'node1', 'address': '1.2.3.4', 'port': 20,
                      'condition': 'DRAINING', 'type': 'SECONDARY',
                      'status': 'OFFLINE'}
-        node = CLBNode.from_node_json(123, node_json)
+        node = CLBNode.from_node_json(123, node_json, False)
         self.assertEqual(
             node,
             CLBNode(node_id='node1', address='1.2.3.4',
@@ -261,7 +261,8 @@ class CLBNodeTests(SynchronousTestCase):
                         lb_id='123', port=20,
                         weight=1,
                         condition=CLBNodeCondition.DRAINING,
-                        type=CLBNodeType.SECONDARY)))
+                        type=CLBNodeType.SECONDARY,
+                        health_monitor=False)))
 
     def test_from_node_json_with_weight(self):
         """
@@ -271,7 +272,7 @@ class CLBNodeTests(SynchronousTestCase):
         node_json = {'id': 'node1', 'address': '1.2.3.4', 'port': 20,
                      'condition': 'DRAINING', 'type': 'SECONDARY',
                      'weight': 50, 'status': 'OFFLINE'}
-        node = CLBNode.from_node_json(123, node_json)
+        node = CLBNode.from_node_json(123, node_json, True)
         self.assertEqual(
             node,
             CLBNode(node_id='node1', address='1.2.3.4',
@@ -281,7 +282,8 @@ class CLBNodeTests(SynchronousTestCase):
                         lb_id='123', port=20,
                         weight=50,
                         condition=CLBNodeCondition.DRAINING,
-                        type=CLBNodeType.SECONDARY)))
+                        type=CLBNodeType.SECONDARY,
+                        health_monitor=True)))
 
 
 class ServiceMetadataTests(SynchronousTestCase):


### PR DESCRIPTION
Part of #1870.

Add function to get CLB health monitor and get it in convergence gathering step. The next (hopefully final) PR will use this info in planner to add node as draining. 