### PR TITLE
ignore GroupPausedError when executing anonymous webhook

### DIFF
--- a/otter/rest/webhooks.py
+++ b/otter/rest/webhooks.py
@@ -10,7 +10,7 @@ import json
 from functools import partial
 
 from otter import controller
-from otter.controller import CannotExecutePolicyError
+from otter.controller import CannotExecutePolicyError, GroupPausedError
 from otter.json_schema import group_schemas
 from otter.json_schema import rest_schemas
 from otter.log import log
@@ -359,6 +359,7 @@ class OtterExecute(object):
         def log_informational_webhook_failure(failure):
             failure.trap(UnrecognizedCapabilityError,
                          CannotExecutePolicyError,
+                         GroupPausedError,
                          NoSuchPolicyError,
                          NoSuchScalingGroupError)
             logl[0].msg("Non-fatal error during webhook execution: {exc!r}",

--- a/otter/test/rest/test_webhooks.py
+++ b/otter/test/rest/test_webhooks.py
@@ -11,7 +11,7 @@ import mock
 from twisted.internet import defer
 from twisted.trial.unittest import SynchronousTestCase
 
-from otter.controller import CannotExecutePolicyError
+from otter.controller import CannotExecutePolicyError, GroupPausedError
 from otter.json_schema import rest_schemas, validate
 from otter.models.interface import (
     NoSuchPolicyError, NoSuchScalingGroupError, NoSuchWebhookError,
@@ -537,6 +537,7 @@ class OneWebhookTestCase(RestAPITestMixin, SynchronousTestCase):
         cap_log = log.bind.return_value.bind.return_value
         exceptions = [
             CannotExecutePolicyError('tenant', 'group', 'policy', 'test'),
+            GroupPausedError('tenant', 'group', 'execute_webhook'),
             NoSuchPolicyError('tenant', 'group', 'policy'),
             NoSuchScalingGroupError('tenant', 'group'),
             UnrecognizedCapabilityError("11111", 1)]


### PR DESCRIPTION
since it is not an error.