### PR TITLE
node.drained_at is 0 instead of None

### DIFF
--- a/otter/convergence/gathering.py
+++ b/otter/convergence/gathering.py
@@ -224,7 +224,7 @@ _DRAINING_RE = re.compile(
 def extract_clb_drained_at(feed):
     """
     Extract time when node was changed to DRAINING from a CLB atom feed. Will
-    return node's creation time if node was created with DRAINING. Return None
+    return node's creation time if node was created with DRAINING. Return 0
     if couldnt find for any reason.
 
     :param list feed: ``list`` of atom entry :class:`Elements`
@@ -235,7 +235,7 @@ def extract_clb_drained_at(feed):
     for entry in feed:
         if _DRAINING_RE.match(atom.summary(entry)):
             return timestamp_to_epoch(atom.updated(entry))
-    return None
+    return 0
 
 
 def get_rcv3_contents():

--- a/otter/test/convergence/test_gathering.py
+++ b/otter/test/convergence/test_gathering.py
@@ -363,13 +363,13 @@ class ExtractDrainedTests(SynchronousTestCase):
         """
         feed = self.parsed_feed(
             ("summary", self.updated1), ("don't care", self.updated2))
-        self.assertIsNone(extract_clb_drained_at(feed))
+        self.assertEqual(extract_clb_drained_at(feed), 0)
 
     def test_empty(self):
         """
         Returns None when there are no entries in the feed
         """
-        self.assertIsNone(extract_clb_drained_at([]))
+        self.assertEqual(extract_clb_drained_at([]), 0)
 
 
 def lb_req(url, json_response, response):


### PR DESCRIPTION
when it cannot find draining info. This fixes #1863 because node will look to be OFFLINE for a very long time resulting in ERRORing the group. The error log might be confusing though.