### PR TITLE
kazoo lock timeout changed to 10 from 120

### DIFF
--- a/otter/models/cass.py
+++ b/otter/models/cass.py
@@ -823,13 +823,13 @@ class CassScalingGroup(object):
             return d.addCallback(_write_state)
 
         lock = self.kz_client.Lock(LOCK_PATH + '/' + self.uuid)
-        lock.acquire = functools.partial(lock.acquire, timeout=120)
+        lock.acquire = functools.partial(lock.acquire, timeout=10)
         local_lock = self.local_locks.get_lock(self.uuid)
         return local_lock.run(
             with_lock, self.reactor, lock, _modify_state,
             log.bind(category='locking', lock_reason='modify_state'),
-            acquire_timeout=150,
-            release_timeout=30)
+            acquire_timeout=11,
+            release_timeout=10)
 
     def update_status(self, status):
         """

--- a/otter/test/models/test_cass_models.py
+++ b/otter/test/models/test_cass_models.py
@@ -799,7 +799,7 @@ class CassScalingGroupTests(CassScalingGroupTestCase):
         self.kz_client.Lock.assert_called_once_with(
             '/locks/' + self.group.uuid)
 
-        self.lock._acquire.assert_called_once_with(timeout=120)
+        self.lock._acquire.assert_called_once_with(timeout=10)
         self.lock.release.assert_called_once_with()
 
     def test_modify_state_local_lock_before_kz_lock(self):
@@ -840,7 +840,7 @@ class CassScalingGroupTests(CassScalingGroupTestCase):
         self.assertFalse(self.lock._acquire.called)
         # After local lock acquired, kz lock is acquired
         local_acquire_d.callback(None)
-        self.lock._acquire.assert_called_once_with(timeout=120)
+        self.lock._acquire.assert_called_once_with(timeout=10)
         # first kz lock is released
         self.lock.release.assert_called_once_with()
         self.assertFalse(llock.release.called)
@@ -871,7 +871,7 @@ class CassScalingGroupTests(CassScalingGroupTestCase):
         self.assertEqual(self.connection.execute.call_count, 0)
         self.kz_client.Lock.assert_called_once_with(
             '/locks/' + self.group.uuid)
-        self.lock._acquire.assert_called_once_with(timeout=120)
+        self.lock._acquire.assert_called_once_with(timeout=10)
         self.assertEqual(self.lock.release.call_count, 0)
 
     def test_modify_state_lock_log_category_locking(self):


### PR DESCRIPTION
Temporary workaround for #1915. The short lock timeout will delete corrupt znode quickly thereby allowing other contenders to get the lock.