### PR TITLE
use PollingLock in SelfHeal service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ endif
 
 coverage:
 	PYRSISTENT_NO_C_EXTENSION=true coverage run --source=${CODEDIR} \
-		--omit="/test/*","*/integration/tests/*","*/integration/lib/test_*.py" \
+		--omit="*/test/*","*/integration/tests/*","*/integration/lib/test_*.py" \
 		--branch `which trial` ${TRIAL_OPTIONS} ${UNITTESTS}
 
 coverage-html: coverage

--- a/otter/convergence/selfheal.py
+++ b/otter/convergence/selfheal.py
@@ -39,7 +39,8 @@ class SelfHeal(MultiService, object):
         represents scheduled call to trigger convergence on a group
     """
 
-    def __init__(self, dispatcher, interval, log, clock, config_func):
+    def __init__(self, dispatcher, interval, log, clock, config_func,
+                 lock=None):
         """
         :var float interval: All groups will be scheduled to be triggered
             within this time
@@ -49,7 +50,7 @@ class SelfHeal(MultiService, object):
         super(SelfHeal, self).__init__()
         self.disp = dispatcher
         self.log = log.bind(otter_service="selfheal")
-        self.lock = zk.PollingLock(dispatcher, "/selfheallock")
+        self.lock = lock or zk.PollingLock(dispatcher, "/selfheallock")
         self.clock = clock
         self.calls = []
         timer = TimerService(

--- a/otter/convergence/selfheal.py
+++ b/otter/convergence/selfheal.py
@@ -46,6 +46,8 @@ class SelfHeal(MultiService, object):
             within this time
         :var callable config_func: Callable used when calling
             :func:`tenant_is_enabled`
+        :var lock: lock object used primarily for testing. If not given, a new
+            lock will be created from ``zk.PollingLock``
         """
         super(SelfHeal, self).__init__()
         self.disp = dispatcher

--- a/otter/integration/tests/test_selfheal.py
+++ b/otter/integration/tests/test_selfheal.py
@@ -14,6 +14,7 @@ from otter.integration.lib.nova import NovaServer
 from otter.integration.lib.resources import TestResources
 from otter.integration.lib.trial_tools import (
     TestHelper,
+    convergence_exec_time,
     get_identity,
     get_resource_mapping,
     region,
@@ -48,6 +49,7 @@ class SelfHealTests(TestCase):
         """
         SelfHeal service will replace deleted server
         """
+        sh_interval = float(os.environ["AS_SELFHEAL_INTERVAL"])
         group, _ = self.helper.create_group(min_entities=1)
         yield group.start(self.rcs, self)
         yield group.wait_for_state(
@@ -63,7 +65,7 @@ class SelfHealTests(TestCase):
             ContainsDict(
                 {"active": MatchesListwise([
                     ContainsDict({"id": NotEquals(server_id)})])}),
-            timeout=float(os.environ["AS_SELFHEAL_INTERVAL"]) * 2)
+            timeout=(sh_interval + convergence_exec_time) * 2)
         # Delete new server again and see if it comes back. It should be
         # back within selfheal interval
         server_id = yield only_server_id(self.rcs, group)
@@ -73,4 +75,4 @@ class SelfHealTests(TestCase):
             ContainsDict(
                 {"active": MatchesListwise([
                     ContainsDict({"id": NotEquals(server_id)})])}),
-            timeout=float(os.environ["AS_SELFHEAL_INTERVAL"]))
+            timeout=sh_interval + convergence_exec_time)

--- a/otter/integration/tests/test_selfheal.py
+++ b/otter/integration/tests/test_selfheal.py
@@ -26,7 +26,7 @@ def only_server_id(rcs, group):
     Extract only server id in the group
     """
     d = group.get_scaling_group_state(rcs, [200])
-    return d.addCallback(lambda (_, state): extract_active_ids(state))
+    return d.addCallback(lambda (_, state): extract_active_ids(state)[0])
 
 
 class SelfHealTests(TestCase):

--- a/otter/tap/api.py
+++ b/otter/tap/api.py
@@ -310,9 +310,8 @@ def makeService(config):
 
             # Setup selfheal service
             shsvc = SelfHeal(
-                dispatcher, kz_client,
-                config_value("selfheal.interval") or 300, log, reactor,
-                config_value)
+                dispatcher, config_value("selfheal.interval") or 300,
+                log, reactor, config_value)
             health_checker.checks["selfheal"] = shsvc.health_check
             shsvc.setServiceParent(parent)
 

--- a/otter/test/models/test_cass_models.py
+++ b/otter/test/models/test_cass_models.py
@@ -855,7 +855,7 @@ class CassScalingGroupTests(CassScalingGroupTestCase):
         self.assertNoResult(d)
         # local lock was acquired first then kz lock
         self.assertTrue(llock.locked)
-        self.assertFalse(self.lb.acquired)
+        self.assertIs(self.lb.acquired, self.lb.NOT_STARTED)
         kz_acquire_d.callback(True)
         self.assertTrue(self.lb.acquired)
         # after modification kz lock is released then local lock
@@ -882,7 +882,7 @@ class CassScalingGroupTests(CassScalingGroupTestCase):
         d = self.group.modify_state(modifier)
         self.failureResultOf(d, ValueError)
         self.assertEqual(self.connection.execute.call_count, 0)
-        self.assertFalse(self.lb.acquired)
+        self.assertIs(self.lb.acquired, self.lb.NOT_STARTED)
 
     def test_modify_state_lock_log_category_locking(self):
         """
@@ -2095,7 +2095,7 @@ class CassScalingGroupTests(CassScalingGroupTestCase):
         self.failureResultOf(d, ValueError)
 
         self.assertFalse(self.connection.execute.called)
-        self.assertFalse(self.lb.acquired)
+        self.assertIs(self.lb.acquired, self.lb.NOT_STARTED)
         # locks znode is not deleted
         self.assertIn("/locks/" + self.group.uuid, self.kz_client.nodes)
 

--- a/otter/test/tap/test_api.py
+++ b/otter/test/tap/test_api.py
@@ -630,13 +630,15 @@ class APIMakeServiceTests(SynchronousTestCase):
         self.log.err.assert_called_once_with(CheckFailure(ValueError),
                                              'Could not start TxKazooClient')
 
+    @mock.patch('otter.tap.api.SelfHeal')
     @mock.patch('otter.tap.api.setup_scheduler')
     @mock.patch('otter.tap.api.TxKazooClient')
     @mock.patch('otter.tap.api.setup_converger')
     def test_kazoo_client_stops(self,
                                 mock_setup_converger,
                                 mock_txkz,
-                                mock_setup_scheduler):
+                                mock_setup_scheduler,
+                                mock_sh):
         """
         TxKazooClient is stopped when parent service stops
         """
@@ -656,13 +658,15 @@ class APIMakeServiceTests(SynchronousTestCase):
         kz_client.stop.return_value.callback(None)
         self.successResultOf(d)
 
+    @mock.patch('otter.tap.api.SelfHeal')
     @mock.patch('otter.tap.api.setup_scheduler')
     @mock.patch('otter.tap.api.TxKazooClient')
     @mock.patch('otter.tap.api.setup_converger')
     def test_kazoo_client_stops_after_supervisor(self,
                                                  mock_setup_converger,
                                                  mock_txkz,
-                                                 mock_setup_scheduler):
+                                                 mock_setup_scheduler,
+                                                 mock_sh):
         """
         Kazoo is stopped after supervisor stops
         """
@@ -729,7 +733,7 @@ class APIMakeServiceTests(SynchronousTestCase):
         from otter.tap import api
         shsvc = mock_sh.return_value
         mock_sh.assert_called_once_with(
-            self.Otter.return_value.dispatcher, kz_client, interval, self.log,
+            self.Otter.return_value.dispatcher, interval, self.log,
             self.reactor, api.config_value)
         self.assertEqual(
             self.health_checker.checks["selfheal"],

--- a/otter/test/util/test_zk.py
+++ b/otter/test/util/test_zk.py
@@ -104,8 +104,9 @@ class ZKCrudModel(object):
 
 class _ZKLock(object):
     """
-    Stub for :obj:`kazoo.recipe.lock.KazooLock` and :obj:`PollingLock`
-    since ``PollingLock`` provides ``KazooLock`` interface.
+    Stub for :obj:`kazoo.recipe.lock.KazooLock` and :obj:`PollingLock`.
+    It provides *_eff implementations based on ``LockBehavior`` for
+    ``PollingLock``
 
     This class is private. Get its object and control it by calling
     ``create_fake_lock``

--- a/otter/test/util/test_zk.py
+++ b/otter/test/util/test_zk.py
@@ -122,6 +122,9 @@ class ZKLock(object):
         self.acquired = acquired
         return r
 
+    def is_acquired_eff(self):
+        return Effect(Const(self.acquired))
+
     def acquire(self, blocking=True, timeout=None):
         assert not self.acquired
         assert (blocking, timeout) == self.acquire_call[:2]

--- a/otter/util/zk.py
+++ b/otter/util/zk.py
@@ -166,24 +166,6 @@ def perform_delete_node(kz_client, dispatcher, intent):
     return kz_client.delete(intent.path, version=intent.version)
 
 
-@attr.s
-class AcquireLock(object):
-    """
-    Intent to acquire lock
-    """
-    lock = attr.ib()
-    blocking = attr.ib(default=True)
-    timeout = attr.ib(default=None)
-
-
-@deferred_performer
-def perform_acquire_lock(dispatcher, intent):
-    """
-    Perform :obj:`AcquireLock`.
-    """
-    return intent.lock.acquire(intent.blocking, intent.timeout)
-
-
 def get_zk_dispatcher(kz_client):
     """Get a dispatcher that can support all of the ZooKeeper intents."""
     return TypeDispatcher({
@@ -197,8 +179,7 @@ def get_zk_dispatcher(kz_client):
         GetChildren:
             partial(perform_get_children, kz_client),
         GetStat:
-            partial(perform_get_stat, kz_client),
-        AcquireLock: perform_acquire_lock
+            partial(perform_get_stat, kz_client)
     })
 
 


### PR DESCRIPTION
Use `PollingLock` from #1925 in `selfheal.py`. Few extra changes:
- Fixed broken selfheal integration test
- Separates Fake lock implementation from its behavior as suggested by @glyph in https://glyph.twistedmatrix.com/2015/05/separate-your-fakes-and-your-inspectors.html