### PR TITLE
remove_clb_nodes only removes 10 nodes at a time

### DIFF
--- a/otter/cloud_client/__init__.py
+++ b/otter/cloud_client/__init__.py
@@ -15,6 +15,7 @@ from effect import (
     TypeDispatcher,
     catch,
     perform,
+    raise_,
     sync_performer)
 from effect.do import do, do_return
 
@@ -33,7 +34,6 @@ from otter.constants import ServiceType
 from otter.indexer import atom
 from otter.log.intents import msg as msg_effect
 from otter.util.config import config_value
-from otter.util.fp import raise_
 from otter.util.http import APIError, append_segments, try_json_with_keys
 from otter.util.http import headers as otter_headers
 from otter.util.pure_http import (

--- a/otter/cloud_client/__init__.py
+++ b/otter/cloud_client/__init__.py
@@ -665,6 +665,7 @@ def remove_clb_nodes(lb_id, node_ids):
     partial = None
     if len(node_ids) > 10:
         # Limit number of nodes to 10 due to CLB's limit
+        node_ids = list(node_ids)
         partial = CLBPartialNodesRemoved(lb_id, node_ids[10:])
         node_ids = node_ids[:10]
     node_ids = map(str, node_ids)

--- a/otter/cloud_client/__init__.py
+++ b/otter/cloud_client/__init__.py
@@ -505,10 +505,18 @@ class CLBNodeLimitError(Exception):
 @attr.s
 class CLBPartialNodesRemoved(Exception):
     """
-    Exception raised when some of the nodes are removed.
+    Exception raised when only some of the nodes are removed.
+
+    :ivar lb_id: CLB ID
+    :type: :obj:`six.text_type`
+    :ivar list not_removed_node_ids: List of node_ids not removed where each
+        node_id is :obj:`six.text_type`
+    :ivar list removed_node_ids: List of node_ids removed where each node_id
+        is :obj:`six.text_type`
     """
-    lb_id = attr.ib()
-    node_ids = attr.ib()    # Node ids not removed
+    lb_id = attr.ib(validator=attr.validators.instance_of(six.text_type))
+    not_removed_node_ids = attr.ib(validator=attr.validators.instance_of(list))
+    removed_node_ids = attr.ib(validator=attr.validators.instance_of(list))
 
 
 def _match_errors(code_keys_exc_mapping, status_code, response_dict):
@@ -649,7 +657,7 @@ def change_clb_node(lb_id, node_id, condition, weight, _type="PRIMARY"):
     # CLB 202 response here has no body, so no response logging needed
 
 
-# Number of nodes that can be deleted in DELETE ../nodes call as per
+# Number of nodes that can be deleted in `DELETE ../nodes` call as per
 # https://developer.rackspace.com/docs/cloud-load-balancers/v1/api-reference/nodes/#bulk-delete-nodes
 CLB_BATCH_DELETE_LIMIT = 10
 
@@ -667,18 +675,19 @@ def remove_clb_nodes(lb_id, node_ids):
     This function will handle the case where *some* of the nodes are valid and
     some aren't, by retrying deleting only the valid ones.
     """
+    node_ids = list(node_ids)
     partial = None
     if len(node_ids) > CLB_BATCH_DELETE_LIMIT:
-        # Limit number of nodes to 10 due to CLB's limit
-        node_ids = list(node_ids)
-        partial = CLBPartialNodesRemoved(lb_id, node_ids[10:])
-        node_ids = node_ids[:10]
-    node_ids = map(str, node_ids)
+        not_removing = node_ids[CLB_BATCH_DELETE_LIMIT:]
+        node_ids = node_ids[:CLB_BATCH_DELETE_LIMIT]
+        partial = CLBPartialNodesRemoved(six.text_type(lb_id),
+                                         map(six.text_type, not_removing),
+                                         map(six.text_type, node_ids))
     eff = service_request(
         ServiceType.CLOUD_LOAD_BALANCERS,
         'DELETE',
         append_segments('loadbalancers', lb_id, 'nodes'),
-        params={'id': node_ids},
+        params={'id': map(str, node_ids)},
         success_pred=has_code(202))
 
     def check_invalid_nodes(exc_info):
@@ -701,7 +710,7 @@ def remove_clb_nodes(lb_id, node_ids):
     ).on(
         error=_only_json_api_errors(
             lambda c, b: _process_clb_api_error(c, b, lb_id))
-    ).on(success=lambda _: raise_(partial) if partial is not None else None)
+    ).on(success=lambda _: None if partial is None else raise_(partial))
     # CLB 202 responses here has no body, so no response logging needed.
 
 

--- a/otter/cloud_client/__init__.py
+++ b/otter/cloud_client/__init__.py
@@ -650,7 +650,7 @@ def change_clb_node(lb_id, node_id, condition, weight, _type="PRIMARY"):
 
 
 # Number of nodes that can be deleted in DELETE ../nodes call as per
-#https://developer.rackspace.com/docs/cloud-load-balancers/v1/api-reference/nodes/#bulk-delete-nodes
+# https://developer.rackspace.com/docs/cloud-load-balancers/v1/api-reference/nodes/#bulk-delete-nodes
 CLB_BATCH_DELETE_LIMIT = 10
 
 

--- a/otter/cloud_client/__init__.py
+++ b/otter/cloud_client/__init__.py
@@ -649,6 +649,11 @@ def change_clb_node(lb_id, node_id, condition, weight, _type="PRIMARY"):
     # CLB 202 response here has no body, so no response logging needed
 
 
+# Number of nodes that can be deleted in DELETE ../nodes call as per
+#https://developer.rackspace.com/docs/cloud-load-balancers/v1/api-reference/nodes/#bulk-delete-nodes
+CLB_BATCH_DELETE_LIMIT = 10
+
+
 def remove_clb_nodes(lb_id, node_ids):
     """
     Remove multiple nodes from a load balancer.
@@ -663,7 +668,7 @@ def remove_clb_nodes(lb_id, node_ids):
     some aren't, by retrying deleting only the valid ones.
     """
     partial = None
-    if len(node_ids) > 10:
+    if len(node_ids) > CLB_BATCH_DELETE_LIMIT:
         # Limit number of nodes to 10 due to CLB's limit
         node_ids = list(node_ids)
         partial = CLBPartialNodesRemoved(lb_id, node_ids[10:])

--- a/otter/test/cloud_client/test_init.py
+++ b/otter/test/cloud_client/test_init.py
@@ -10,6 +10,7 @@ from effect import (
     Effect,
     TypeDispatcher,
     base_dispatcher,
+    raise_,
     sync_perform)
 from effect.testing import EQFDispatcher, SequenceDispatcher, perform_sequence
 
@@ -83,7 +84,6 @@ from otter.test.utils import (
 )
 from otter.test.worker.test_launch_server_v1 import fake_service_catalog
 from otter.util.config import set_config_data
-from otter.util.fp import raise_
 from otter.util.http import APIError, headers
 from otter.util.pure_http import Request, has_code
 from otter.util.weaklocks import WeakLocks

--- a/otter/test/convergence/test_selfheal.py
+++ b/otter/test/convergence/test_selfheal.py
@@ -2,7 +2,7 @@
 Tests for :mod:`otter.convergence.selfheal`
 """
 
-from effect import Effect, base_dispatcher, sync_perform
+from effect import Effect, base_dispatcher, raise_, sync_perform
 from effect.testing import SequenceDispatcher
 
 import mock
@@ -20,7 +20,6 @@ from otter.test.util.test_zk import create_fake_lock
 from otter.test.utils import (
     CheckFailure, const, intent_func, mock_log, nested_sequence, noop, patch,
     perform_sequence)
-from otter.util.fp import raise_
 
 
 class SelfHealTests(SynchronousTestCase):

--- a/otter/test/convergence/test_selfheal.py
+++ b/otter/test/convergence/test_selfheal.py
@@ -19,7 +19,8 @@ from otter.models.interface import (
 from otter.test.util.test_zk import create_fake_lock
 from otter.test.utils import (
     CheckFailure, const, intent_func, mock_log, nested_sequence, noop, patch,
-    perform_sequence, raise_)
+    perform_sequence)
+from otter.util.fp import raise_
 
 
 class SelfHealTests(SynchronousTestCase):

--- a/otter/test/convergence/test_service.py
+++ b/otter/test/convergence/test_service.py
@@ -7,7 +7,8 @@ from datetime import datetime
 import attr
 
 from effect import (
-    ComposedDispatcher, Effect, Error, Func, base_dispatcher, sync_perform)
+    ComposedDispatcher, Effect, Error, Func, base_dispatcher, raise_,
+    sync_perform)
 from effect.ref import (
     ModifyReference, ReadReference, Reference, reference_dispatcher)
 from effect.testing import (
@@ -72,7 +73,6 @@ from otter.test.utils import (
     noop,
     raise_to_exc_info,
     transform_eq)
-from otter.util.fp import raise_
 from otter.util.zk import CreateOrSet, DeleteNode, GetChildren, GetStat
 
 

--- a/otter/test/convergence/test_service.py
+++ b/otter/test/convergence/test_service.py
@@ -70,9 +70,9 @@ from otter.test.utils import (
     mock_group, mock_log,
     nested_sequence,
     noop,
-    raise_,
     raise_to_exc_info,
     transform_eq)
+from otter.util.fp import raise_
 from otter.util.zk import CreateOrSet, DeleteNode, GetChildren, GetStat
 
 

--- a/otter/test/convergence/test_steps.py
+++ b/otter/test/convergence/test_steps.py
@@ -67,11 +67,11 @@ from otter.test.utils import (
     intent_func,
     matches,
     noop,
-    raise_,
     resolve_effect,
     stack,
     stub_pure_response,
     transform_eq)
+from otter.util.fp import raise_
 from otter.util.hashkey import generate_server_name
 from otter.util.http import APIError
 from otter.util.retry import (

--- a/otter/test/convergence/test_steps.py
+++ b/otter/test/convergence/test_steps.py
@@ -2,7 +2,7 @@
 import json
 from uuid import uuid4
 
-from effect import Effect, Func, base_dispatcher, sync_perform
+from effect import Effect, Func, base_dispatcher, raise_, sync_perform
 from effect.testing import SequenceDispatcher, perform_sequence
 
 from mock import ANY, patch
@@ -71,7 +71,6 @@ from otter.test.utils import (
     stack,
     stub_pure_response,
     transform_eq)
-from otter.util.fp import raise_
 from otter.util.hashkey import generate_server_name
 from otter.util.http import APIError
 from otter.util.retry import (

--- a/otter/test/log/test_cloudfeeds.py
+++ b/otter/test/log/test_cloudfeeds.py
@@ -3,7 +3,7 @@ Tests for otter.cloudfeeds
 """
 from functools import partial
 
-from effect import Effect, TypeDispatcher
+from effect import Effect, TypeDispatcher, raise_
 from effect.testing import perform_sequence
 
 import mock
@@ -35,7 +35,6 @@ from otter.test.utils import (
     retry_sequence,
     stub_pure_response
 )
-from otter.util.fp import raise_
 from otter.util.http import APIError
 from otter.util.retry import (
     Retry,

--- a/otter/test/log/test_cloudfeeds.py
+++ b/otter/test/log/test_cloudfeeds.py
@@ -32,10 +32,10 @@ from otter.test.utils import (
     CheckFailure,
     mock_log,
     nested_sequence,
-    raise_,
     retry_sequence,
     stub_pure_response
 )
+from otter.util.fp import raise_
 from otter.util.http import APIError
 from otter.util.retry import (
     Retry,

--- a/otter/test/log/test_intents.py
+++ b/otter/test/log/test_intents.py
@@ -7,6 +7,7 @@ from effect import (
     Constant,
     Effect,
     base_dispatcher,
+    raise_,
     sync_perform)
 from effect.testing import perform_sequence
 
@@ -27,7 +28,6 @@ from otter.log.intents import (
     with_log)
 from otter.test.utils import (
     CheckFailureValue, IsBoundWith, matches, mock_log)
-from otter.util.fp import raise_
 
 
 class LogDispatcherTests(SynchronousTestCase):

--- a/otter/test/log/test_intents.py
+++ b/otter/test/log/test_intents.py
@@ -26,7 +26,8 @@ from otter.log.intents import (
     msg_with_time,
     with_log)
 from otter.test.utils import (
-    CheckFailureValue, IsBoundWith, matches, mock_log, raise_)
+    CheckFailureValue, IsBoundWith, matches, mock_log)
+from otter.util.fp import raise_
 
 
 class LogDispatcherTests(SynchronousTestCase):

--- a/otter/test/log/test_spec.py
+++ b/otter/test/log/test_spec.py
@@ -16,7 +16,8 @@ from otter.log.spec import (
     split_execute_convergence,
     split_list_servers
 )
-from otter.test.utils import CheckFailureValue, raise_
+from otter.test.utils import CheckFailureValue
+from otter.util.fp import raise_
 
 
 class SpecificationObserverWrapperTests(SynchronousTestCase):

--- a/otter/test/log/test_spec.py
+++ b/otter/test/log/test_spec.py
@@ -3,6 +3,8 @@ Tests for log_spec.py
 """
 import json
 
+from effect import raise_
+
 from toolz.dicttoolz import assoc, dissoc
 
 from twisted.trial.unittest import SynchronousTestCase
@@ -17,7 +19,6 @@ from otter.log.spec import (
     split_list_servers
 )
 from otter.test.utils import CheckFailureValue
-from otter.util.fp import raise_
 
 
 class SpecificationObserverWrapperTests(SynchronousTestCase):

--- a/otter/test/test_controller.py
+++ b/otter/test/test_controller.py
@@ -42,11 +42,10 @@ from otter.test.utils import (
     nested_sequence,
     noop,
     patch,
-    raise_,
     set_non_conv_tenant,
     test_dispatcher)
 from otter.util.config import set_config_data
-from otter.util.fp import assoc_obj
+from otter.util.fp import assoc_obj, raise_
 from otter.util.retry import (
     Retry, ShouldDelayAndRetry, exponential_backoff_interval, retry_times)
 from otter.util.timestamp import MIN

--- a/otter/test/test_controller.py
+++ b/otter/test/test_controller.py
@@ -6,6 +6,7 @@ from datetime import datetime, timedelta
 from effect import (
     ComposedDispatcher,
     Effect,
+    raise_,
     sync_perform)
 from effect.testing import (
     SequenceDispatcher, parallel_sequence, perform_sequence)
@@ -45,7 +46,7 @@ from otter.test.utils import (
     set_non_conv_tenant,
     test_dispatcher)
 from otter.util.config import set_config_data
-from otter.util.fp import assoc_obj, raise_
+from otter.util.fp import assoc_obj
 from otter.util.retry import (
     Retry, ShouldDelayAndRetry, exponential_backoff_interval, retry_times)
 from otter.util.timestamp import MIN

--- a/otter/test/test_testutils.py
+++ b/otter/test/test_testutils.py
@@ -14,9 +14,9 @@ from zope.interface import Attribute, Interface
 
 from otter.test.utils import (
     iMock,
-    raise_,
     retry_sequence
 )
+from otter.util.fp import raise_
 from otter.util.retry import (
     Retry,
     ShouldDelayAndRetry,

--- a/otter/test/test_testutils.py
+++ b/otter/test/test_testutils.py
@@ -1,7 +1,8 @@
 """
 Tests for :obj:`otter.test.utils`.
 """
-from effect import ComposedDispatcher, Effect, base_dispatcher, sync_performer
+from effect import (
+    ComposedDispatcher, Effect, base_dispatcher, raise_, sync_performer)
 from effect.testing import perform_sequence
 
 from mock import ANY
@@ -16,7 +17,6 @@ from otter.test.utils import (
     iMock,
     retry_sequence
 )
-from otter.util.fp import raise_
 from otter.util.retry import (
     Retry,
     ShouldDelayAndRetry,

--- a/otter/test/utils.py
+++ b/otter/test/utils.py
@@ -10,7 +10,7 @@ from operator import attrgetter
 
 from effect import (
     ComposedDispatcher, Constant, Effect, ParallelEffects, TypeDispatcher,
-    base_dispatcher)
+    base_dispatcher, raise_)
 from effect.async import perform_parallel_async
 from effect.testing import (
     perform_sequence,
@@ -44,7 +44,7 @@ from otter.models.interface import IScalingGroup, IScalingGroupServersCache
 from otter.supervisor import ISupervisor
 from otter.util.config import set_config_data, update_config_data
 from otter.util.deferredutils import DeferredPool
-from otter.util.fp import raise_, set_in
+from otter.util.fp import set_in
 from otter.util.retry import Retry, ShouldDelayAndRetry, perform_retry
 
 

--- a/otter/test/utils.py
+++ b/otter/test/utils.py
@@ -44,7 +44,7 @@ from otter.models.interface import IScalingGroup, IScalingGroupServersCache
 from otter.supervisor import ISupervisor
 from otter.util.config import set_config_data, update_config_data
 from otter.util.deferredutils import DeferredPool
-from otter.util.fp import set_in
+from otter.util.fp import raise_, set_in
 from otter.util.retry import Retry, ShouldDelayAndRetry, perform_retry
 
 
@@ -884,11 +884,6 @@ def match_all(things):
     the given things.
     """
     return transform_eq(lambda o: [o]*len(things), things)
-
-
-def raise_(e):
-    """Raise the exception. Useful for lambdas."""
-    raise e
 
 
 def raise_to_exc_info(e):

--- a/otter/util/fp.py
+++ b/otter/util/fp.py
@@ -122,8 +122,3 @@ def set_in(mapping, keys, new_value):
     else:
         child = mapping.get(keys[0], pmap())
         return mapping.set(keys[0], set_in(child, keys[1:], new_value))
-
-
-def raise_(e):
-    """Raise the exception. Useful for lambdas."""
-    raise e

--- a/otter/util/fp.py
+++ b/otter/util/fp.py
@@ -122,3 +122,8 @@ def set_in(mapping, keys, new_value):
     else:
         child = mapping.get(keys[0], pmap())
         return mapping.set(keys[0], set_in(child, keys[1:], new_value))
+
+
+def raise_(e):
+    """Raise the exception. Useful for lambdas."""
+    raise e

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ testtools==1.9.0
 croniter==0.3.5
 txkazoo==0.0.6b2
 kazoo==2.2.1
-effect==0.10
+effect==0.10.1
 txeffect==0.9
 characteristic==14.3.0
 attrs==15.0.0

--- a/requirements/mimic.txt
+++ b/requirements/mimic.txt
@@ -1,1 +1,1 @@
-git+https://github.com/rackerlabs/mimic.git@a778c2e5d7a7725d4a610238a905dd40cf078b87
+git+https://github.com/rackerlabs/mimic.git@f317ee5d322aa7cb2b117e2984dfe8ef10558cd5


### PR DESCRIPTION
Fixes #1929. If more than 10 nodes are to be removed then convergence will be retried where rest of the nodes will be added. This is because [`RemoveCLBNodes`](https://github.com/rackerlabs/otter/blob/6df2b822fb8543727d22476d88d0a76b7dbee11c/otter/convergence/steps.py#L322) step considers any unknown error to be temporary and [returns RETRY](https://github.com/rackerlabs/otter/blob/6df2b822fb8543727d22476d88d0a76b7dbee11c/otter/convergence/steps.py#L127). 

Also moved `raise_` from `test.utils` to `utils.fp` to use it in non-test code.