### PR TITLE
Mention about deleted CLB resulting in ERROR group

### DIFF
--- a/api-docs/rst/dev-guide/release-notes/as_20151204.rst
+++ b/api-docs/rst/dev-guide/release-notes/as_20151204.rst
@@ -28,6 +28,13 @@ Behavioral changes
   In the current release, the server remains in the scaling group instead of
   being deleted.
 
+* An autoscaled server is tied to the load balancer it was originally attached to.
+  This means that changing load balancer in launch configuration does not automatically attach
+  all existing servers in new load balancer. It only attaches *new* servers to the new load balancer.
+  Convergence ensures that all servers are always attached to their respective
+  load balancers. Hence, deleting a load balancer that was originally configured in the
+  scaling group will result that group in ``ERROR``.
+
 Known issues
 ~~~~~~~~~~~~
 |no changes|


### PR DESCRIPTION
Basically warns about https://github.com/rackerlabs/otter/wiki/Scaling-group-ERRORs-with-%22Cannot-find-CLB%22-reason among list of "behavioral changes" in https://developer.rackspace.com/docs/autoscale/v1/developer-guide/#document-release-notes