### PR TITLE
unpin lxml so we can use the latest version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ twisted==16.1.1
 service_identity==14.0.0
 jsonschema==2.4.0
 iso8601==0.1.8
-lxml
+lxml==3.6.4
 treq==15.1.0
 silverberg==0.1.12
 pyOpenSSL==0.14

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ twisted==16.1.1
 service_identity==14.0.0
 jsonschema==2.4.0
 iso8601==0.1.8
-lxml==3.4.1
+lxml
 treq==15.1.0
 silverberg==0.1.12
 pyOpenSSL==0.14


### PR DESCRIPTION
pinning lxml to 3.4.1 was causing the devvm  to jump through a lot of hoops to build it. Functional tests pass with the latest version so we should unpin it (or we can pin it to 3.6.4).

https://gist.github.com/shawnashlee/dedc78e73341fadf1e1c19673a9e1be7

```
Ran 176 tests in 82.525s

OK (skipped=8)
```