### PR TITLE
Nosuchendpoint error is terminal

### DIFF
--- a/otter/convergence/service.py
+++ b/otter/convergence/service.py
@@ -586,6 +586,9 @@ def converge_one_group(currently_converging, recently_converged, waiting,
         # We don't need to spam the logs about this, it's to be expected
         return
     except (NoSuchScalingGroupError, NoSuchEndpoint):
+       # NoSuchEndpoint occurs on a suspended or closed account. This is
+       # temporarily added until https://github.com/rackerlabs/autoscaling-chef/issues/833
+       # gets implemented
         yield err(None, 'converge-fatal-error')
         yield _clean_waiting(waiting, group_id)
         yield delete_divergent_flag(tenant_id, group_id, version)

--- a/otter/convergence/service.py
+++ b/otter/convergence/service.py
@@ -112,6 +112,7 @@ from twisted.application.service import MultiService
 
 from txeffect import exc_info_to_failure, perform
 
+from otter.auth import NoSuchEndpoint
 from otter.cloud_client import TenantScope
 from otter.constants import CONVERGENCE_DIRTY_DIR
 from otter.convergence.composition import (get_desired_server_group_state,
@@ -213,7 +214,8 @@ def _execute_steps(steps):
     Given a set of steps, executes them, logs the result, and returns the worst
     priority with a list of reasons for that result.
 
-    :return: a tuple of (:class:`StepResult` constant., list of reasons)
+    :return: a tuple of (:class:`StepResult` constant,
+                         list of :obj:`ErrorReason`)
     """
     if len(steps) > 0:
         results = yield steps_to_effect(steps)
@@ -390,6 +392,10 @@ def convergence_succeeded(executor, scaling_group, group_state, resources,
 def convergence_failed(scaling_group, reasons, timedout=False):
     """
     Handle convergence failure
+
+    :param scaling_group: :obj:`IScalingGroup` object
+    :param reasons: List of :obj:`ErrorReason` objects
+    :param bool timedout: Has convergence failed due to reason timing out?
     """
     yield Effect(UpdateGroupStatus(scaling_group=scaling_group,
                                    status=ScalingGroupStatus.ERROR))
@@ -579,7 +585,7 @@ def converge_one_group(currently_converging, recently_converged, waiting,
     except ConcurrentError:
         # We don't need to spam the logs about this, it's to be expected
         return
-    except NoSuchScalingGroupError:
+    except (NoSuchScalingGroupError, NoSuchEndpoint):
         yield err(None, 'converge-fatal-error')
         yield _clean_waiting(waiting, group_id)
         yield delete_divergent_flag(tenant_id, group_id, version)

--- a/otter/convergence/service.py
+++ b/otter/convergence/service.py
@@ -586,9 +586,10 @@ def converge_one_group(currently_converging, recently_converged, waiting,
         # We don't need to spam the logs about this, it's to be expected
         return
     except (NoSuchScalingGroupError, NoSuchEndpoint):
-       # NoSuchEndpoint occurs on a suspended or closed account. This is
-       # temporarily added until https://github.com/rackerlabs/autoscaling-chef/issues/833
-       # gets implemented
+        # NoSuchEndpoint occurs on a suspended or closed account. This is
+        # temporarily added until
+        # https://github.com/rackerlabs/autoscaling-chef/issues/833
+        # gets implemented
         yield err(None, 'converge-fatal-error')
         yield _clean_waiting(waiting, group_id)
         yield delete_divergent_flag(tenant_id, group_id, version)


### PR DESCRIPTION
When an account is suspended or closed, its groups error with `NoSuchEndpoint` probably because its service catalog does not contain compute or CLB services. These group's convergence fails and keeps trying again every 30s because convergence considers any unknown error as  transient. This PR considers it as terminal and stops further convergence. This is temporary until https://github.com/rackerlabs/autoscaling-chef/issues/833 is implemented. 