### PR TITLE
remove temporary part of the comment - thanks @glyph

### DIFF
--- a/otter/convergence/service.py
+++ b/otter/convergence/service.py
@@ -586,10 +586,7 @@ def converge_one_group(currently_converging, recently_converged, waiting,
         # We don't need to spam the logs about this, it's to be expected
         return
     except (NoSuchScalingGroupError, NoSuchEndpoint):
-        # NoSuchEndpoint occurs on a suspended or closed account. This is
-        # temporarily added until
-        # https://github.com/rackerlabs/autoscaling-chef/issues/833
-        # gets implemented
+        # NoSuchEndpoint occurs on a suspended or closed account
         yield err(None, 'converge-fatal-error')
         yield _clean_waiting(waiting, group_id)
         yield delete_divergent_flag(tenant_id, group_id, version)


### PR DESCRIPTION
Since it is possible to execute convergence on a suspended account even after implementing https://github.com/rackerlabs/autoscaling-chef/issues/833 as convergence could've been triggered just after account got suspended but before otter received the event.