### PR TITLE
Group ERRORs on NoSuchEndpoint exception

### DIFF
--- a/otter/convergence/errors.py
+++ b/otter/convergence/errors.py
@@ -86,7 +86,7 @@ def _present_server_over_limit_error(exception):
 
 @_present_exception.register(NoSuchEndpoint)
 def _present_no_such_endpoint(exception):
-    fmt = ("Could not locate service {} in your service catalog. "
+    fmt = ("Could not locate service {} in the service catalog. "
            "Please check if your account is still active.")
     return fmt.format(exception.service_name)
 

--- a/otter/convergence/errors.py
+++ b/otter/convergence/errors.py
@@ -86,8 +86,9 @@ def _present_server_over_limit_error(exception):
 
 @_present_exception.register(NoSuchEndpoint)
 def _present_no_such_endpoint(exception):
-    return "Could not locate service {} in {} region".format(
-        exception.service_name, service.region)
+    fmt = ("Could not locate service {} in your service catalog. "
+           "Please check if your account is still active.")
+    return fmt.format(exception.service_name)
 
 
 @match(ErrorReason)

--- a/otter/convergence/errors.py
+++ b/otter/convergence/errors.py
@@ -6,6 +6,7 @@ from sumtypes import match
 
 from toolz.functoolz import identity
 
+from otter.auth import NoSuchEndpoint
 from otter.cloud_client import (
     CLBDeletedError,
     CLBNodeLimitError,
@@ -81,6 +82,12 @@ def _present_server_configuration_error(exception):
 @_present_exception.register(CreateServerOverQuoteError)
 def _present_server_over_limit_error(exception):
     return "Servers cannot be created: {0}".format(exception.message)
+
+
+@_present_exception.register(NoSuchEndpoint)
+def _present_no_such_endpoint(exception):
+    return "Could not locate service {} in {} region".format(
+        exception.service_name, service.region)
 
 
 @match(ErrorReason)

--- a/otter/convergence/service.py
+++ b/otter/convergence/service.py
@@ -599,7 +599,7 @@ def converge_one_group(currently_converging, recently_converged, waiting,
     except ConcurrentError:
         # We don't need to spam the logs about this, it's to be expected
         return
-    except (NoSuchScalingGroupError, NoSuchEndpoint):
+    except NoSuchScalingGroupError:
         # NoSuchEndpoint occurs on a suspended or closed account
         yield err(None, 'converge-fatal-error')
         yield _clean_waiting(waiting, group_id)

--- a/otter/models/intents.py
+++ b/otter/models/intents.py
@@ -119,13 +119,15 @@ class UpdateGroupErrorReasons(object):
     """
     Intent to update group's error reasons
     """
-    group = attr.ib()
+    tenant_id = attr.ib()
+    group_id = attr.ib()
     reasons = attr.ib()
 
 
 @deferred_performer
-def perform_update_error_reasons(disp, intent):
-    return intent.group.update_error_reasons(intent.reasons)
+def perform_update_error_reasons(log, store, disp, intent):
+    group = store.get_scaling_group(log, intent.tenant_id, intent.group_id)
+    return group.update_error_reasons(intent.reasons)
 
 
 @attr.s
@@ -157,7 +159,8 @@ def get_model_dispatcher(log, store):
         LoadAndUpdateGroupStatus:
             partial(perform_load_and_update_group_status, log, store),
         UpdateServersCache: perform_update_servers_cache,
-        UpdateGroupErrorReasons: perform_update_error_reasons,
+        UpdateGroupErrorReasons:
+            partial(perform_update_error_reasons, log, store),
         ModifyGroupStatePaused: perform_modify_group_state_paused,
         GetAllValidGroups: partial(perform_get_all_valid_groups, store),
     })

--- a/otter/test/convergence/test_errors.py
+++ b/otter/test/convergence/test_errors.py
@@ -2,6 +2,7 @@ import traceback
 
 from twisted.trial.unittest import SynchronousTestCase
 
+from otter.auth import NoSuchEndpoint
 from otter.cloud_client import (
     CLBDeletedError,
     CLBNodeLimitError,
@@ -49,7 +50,10 @@ class PresentReasonsTests(SynchronousTestCase):
             CreateServerConfigurationError("Your server is wrong"):
                 'Server launch configuration is invalid: Your server is wrong',
             CreateServerOverQuoteError("You are over quota"):
-                'Servers cannot be created: You are over quota'
+                'Servers cannot be created: You are over quota',
+            NoSuchEndpoint(service_name="nova", region="ord"):
+                "Could not locate service nova in the service catalog. "
+                "Please check if your account is still active."
         }
         excs = excs.items()
         self.assertEqual(

--- a/otter/test/convergence/test_service.py
+++ b/otter/test/convergence/test_service.py
@@ -398,6 +398,13 @@ class ConvergeOneGroupTests(SynchronousTestCase):
         """
         When fatal error occurs, it is logged and divergent flag is deleted
         """
+
+    def test_scaling_group_disappears(self):
+        """
+        When the scaling group disappears, a fatal error is logged and the
+        dirty flag is cleaned up.
+        """
+        expected_error = NoSuchScalingGroupError(self.tenant_id, self.group_id)
         sequence = [
             (self._exec_intent, lambda i: raise_(expected_error)),
             (LogErr(CheckFailureValue(expected_error),
@@ -405,22 +412,6 @@ class ConvergeOneGroupTests(SynchronousTestCase):
              noop),
         ] + self._clean_divergent()
         self._verify_sequence(sequence)
-
-    def test_scaling_group_disappears(self):
-        """
-        When the scaling group disappears, a fatal error is logged and the
-        dirty flag is cleaned up.
-        """
-        self._test_fatal_error(
-            NoSuchScalingGroupError(self.tenant_id, self.group_id))
-
-    def test_no_such_endpoint(self):
-        """
-        When execution errors with NoSuchEndpoint, a fatal error is logged and
-        the dirty flag is cleaned up.
-        """
-        self._test_fatal_error(
-            NoSuchEndpoint(service_name="servers", region="DFW"))
 
     def test_unexpected_errors(self):
         """

--- a/otter/test/models/test_intents.py
+++ b/otter/test/models/test_intents.py
@@ -166,9 +166,9 @@ class ScalingGroupIntentsTests(SynchronousTestCase):
         Performing :obj:`UpdateGroupErrorReasons` calls `update_error_reasons`
         """
         self.group.update_error_reasons.return_value = None
-        intent = UpdateGroupErrorReasons(self.group, ['r1', 'r2'])
-        dispatcher = self.get_dispatcher(self.get_store())
-        self.assertIsNone(sync_perform(dispatcher, Effect(intent)))
+        eff = Effect(UpdateGroupErrorReasons('t', 'g', ['r1', 'r2']))
+        result = self.perform_with_group(eff, (self.log, 't', 'g'), self.group)
+        self.assertIsNone(result)
         self.group.update_error_reasons.assert_called_once_with(['r1', 'r2'])
 
     def test_modify_group_state_paused(self):


### PR DESCRIPTION
This is the better version of #1943 which was in fact buggy fix. It should catch `FirstError` and check for `NoSuchEndpoint`. This PR reverts that change. It catches the error during convergence execution and ERRORs the group with the appropriate reason. This is better because selfheal does not trigger convergence once the group is in ERROR. This was not the case with #1943 where it temporarily stopped convergence but selfheal would've triggered it every 5 mins. Tested this on dev by pointing to prod identity and using a suspended account.