### PR TITLE
Fixes error introduced in commit 5dcd716

### DIFF
--- a/otter/convergence/gathering.py
+++ b/otter/convergence/gathering.py
@@ -35,7 +35,6 @@ from otter.convergence.model import (
     group_id_from_metadata)
 from otter.indexer import atom
 from otter.models.cass import CassScalingGroupServersCache
-from otter.util.fp import assoc_obj
 from otter.util.http import append_segments
 from otter.util.retry import (
     exponential_backoff_interval, retry_effect, retry_times)
@@ -211,9 +210,9 @@ def get_clb_contents():
         if node.description.lb_id in deleted_lbs:
             return None
         if feed is not None:
-            return assoc_obj(node, drained_at=extract_clb_drained_at(feed))
-        else:
-            return node
+            node.drained_at = extract_clb_drained_at(feed)
+        return node
+
     nodes = map(update_drained_at, concat(lb_nodes.values()))
     yield do_return((
         list(filter(bool, nodes)),

--- a/otter/test/convergence/test_gathering.py
+++ b/otter/test/convergence/test_gathering.py
@@ -4,6 +4,8 @@ from copy import deepcopy
 from datetime import datetime
 from functools import partial
 
+import attr
+
 from effect import (
     ComposedDispatcher,
     Constant,
@@ -64,7 +66,6 @@ from otter.test.utils import (
     server,
     stack
 )
-from otter.util.fp import assoc_obj
 from otter.util.retry import (
     Retry, ShouldDelayAndRetry, exponential_backoff_interval, retry_times)
 from otter.util.timestamp import timestamp_to_epoch
@@ -492,12 +493,10 @@ class GetCLBContentsTests(SynchronousTestCase):
         eff = get_clb_contents()
         self.assertEqual(
             perform_sequence(seq, eff),
-            ([assoc_obj(CLBNode.from_node_json(1, node11),
-                        drained_at=1.0),
+            ([attr.assoc(CLBNode.from_node_json(1, node11), _drained_at=1.0),
               CLBNode.from_node_json(1, node12),
               CLBNode.from_node_json(2, node21),
-              assoc_obj(CLBNode.from_node_json(2, node22),
-                        drained_at=2.0)],
+              attr.assoc(CLBNode.from_node_json(2, node22), _drained_at=2.0)],
              {'1': CLB(True), '2': CLB(False)}))
 
     def test_no_lb(self):
@@ -605,7 +604,7 @@ class GetCLBContentsTests(SynchronousTestCase):
         eff = get_clb_contents()
         self.assertEqual(
             perform_sequence(seq, eff),
-            ([assoc_obj(CLBNode.from_node_json(2, node21), drained_at=2.0)],
+            ([attr.assoc(CLBNode.from_node_json(2, node21), _drained_at=2.0)],
              {'2': CLB(True)}))
 
 


### PR DESCRIPTION
`assoc_obj` was the real culprit in commit 5dcd716 which returned `CLBNode` with `_drained_at=None` all the time. (I never liked it from the beginning). This made the unit tests pass as code and test got objects with `None` `drained_at`. Fixed by switching to attr and using its assoc method which ensures the attribute exists before accepting.