### PR TITLE
remove unnecessary undocumented on_error flag

### DIFF
--- a/otter/rest/groups.py
+++ b/otter/rest/groups.py
@@ -670,20 +670,10 @@ class OtterGroup(object):
         Trigger convergence on given scaling group
         """
 
-        class ConvergeErrorGroup(Exception):
-            pass
-
         def can_converge(group, state):
             if state.paused:
                 raise GroupPausedError(group.tenant_id, group.uuid, "converge")
-            conv_on_error = extract_bool_arg(request, 'on_error', True)
-            if not conv_on_error and state.status == ScalingGroupStatus.ERROR:
-                raise ConvergeErrorGroup()
             return state
-
-        def converge_error_group_header(f):
-            f.trap(ConvergeErrorGroup)
-            request.setHeader("x-not-converging", "true")
 
         if tenant_is_enabled(self.tenant_id, config_value):
             group = self.store.get_scaling_group(
@@ -692,7 +682,7 @@ class OtterGroup(object):
                 self.dispatcher,
                 group,
                 bound_log_kwargs(self.log),
-                can_converge).addErrback(converge_error_group_header)
+                can_converge)
         else:
             request.setResponseCode(404)
 

--- a/otter/test/rest/test_groups.py
+++ b/otter/test/rest/test_groups.py
@@ -1201,24 +1201,6 @@ class OneGroupTestCase(RestAPITestMixin, SynchronousTestCase):
             403, endpoint='{}converge'.format(self.endpoint), method='POST')
         self.assertTrue(self.mock_controller.modify_and_trigger.called)
 
-    def test_error_group_converge(self):
-        """
-        Calling `../converge?on_error=False` will not trigger convergence
-        on ERROR group
-        """
-        set_config_data({'convergence-tenants': ['11111']})
-        self.addCleanup(set_config_data, {})
-        self.mock_state = GroupState(
-            '11111', 'one', '', {}, {}, None, {}, False,
-            ScalingGroupStatus.ERROR)  # error group
-        response_wrapper = self.request(
-            endpoint='{}converge?on_error=false'.format(self.endpoint),
-            method='POST')
-        self.assert_response(response_wrapper, 204)
-        values = response_wrapper.response.headers.getRawHeaders(
-            'x-not-converging')
-        self.assertEqual(values, ["true"])
-
     def test_group_converge_worker_tenant(self):
         """
         Calling `../converge` on non-convergence enabled tenant returns 404


### PR DESCRIPTION
`POST ../groupId/converge` contains an undocumented flag `on_error=False` which when given will check if group is in ERROR before triggering convergence. The documented and right behavior is to always trigger convergence. This was a hack for cron based selfheal that was removed in #1887. This change should have been along that.