### PR TITLE
run realtime mimic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ subunit-output.txt
 .DS_Store
 docbook/target
 _trial_temp.lock
+_docker_trial_tmp

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,8 @@ services:
         ports:
             - "2181:2181"
     mimic: 
-        build: https://github.com/rackerlabs/mimic.git#f317ee5d322aa7cb2b117e2984dfe8ef10558cd5
+        build: https://github.com/rackerlabs/mimic.git#594dd5c8e80b670fa2d0c42f5eec9645e14aa54e
+        command: twistd -n mimic --realtime --verbose
     cafe:
         build:
             context: .
@@ -50,6 +51,7 @@ services:
             dockerfile: docker/otter/Dockerfile
         volumes:
             - ./otter:/app/otter
+            - ./_docker_trial_tmp:/tmp
         environment:
             - AS_USERNAME=jenkins_user
             - AS_PASSWORD=jenkins_password
@@ -65,7 +67,7 @@ services:
             - AS_SELFHEAL_INTERVAL=20
         command:
             dockerize -timeout 60s -wait http://otter:9000/health -wait http://mimic:8900
-                trial -j10 otter.integration.tests
+                trial -j10 --temp-directory=/tmp/_trial_temp otter.integration.tests
         depends_on:
             - otter
             - mimic


### PR DESCRIPTION
Since all integration tests expect realtime. Also mounting trial docker's temporary directory to capture logs.