### PR TITLE
Servers cache bugfix

### DIFF
--- a/otter/convergence/service.py
+++ b/otter/convergence/service.py
@@ -348,7 +348,7 @@ def execute_convergence(tenant_id, group_id, build_timeout, waiting,
     # Handle the status from execution
     if worst_status == StepResult.SUCCESS:
         result = yield convergence_succeeded(
-            executor, scaling_group, group_state, resources, now_dt)
+            executor, scaling_group, group_state, resources)
     elif worst_status == StepResult.FAILURE:
         result = yield convergence_failed(tenant_id, group_id, reasons)
     elif worst_status is StepResult.LIMITED_RETRY:
@@ -376,8 +376,7 @@ def update_stacks_cache(scaling_group, now, stacks, include_deleted=True):
 
 
 @do
-def convergence_succeeded(executor, scaling_group, group_state, resources,
-                          now):
+def convergence_succeeded(executor, scaling_group, group_state, resources):
     """
     Handle convergence success
     """
@@ -392,6 +391,7 @@ def convergence_succeeded(executor, scaling_group, group_state, resources,
         yield cf_msg('group-status-active',
                      status=ScalingGroupStatus.ACTIVE.name)
     # update servers cache with latest servers
+    now = yield Effect(Func(datetime.utcnow))
     yield executor.update_cache(scaling_group, now, include_deleted=False,
                                 **resources)
     yield do_return(ConvergenceIterationStatus.Stop())

--- a/otter/convergence/service.py
+++ b/otter/convergence/service.py
@@ -83,6 +83,21 @@ The top-level entry-points into this module are :func:`trigger_convergence` and
 # or config has changed), only if there are _any_ outstanding requests for
 # convergence, since convergence always uses the most recent data.
 
+
+# # Note [Convergence servers cache]
+# Each convergence cycle runs 3 primary steps: gather, generate plan and
+# execute plan. For launch_server type convergence it keeps cache of servers
+# fetched during gather step to provide 2 functionalities: provide quick list
+# for `GET .../groupId/state` API and to keep track of deleted servers IPs to
+# remove those IPs from group's LBs. The cache is updated during fetch step and
+# after the execution with information about which servers are in their
+# respective LBs. The cache stores multiple versions based on timestamp. See
+# `IScalingGroupServersCache`. Hence, each call to cache update is expected to
+# have higher timestamp which it mostly will since it is always called from
+# same node. The cache interface can be better.
+# See https://github.com/rackerlabs/otter/issues/1966
+
+
 import operator
 import time
 import uuid
@@ -266,6 +281,7 @@ def convergence_exec_data(tenant_id, group_id, now, get_executor):
         desired_capacity = 0
     else:
         desired_capacity = group_state.desired
+        # See [Convergence servers cache] comment on top of the file.
         yield executor.update_cache(scaling_group, now, **resources)
 
     desired_group_state = executor.get_desired_group_state(
@@ -390,7 +406,8 @@ def convergence_succeeded(executor, scaling_group, group_state, resources):
                                        status=ScalingGroupStatus.ACTIVE))
         yield cf_msg('group-status-active',
                      status=ScalingGroupStatus.ACTIVE.name)
-    # update servers cache with latest servers
+    # update servers cache with latest servers.
+    # See [Convergence servers cache] comment on top of the file.
     now = yield Effect(Func(datetime.utcnow))
     yield executor.update_cache(scaling_group, now, include_deleted=False,
                                 **resources)

--- a/otter/models/cass.py
+++ b/otter/models/cass.py
@@ -1843,7 +1843,7 @@ class CassScalingGroupServersCache(object):
         - `time` must be higher for subsequent calls.
         """
         # get current servers
-        current, last_update = yield self.get_servers()
+        current, last_update = yield self.get_servers(False)
         if last_update is not None and time <= last_update:
             raise ValueError(
                 "Given time arg {} must be greater than time of earlier "

--- a/otter/models/cass.py
+++ b/otter/models/cass.py
@@ -1853,10 +1853,12 @@ class CassScalingGroupServersCache(object):
             params = assoc(self.params, "last_update", time)
             queries = []
             for i, server in enumerate(servers):
-                params['server_id{}'.format(i)] = server['id']
-                params['server_as_active{}'.format(i)] = server.pop(
-                    '_is_as_active', False)
-                params['server_blob{}'.format(i)] = json.dumps(server)
+                params.update({
+                    'server_id{}'.format(i): server['id'],
+                    'server_as_active{}'.format(i): server.pop('_is_as_active',
+                                                               False),
+                    'server_blob{}'.format(i): json.dumps(server)
+                })
                 queries.append(query.format(cf=self.table, i=i))
             yield cql_eff(batch(queries), params)
 

--- a/otter/models/intents.py
+++ b/otter/models/intents.py
@@ -111,7 +111,7 @@ class UpdateServersCache(object):
 def perform_update_servers_cache(disp, intent):
     """ Perform :obj:`UpdateServersCache` """
     cache = CassScalingGroupServersCache(intent.tenant_id, intent.group_id)
-    return cache.insert_servers(intent.time, intent.servers, True)
+    return cache.update_servers(intent.time, intent.servers)
 
 
 @attr.s

--- a/otter/models/interface.py
+++ b/otter/models/interface.py
@@ -663,15 +663,13 @@ class IScalingGroupServersCache(Interface):
         :return: Effect of None
         """
 
-    def delete_servers(time, servers):
+    def delete_servers(time):
         """
-        Remove given servers of the group cache
+        Delete servers stored on the given timestamp
 
         :param datetime time: Update time of the cache
-        :param list servers: List of server dicts with optional "_is_as_active"
-            field with boolean value to represent if this server has become
-            active from autoscale's perpective. This field will be popped
-            before storing the blob
+
+        :return: Effect of None
         """
 
 

--- a/otter/models/interface.py
+++ b/otter/models/interface.py
@@ -637,7 +637,7 @@ class IScalingGroupServersCache(Interface):
     tenant_id = Attribute("Rackspace Tenant ID of the owner of this group.")
     group_id = Attribute("UUID of the scaling group - immutable.")
 
-    def get_servers(only_as_active):
+    def get_servers(only_as_active):    # pragma: no cover
         """
         Return latest cache of servers in a group along with last time the
         cache was updated.
@@ -650,7 +650,7 @@ class IScalingGroupServersCache(Interface):
         :rtype: Effect
         """
 
-    def update_servers(time, servers):
+    def update_servers(time, servers):  # pragma: no cover
         """
         Update the servers cache of the group with given list of servers
 
@@ -663,7 +663,7 @@ class IScalingGroupServersCache(Interface):
         :return: Effect of None
         """
 
-    def delete_servers(time):
+    def delete_servers(time):  # pragma: no cover
         """
         Delete servers stored on the given timestamp
 

--- a/otter/models/interface.py
+++ b/otter/models/interface.py
@@ -650,24 +650,28 @@ class IScalingGroupServersCache(Interface):
         :rtype: Effect
         """
 
-    def insert_servers(last_update, servers, clear_others):
+    def update_servers(time, servers):
         """
-        Update the servers cache of the group with last update time
+        Update the servers cache of the group with given list of servers
 
-        :param datetime last_update: Update time of the cache
+        :param datetime time: Update time of the cache
         :param list servers: List of server dicts with optional "_is_as_active"
             field with boolean value to represent if this server has become
             active from autoscale's perpective. This field will be popped
             before storing the blob
-        :param bool clear_others: Should any other cache from a different
-            update_time be deleted?
 
         :return: Effect of None
         """
 
-    def delete_servers():
+    def delete_servers(time, servers):
         """
-        Remove all servers of the group
+        Remove given servers of the group cache
+
+        :param datetime time: Update time of the cache
+        :param list servers: List of server dicts with optional "_is_as_active"
+            field with boolean value to represent if this server has become
+            active from autoscale's perpective. This field will be popped
+            before storing the blob
         """
 
 

--- a/otter/test/convergence/test_service.py
+++ b/otter/test/convergence/test_service.py
@@ -12,7 +12,7 @@ from effect import (
 from effect.ref import (
     ModifyReference, ReadReference, Reference, reference_dispatcher)
 from effect.testing import (
-    SequenceDispatcher, conste, intent_func, nested_sequence, noop,
+    SequenceDispatcher, const, conste, intent_func, nested_sequence, noop,
     parallel_sequence, perform_sequence)
 
 from kazoo.exceptions import BadVersionError, NoNodeError

--- a/otter/test/models/test_cass_models.py
+++ b/otter/test/models/test_cass_models.py
@@ -3845,7 +3845,7 @@ class CassGroupServersCacheTests(SynchronousTestCase):
         servers are empty
         """
         self.cache.get_servers = intent_func("gs")
-        seq = [(("gs",), const(([], None)))]
+        seq = [(("gs", False), const(([], None)))]
         eff = self.cache.update_servers(self.dt, [])
         self.assertIsNone(perform_sequence(seq, eff))
 
@@ -3856,7 +3856,7 @@ class CassGroupServersCacheTests(SynchronousTestCase):
         """
         self.cache.get_servers = intent_func("gs")
         seq = [
-            (("gs",), const(([], None))),
+            (("gs", False), const(([], None))),
             self._insert_servers_tuple(self.dt)
         ]
         eff = self.cache.update_servers(
@@ -3873,7 +3873,7 @@ class CassGroupServersCacheTests(SynchronousTestCase):
         got_servers = [{"id": "ga"}, {"id": "gb"}]
         new_dt = self.dt + timedelta(seconds=2)
         seq = [
-            (("gs",), const((got_servers, self.dt))),
+            (("gs", False), const((got_servers, self.dt))),
             self._insert_servers_tuple(dt=new_dt),
             (("ds", self.dt, got_servers), noop)
         ]
@@ -3888,11 +3888,9 @@ class CassGroupServersCacheTests(SynchronousTestCase):
         """
         self.cache.get_servers = intent_func("gs")
         time = self.dt - timedelta(seconds=2)
-        seq = [(("gs",), const(([{"id": "ga"}], self.dt)))]
+        seq = [(("gs", False), const(([{"id": "ga"}], self.dt)))]
         eff = self.cache.update_servers(time, [{"id": "a"}])
         self.assertRaises(ValueError, perform_sequence, seq, eff)
-
-    #def server(self, id,
 
     def test_delete_servers(self):
         """

--- a/otter/test/models/test_cass_models.py
+++ b/otter/test/models/test_cass_models.py
@@ -10,7 +10,8 @@ from functools import partial
 
 from effect import (
     Effect, ParallelEffects, TypeDispatcher, sync_perform)
-from effect.testing import perform_sequence, resolve_effect
+from effect.testing import (
+    const, intent_func, noop, perform_sequence, resolve_effect)
 
 from jsonschema import ValidationError
 
@@ -72,11 +73,8 @@ from otter.test.util.test_zk import ZKCrudModel, create_fake_lock
 from otter.test.utils import (
     DummyException,
     LockMixin,
-    const,
-    intent_func,
     matches,
     mock_log,
-    noop,
     patch,
     test_dispatcher)
 from otter.util.config import set_config_data

--- a/otter/test/models/test_intents.py
+++ b/otter/test/models/test_intents.py
@@ -154,7 +154,7 @@ class ScalingGroupIntentsTests(SynchronousTestCase):
         def perform_update_tuple(disp, intent):
             self.assertEqual(
                 intent,
-                ('cacheistidgid', dt, [{'id': 'a'}], True))
+                ('cacheistidgid', dt, [{'id': 'a'}]))
 
         disp = ComposedDispatcher([
             TypeDispatcher({tuple: perform_update_tuple}),

--- a/otter/test/utils.py
+++ b/otter/test/utils.py
@@ -983,8 +983,8 @@ class EffectServersCache(object):
     def get_servers(self, with_as_active):
         return Effect((self.ids("gs"), with_as_active))
 
-    def insert_servers(self, time, servers, clear):
-        return Effect((self.ids("is"), time, servers, clear))
+    def update_servers(self, time, servers):
+        return Effect((self.ids("is"), time, servers))
 
     def delete_servers(self):
         return Effect(self.ids("ds"))


### PR DESCRIPTION
Fixes #1828. Each update of cache is stored on a timestamp. The implementation expects it to be monotonically increasing which it currently almost does as each update call is always from the same node. Unfortunately, the timestamp knowledge of implementation has creeped into the interface and its callers which I am not proud of. IMHO a simple impl that doesn't store based on timestamp but just merges the servers during update operation will be nice but it requires DB schema changes that I don't want to do now.