### PR TITLE
docker cafe logs on host

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -19,3 +19,5 @@ subunit-output.txt
 *.pydev*
 .DS_Store
 _trial_temp.lock
+_docker_trial_tmp
+_docker_cafe_logs

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ subunit-output.txt
 docbook/target
 _trial_temp.lock
 _docker_trial_tmp
+_docker_cafe_logs

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,7 @@ services:
         volumes:
             - ./autoscale_cloudroast/test_repo:/cafe/autoscale_cloudroast/test_repo
             - ./autoscale_cloudcafe/autoscale_fixtures:/cafe/autoscale_cloudcafe/autoscale_fixtures
+            - ./_docker_cafe_logs:/root/.cloudcafe/logs/autoscale
         command:
             dev-convergence -p functional
         depends_on:


### PR DESCRIPTION
Mounting logs dir from cafe container for debugging. Otherwise, the logs are not accessible once the cafe container stops.