### PR TITLE
moved cloud_client CLB functions to clb.py

### DIFF
--- a/otter/cloud_client/clb.py
+++ b/otter/cloud_client/clb.py
@@ -1,0 +1,443 @@
+from functools import partial
+from operator import itemgetter
+from urlparse import parse_qs, urlparse
+
+import attr
+
+from characteristic import Attribute, attributes
+
+from effect import catch, raise_
+from effect.do import do, do_return
+
+import six
+
+from toolz.functoolz import identity
+from toolz.itertoolz import concat
+
+from otter.cloud_client import (
+    log_success_response,
+    match_errors,
+    only_json_api_errors,
+    regex,
+    service_request)
+from otter.constants import ServiceType
+from otter.indexer import atom
+from otter.util.http import APIError, append_segments, try_json_with_keys
+from otter.util.pure_http import has_code
+
+
+# ----- CLB requests and error parsing -----
+
+_CLB_IMMUTABLE_PATTERN = regex(
+    "Load\s*Balancer '\d+' has a status of '[^']+' and is considered "
+    "immutable")
+_CLB_NOT_ACTIVE_PATTERN = regex("Load\s*Balancer is not ACTIVE")
+_CLB_DELETED_PATTERN = regex(
+    "(Load\s*Balancer '\d+' has a status of 'PENDING_DELETE' and is|"
+    "The load balancer is deleted and) considered immutable")
+_CLB_MARKED_DELETED_PATTERN = regex(
+    "The load\s*balancer is marked as deleted")
+_CLB_NO_SUCH_NODE_PATTERN = regex(
+    "Node with id #\d+ not found for load\s*balancer #\d+$")
+_CLB_NO_SUCH_LB_PATTERN = regex(
+    "Load\s*balancer not found")
+_CLB_DUPLICATE_NODES_PATTERN = regex(
+    "Duplicate nodes detected. One or more nodes already configured "
+    "on load\s*balancer")
+_CLB_NODE_LIMIT_PATTERN = regex(
+    "Nodes must not exceed (\d+) per load\s*balancer")
+_CLB_NODE_REMOVED_PATTERN = regex(
+    "Node ids ((?:\d+,)*(?:\d+)) are not a part of your load\s*balancer")
+_CLB_OVER_LIMIT_PATTERN = regex("OverLimit Retry\.{3}")
+
+
+@attributes([Attribute('lb_id', instance_of=six.text_type)])
+class CLBImmutableError(Exception):
+    """
+    Error to be raised when the CLB is in some status that causes is to be
+    temporarily immutable.
+
+    This exception is _not_ used when the status is PENDING_DELETE. See
+    :obj:`CLBDeletedError`.
+    """
+
+
+@attributes([Attribute('lb_id', instance_of=six.text_type)])
+class CLBNotFoundError(Exception):
+    """A CLB doesn't exist. Superclass of other, more specific exceptions."""
+
+
+class CLBDeletedError(CLBNotFoundError):
+    """
+    Error to be raised when the CLB has been deleted or is being deleted.
+    This is distinct from it not existing.
+    """
+
+
+class NoSuchCLBError(CLBNotFoundError):
+    """
+    Error to be raised when the CLB never existed in the first place (or it
+    has been deleted so long that there is no longer a record of it).
+    """
+
+
+@attributes([Attribute('lb_id', instance_of=six.text_type),
+             Attribute('node_id', instance_of=six.text_type)])
+class NoSuchCLBNodeError(Exception):
+    """
+    Error to be raised when attempting to modify a CLB node that no longer
+    exists.
+    """
+
+
+@attributes([Attribute('lb_id', instance_of=six.text_type)])
+class CLBNotActiveError(Exception):
+    """
+    Error to be raised when a CLB is not ACTIVE (and we have no more
+    information about what its actual state is).
+    """
+
+
+@attributes([Attribute('lb_id', instance_of=six.text_type)])
+class CLBRateLimitError(Exception):
+    """
+    Error to be raised when CLB returns 413 (rate limiting).
+    """
+
+
+@attributes([Attribute('lb_id', instance_of=six.text_type)])
+class CLBDuplicateNodesError(Exception):
+    """
+    Error to be raised only when adding one or more nodes to a CLB whose
+    address and port are mapped on the CLB.
+    """
+
+
+@attributes([Attribute('lb_id', instance_of=six.text_type),
+             Attribute("node_limit", instance_of=int)])
+class CLBNodeLimitError(Exception):
+    """
+    Error to be raised only when adding one or more nodes to a CLB: adding
+    that number of nodes would exceed the maximum number of nodes allowed on
+    the CLB.
+    """
+
+
+@attr.s
+class CLBPartialNodesRemoved(Exception):
+    """
+    Exception raised when only some of the nodes are removed.
+
+    :ivar lb_id: CLB ID
+    :type: :obj:`six.text_type`
+    :ivar list not_removed_node_ids: List of node_ids not removed where each
+        node_id is :obj:`six.text_type`
+    :ivar list removed_node_ids: List of node_ids removed where each node_id
+        is :obj:`six.text_type`
+    """
+    lb_id = attr.ib(validator=attr.validators.instance_of(six.text_type))
+    not_removed_node_ids = attr.ib(validator=attr.validators.instance_of(list))
+    removed_node_ids = attr.ib(validator=attr.validators.instance_of(list))
+
+
+def _expand_clb_matches(matches_tuples, lb_id, node_id=None):
+    """
+    All CLB messages have only the keys ("message",), and the exception tpye
+    takes a load balancer ID and maybe a node ID.  So expand a tuple that looks
+    like:
+
+    (code, pattern, exc_type)
+
+    to
+
+    (code, ("message",), pattern, partial(exc_type, lb_id=lb_id))
+
+    and maybe the partial will include the node ID too if it's provided.
+    """
+    params = {"lb_id": six.text_type(lb_id)}
+    if node_id is not None:
+        params["node_id"] = six.text_type(node_id)
+
+    return [(m[0], ("message",), m[1], partial(m[2], **params))
+            for m in matches_tuples]
+
+
+def _process_clb_api_error(api_error_code, json_body, lb_id):
+    """
+    Attempt to parse generic CLB API error messages, and raise recognized
+    exceptions in their place.
+
+    :param int api_error_code: The status code from the HTTP request
+    :param dict json_body: The error message, parsed as a JSON dict.
+    :param string lb_id: The load balancer ID
+
+    :raises: :class:`CLBImmutableError`, :class:`CLBDeletedError`,
+        :class:`NoSuchCLBError`, :class:`APIError` by itself
+    """
+    mappings = (
+        # overLimit is different than the other CLB messages because it's
+        # produced by repose
+        [(413, ("overLimit", "message"), _CLB_OVER_LIMIT_PATTERN,
+          partial(CLBRateLimitError, lb_id=six.text_type(lb_id)))] +
+        _expand_clb_matches(
+            [(422, _CLB_DELETED_PATTERN, CLBDeletedError),
+             (410, _CLB_MARKED_DELETED_PATTERN, CLBDeletedError),
+             (422, _CLB_IMMUTABLE_PATTERN, CLBImmutableError),
+             (422, _CLB_NOT_ACTIVE_PATTERN, CLBNotActiveError),
+             (404, _CLB_NO_SUCH_LB_PATTERN, NoSuchCLBError)],
+            lb_id))
+    return match_errors(mappings, api_error_code, json_body)
+
+
+def add_clb_nodes(lb_id, nodes):
+    """
+    Generate effect to add one or more nodes to a load balancer.
+
+    Note: This is not correctly documented in the load balancer documentation -
+    it is documented as "Add Node" (singular), but the examples show multiple
+    nodes being added.
+
+    :param str lb_id: The load balancer ID to add the nodes to
+    :param list nodes: A list of node dictionaries that each look like::
+
+        {
+            "address": "valid ip address",
+            "port": 80,
+            "condition": "ENABLED",
+            "weight": 1,
+            "type": "PRIMARY"
+        }
+
+        (weight and type are optional)
+
+    :return: :class:`ServiceRequest` effect
+
+    :raises: :class:`CLBImmutableError`, :class:`CLBDeletedError`,
+        :class:`NoSuchCLBError`, :class:`CLBDuplicateNodesError`,
+        :class:`APIError`
+    """
+    eff = service_request(
+        ServiceType.CLOUD_LOAD_BALANCERS,
+        'POST',
+        append_segments('loadbalancers', lb_id, 'nodes'),
+        data={'nodes': nodes},
+        success_pred=has_code(202))
+
+    @only_json_api_errors
+    def _parse_known_errors(code, json_body):
+        mappings = _expand_clb_matches(
+            [(422, _CLB_DUPLICATE_NODES_PATTERN, CLBDuplicateNodesError)],
+            lb_id)
+        match_errors(mappings, code, json_body)
+        _process_clb_api_error(code, json_body, lb_id)
+        process_nodelimit_error(code, json_body, lb_id)
+
+    return eff.on(error=_parse_known_errors).on(
+        log_success_response('request-add-clb-nodes', identity))
+
+
+def process_nodelimit_error(code, json_body, lb_id):
+    """
+    Parse error that causes CLBNodeLimitError along with limit and raise it
+    """
+    if code != 413:
+        return
+    match = _CLB_NODE_LIMIT_PATTERN.match(json_body.get("message", ""))
+    if match is not None:
+        limit = int(match.group(1))
+        raise CLBNodeLimitError(lb_id=six.text_type(lb_id), node_limit=limit)
+
+
+def change_clb_node(lb_id, node_id, condition, weight, _type="PRIMARY"):
+    """
+    Generate effect to change a node on a load balancer.
+
+    :param str lb_id: The load balancer ID to add the nodes to
+    :param str node_id: The node id to change.
+    :param str condition: The condition to change to: one of "ENABLED",
+        "DRAINING", or "DISABLED"
+    :param int weight: The weight to change to.
+    :param str _type: The type to change the CLB node to.
+
+    :return: :class:`ServiceRequest` effect
+
+    :raises: :class:`CLBImmutableError`, :class:`CLBDeletedError`,
+        :class:`NoSuchCLBError`, :class:`NoSuchCLBNodeError`, :class:`APIError`
+    """
+    eff = service_request(
+        ServiceType.CLOUD_LOAD_BALANCERS,
+        'PUT',
+        append_segments('loadbalancers', lb_id, 'nodes', node_id),
+        data={'node': {
+            'condition': condition, 'weight': weight, 'type': _type}},
+        success_pred=has_code(202))
+
+    @only_json_api_errors
+    def _parse_known_errors(code, json_body):
+        _process_clb_api_error(code, json_body, lb_id)
+        match_errors(
+            _expand_clb_matches(
+                [(404, _CLB_NO_SUCH_NODE_PATTERN, NoSuchCLBNodeError)],
+                lb_id=lb_id, node_id=node_id),
+            code,
+            json_body)
+
+    return eff.on(error=_parse_known_errors)
+    # CLB 202 response here has no body, so no response logging needed
+
+
+# Number of nodes that can be deleted in `DELETE ../nodes` call as per
+# https://developer.rackspace.com/docs/cloud-load-balancers/v1/api-reference/nodes/#bulk-delete-nodes
+CLB_BATCH_DELETE_LIMIT = 10
+
+
+def remove_clb_nodes(lb_id, node_ids):
+    """
+    Remove multiple nodes from a load balancer.
+
+    :param str lb_id: A load balancer ID.
+    :param node_ids: iterable of node IDs.
+    :return: Effect of None.
+
+    Succeeds on 202.
+
+    This function will handle the case where *some* of the nodes are valid and
+    some aren't, by retrying deleting only the valid ones.
+    """
+    node_ids = list(node_ids)
+    partial = None
+    if len(node_ids) > CLB_BATCH_DELETE_LIMIT:
+        not_removing = node_ids[CLB_BATCH_DELETE_LIMIT:]
+        node_ids = node_ids[:CLB_BATCH_DELETE_LIMIT]
+        partial = CLBPartialNodesRemoved(six.text_type(lb_id),
+                                         map(six.text_type, not_removing),
+                                         map(six.text_type, node_ids))
+    eff = service_request(
+        ServiceType.CLOUD_LOAD_BALANCERS,
+        'DELETE',
+        append_segments('loadbalancers', lb_id, 'nodes'),
+        params={'id': map(str, node_ids)},
+        success_pred=has_code(202))
+
+    def check_invalid_nodes(exc_info):
+        code = exc_info[1].code
+        body = exc_info[1].body
+        if code == 400:
+            message = try_json_with_keys(
+                body, ["validationErrors", "messages", 0])
+            if message is not None:
+                match = _CLB_NODE_REMOVED_PATTERN.match(message)
+                if match:
+                    removed = concat([group.split(',')
+                                      for group in match.groups()])
+                    return remove_clb_nodes(lb_id,
+                                            set(node_ids) - set(removed))
+        six.reraise(*exc_info)
+
+    return eff.on(
+        error=catch(APIError, check_invalid_nodes)
+    ).on(
+        error=only_json_api_errors(
+            lambda c, b: _process_clb_api_error(c, b, lb_id))
+    ).on(success=lambda _: None if partial is None else raise_(partial))
+    # CLB 202 responses here has no body, so no response logging needed.
+
+
+def get_clb_nodes(lb_id):
+    """
+    Fetch the nodes of the given load balancer. Returns list of node JSON.
+    """
+    return service_request(
+        ServiceType.CLOUD_LOAD_BALANCERS,
+        'GET',
+        append_segments('loadbalancers', str(lb_id), 'nodes'),
+    ).on(
+        error=only_json_api_errors(
+            lambda c, b: _process_clb_api_error(c, b, lb_id))
+    ).on(
+        log_success_response('request-list-clb-nodes', identity)
+    ).on(
+        success=lambda (response, body): body['nodes'])
+
+
+def get_clbs():
+    """Fetch all LBs for a tenant. Returns list of loadbalancer JSON."""
+    return service_request(
+        ServiceType.CLOUD_LOAD_BALANCERS, 'GET', 'loadbalancers',
+    ).on(
+        log_success_response('request-list-clbs', identity)
+    ).on(
+        success=lambda (response, body): body['loadBalancers'])
+
+
+def _node_feed_page(lb_id, node_id, params):
+    """
+    Return page of CLB node feed
+
+    :param int lb_id: Cloud Load balancer ID
+    :param int node_id: Node ID of in loadbalancer node
+    :param dict params: Request query parameters
+
+    :returns: Unparsed response body as string
+    :rtype: `str`
+    """
+    return service_request(
+        ServiceType.CLOUD_LOAD_BALANCERS, 'GET',
+        append_segments('loadbalancers', str(lb_id), 'nodes',
+                        '{}.atom'.format(node_id)),
+        params=params,
+        json_response=False
+    ).on(
+        error=only_json_api_errors(
+            lambda c, b: _process_clb_api_error(c, b, lb_id))
+    ).on(
+        log_success_response('request-get-clb-node-feed', identity)
+    ).on(itemgetter(1))
+
+
+@do
+def get_clb_node_feed(lb_id, node_id):
+    """
+    Get the atom feed associated with a CLB node.
+
+    :param int lb_id: Cloud Load balancer ID
+    :param int node_id: Node ID of in loadbalancer node
+
+    :returns: Effect of ``list`` of atom entry :class:`Element`
+    :rtype: ``Effect``
+    """
+    all_entries = []
+    params = {}
+    while True:
+        feed_str = yield _node_feed_page(lb_id, node_id, params)
+        feed = atom.parse(feed_str)
+        entries = atom.entries(feed)
+        if entries == []:
+            break
+        all_entries.extend(entries)
+        next_link = atom.next_link(feed)
+        if not next_link:
+            break
+        params = parse_qs(urlparse(next_link).query)
+    yield do_return(all_entries)
+
+
+def get_clb_health_monitor(lb_id):
+    """
+    Return CLB health monitor setting
+
+    :param int lb_id: Loadbalancer ID
+
+    :return: ``Effect`` of ``dict`` representing health monitor config
+    """
+    return service_request(
+        ServiceType.CLOUD_LOAD_BALANCERS,
+        'GET',
+        append_segments('loadbalancers', str(lb_id), 'healthmonitor')
+    ).on(
+        error=only_json_api_errors(
+            lambda c, b: _process_clb_api_error(c, b, lb_id))
+    ).on(
+        log_success_response('request-get-clb-healthmon', identity)
+    ).on(
+        success=lambda (response, body): body["healthMonitor"])

--- a/otter/convergence/errors.py
+++ b/otter/convergence/errors.py
@@ -8,10 +8,12 @@ from toolz.functoolz import identity
 
 from otter.auth import NoSuchEndpoint
 from otter.cloud_client import (
+    CreateServerConfigurationError,
+    CreateServerOverQuoteError
+)
+from otter.cloud_client.clb import (
     CLBDeletedError,
     CLBNodeLimitError,
-    CreateServerConfigurationError,
-    CreateServerOverQuoteError,
     NoSuchCLBError,
     NoSuchCLBNodeError
 )

--- a/otter/convergence/gathering.py
+++ b/otter/convergence/gathering.py
@@ -14,14 +14,17 @@ from toolz.itertoolz import concat
 
 from otter.auth import NoSuchEndpoint
 from otter.cloud_client import (
+    list_servers_details_all,
+    list_stacks_all,
+    service_request
+)
+from otter.cloud_client.clb import (
     CLBNotFoundError,
     get_clb_health_monitor,
     get_clb_node_feed,
     get_clb_nodes,
-    get_clbs,
-    list_servers_details_all,
-    list_stacks_all,
-    service_request)
+    get_clbs
+)
 from otter.constants import ServiceType
 from otter.convergence.model import (
     CLB,
@@ -32,7 +35,8 @@ from otter.convergence.model import (
     RCv3Description,
     RCv3Node,
     get_stack_tag_for_group,
-    group_id_from_metadata)
+    group_id_from_metadata
+)
 from otter.indexer import atom
 from otter.models.cass import CassScalingGroupServersCache
 from otter.util.http import append_segments

--- a/otter/convergence/steps.py
+++ b/otter/convergence/steps.py
@@ -19,23 +19,24 @@ from twisted.python.constants import NamedConstant
 from zope.interface import Interface, implementer
 
 from otter.cloud_client import (
-    CLBNodeLimitError,
-    CLBNotFoundError,
     CreateServerConfigurationError,
     CreateServerOverQuoteError,
-    NoSuchCLBNodeError,
-    add_clb_nodes,
-    change_clb_node,
     check_stack,
     create_server,
     create_stack,
     delete_stack,
     has_code,
-    remove_clb_nodes,
     rcv3,
     service_request,
     set_nova_metadata_item,
     update_stack)
+from otter.cloud_client.clb import (
+    CLBNodeLimitError,
+    CLBNotFoundError,
+    NoSuchCLBNodeError,
+    add_clb_nodes,
+    change_clb_node,
+    remove_clb_nodes)
 from otter.constants import ServiceType
 from otter.convergence.model import ErrorReason, HeatStack, StepResult
 from otter.util.fp import set_in

--- a/otter/test/cloud_client/test_clb.py
+++ b/otter/test/cloud_client/test_clb.py
@@ -1,0 +1,531 @@
+"""Tests for otter.cloud_client.clb"""
+
+import json
+
+from effect import sync_perform
+from effect.testing import EQFDispatcher, perform_sequence
+
+import six
+
+from twisted.trial.unittest import SynchronousTestCase
+
+from otter.cloud_client import service_request
+from otter.cloud_client.clb import (
+    CLBDeletedError,
+    CLBDuplicateNodesError,
+    CLBImmutableError,
+    CLBNodeLimitError,
+    CLBNotActiveError,
+    CLBPartialNodesRemoved,
+    CLBRateLimitError,
+    CLB_BATCH_DELETE_LIMIT,
+    NoSuchCLBError,
+    NoSuchCLBNodeError,
+    add_clb_nodes,
+    change_clb_node,
+    get_clb_health_monitor,
+    get_clb_node_feed,
+    get_clb_nodes,
+    get_clbs,
+    remove_clb_nodes)
+from otter.constants import ServiceType
+from otter.indexer import atom
+from otter.test.cloud_client.test_init import log_intent, service_request_eqf
+from otter.test.utils import (
+    StubResponse,
+    const,
+    noop,
+    stub_json_response,
+    stub_pure_response
+)
+from otter.util.http import APIError
+from otter.util.pure_http import has_code
+
+
+def assert_parses_common_clb_errors(testcase, intent, eff, lb_id):
+    """
+    Assert that the effect produced performs the common CLB error parsing:
+    :class:`CLBImmutableError`, :class:`CLBDescription`,
+    :class:`NoSuchCLBError`, :class:`CLBRateLimitError`,
+    :class:`APIError`
+
+    :param :obj:`twisted.trial.unittest.TestCase` testcase: Test object
+    :param intent: expected ``ServiceRequest`` intent
+    :param eff: Effect returned from function being tested
+    :param lb_id: ID of load balancer being accessed in the function being
+        tested
+    """
+    json_responses_and_errs = [
+        ("Load Balancer '{0}' has a status of 'BUILD' and is "
+         "considered immutable.", 422, CLBImmutableError),
+        ("Load Balancer '{0}' has a status of 'PENDING_UPDATE' and is "
+         "considered immutable.", 422, CLBImmutableError),
+        ("Load Balancer '{0}' has a status of 'unexpected status' and is "
+         "considered immutable.", 422, CLBImmutableError),
+        ("Load Balancer '{0}' has a status of 'PENDING_DELETE' and is "
+         "considered immutable.", 422, CLBDeletedError),
+        ("The load balancer is deleted and considered immutable.",
+         422, CLBDeletedError),
+        ("Load balancer not found.", 404, NoSuchCLBError),
+        ("LoadBalancer is not ACTIVE", 422, CLBNotActiveError),
+        ("The loadbalancer is marked as deleted.", 410, CLBDeletedError),
+    ]
+
+    for msg, code, err in json_responses_and_errs:
+        msg = msg.format(lb_id)
+        resp = stub_pure_response(
+            json.dumps({'message': msg, 'code': code, 'details': ''}),
+            code)
+        with testcase.assertRaises(err) as cm:
+            perform_sequence([(intent, service_request_eqf(resp))], eff)
+        testcase.assertEqual(cm.exception,
+                             err(msg, lb_id=six.text_type(lb_id)))
+
+    # OverLimit Retry is different because it's produced by repose
+    over_limit = stub_pure_response(
+        json.dumps({
+            "overLimit": {
+                "message": "OverLimit Retry...",
+                "code": 413,
+                "retryAfter": "2015-06-13T22:30:10Z",
+                "details": "Error Details..."
+            }
+        }),
+        413)
+    with testcase.assertRaises(CLBRateLimitError) as cm:
+        perform_sequence([(intent, service_request_eqf(over_limit))], eff)
+    testcase.assertEqual(
+        cm.exception,
+        CLBRateLimitError("OverLimit Retry...",
+                          lb_id=six.text_type(lb_id)))
+
+    # Ignored errors
+    bad_resps = [
+        stub_pure_response(
+            json.dumps({
+                'message': ("Load Balancer '{0}' has a status of 'BROKEN' "
+                            "and is considered immutable."),
+                'code': 422}),
+            422),
+        stub_pure_response(
+            json.dumps({
+                'message': ("The load balancer is deleted and considered "
+                            "immutable"),
+                'code': 404}),
+            404),
+        stub_pure_response(
+            json.dumps({
+                'message': "Cloud load balancers is down",
+                'code': 500}),
+            500),
+        stub_pure_response(
+            json.dumps({
+                'message': "this is not an over limit message",
+                'code': 413}),
+            413),
+        stub_pure_response("random repose error message", 404),
+        stub_pure_response("random repose error message", 413)
+    ]
+
+    for resp in bad_resps:
+        with testcase.assertRaises(APIError) as cm:
+            perform_sequence([(intent, service_request_eqf(resp))], eff)
+        testcase.assertEqual(
+            cm.exception,
+            APIError(headers={}, code=resp[0].code, body=resp[1],
+                     method='method', url='original/request/URL'))
+
+
+class CLBClientTests(SynchronousTestCase):
+    """
+    Tests for CLB client functions, such as :obj:`change_clb_node`.
+    """
+    @property
+    def lb_id(self):
+        """What is my LB ID"""
+        return "123456"
+
+    def test_change_clb_node(self):
+        """
+        Produce a request for modifying a node on a load balancer, which
+        returns a successful result on 202.
+
+        Parse the common CLB errors, and :class:`NoSuchCLBNodeError`.
+        """
+        eff = change_clb_node(lb_id=self.lb_id, node_id='1234',
+                              condition="DRAINING", weight=50,
+                              _type='SECONDARY')
+        expected = service_request(
+            ServiceType.CLOUD_LOAD_BALANCERS,
+            'PUT',
+            'loadbalancers/{0}/nodes/1234'.format(self.lb_id),
+            data={'node': {'condition': 'DRAINING',
+                           'weight': 50, 'type': 'SECONDARY'}},
+            success_pred=has_code(202))
+
+        # success
+        dispatcher = EQFDispatcher([(
+            expected.intent,
+            service_request_eqf(stub_pure_response('', 202)))])
+        self.assertEqual(sync_perform(dispatcher, eff),
+                         stub_pure_response(None, 202))
+
+        # NoSuchCLBNode failure
+        msg = "Node with id #1234 not found for loadbalancer #{0}".format(
+            self.lb_id)
+        no_such_node = stub_pure_response(
+            json.dumps({'message': msg, 'code': 404}), 404)
+        dispatcher = EQFDispatcher([(
+            expected.intent, service_request_eqf(no_such_node))])
+
+        with self.assertRaises(NoSuchCLBNodeError) as cm:
+            sync_perform(dispatcher, eff)
+        self.assertEqual(
+            cm.exception,
+            NoSuchCLBNodeError(msg, lb_id=six.text_type(self.lb_id),
+                               node_id=u'1234'))
+
+        # all the common failures
+        assert_parses_common_clb_errors(self, expected.intent, eff, "123456")
+
+    def test_change_clb_node_default_type(self):
+        """
+        Produce a request for modifying a node on a load balancer with the
+        default type, which returns a successful result on 202.
+        """
+        eff = change_clb_node(lb_id=self.lb_id, node_id='1234',
+                              condition="DRAINING", weight=50)
+        expected = service_request(
+            ServiceType.CLOUD_LOAD_BALANCERS,
+            'PUT',
+            'loadbalancers/{0}/nodes/1234'.format(self.lb_id),
+            data={'node': {'condition': 'DRAINING',
+                           'weight': 50, 'type': 'PRIMARY'}},
+            success_pred=has_code(202))
+
+        dispatcher = EQFDispatcher([(
+            expected.intent,
+            service_request_eqf(stub_pure_response('', 202)))])
+        self.assertEqual(sync_perform(dispatcher, eff),
+                         stub_pure_response(None, 202))
+
+    def test_add_clb_nodes(self):
+        """
+        Produce a request for adding nodes to a load balancer, which returns
+        a successful result on a 202.
+
+        Parse the common CLB errors, and a :class:`CLBDuplicateNodesError`.
+        """
+        nodes = [{"address": "1.1.1.1", "port": 80, "condition": "ENABLED"},
+                 {"address": "1.1.1.2", "port": 80, "condition": "ENABLED"},
+                 {"address": "1.1.1.5", "port": 81, "condition": "ENABLED"}]
+
+        eff = add_clb_nodes(lb_id=self.lb_id, nodes=nodes)
+        expected = service_request(
+            ServiceType.CLOUD_LOAD_BALANCERS,
+            'POST',
+            'loadbalancers/{0}/nodes'.format(self.lb_id),
+            data={'nodes': nodes},
+            success_pred=has_code(202))
+
+        # success
+        seq = [
+            (expected.intent, lambda i: stub_json_response({}, 202, {})),
+            (log_intent('request-add-clb-nodes', {}), lambda _: None)]
+        self.assertEqual(perform_sequence(seq, eff),
+                         (StubResponse(202, {}), {}))
+
+        # CLBDuplicateNodesError failure
+        msg = ("Duplicate nodes detected. One or more nodes already "
+               "configured on load balancer.")
+        duplicate_nodes = stub_pure_response(
+            json.dumps({'message': msg, 'code': 422}), 422)
+        dispatcher = EQFDispatcher([(
+            expected.intent, service_request_eqf(duplicate_nodes))])
+
+        with self.assertRaises(CLBDuplicateNodesError) as cm:
+            sync_perform(dispatcher, eff)
+        self.assertEqual(
+            cm.exception,
+            CLBDuplicateNodesError(msg, lb_id=six.text_type(self.lb_id)))
+
+        # CLBNodeLimitError failure
+        msg = "Nodes must not exceed 25 per load balancer."
+        limit = stub_pure_response(
+            json.dumps({'message': msg, 'code': 413}), 413)
+        dispatcher = EQFDispatcher([(
+            expected.intent, service_request_eqf(limit))])
+
+        with self.assertRaises(CLBNodeLimitError) as cm:
+            sync_perform(dispatcher, eff)
+        self.assertEqual(
+            cm.exception,
+            CLBNodeLimitError(msg, lb_id=six.text_type(self.lb_id),
+                              node_limit=25))
+
+        # all the common failures
+        assert_parses_common_clb_errors(self, expected.intent, eff, "123456")
+
+    def expected_node_removal_req(self, nodes=(1, 2)):
+        """
+        :return: Expected effect for a node removal request.
+        """
+        return service_request(
+            ServiceType.CLOUD_LOAD_BALANCERS,
+            'DELETE',
+            'loadbalancers/{}/nodes'.format(self.lb_id),
+            params={'id': map(str, nodes)},
+            success_pred=has_code(202))
+
+    def test_remove_clb_nodes_success(self):
+        """
+        A DELETE request is sent, and the Effect returns None if 202 is
+        returned.
+        """
+        eff = remove_clb_nodes(self.lb_id, ["1", "2"])
+        seq = [
+            (self.expected_node_removal_req().intent,
+             service_request_eqf(stub_pure_response({}, 202))),
+        ]
+        result = perform_sequence(seq, eff)
+        self.assertIs(result, None)
+
+    def test_remove_clb_nodes_handles_standard_clb_errors(self):
+        """
+        Common CLB errors about it being in a deleted state, pending update,
+        etc. are handled.
+        """
+        eff = remove_clb_nodes(self.lb_id, ["1", "2"])
+        assert_parses_common_clb_errors(
+            self, self.expected_node_removal_req().intent, eff, "123456")
+
+    def test_remove_clb_nodes_non_202(self):
+        """Any random HTTP response code is bubbled up as an APIError."""
+        eff = remove_clb_nodes(self.lb_id, ["1", "2"])
+        seq = [
+            (self.expected_node_removal_req().intent,
+             service_request_eqf(stub_pure_response({}, 200))),
+        ]
+        self.assertRaises(APIError, perform_sequence, seq, eff)
+
+    def test_remove_clb_nodes_random_400(self):
+        """Random 400s that can't be parsed are bubbled up as an APIError."""
+        error_bodies = [
+            {'validationErrors': {'messages': ['bar']}},
+            {'messages': 'bar'},
+            {'validationErrors': {'messages': []}},
+            "random non-json"
+        ]
+        for body in error_bodies:
+            eff = remove_clb_nodes(self.lb_id, ["1", "2"])
+            seq = [
+                (self.expected_node_removal_req().intent,
+                 service_request_eqf(stub_pure_response(body, 400))),
+            ]
+            self.assertRaises(APIError, perform_sequence, seq, eff)
+
+    def test_remove_clb_nodes_retry_on_some_invalid_nodes(self):
+        """
+        When CLB returns an error indicating that some of the nodes are
+        invalid, the request is retried without the offending nodes.
+        """
+        node_ids = map(str, range(1, 5))
+        eff = remove_clb_nodes(self.lb_id, node_ids)
+        response = stub_pure_response(
+            {'validationErrors': {'messages': [
+                'Node ids 1,3 are not a part of your loadbalancer']}},
+            400)
+        response2 = stub_pure_response({}, 202)
+        seq = [
+            (self.expected_node_removal_req(node_ids).intent,
+             service_request_eqf(response)),
+            (self.expected_node_removal_req(["2", "4"]).intent,
+             service_request_eqf(response2))
+        ]
+        self.assertIs(perform_sequence(seq, eff), None)
+
+    def test_remove_clb_nodes_partial_success(self):
+        """
+        ``remove_clb_nodes`` removes only CLB_BATCH_DELETE_LIMIT nodes and
+        raises ``CLBPartialNodesRemoved`` with remaining nodes
+        """
+        limit = CLB_BATCH_DELETE_LIMIT
+        node_ids = map(str, range(limit + 2))
+        removed = map(six.text_type, range(limit))
+        not_removed = map(six.text_type, range(limit, limit + 2))
+        eff = remove_clb_nodes(self.lb_id, node_ids)
+        seq = [
+            (self.expected_node_removal_req(removed).intent,
+             service_request_eqf(stub_pure_response({}, 202))),
+        ]
+        with self.assertRaises(CLBPartialNodesRemoved) as ce:
+            perform_sequence(seq, eff)
+        self.assertEqual(
+            ce.exception,
+            CLBPartialNodesRemoved(
+                six.text_type(self.lb_id), not_removed, removed))
+
+    def test_get_clbs(self):
+        """Returns all the load balancer details from the LBs endpoint."""
+        expected = service_request(
+            ServiceType.CLOUD_LOAD_BALANCERS, 'GET', 'loadbalancers')
+        req = get_clbs()
+        body = {'loadBalancers': 'lbs!'}
+        seq = [
+            (expected.intent, lambda i: stub_json_response(body)),
+            (log_intent('request-list-clbs', body), lambda _: None)]
+        self.assertEqual(perform_sequence(seq, req), 'lbs!')
+
+    def test_get_clb_nodes(self):
+        """:func:`get_clb_nodes` returns all the nodes for a LB."""
+        req = get_clb_nodes(self.lb_id)
+        expected = service_request(
+            ServiceType.CLOUD_LOAD_BALANCERS,
+            'GET', 'loadbalancers/123456/nodes')
+        body = {'nodes': 'nodes!'}
+        seq = [
+            (expected.intent, lambda i: stub_json_response(body)),
+            (log_intent('request-list-clb-nodes', body), lambda _: None)]
+        self.assertEqual(perform_sequence(seq, req), 'nodes!')
+
+    def test_get_clb_nodes_error_handling(self):
+        """:func:`get_clb_nodes` parses the common CLB errors."""
+        expected = service_request(
+            ServiceType.CLOUD_LOAD_BALANCERS,
+            'GET', 'loadbalancers/123456/nodes')
+        assert_parses_common_clb_errors(
+            self, expected.intent, get_clb_nodes(self.lb_id), "123456")
+
+    def test_get_clb_health_mon(self):
+        """
+        :func:`get_clb_health_monitor` calls
+        ``GET .../loadbalancers/lb_id/healthmonitor`` and returns setting
+        inside {"healthMonitor": ...}
+        """
+        expected = service_request(
+            ServiceType.CLOUD_LOAD_BALANCERS,
+            'GET', 'loadbalancers/123456/healthmonitor')
+        settings = {
+            "type": "CONNECT",
+            "delay": 10,
+            "timeout": 10,
+            "attemptsBeforeDeactivation": 3
+        }
+        body = {"healthMonitor": settings}
+        seq = [
+            (expected.intent, const(stub_json_response(body))),
+            (log_intent('request-get-clb-healthmon', body), noop)
+        ]
+        self.assertEqual(
+            perform_sequence(seq, get_clb_health_monitor(self.lb_id)),
+            settings)
+
+    def test_get_clb_health_mon_error(self):
+        """
+        :func:`get_clb_health_monitor` parses the common CLB errors.
+        """
+        expected = service_request(
+            ServiceType.CLOUD_LOAD_BALANCERS, 'GET',
+            'loadbalancers/123456/healthmonitor')
+        assert_parses_common_clb_errors(
+            self, expected.intent, get_clb_health_monitor(self.lb_id),
+            self.lb_id)
+
+
+class GetCLBNodeFeedTests(SynchronousTestCase):
+
+    entry = '<entry><summary>{}</summary></entry>'
+    feed_fmt = (
+        '<feed xmlns="http://www.w3.org/2005/Atom">'
+        '<link rel="next" href="{next_link}"/>{entries}</feed>')
+
+    def svc_intent(self, params={}):
+        return service_request(
+            ServiceType.CLOUD_LOAD_BALANCERS, "GET",
+            "loadbalancers/12/nodes/13.atom", params=params,
+            json_response=False).intent
+
+    def feed(self, next_link, summaries):
+        return self.feed_fmt.format(
+            next_link=next_link,
+            entries=''.join(self.entry.format(s) for s in summaries))
+
+    def test_empty(self):
+        """
+        Does not goto next link when there are no entries and returns []
+        """
+        feedstr = self.feed("next-doesnt-matter", [])
+        seq = [
+            (self.svc_intent(), const(stub_json_response(feedstr))),
+            (log_intent("request-get-clb-node-feed", feedstr), const(feedstr))
+        ]
+        self.assertEqual(
+            perform_sequence(seq, get_clb_node_feed("12", "13")), [])
+
+    def test_single_page(self):
+        """
+        Collects entries and goes to next link if there are entries and returns
+        if next one is empty
+        """
+        feed1_str = self.feed("https://url?page=2", ["summary1", "summ2"])
+        feed2_str = self.feed("next-link", [])
+        seq = [
+            (self.svc_intent(), const(stub_json_response(feed1_str))),
+            (log_intent("request-get-clb-node-feed", feed1_str),
+             const(feed1_str)),
+            (self.svc_intent({"page": ['2']}),
+             const(stub_json_response(feed2_str))),
+            (log_intent("request-get-clb-node-feed", feed2_str),
+             const(feed2_str)),
+        ]
+        entries = perform_sequence(seq, get_clb_node_feed("12", "13"))
+        self.assertEqual(
+            [atom.summary(entry) for entry in entries], ["summary1", "summ2"])
+
+    def test_multiple_pages(self):
+        """
+        Collects entries and goes to next link if there are entries and
+        continues until next link returns empty list
+        """
+        feed1_str = self.feed("https://url?page=2", ["summ1", "summ2"])
+        feed2_str = self.feed("https://url?page=3", ["summ3", "summ4"])
+        feed3_str = self.feed("next-link", [])
+        seq = [
+            (self.svc_intent(), const(stub_json_response(feed1_str))),
+            (log_intent("request-get-clb-node-feed", feed1_str),
+             const(feed1_str)),
+            (self.svc_intent({"page": ['2']}),
+             const(stub_json_response(feed2_str))),
+            (log_intent("request-get-clb-node-feed", feed2_str),
+             const(feed2_str)),
+            (self.svc_intent({"page": ['3']}),
+             const(stub_json_response(feed3_str))),
+            (log_intent("request-get-clb-node-feed", feed3_str),
+             const(feed3_str)),
+        ]
+        entries = perform_sequence(seq, get_clb_node_feed("12", "13"))
+        self.assertEqual(
+            [atom.summary(entry) for entry in entries],
+            ["summ1", "summ2", "summ3", "summ4"])
+
+    def test_no_next_link(self):
+        """
+        Returns entries collected till now if there is no next link
+        """
+        feedstr = (
+            '<feed xmlns="http://www.w3.org/2005/Atom">'
+            '<entry><summary>summary</summary></entry></feed>')
+        seq = [
+            (self.svc_intent(), const(stub_json_response(feedstr))),
+            (log_intent("request-get-clb-node-feed", feedstr),
+             const(feedstr))
+        ]
+        entries = perform_sequence(seq, get_clb_node_feed("12", "13"))
+        self.assertEqual(atom.summary(entries[0]), "summary")
+
+    def test_error_handling(self):
+        """
+        Parses regular CLB errors and raises corresponding exceptions
+        """
+        assert_parses_common_clb_errors(
+            self, self.svc_intent(), get_clb_node_feed("12", "13"), "12")

--- a/otter/test/cloud_client/test_init.py
+++ b/otter/test/cloud_client/test_init.py
@@ -27,18 +27,8 @@ from txeffect import perform
 
 from otter.auth import Authenticate, InvalidateToken
 from otter.cloud_client import (
-    CLBDeletedError,
-    CLBDuplicateNodesError,
-    CLBImmutableError,
-    CLBNodeLimitError,
-    CLBNotActiveError,
-    CLBPartialNodesRemoved,
-    CLBRateLimitError,
-    CLB_BATCH_DELETE_LIMIT,
     CreateServerConfigurationError,
     CreateServerOverQuoteError,
-    NoSuchCLBError,
-    NoSuchCLBNodeError,
     NoSuchServerError,
     NovaComputeFaultError,
     NovaRateLimitError,
@@ -49,37 +39,26 @@ from otter.cloud_client import (
     _default_throttler,
     _perform_throttle,
     add_bind_service,
-    add_clb_nodes,
-    change_clb_node,
     check_stack,
     concretize_service_request,
     create_server,
     create_stack,
     delete_stack,
-    get_clb_health_monitor,
-    get_clb_node_feed,
-    get_clb_nodes,
-    get_clbs,
     get_cloud_client_dispatcher,
     get_server_details,
     list_servers_details_all,
     list_servers_details_page,
     list_stacks_all,
     perform_tenant_scope,
-    remove_clb_nodes,
     service_request,
     set_nova_metadata_item,
     update_stack)
 from otter.constants import ServiceType
-from otter.indexer import atom
 from otter.log.intents import Log
 from otter.test.utils import (
     StubResponse,
-    const,
     nested_sequence,
-    noop,
     resolve_effect,
-    stub_json_response,
     stub_pure_response
 )
 from otter.test.worker.test_launch_server_v1 import fake_service_catalog
@@ -151,6 +130,22 @@ def log_intent(msg_type, body, log_as_json=True, req_body=''):
          'request_id': "original-request-id",
          'response_body': body, 'request_body': req_body}
     )
+
+
+def _perform_one_request(intent, effect, response_code, response_body,
+                         log_intent=None):
+    """
+    Perform a request effect using EQFDispatcher, providing the given
+    body and status code.
+    """
+    seq = [(
+        intent,
+        service_request_eqf(
+            stub_pure_response(response_body, response_code))
+    )]
+    if log_intent is not None:
+        seq.append((log_intent, lambda _: None))
+    return perform_sequence(seq, effect)
 
 
 class BindServiceTests(SynchronousTestCase):
@@ -612,511 +607,6 @@ class PerformTenantScopeTests(SynchronousTestCase):
             sync_perform(self.dispatcher, Effect(tscope)),
             ('concretized', self.authenticator, self.log, self.service_configs,
              self.throttler, 1, ereq.intent))
-
-
-def assert_parses_common_clb_errors(testcase, intent, eff, lb_id):
-    """
-    Assert that the effect produced performs the common CLB error parsing:
-    :class:`CLBImmutableError`, :class:`CLBDescription`,
-    :class:`NoSuchCLBError`, :class:`CLBRateLimitError`,
-    :class:`APIError`
-
-    :param :obj:`twisted.trial.unittest.TestCase` testcase: Test object
-    :param intent: expected ``ServiceRequest`` intent
-    :param eff: Effect returned from function being tested
-    :param lb_id: ID of load balancer being accessed in the function being
-        tested
-    """
-    json_responses_and_errs = [
-        ("Load Balancer '{0}' has a status of 'BUILD' and is "
-         "considered immutable.", 422, CLBImmutableError),
-        ("Load Balancer '{0}' has a status of 'PENDING_UPDATE' and is "
-         "considered immutable.", 422, CLBImmutableError),
-        ("Load Balancer '{0}' has a status of 'unexpected status' and is "
-         "considered immutable.", 422, CLBImmutableError),
-        ("Load Balancer '{0}' has a status of 'PENDING_DELETE' and is "
-         "considered immutable.", 422, CLBDeletedError),
-        ("The load balancer is deleted and considered immutable.",
-         422, CLBDeletedError),
-        ("Load balancer not found.", 404, NoSuchCLBError),
-        ("LoadBalancer is not ACTIVE", 422, CLBNotActiveError),
-        ("The loadbalancer is marked as deleted.", 410, CLBDeletedError),
-    ]
-
-    for msg, code, err in json_responses_and_errs:
-        msg = msg.format(lb_id)
-        resp = stub_pure_response(
-            json.dumps({'message': msg, 'code': code, 'details': ''}),
-            code)
-        with testcase.assertRaises(err) as cm:
-            perform_sequence([(intent, service_request_eqf(resp))], eff)
-        testcase.assertEqual(cm.exception,
-                             err(msg, lb_id=six.text_type(lb_id)))
-
-    # OverLimit Retry is different because it's produced by repose
-    over_limit = stub_pure_response(
-        json.dumps({
-            "overLimit": {
-                "message": "OverLimit Retry...",
-                "code": 413,
-                "retryAfter": "2015-06-13T22:30:10Z",
-                "details": "Error Details..."
-            }
-        }),
-        413)
-    with testcase.assertRaises(CLBRateLimitError) as cm:
-        perform_sequence([(intent, service_request_eqf(over_limit))], eff)
-    testcase.assertEqual(
-        cm.exception,
-        CLBRateLimitError("OverLimit Retry...",
-                          lb_id=six.text_type(lb_id)))
-
-    # Ignored errors
-    bad_resps = [
-        stub_pure_response(
-            json.dumps({
-                'message': ("Load Balancer '{0}' has a status of 'BROKEN' "
-                            "and is considered immutable."),
-                'code': 422}),
-            422),
-        stub_pure_response(
-            json.dumps({
-                'message': ("The load balancer is deleted and considered "
-                            "immutable"),
-                'code': 404}),
-            404),
-        stub_pure_response(
-            json.dumps({
-                'message': "Cloud load balancers is down",
-                'code': 500}),
-            500),
-        stub_pure_response(
-            json.dumps({
-                'message': "this is not an over limit message",
-                'code': 413}),
-            413),
-        stub_pure_response("random repose error message", 404),
-        stub_pure_response("random repose error message", 413)
-    ]
-
-    for resp in bad_resps:
-        with testcase.assertRaises(APIError) as cm:
-            perform_sequence([(intent, service_request_eqf(resp))], eff)
-        testcase.assertEqual(
-            cm.exception,
-            APIError(headers={}, code=resp[0].code, body=resp[1],
-                     method='method', url='original/request/URL'))
-
-
-class CLBClientTests(SynchronousTestCase):
-    """
-    Tests for CLB client functions, such as :obj:`change_clb_node`.
-    """
-    @property
-    def lb_id(self):
-        """What is my LB ID"""
-        return "123456"
-
-    def test_change_clb_node(self):
-        """
-        Produce a request for modifying a node on a load balancer, which
-        returns a successful result on 202.
-
-        Parse the common CLB errors, and :class:`NoSuchCLBNodeError`.
-        """
-        eff = change_clb_node(lb_id=self.lb_id, node_id='1234',
-                              condition="DRAINING", weight=50,
-                              _type='SECONDARY')
-        expected = service_request(
-            ServiceType.CLOUD_LOAD_BALANCERS,
-            'PUT',
-            'loadbalancers/{0}/nodes/1234'.format(self.lb_id),
-            data={'node': {'condition': 'DRAINING',
-                           'weight': 50, 'type': 'SECONDARY'}},
-            success_pred=has_code(202))
-
-        # success
-        dispatcher = EQFDispatcher([(
-            expected.intent,
-            service_request_eqf(stub_pure_response('', 202)))])
-        self.assertEqual(sync_perform(dispatcher, eff),
-                         stub_pure_response(None, 202))
-
-        # NoSuchCLBNode failure
-        msg = "Node with id #1234 not found for loadbalancer #{0}".format(
-            self.lb_id)
-        no_such_node = stub_pure_response(
-            json.dumps({'message': msg, 'code': 404}), 404)
-        dispatcher = EQFDispatcher([(
-            expected.intent, service_request_eqf(no_such_node))])
-
-        with self.assertRaises(NoSuchCLBNodeError) as cm:
-            sync_perform(dispatcher, eff)
-        self.assertEqual(
-            cm.exception,
-            NoSuchCLBNodeError(msg, lb_id=six.text_type(self.lb_id),
-                               node_id=u'1234'))
-
-        # all the common failures
-        assert_parses_common_clb_errors(self, expected.intent, eff, "123456")
-
-    def test_change_clb_node_default_type(self):
-        """
-        Produce a request for modifying a node on a load balancer with the
-        default type, which returns a successful result on 202.
-        """
-        eff = change_clb_node(lb_id=self.lb_id, node_id='1234',
-                              condition="DRAINING", weight=50)
-        expected = service_request(
-            ServiceType.CLOUD_LOAD_BALANCERS,
-            'PUT',
-            'loadbalancers/{0}/nodes/1234'.format(self.lb_id),
-            data={'node': {'condition': 'DRAINING',
-                           'weight': 50, 'type': 'PRIMARY'}},
-            success_pred=has_code(202))
-
-        dispatcher = EQFDispatcher([(
-            expected.intent,
-            service_request_eqf(stub_pure_response('', 202)))])
-        self.assertEqual(sync_perform(dispatcher, eff),
-                         stub_pure_response(None, 202))
-
-    def test_add_clb_nodes(self):
-        """
-        Produce a request for adding nodes to a load balancer, which returns
-        a successful result on a 202.
-
-        Parse the common CLB errors, and a :class:`CLBDuplicateNodesError`.
-        """
-        nodes = [{"address": "1.1.1.1", "port": 80, "condition": "ENABLED"},
-                 {"address": "1.1.1.2", "port": 80, "condition": "ENABLED"},
-                 {"address": "1.1.1.5", "port": 81, "condition": "ENABLED"}]
-
-        eff = add_clb_nodes(lb_id=self.lb_id, nodes=nodes)
-        expected = service_request(
-            ServiceType.CLOUD_LOAD_BALANCERS,
-            'POST',
-            'loadbalancers/{0}/nodes'.format(self.lb_id),
-            data={'nodes': nodes},
-            success_pred=has_code(202))
-
-        # success
-        seq = [
-            (expected.intent, lambda i: stub_json_response({}, 202, {})),
-            (log_intent('request-add-clb-nodes', {}), lambda _: None)]
-        self.assertEqual(perform_sequence(seq, eff),
-                         (StubResponse(202, {}), {}))
-
-        # CLBDuplicateNodesError failure
-        msg = ("Duplicate nodes detected. One or more nodes already "
-               "configured on load balancer.")
-        duplicate_nodes = stub_pure_response(
-            json.dumps({'message': msg, 'code': 422}), 422)
-        dispatcher = EQFDispatcher([(
-            expected.intent, service_request_eqf(duplicate_nodes))])
-
-        with self.assertRaises(CLBDuplicateNodesError) as cm:
-            sync_perform(dispatcher, eff)
-        self.assertEqual(
-            cm.exception,
-            CLBDuplicateNodesError(msg, lb_id=six.text_type(self.lb_id)))
-
-        # CLBNodeLimitError failure
-        msg = "Nodes must not exceed 25 per load balancer."
-        limit = stub_pure_response(
-            json.dumps({'message': msg, 'code': 413}), 413)
-        dispatcher = EQFDispatcher([(
-            expected.intent, service_request_eqf(limit))])
-
-        with self.assertRaises(CLBNodeLimitError) as cm:
-            sync_perform(dispatcher, eff)
-        self.assertEqual(
-            cm.exception,
-            CLBNodeLimitError(msg, lb_id=six.text_type(self.lb_id),
-                              node_limit=25))
-
-        # all the common failures
-        assert_parses_common_clb_errors(self, expected.intent, eff, "123456")
-
-    def expected_node_removal_req(self, nodes=(1, 2)):
-        """
-        :return: Expected effect for a node removal request.
-        """
-        return service_request(
-            ServiceType.CLOUD_LOAD_BALANCERS,
-            'DELETE',
-            'loadbalancers/{}/nodes'.format(self.lb_id),
-            params={'id': map(str, nodes)},
-            success_pred=has_code(202))
-
-    def test_remove_clb_nodes_success(self):
-        """
-        A DELETE request is sent, and the Effect returns None if 202 is
-        returned.
-        """
-        eff = remove_clb_nodes(self.lb_id, ["1", "2"])
-        seq = [
-            (self.expected_node_removal_req().intent,
-             service_request_eqf(stub_pure_response({}, 202))),
-        ]
-        result = perform_sequence(seq, eff)
-        self.assertIs(result, None)
-
-    def test_remove_clb_nodes_handles_standard_clb_errors(self):
-        """
-        Common CLB errors about it being in a deleted state, pending update,
-        etc. are handled.
-        """
-        eff = remove_clb_nodes(self.lb_id, ["1", "2"])
-        assert_parses_common_clb_errors(
-            self, self.expected_node_removal_req().intent, eff, "123456")
-
-    def test_remove_clb_nodes_non_202(self):
-        """Any random HTTP response code is bubbled up as an APIError."""
-        eff = remove_clb_nodes(self.lb_id, ["1", "2"])
-        seq = [
-            (self.expected_node_removal_req().intent,
-             service_request_eqf(stub_pure_response({}, 200))),
-        ]
-        self.assertRaises(APIError, perform_sequence, seq, eff)
-
-    def test_remove_clb_nodes_random_400(self):
-        """Random 400s that can't be parsed are bubbled up as an APIError."""
-        error_bodies = [
-            {'validationErrors': {'messages': ['bar']}},
-            {'messages': 'bar'},
-            {'validationErrors': {'messages': []}},
-            "random non-json"
-        ]
-        for body in error_bodies:
-            eff = remove_clb_nodes(self.lb_id, ["1", "2"])
-            seq = [
-                (self.expected_node_removal_req().intent,
-                 service_request_eqf(stub_pure_response(body, 400))),
-            ]
-            self.assertRaises(APIError, perform_sequence, seq, eff)
-
-    def test_remove_clb_nodes_retry_on_some_invalid_nodes(self):
-        """
-        When CLB returns an error indicating that some of the nodes are
-        invalid, the request is retried without the offending nodes.
-        """
-        node_ids = map(str, range(1, 5))
-        eff = remove_clb_nodes(self.lb_id, node_ids)
-        response = stub_pure_response(
-            {'validationErrors': {'messages': [
-                'Node ids 1,3 are not a part of your loadbalancer']}},
-            400)
-        response2 = stub_pure_response({}, 202)
-        seq = [
-            (self.expected_node_removal_req(node_ids).intent,
-             service_request_eqf(response)),
-            (self.expected_node_removal_req(["2", "4"]).intent,
-             service_request_eqf(response2))
-        ]
-        self.assertIs(perform_sequence(seq, eff), None)
-
-    def test_remove_clb_nodes_partial_success(self):
-        """
-        ``remove_clb_nodes`` removes only CLB_BATCH_DELETE_LIMIT nodes and
-        raises ``CLBPartialNodesRemoved`` with remaining nodes
-        """
-        limit = CLB_BATCH_DELETE_LIMIT
-        node_ids = map(str, range(limit + 2))
-        removed = map(six.text_type, range(limit))
-        not_removed = map(six.text_type, range(limit, limit + 2))
-        eff = remove_clb_nodes(self.lb_id, node_ids)
-        seq = [
-            (self.expected_node_removal_req(removed).intent,
-             service_request_eqf(stub_pure_response({}, 202))),
-        ]
-        with self.assertRaises(CLBPartialNodesRemoved) as ce:
-            perform_sequence(seq, eff)
-        self.assertEqual(
-            ce.exception,
-            CLBPartialNodesRemoved(
-                six.text_type(self.lb_id), not_removed, removed))
-
-    def test_get_clbs(self):
-        """Returns all the load balancer details from the LBs endpoint."""
-        expected = service_request(
-            ServiceType.CLOUD_LOAD_BALANCERS, 'GET', 'loadbalancers')
-        req = get_clbs()
-        body = {'loadBalancers': 'lbs!'}
-        seq = [
-            (expected.intent, lambda i: stub_json_response(body)),
-            (log_intent('request-list-clbs', body), lambda _: None)]
-        self.assertEqual(perform_sequence(seq, req), 'lbs!')
-
-    def test_get_clb_nodes(self):
-        """:func:`get_clb_nodes` returns all the nodes for a LB."""
-        req = get_clb_nodes(self.lb_id)
-        expected = service_request(
-            ServiceType.CLOUD_LOAD_BALANCERS,
-            'GET', 'loadbalancers/123456/nodes')
-        body = {'nodes': 'nodes!'}
-        seq = [
-            (expected.intent, lambda i: stub_json_response(body)),
-            (log_intent('request-list-clb-nodes', body), lambda _: None)]
-        self.assertEqual(perform_sequence(seq, req), 'nodes!')
-
-    def test_get_clb_nodes_error_handling(self):
-        """:func:`get_clb_nodes` parses the common CLB errors."""
-        expected = service_request(
-            ServiceType.CLOUD_LOAD_BALANCERS,
-            'GET', 'loadbalancers/123456/nodes')
-        assert_parses_common_clb_errors(
-            self, expected.intent, get_clb_nodes(self.lb_id), "123456")
-
-    def test_get_clb_health_mon(self):
-        """
-        :func:`get_clb_health_monitor` calls
-        ``GET .../loadbalancers/lb_id/healthmonitor`` and returns setting
-        inside {"healthMonitor": ...}
-        """
-        expected = service_request(
-            ServiceType.CLOUD_LOAD_BALANCERS,
-            'GET', 'loadbalancers/123456/healthmonitor')
-        settings = {
-            "type": "CONNECT",
-            "delay": 10,
-            "timeout": 10,
-            "attemptsBeforeDeactivation": 3
-        }
-        body = {"healthMonitor": settings}
-        seq = [
-            (expected.intent, const(stub_json_response(body))),
-            (log_intent('request-get-clb-healthmon', body), noop)
-        ]
-        self.assertEqual(
-            perform_sequence(seq, get_clb_health_monitor(self.lb_id)),
-            settings)
-
-    def test_get_clb_health_mon_error(self):
-        """
-        :func:`get_clb_health_monitor` parses the common CLB errors.
-        """
-        expected = service_request(
-            ServiceType.CLOUD_LOAD_BALANCERS, 'GET',
-            'loadbalancers/123456/healthmonitor')
-        assert_parses_common_clb_errors(
-            self, expected.intent, get_clb_health_monitor(self.lb_id),
-            self.lb_id)
-
-
-class GetCLBNodeFeedTests(SynchronousTestCase):
-
-    entry = '<entry><summary>{}</summary></entry>'
-    feed_fmt = (
-        '<feed xmlns="http://www.w3.org/2005/Atom">'
-        '<link rel="next" href="{next_link}"/>{entries}</feed>')
-
-    def svc_intent(self, params={}):
-        return service_request(
-            ServiceType.CLOUD_LOAD_BALANCERS, "GET",
-            "loadbalancers/12/nodes/13.atom", params=params,
-            json_response=False).intent
-
-    def feed(self, next_link, summaries):
-        return self.feed_fmt.format(
-            next_link=next_link,
-            entries=''.join(self.entry.format(s) for s in summaries))
-
-    def test_empty(self):
-        """
-        Does not goto next link when there are no entries and returns []
-        """
-        feedstr = self.feed("next-doesnt-matter", [])
-        seq = [
-            (self.svc_intent(), const(stub_json_response(feedstr))),
-            (log_intent("request-get-clb-node-feed", feedstr), const(feedstr))
-        ]
-        self.assertEqual(
-            perform_sequence(seq, get_clb_node_feed("12", "13")), [])
-
-    def test_single_page(self):
-        """
-        Collects entries and goes to next link if there are entries and returns
-        if next one is empty
-        """
-        feed1_str = self.feed("https://url?page=2", ["summary1", "summ2"])
-        feed2_str = self.feed("next-link", [])
-        seq = [
-            (self.svc_intent(), const(stub_json_response(feed1_str))),
-            (log_intent("request-get-clb-node-feed", feed1_str),
-             const(feed1_str)),
-            (self.svc_intent({"page": ['2']}),
-             const(stub_json_response(feed2_str))),
-            (log_intent("request-get-clb-node-feed", feed2_str),
-             const(feed2_str)),
-        ]
-        entries = perform_sequence(seq, get_clb_node_feed("12", "13"))
-        self.assertEqual(
-            [atom.summary(entry) for entry in entries], ["summary1", "summ2"])
-
-    def test_multiple_pages(self):
-        """
-        Collects entries and goes to next link if there are entries and
-        continues until next link returns empty list
-        """
-        feed1_str = self.feed("https://url?page=2", ["summ1", "summ2"])
-        feed2_str = self.feed("https://url?page=3", ["summ3", "summ4"])
-        feed3_str = self.feed("next-link", [])
-        seq = [
-            (self.svc_intent(), const(stub_json_response(feed1_str))),
-            (log_intent("request-get-clb-node-feed", feed1_str),
-             const(feed1_str)),
-            (self.svc_intent({"page": ['2']}),
-             const(stub_json_response(feed2_str))),
-            (log_intent("request-get-clb-node-feed", feed2_str),
-             const(feed2_str)),
-            (self.svc_intent({"page": ['3']}),
-             const(stub_json_response(feed3_str))),
-            (log_intent("request-get-clb-node-feed", feed3_str),
-             const(feed3_str)),
-        ]
-        entries = perform_sequence(seq, get_clb_node_feed("12", "13"))
-        self.assertEqual(
-            [atom.summary(entry) for entry in entries],
-            ["summ1", "summ2", "summ3", "summ4"])
-
-    def test_no_next_link(self):
-        """
-        Returns entries collected till now if there is no next link
-        """
-        feedstr = (
-            '<feed xmlns="http://www.w3.org/2005/Atom">'
-            '<entry><summary>summary</summary></entry></feed>')
-        seq = [
-            (self.svc_intent(), const(stub_json_response(feedstr))),
-            (log_intent("request-get-clb-node-feed", feedstr),
-             const(feedstr))
-        ]
-        entries = perform_sequence(seq, get_clb_node_feed("12", "13"))
-        self.assertEqual(atom.summary(entries[0]), "summary")
-
-    def test_error_handling(self):
-        """
-        Parses regular CLB errors and raises corresponding exceptions
-        """
-        assert_parses_common_clb_errors(
-            self, self.svc_intent(), get_clb_node_feed("12", "13"), "12")
-
-
-def _perform_one_request(intent, effect, response_code, response_body,
-                         log_intent=None):
-    """
-    Perform a request effect using EQFDispatcher, providing the given
-    body and status code.
-    """
-    seq = [(
-        intent,
-        service_request_eqf(
-            stub_pure_response(response_body, response_code))
-    )]
-    if log_intent is not None:
-        seq.append((log_intent, lambda _: None))
-    return perform_sequence(seq, effect)
 
 
 class NovaClientTests(SynchronousTestCase):

--- a/otter/test/convergence/test_errors.py
+++ b/otter/test/convergence/test_errors.py
@@ -4,10 +4,12 @@ from twisted.trial.unittest import SynchronousTestCase
 
 from otter.auth import NoSuchEndpoint
 from otter.cloud_client import (
+    CreateServerConfigurationError,
+    CreateServerOverQuoteError
+)
+from otter.cloud_client.clb import (
     CLBDeletedError,
     CLBNodeLimitError,
-    CreateServerConfigurationError,
-    CreateServerOverQuoteError,
     NoSuchCLBError,
     NoSuchCLBNodeError
 )

--- a/otter/test/convergence/test_gathering.py
+++ b/otter/test/convergence/test_gathering.py
@@ -28,10 +28,9 @@ from toolz.functoolz import compose
 from twisted.trial.unittest import SynchronousTestCase
 
 from otter.auth import NoSuchEndpoint
-from otter.cloud_client import (
-    CLBNotFoundError,
-    service_request
-)
+from otter.cloud_client import service_request
+from otter.cloud_client.clb import CLBNotFoundError
+
 from otter.constants import ServiceType
 from otter.convergence.gathering import (
     extract_clb_drained_at,

--- a/otter/test/convergence/test_service.py
+++ b/otter/test/convergence/test_service.py
@@ -24,7 +24,8 @@ from pyrsistent import freeze, pbag, pmap, pset, s, thaw
 from twisted.trial.unittest import SynchronousTestCase
 
 from otter.auth import NoSuchEndpoint
-from otter.cloud_client import NoSuchCLBError, TenantScope
+from otter.cloud_client import TenantScope
+from otter.cloud_client.clb import NoSuchCLBError
 from otter.constants import CONVERGENCE_DIRTY_DIR
 from otter.convergence.composition import (get_desired_server_group_state,
                                            get_desired_stack_group_state)

--- a/otter/test/convergence/test_steps.py
+++ b/otter/test/convergence/test_steps.py
@@ -14,17 +14,8 @@ from testtools.matchers import ContainsAll
 from twisted.trial.unittest import SynchronousTestCase
 
 from otter.cloud_client import (
-    CLBDeletedError,
-    CLBDuplicateNodesError,
-    CLBImmutableError,
-    CLBNodeLimitError,
-    CLBNotActiveError,
-    CLBNotFoundError,
-    CLBRateLimitError,
     CreateServerConfigurationError,
     CreateServerOverQuoteError,
-    NoSuchCLBError,
-    NoSuchCLBNodeError,
     NoSuchServerError,
     NovaComputeFaultError,
     NovaRateLimitError,
@@ -33,16 +24,29 @@ from otter.cloud_client import (
     create_stack,
     delete_stack,
     has_code,
-    service_request,
     rcv3,
-    update_stack)
+    service_request,
+    update_stack
+)
+from otter.cloud_client.clb import (
+    CLBDeletedError,
+    CLBDuplicateNodesError,
+    CLBImmutableError,
+    CLBNodeLimitError,
+    CLBNotActiveError,
+    CLBNotFoundError,
+    CLBRateLimitError,
+    NoSuchCLBError,
+    NoSuchCLBNodeError
+)
 from otter.constants import ServiceType
 from otter.convergence.model import (
     CLBDescription,
     CLBNodeCondition,
     CLBNodeType,
     ErrorReason,
-    StepResult)
+    StepResult
+)
 from otter.convergence.steps import (
     AddNodesToCLB,
     BulkAddToRCv3,
@@ -70,7 +74,8 @@ from otter.test.utils import (
     resolve_effect,
     stack,
     stub_pure_response,
-    transform_eq)
+    transform_eq
+)
 from otter.util.hashkey import generate_server_name
 from otter.util.http import APIError
 from otter.util.retry import (


### PR DESCRIPTION
And changed all the callers to point to the new place. This will help in refactoring another PR I've in mind to split out reading feeds as a generic function. Sorry this is too long but be ensured this is pure refactor. 