### PR TITLE
Common function to read feed entries

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -65,7 +65,7 @@
         "service": "cloudFeeds",
         "tenant_id": "identity_admin_tenant",
         "url": "http://cfurl.net/not/in/service/catalog",
-        "customer_acess_events_url": "https://dfwurl/not_in_catalog"
+        "customer_acess_events": {"url": "https://dfwurl/not_in_catalog"}
     },
     "converger": {
         "build_timeout": 3600,

--- a/config.example.json
+++ b/config.example.json
@@ -64,8 +64,12 @@
     "cloudfeeds": {
         "service": "cloudFeeds",
         "tenant_id": "identity_admin_tenant",
-        "url": "https://cfurl.example.net/not/in/service/catalog",
-        "customer_acess_events": {"url": "https://dfwcf.example.net/not_in_catalog"}
+        "url": "https://cfurl.example.net/not/in/service/catalog"
+    },
+    "terminator": {
+        "interval": 300,
+        "tenant_id": "identity_admin_tenant",
+        "cf_cap_url": "https://cfurl.example.net/not/in/service/catalog"
     },
     "converger": {
         "build_timeout": 3600,

--- a/config.example.json
+++ b/config.example.json
@@ -64,7 +64,8 @@
     "cloudfeeds": {
         "service": "cloudFeeds",
         "tenant_id": "identity_admin_tenant",
-        "url": "http://cfurl.net/not/in/service/catalog"
+        "url": "http://cfurl.net/not/in/service/catalog",
+        "customer_acess_events_url": "https://dfwurl/not_in_catalog"
     },
     "converger": {
         "build_timeout": 3600,

--- a/config.example.json
+++ b/config.example.json
@@ -64,8 +64,8 @@
     "cloudfeeds": {
         "service": "cloudFeeds",
         "tenant_id": "identity_admin_tenant",
-        "url": "http://cfurl.net/not/in/service/catalog",
-        "customer_acess_events": {"url": "https://dfwurl/not_in_catalog"}
+        "url": "https://cfurl.example.net/not/in/service/catalog",
+        "customer_acess_events": {"url": "https://dfwcf.example.net/not_in_catalog"}
     },
     "converger": {
         "build_timeout": 3600,

--- a/otter/cloud_client/__init__.py
+++ b/otter/cloud_client/__init__.py
@@ -182,8 +182,6 @@ def concretize_service_request(
         log = service_request.log
 
     service_config = service_configs[service_request.service_type]
-    region = service_config['region']
-    service_name = service_config['name']
 
     def got_auth((token, catalog)):
         request_ = add_headers(otter_headers(token), request)
@@ -193,6 +191,8 @@ def concretize_service_request(
         if 'url' in service_config:
             request_ = add_bind_root(service_config['url'], request_)
         else:
+            region = service_config['region']
+            service_name = service_config['name']
             request_ = add_bind_service(
                 catalog, service_name, region, log, request_)
         request_ = add_error_handling(

--- a/otter/cloud_client/cloudfeeds.py
+++ b/otter/cloud_client/cloudfeeds.py
@@ -2,8 +2,15 @@
 Cloud feeds related APIs
 """
 
+from urlparse import parse_qs, urlparse
+
+from effect.do import do, do_return
+
+from twisted.python.constants import NamedConstant, Names
+
 from otter.cloud_client import service_request
 from otter.constants import ServiceType
+from otter.indexer import atom
 from otter.util.http import append_segments
 from otter.util.pure_http import has_code
 
@@ -22,3 +29,48 @@ def publish_autoscale_event(event, log=None):
             'content-type': ['application/vnd.rackspace.atom+json']},
         data=event, log=log, success_pred=has_code(201),
         json_response=False)
+
+
+class Direction(Names):
+    """
+    Which direction to follow the feeds?
+    """
+    PREVIOUS = NamedConstant()
+    NEXT = NamedConstant()
+
+
+@do
+def read_entries(service_type, url, params, direction):
+    """
+    Read all feed entries and follow in given direction until it is empty
+
+    :param service_type: Either CLOUD_FEEDS or CLOUD_FEEDS_CAP
+    :type service_type: A member of :class:`ServiceType`
+    :param str url: CF URL to append
+    :param dict params: HTTP parameters
+    :param direction: Where to continue fetching?
+    :type direction: A member of :class:`Direction`
+
+    :return: (``list`` of :obj:`Element`, last fetched params) tuple
+    """
+    if direction == Direction.PREVIOUS:
+        direction_link = atom.previous_link
+    elif direction == Direction.NEXT:
+        direction_link = atom.next_link
+    else:
+        raise ValueError("Invalid direction")
+    all_entries = []
+    while True:
+        resp, feed_str = yield service_request(
+            service_type, "GET", url, params=params,
+            json_response=False)
+        feed = atom.parse(feed_str)
+        entries = atom.entries(feed)
+        if entries == []:
+            break
+        all_entries.extend(entries)
+        link = direction_link(feed)
+        if link is None:
+            break
+        params = parse_qs(urlparse(link).query)
+    yield do_return((all_entries, params))

--- a/otter/cloud_client/cloudfeeds.py
+++ b/otter/cloud_client/cloudfeeds.py
@@ -42,7 +42,8 @@ class Direction(Names):
 
 
 @do
-def read_entries(service_type, url, params, direction, log_msg_type=None):
+def read_entries(service_type, url, params, direction, follow_limit=100,
+                 log_msg_type=None):
     """
     Read all feed entries and follow in given direction until it is empty
 
@@ -52,6 +53,8 @@ def read_entries(service_type, url, params, direction, log_msg_type=None):
     :param dict params: HTTP parameters
     :param direction: Where to continue fetching?
     :type direction: A member of :class:`Direction`
+    :param int follow_limit: Maximum number of times to follow in given
+        direction
 
     :return: (``list`` of :obj:`Element`, last fetched params) tuple
     """
@@ -68,7 +71,7 @@ def read_entries(service_type, url, params, direction, log_msg_type=None):
         log_cb = identity
 
     all_entries = []
-    while True:
+    while follow_limit > 0:
         resp, feed_str = yield service_request(
             service_type, "GET", url, params=params,
             json_response=False).on(log_cb)
@@ -81,4 +84,5 @@ def read_entries(service_type, url, params, direction, log_msg_type=None):
         if link is None:
             break
         params = parse_qs(urlparse(link).query)
+        follow_limit -= 1
     yield do_return((all_entries, params))

--- a/otter/constants.py
+++ b/otter/constants.py
@@ -59,22 +59,18 @@ def get_service_configs(config):
         configs[ServiceType.CLOUD_METRICS_INGEST] = {
             'name': metrics['service'], 'region': metrics['region']}
 
-    # {"cloudfeeds"...} contains config for 2 feeds services: One where otter
-    # pushes scaling group events `otter.log.cloudfeeds` as {"url": ...}
-    # and other where it fetches customer access events for terminator which
-    # is {"customer_access_events": {"url": "https://url"} or
-    #                               {"name": "service name"}}
-    # The {"name"..} option is to test otter against mimic that only returns
-    # URLs from service catalog.
+    # {"cloudfeeds": {"url": "https://url"}} config is for service which
+    # is used to push scaling group events: `otter.log.cloudfeeds`.
     cf = config.get('cloudfeeds')
     if cf is not None:
         configs[ServiceType.CLOUD_FEEDS] = {'url': cf['url']}
-        cap_conf = cf.get("customer_access_events")
-        if cap_conf is not None:
-            if "url" in cap_conf:
-                cap_service_conf = {"url": cap_conf["url"]}
-            else:
-                cap_service_conf = {"name": cap_conf["name"], "region": region}
-            configs[ServiceType.CLOUD_FEEDS_CAP] = cap_service_conf
+
+    # "terminator" contains config to setup terminator service and
+    # cloud feed client to access customer access policy events. This and
+    # above cloudfeeds service have fixed URL as opposed to service being
+    # there  in service catalog
+    term = config.get('terminator')
+    if term is not None:
+        configs[ServiceType.CLOUD_FEEDS_CAP] = {'url': term['cf_cap_url']}
 
     return configs

--- a/otter/constants.py
+++ b/otter/constants.py
@@ -62,7 +62,7 @@ def get_service_configs(config):
     # {"cloudfeeds"...} contains config for 2 feeds services: One where otter
     # pushes scaling group events `otter.log.cloudfeeds` as {"url": ...}
     # and other where it fetches customer access events for terminator which
-    # is {"customer_access_events": {"url": "http://url"} or
+    # is {"customer_access_events": {"url": "https://url"} or
     #                               {"name": "service name"}}
     # The {"name"..} option is to test otter against mimic that only returns
     # URLs from service catalog.

--- a/otter/constants.py
+++ b/otter/constants.py
@@ -8,12 +8,18 @@ CONVERGENCE_PARTITIONER_PATH = '/convergence-partitioner'
 
 
 class ServiceType(Names):
-    """Constants representing Rackspace cloud services."""
+    """
+    Constants representing Rackspace cloud services.
+
+    Note: CLOUD_FEEDS_CAP represents customer access policy events which like
+    CLOUD_FEEDS is fixed URL but different from CLOUD_FEEDS.
+    """
     CLOUD_SERVERS = NamedConstant()
     CLOUD_LOAD_BALANCERS = NamedConstant()
     RACKCONNECT_V3 = NamedConstant()
     CLOUD_METRICS_INGEST = NamedConstant()
     CLOUD_FEEDS = NamedConstant()
+    CLOUD_FEEDS_CAP = NamedConstant()
     CLOUD_ORCHESTRATION = NamedConstant()
 
 
@@ -54,8 +60,9 @@ def get_service_configs(config):
 
     cf = config.get('cloudfeeds')
     if cf is not None:
-        configs[ServiceType.CLOUD_FEEDS] = {
-            'name': cf['service'], 'region': config['region'],
-            'url': cf['url']}
+        configs[ServiceType.CLOUD_FEEDS] = {'url': cf['url']}
+        customer_access_url = cf.get("customer_access_events_url")
+        if customer_access_url is not None:
+            configs[ServiceType.CLOUD_FEEDS_CAP] = {'url': customer_access_url}
 
     return configs

--- a/otter/test/cloud_client/test_clb.py
+++ b/otter/test/cloud_client/test_clb.py
@@ -4,7 +4,7 @@ import json
 
 from effect import sync_perform
 from effect.testing import (
-    EQFDispatcher, const,intent_func,  noop, perform_sequence)
+    EQFDispatcher, const, intent_func, noop, perform_sequence)
 
 import six
 

--- a/otter/test/cloud_client/test_clb.py
+++ b/otter/test/cloud_client/test_clb.py
@@ -29,11 +29,11 @@ from otter.cloud_client.clb import (
     get_clbs,
     remove_clb_nodes)
 from otter.constants import ServiceType
-from otter.indexer import atom
 from otter.test.cloud_client.test_init import log_intent, service_request_eqf
 from otter.test.utils import (
     StubResponse,
     const,
+    intent_func,
     noop,
     stub_json_response,
     stub_pure_response
@@ -433,99 +433,33 @@ class CLBClientTests(SynchronousTestCase):
 
 
 class GetCLBNodeFeedTests(SynchronousTestCase):
+    """
+    Tests for :func:`get_clb_node_feed`
+    """
 
-    entry = '<entry><summary>{}</summary></entry>'
-    feed_fmt = (
-        '<feed xmlns="http://www.w3.org/2005/Atom">'
-        '<link rel="next" href="{next_link}"/>{entries}</feed>')
-
-    def svc_intent(self, params={}):
-        return service_request(
-            ServiceType.CLOUD_LOAD_BALANCERS, "GET",
-            "loadbalancers/12/nodes/13.atom", params=params,
-            json_response=False).intent
-
-    def feed(self, next_link, summaries):
-        return self.feed_fmt.format(
-            next_link=next_link,
-            entries=''.join(self.entry.format(s) for s in summaries))
-
-    def test_empty(self):
+    def test_calls_read_entries(self):
         """
-        Does not goto next link when there are no entries and returns []
+        Calls `cf.read_entries` with CLB servicetype and atom URL and returns
+        the feed part of the result
         """
-        feedstr = self.feed("next-doesnt-matter", [])
+        from otter.cloud_client.clb import cf
+        self.patch(cf, "read_entries", intent_func("re"))
+        eff = get_clb_node_feed("12", "13")
         seq = [
-            (self.svc_intent(), const(stub_json_response(feedstr))),
-            (log_intent("request-get-clb-node-feed", feedstr), const(feedstr))
+            (("re", ServiceType.CLOUD_LOAD_BALANCERS,
+              "loadbalancers/12/nodes/13.atom", {}, cf.Direction.NEXT,
+              "request-get-clb-node-feed"),
+             const((["feed1"], {"param": "2"})))
         ]
-        self.assertEqual(
-            perform_sequence(seq, get_clb_node_feed("12", "13")), [])
-
-    def test_single_page(self):
-        """
-        Collects entries and goes to next link if there are entries and returns
-        if next one is empty
-        """
-        feed1_str = self.feed("https://url?page=2", ["summary1", "summ2"])
-        feed2_str = self.feed("next-link", [])
-        seq = [
-            (self.svc_intent(), const(stub_json_response(feed1_str))),
-            (log_intent("request-get-clb-node-feed", feed1_str),
-             const(feed1_str)),
-            (self.svc_intent({"page": ['2']}),
-             const(stub_json_response(feed2_str))),
-            (log_intent("request-get-clb-node-feed", feed2_str),
-             const(feed2_str)),
-        ]
-        entries = perform_sequence(seq, get_clb_node_feed("12", "13"))
-        self.assertEqual(
-            [atom.summary(entry) for entry in entries], ["summary1", "summ2"])
-
-    def test_multiple_pages(self):
-        """
-        Collects entries and goes to next link if there are entries and
-        continues until next link returns empty list
-        """
-        feed1_str = self.feed("https://url?page=2", ["summ1", "summ2"])
-        feed2_str = self.feed("https://url?page=3", ["summ3", "summ4"])
-        feed3_str = self.feed("next-link", [])
-        seq = [
-            (self.svc_intent(), const(stub_json_response(feed1_str))),
-            (log_intent("request-get-clb-node-feed", feed1_str),
-             const(feed1_str)),
-            (self.svc_intent({"page": ['2']}),
-             const(stub_json_response(feed2_str))),
-            (log_intent("request-get-clb-node-feed", feed2_str),
-             const(feed2_str)),
-            (self.svc_intent({"page": ['3']}),
-             const(stub_json_response(feed3_str))),
-            (log_intent("request-get-clb-node-feed", feed3_str),
-             const(feed3_str)),
-        ]
-        entries = perform_sequence(seq, get_clb_node_feed("12", "13"))
-        self.assertEqual(
-            [atom.summary(entry) for entry in entries],
-            ["summ1", "summ2", "summ3", "summ4"])
-
-    def test_no_next_link(self):
-        """
-        Returns entries collected till now if there is no next link
-        """
-        feedstr = (
-            '<feed xmlns="http://www.w3.org/2005/Atom">'
-            '<entry><summary>summary</summary></entry></feed>')
-        seq = [
-            (self.svc_intent(), const(stub_json_response(feedstr))),
-            (log_intent("request-get-clb-node-feed", feedstr),
-             const(feedstr))
-        ]
-        entries = perform_sequence(seq, get_clb_node_feed("12", "13"))
-        self.assertEqual(atom.summary(entries[0]), "summary")
+        self.assertEqual(perform_sequence(seq, eff), ["feed1"])
 
     def test_error_handling(self):
         """
         Parses regular CLB errors and raises corresponding exceptions
         """
+        svc_intent = service_request(
+            ServiceType.CLOUD_LOAD_BALANCERS, "GET",
+            "loadbalancers/12/nodes/13.atom", params={},
+            json_response=False).intent
         assert_parses_common_clb_errors(
-            self, self.svc_intent(), get_clb_node_feed("12", "13"), "12")
+            self, svc_intent, get_clb_node_feed("12", "13"), "12")

--- a/otter/test/cloud_client/test_cloudfeeds.py
+++ b/otter/test/cloud_client/test_cloudfeeds.py
@@ -3,7 +3,8 @@
 from functools import wraps
 
 from effect import sync_perform
-from effect.testing import EQFDispatcher, base_dispatcher, perform_sequence
+from effect.testing import (
+    EQFDispatcher, base_dispatcher, const, noop, perform_sequence)
 
 from twisted.trial.unittest import SynchronousTestCase
 
@@ -12,8 +13,7 @@ from otter.cloud_client import service_request
 from otter.constants import ServiceType
 from otter.indexer import atom
 from otter.test.cloud_client.test_init import log_intent, service_request_eqf
-from otter.test.utils import (
-    const, noop, stub_json_response, stub_pure_response)
+from otter.test.utils import stub_json_response, stub_pure_response
 from otter.util.pure_http import APIError, has_code
 
 

--- a/otter/test/cloud_client/test_cloudfeeds.py
+++ b/otter/test/cloud_client/test_cloudfeeds.py
@@ -1,15 +1,17 @@
 """Tests for otter.cloud_client.cloudfeeds"""
 
 from effect import sync_perform
-from effect.testing import EQFDispatcher
+from effect.testing import (
+    EQFDispatcher, base_dispatcher, perform_sequence, sync_perform)
 
 from twisted.trial.unittest import SynchronousTestCase
 
 from otter.cloud_client import service_request
-from otter.cloud_client.cloudfeeds import publish_autoscale_event
+from otter.cloud_client import cloudfeeds as cf
 from otter.constants import ServiceType
+from otter.indexer import atom
 from otter.test.cloud_client.test_init import service_request_eqf
-from otter.test.utils import stub_pure_response
+from otter.test.utils import const, stub_json_response, stub_pure_response
 from otter.util.pure_http import APIError, has_code
 
 
@@ -22,7 +24,7 @@ class CloudFeedsTests(SynchronousTestCase):
         Publish an event to cloudfeeds.  Successfully handle non-JSON data.
         """
         _log = object()
-        eff = publish_autoscale_event({'event': 'stuff'}, log=_log)
+        eff = cf.publish_autoscale_event({'event': 'stuff'}, log=_log)
         expected = service_request(
             ServiceType.CLOUD_FEEDS, 'POST',
             'autoscale/events',
@@ -43,3 +45,132 @@ class CloudFeedsTests(SynchronousTestCase):
             expected.intent,
             service_request_eqf(stub_pure_response('<this is xml>', 202)))])
         self.assertRaises(APIError, sync_perform, dispatcher, eff)
+
+
+class ReadEntriesTests(SynchronousTestCase):
+
+    entry = '<entry><summary>{}</summary></entry>'
+    feed_fmt = (
+        '<feed xmlns="http://www.w3.org/2005/Atom">'
+        '<link rel="{rel}" href="{rel_link}"/>'
+        '{entries}</feed>')
+    url = "http://url"
+    directions = {"previous": cf.Direction.PREVIOUS,
+                  "next": cf.Direction.NEXT}
+    service_type = ServiceType.CLOUD_FEEDS
+
+    def svc_intent(self, params={}):
+        return service_request(
+            self.service_type, "GET",
+            self.url, params=params, json_response=False).intent
+
+    def feed(self, rel, link, summaries):
+        return self.feed_fmt.format(
+            rel=rel, rel_link=link,
+            entries=''.join(self.entry.format(s) for s in summaries))
+
+    def _test_empty(self, rel):
+        """
+        Does not go further when there are no entries and return []
+        """
+        feedstr = self.feed(rel, "link-doesnt-matter", [])
+        seq = [
+            (self.svc_intent(), const(stub_json_response(feedstr)))
+        ]
+        entries_eff = cf.read_entries(
+            self.service_type, self.url, {}, self.directions[rel])
+        self.assertEqual(perform_sequence(seq, entries_eff), ([], {}))
+
+    def test_empty_previous(self):
+        self._test_empty("previous")
+
+    def test_empty_next(self):
+        self._test_empty("next")
+
+    def _test_single_page(self, rel):
+        """
+        Collects entries and goes to next link if there are entries and returns
+        if next one is empty
+        """
+        feed1str = self.feed(rel, "https://url?page=2", ["summary1", "summ2"])
+        feed2str = self.feed(rel, "link", [])
+        seq = [
+            (self.svc_intent({"a": "b"}), const(stub_json_response(feed1str))),
+            (self.svc_intent({"page": ['2']}),
+             const(stub_json_response(feed2str)))
+        ]
+        entries, params = perform_sequence(
+            seq,
+            cf.read_entries(
+                self.service_type, self.url, {"a": "b"}, self.directions[rel]))
+        self.assertEqual(
+            [atom.summary(entry) for entry in entries],
+            ["summary1", "summ2"])
+        self.assertEqual(params, {"page": ["2"]})
+
+    def test_single_page_previous(self):
+        self._test_single_page("previous")
+
+    def test_single_page_next(self):
+        self._test_single_page("next")
+
+    def _test_multiple_pages(self, rel):
+        """
+        Collects entries and goes to next link if there are entries and
+        continues until next link returns empty list
+        """
+        feed1_str = self.feed(rel, "https://url?page=2", ["summ1", "summ2"])
+        feed2_str = self.feed(rel, "https://url?page=3", ["summ3", "summ4"])
+        feed3_str = self.feed(rel, "link", [])
+        seq = [
+            (self.svc_intent(), const(stub_json_response(feed1_str))),
+            (self.svc_intent({"page": ['2']}),
+             const(stub_json_response(feed2_str))),
+            (self.svc_intent({"page": ['3']}),
+             const(stub_json_response(feed3_str))),
+        ]
+        entries, params = perform_sequence(
+            seq,
+            cf.read_entries(
+                self.service_type, self.url, {}, self.directions[rel]))
+        self.assertEqual(
+            [atom.summary(entry) for entry in entries],
+            ["summ1", "summ2", "summ3", "summ4"])
+        self.assertEqual(params, {"page": ["3"]})
+
+    def test_multiple_pages_previous(self):
+        self._test_multiple_pages("previous")
+
+    def test_multiple_pages_next(self):
+        self._test_multiple_pages("next")
+
+    def _test_no_link(self, rel):
+        """
+        Returns entries collected till now if there is no rel link
+        """
+        feedstr = (
+            '<feed xmlns="http://www.w3.org/2005/Atom">'
+            '<entry><summary>summary</summary></entry></feed>')
+        seq = [
+            (self.svc_intent({"a": "b"}), const(stub_json_response(feedstr)))
+        ]
+        entries, params = perform_sequence(
+            seq,
+            cf.read_entries(
+                self.service_type, self.url, {"a": "b"}, self.directions[rel]))
+        self.assertEqual(atom.summary(entries[0]), "summary")
+        self.assertEqual(params, {"a": "b"})
+
+    def test_no_link_previous(self):
+        self._test_no_link("previous")
+
+    def test_no_link_next(self):
+        self._test_no_link("next")
+
+    def test_invalid_direction(self):
+        """
+        Calling `read_entries` with invalid direction raises ValueError
+        """
+        self.assertRaises(
+            ValueError, sync_perform, base_dispatcher,
+            cf.read_entries(self.service_type, self.url, {}, "bad"))

--- a/otter/test/cloud_client/test_init.py
+++ b/otter/test/cloud_client/test_init.py
@@ -80,8 +80,6 @@ def make_service_configs():
             'name': 'cloudLoadBalancers',
             'region': 'DFW'},
         ServiceType.CLOUD_FEEDS: {
-            'name': 'cloud_feeds',
-            'region': 'DFW',
             'url': 'special cloudfeeds url'
         },
         ServiceType.CLOUD_ORCHESTRATION: {

--- a/otter/test/tap/test_api.py
+++ b/otter/test/tap/test_api.py
@@ -495,8 +495,7 @@ class APIMakeServiceTests(SynchronousTestCase):
                               'url': 'url'}
         makeService(conf)
         serv_confs = get_service_configs(conf)
-        serv_confs[ServiceType.CLOUD_FEEDS] = {
-            'name': 'cloudFeeds', 'region': 'ord', 'url': 'url'}
+        serv_confs[ServiceType.CLOUD_FEEDS] = {'url': 'url'}
 
         self.assertEqual(len(get_fanout().subobservers), 1)
         cf_observer = get_fanout().subobservers[0]

--- a/otter/test/test_constants.py
+++ b/otter/test/test_constants.py
@@ -22,8 +22,8 @@ class GetServiceMappingTests(SynchronousTestCase):
             'region': 'DFW',
             'metrics': {'service': 'm',
                         'region': 'IAD'},
-            'cloudfeeds': {'url': 'cf_url',
-                           "customer_access_events": {"url": "cap_url"}}
+            'cloudfeeds': {'url': 'cf_url'},
+            'terminator': {'cf_cap_url': 'cap_url'}
         }
 
     def test_takes_from_config(self):
@@ -62,20 +62,10 @@ class GetServiceMappingTests(SynchronousTestCase):
         Does not return cloud feeds services if the config is not there
         """
         del self.config['cloudfeeds']
+        del self.config['terminator']
         confs = get_service_configs(self.config)
         self.assertNotIn(ServiceType.CLOUD_FEEDS, confs)
         self.assertNotIn(ServiceType.CLOUD_FEEDS_CAP, confs)
-
-    def test_cloudfeeds_cap(self):
-        """
-        Includes CLOUD_FEEDS_CAP service with "name" and "region" when
-        "customer_access_events" is {"name": "service"} in config
-        """
-        self.config["cloudfeeds"]["customer_access_events"] = {"name": "cap"}
-        srv_confs = get_service_configs(self.config)
-        self.assertEqual(
-            srv_confs[ServiceType.CLOUD_FEEDS_CAP],
-            {"name": "cap", "region": "DFW"})
 
     def test_metrics_optional(self):
         """

--- a/otter/test/test_constants.py
+++ b/otter/test/test_constants.py
@@ -14,14 +14,17 @@ class GetServiceMappingTests(SynchronousTestCase):
         """
         Sample config
         """
-        self.config = {'cloudServersOpenStack': 'nova',
-                       'cloudLoadBalancers': 'clb',
-                       'cloudOrchestration': 'orch',
-                       'rackconnect': 'rc',
-                       'region': 'DFW',
-                       'metrics': {'service': 'm',
-                                   'region': 'IAD'},
-                       'cloudfeeds': {'service': 'cf', 'url': 'url'}}
+        self.config = {
+            'cloudServersOpenStack': 'nova',
+            'cloudLoadBalancers': 'clb',
+            'cloudOrchestration': 'orch',
+            'rackconnect': 'rc',
+            'region': 'DFW',
+            'metrics': {'service': 'm',
+                        'region': 'IAD'},
+            'cloudfeeds': {'url': 'cf_url',
+                           "customer_access_events": {"url": "cap_url"}}
+        }
 
     def test_takes_from_config(self):
         """
@@ -50,28 +53,29 @@ class GetServiceMappingTests(SynchronousTestCase):
                     'name': 'm',
                     'region': 'IAD',
                 },
-                ServiceType.CLOUD_FEEDS: {
-                    'url': 'url'
-                }
+                ServiceType.CLOUD_FEEDS: {'url': 'cf_url'},
+                ServiceType.CLOUD_FEEDS_CAP: {"url": "cap_url"},
             })
 
     def test_cloudfeeds_optional(self):
         """
-        Does not return cloud feeds service if the config is not there
+        Does not return cloud feeds services if the config is not there
         """
         del self.config['cloudfeeds']
-        self.assertNotIn(ServiceType.CLOUD_FEEDS,
-                         get_service_configs(self.config))
+        confs = get_service_configs(self.config)
+        self.assertNotIn(ServiceType.CLOUD_FEEDS, confs)
+        self.assertNotIn(ServiceType.CLOUD_FEEDS_CAP, confs)
 
     def test_cloudfeeds_cap(self):
         """
-        Includes CLOUD_FEEDS_CAP service if "customer_access_events_url" is
-        there in cloudfeeds config
+        Includes CLOUD_FEEDS_CAP service with "name" and "region" when
+        "customer_access_events" is {"name": "service"} in config
         """
-        self.config["cloudfeeds"]["customer_access_events_url"] = "capurl"
+        self.config["cloudfeeds"]["customer_access_events"] = {"name": "cap"}
         srv_confs = get_service_configs(self.config)
         self.assertEqual(
-            srv_confs[ServiceType.CLOUD_FEEDS_CAP]["url"], "capurl")
+            srv_confs[ServiceType.CLOUD_FEEDS_CAP],
+            {"name": "cap", "region": "DFW"})
 
     def test_metrics_optional(self):
         """

--- a/otter/test/test_constants.py
+++ b/otter/test/test_constants.py
@@ -51,8 +51,6 @@ class GetServiceMappingTests(SynchronousTestCase):
                     'region': 'IAD',
                 },
                 ServiceType.CLOUD_FEEDS: {
-                    'name': 'cf',
-                    'region': 'DFW',
                     'url': 'url'
                 }
             })
@@ -64,6 +62,16 @@ class GetServiceMappingTests(SynchronousTestCase):
         del self.config['cloudfeeds']
         self.assertNotIn(ServiceType.CLOUD_FEEDS,
                          get_service_configs(self.config))
+
+    def test_cloudfeeds_cap(self):
+        """
+        Includes CLOUD_FEEDS_CAP service if "customer_access_events_url" is
+        there in cloudfeeds config
+        """
+        self.config["cloudfeeds"]["customer_access_events_url"] = "capurl"
+        srv_confs = get_service_configs(self.config)
+        self.assertEqual(
+            srv_confs[ServiceType.CLOUD_FEEDS_CAP]["url"], "capurl")
 
     def test_metrics_optional(self):
         """


### PR DESCRIPTION
Part of [terminator](https://github.com/rackerlabs/autoscaling-chef/issues/833) PR. 

Common function to read feed entries is implemented in `otter.cloud_client.cloudfeeds` which is currently being used by `clb.get_node_feed` and will also be used by terminator to get customer access events. 