### PR TITLE
Try to pull mimic from an alternative repo so that we can update it.

### DIFF
--- a/requirements/mimic.txt
+++ b/requirements/mimic.txt
@@ -1,1 +1,1 @@
-git+https://github.com/rackerlabs/mimic.git@594dd5c8e80b670fa2d0c42f5eec9645e14aa54e
+git+ssh://github.com/rackerlabs/autoscale-mimic.git@autoscale


### PR DESCRIPTION
In this case, we don't have rights to commit to rackerlabs/mimic. In fact, I
don't think I can even hit the "fork" button on it, although I might've just
encountered a problem with forking to the same org (rackerlabs) because it has
the same name. I don't remember for sure, but we'll want the repo in rackerlabs
anyway, so I cloned it locally and made a differently-named repo in rackerlabs
for it. We can commit here. Theoretical syncing with upstream will just have to
go through a local git repo. Upstream has dead development, though, probably not
an issue.

To start with, I have created branch "autoscale" from commit 594dd5c, which
came from otter/requirements/mimic.txt.

I don't know if this takes care of mimic everywhere. I might need additional
commits on this branch to even make sure that we use the right mimic on the
preprod role nodes, but it does seem like I definitely need this much. If no
commits follow this up, it probably worked.